### PR TITLE
Adding __hash__'s where there are __eq__'s

### DIFF
--- a/abjad/tools/abjadbooktools/CodeBlock.py
+++ b/abjad/tools/abjadbooktools/CodeBlock.py
@@ -196,6 +196,15 @@ class CodeBlock(AbjadObject):
 
     ### PUBLIC PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(CodeBlock, self).__hash__()
+
     @property
     def hide(self):
         r'''Is true when code block should hide.

--- a/abjad/tools/datastructuretools/CyclicTuple.py
+++ b/abjad/tools/datastructuretools/CyclicTuple.py
@@ -95,6 +95,15 @@ class CyclicTuple(AbjadObject, tuple):
         result = [self[n] for n in range(start_index, stop_index)]
         return tuple(result)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(CyclicTuple, self).__hash__()
+
     def __str__(self):
         r'''String representation of cyclic tuple.
 

--- a/abjad/tools/datastructuretools/PayloadTree.py
+++ b/abjad/tools/datastructuretools/PayloadTree.py
@@ -259,6 +259,15 @@ class PayloadTree(AbjadObject):
         '''
         return vars(self)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(PayloadTree, self).__hash__()
+
     def __len__(self):
         r'''Number of children in payload tree.
 

--- a/abjad/tools/datastructuretools/StatalServer.py
+++ b/abjad/tools/datastructuretools/StatalServer.py
@@ -42,6 +42,15 @@ class StatalServer(AbjadObject):
 
     ### PUBLIC PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(StatalServer, self).__hash__()
+
     @property
     def cyclic_tree(self):
         r'''Statal server cyclic tree.

--- a/abjad/tools/datastructuretools/StatalServerCursor.py
+++ b/abjad/tools/datastructuretools/StatalServerCursor.py
@@ -123,6 +123,15 @@ class StatalServerCursor(AbjadObject):
 
     ### PRIVATE METHODS ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(StatalServerCursor, self).__hash__()
+
     def _get_manifest_payload_of_next_n_nodes_at_level(self, n=1, level=-1):
         result = []
         #print

--- a/abjad/tools/datastructuretools/TreeNode.py
+++ b/abjad/tools/datastructuretools/TreeNode.py
@@ -61,6 +61,15 @@ class TreeNode(AbjadObject):
             state[name] = getattr(self, name)
         return state
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(TreeNode, self).__hash__()
+
     def __ne__(self, expr):
         r'''Is true when tree node does not equal `expr`. Otherwise false.
 

--- a/abjad/tools/datastructuretools/TypedCollection.py
+++ b/abjad/tools/datastructuretools/TypedCollection.py
@@ -67,6 +67,15 @@ class TypedCollection(AbjadObject):
         '''
         return (self._collection, self.item_class)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(TypedCollection, self).__hash__()
+
     def __iter__(self):
         r'''Iterates typed collection.
 

--- a/abjad/tools/indicatortools/Annotation.py
+++ b/abjad/tools/indicatortools/Annotation.py
@@ -78,6 +78,15 @@ class Annotation(AbjadObject):
 
     ### PRIVATE PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Annotation, self).__hash__()
+
     @property
     def _repr_specification(self):
         return new(

--- a/abjad/tools/indicatortools/Arpeggio.py
+++ b/abjad/tools/indicatortools/Arpeggio.py
@@ -61,6 +61,15 @@ class Arpeggio(AbjadObject):
 
     ### PRIVATE PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Arpeggio, self).__hash__()
+
     @property
     def _lilypond_format(self):
         return r'\arpeggio'

--- a/abjad/tools/indicatortools/Articulation.py
+++ b/abjad/tools/indicatortools/Articulation.py
@@ -203,6 +203,15 @@ class Articulation(AbjadObject):
             return self._lilypond_format
         return str(self)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Articulation, self).__hash__()
+
     def __illustrate__(self):
         r'''Illustrates articulation.
 

--- a/abjad/tools/indicatortools/BarLine.py
+++ b/abjad/tools/indicatortools/BarLine.py
@@ -68,6 +68,15 @@ class BarLine(AbjadObject):
 
     ### PRIVATE PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(BarLine, self).__hash__()
+
     @property
     def _contents_repr_string(self):
         return repr(self.abbreviation)

--- a/abjad/tools/indicatortools/BendAfter.py
+++ b/abjad/tools/indicatortools/BendAfter.py
@@ -56,6 +56,15 @@ class BendAfter(AbjadObject):
                 return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(BendAfter, self).__hash__()
+
     def __str__(self):
         r'''String representation of bend after.
 

--- a/abjad/tools/indicatortools/Clef.py
+++ b/abjad/tools/indicatortools/Clef.py
@@ -175,6 +175,15 @@ class Clef(AbjadObject):
         superclass = super(Clef, self)
         return superclass.__format__(format_specification=format_specification)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Clef, self).__hash__()
+
     def __ne__(self, arg):
         r'''Is true when clef of `arg` does not equal clef name of clef.
         Otherwise false.

--- a/abjad/tools/indicatortools/Dynamic.py
+++ b/abjad/tools/indicatortools/Dynamic.py
@@ -148,6 +148,15 @@ class Dynamic(AbjadObject):
 
     ### PRIVATE PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Dynamic, self).__hash__()
+
     @property
     def _contents_repr_string(self):
         return repr(self._name)

--- a/abjad/tools/indicatortools/IndicatorExpression.py
+++ b/abjad/tools/indicatortools/IndicatorExpression.py
@@ -67,6 +67,15 @@ class IndicatorExpression(AbjadObject):
                     return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(IndicatorExpression, self).__hash__()
+
     def __repr__(self):
         '''Gets interpreter representation of indicator expression.
 

--- a/abjad/tools/indicatortools/KeyCluster.py
+++ b/abjad/tools/indicatortools/KeyCluster.py
@@ -77,6 +77,15 @@ class KeyCluster(AbjadObject):
 
     ### PRIVATE PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(KeyCluster, self).__hash__()
+
     @property
     def _lilypond_format_bundle(self):
         from abjad.tools import markuptools

--- a/abjad/tools/indicatortools/KeySignature.py
+++ b/abjad/tools/indicatortools/KeySignature.py
@@ -65,6 +65,15 @@ class KeySignature(AbjadObject):
                     return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(KeySignature, self).__hash__()
+
     def __str__(self):
         r'''String representation of key signature.
 

--- a/abjad/tools/indicatortools/LaissezVibrer.py
+++ b/abjad/tools/indicatortools/LaissezVibrer.py
@@ -41,6 +41,15 @@ class LaissezVibrer(AbjadObject):
         '''
         return isinstance(expr, type(self))
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(LaissezVibrer, self).__hash__()
+
     def __str__(self):
         r'''String representation of laissez vibrer.
 

--- a/abjad/tools/indicatortools/LilyPondCommand.py
+++ b/abjad/tools/indicatortools/LilyPondCommand.py
@@ -121,6 +121,15 @@ class LilyPondCommand(AbjadObject):
 
     ### PRIVATE PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(LilyPondCommand, self).__hash__()
+
     @property
     def _contents_repr_string(self):
         return repr(self.name)

--- a/abjad/tools/indicatortools/LilyPondComment.py
+++ b/abjad/tools/indicatortools/LilyPondComment.py
@@ -81,6 +81,15 @@ class LilyPondComment(AbjadObject):
             return self._contents_string == expr._contents_string
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(LilyPondComment, self).__hash__()
+
     def __str__(self):
         r'''Gets string format of LilyPond comment.
 

--- a/abjad/tools/indicatortools/StaffChange.py
+++ b/abjad/tools/indicatortools/StaffChange.py
@@ -78,6 +78,15 @@ class StaffChange(AbjadObject):
             return self.staff is expr.staff
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(StaffChange, self).__hash__()
+
     def __str__(self):
         r'''Gets string format of staff change.
 

--- a/abjad/tools/indicatortools/StemTremolo.py
+++ b/abjad/tools/indicatortools/StemTremolo.py
@@ -127,6 +127,15 @@ class StemTremolo(AbjadObject):
             return systemtools.StorageFormatManager.get_storage_format(self)
         return str(self)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(StemTremolo, self).__hash__()
+
     def __str__(self):
         r'''String representation of stem tremolo.
 

--- a/abjad/tools/indicatortools/Tempo.py
+++ b/abjad/tools/indicatortools/Tempo.py
@@ -191,6 +191,15 @@ class Tempo(AbjadObject):
             return self._lilypond_format
         return str(self)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Tempo, self).__hash__()
+
     def __lt__(self, arg):
         r'''Is true when `arg` is a tempo with quarters per minute greater than
         that of this tempo. Otherwise false.

--- a/abjad/tools/indicatortools/TimeSignature.py
+++ b/abjad/tools/indicatortools/TimeSignature.py
@@ -172,6 +172,15 @@ class TimeSignature(AbjadObject):
         else:
             raise TypeError
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(TimeSignature, self).__hash__()
+
     def __le__(self, arg):
         r'''Is true when duration of time signature is less than duration of
         `arg`. Otherwise false.

--- a/abjad/tools/layouttools/SpacingIndication.py
+++ b/abjad/tools/layouttools/SpacingIndication.py
@@ -86,6 +86,15 @@ class SpacingIndication(AbjadObject):
 
     ### PRIVATE PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(SpacingIndication, self).__hash__()
+
     @property
     def _repr_specification(self):
         return new(

--- a/abjad/tools/lilypondnametools/LilyPondNameManager.py
+++ b/abjad/tools/lilypondnametools/LilyPondNameManager.py
@@ -24,6 +24,15 @@ class LilyPondNameManager(AbjadObject):
         import copy
         return copy.deepcopy(vars(self))
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(LilyPondNameManager, self).__hash__()
+
     def __repr__(self):
         r'''Gets interpreter representation of LilyPond name manager.
 

--- a/abjad/tools/markuptools/MarkupCommand.py
+++ b/abjad/tools/markuptools/MarkupCommand.py
@@ -117,6 +117,15 @@ class MarkupCommand(AbjadObject):
             return self._lilypond_format
         return str(self)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(MarkupCommand, self).__hash__()
+
     def __str__(self):
         r'''Gets string representation of markup command.
 

--- a/abjad/tools/mathtools/Infinity.py
+++ b/abjad/tools/mathtools/Infinity.py
@@ -65,6 +65,15 @@ class Infinity(AbjadObject):
         '''
         return self._value > expr
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Infinity, self).__hash__()
+
     def __le__(self, expr):
         r'''Is true when `expr` is infinite. Otherwise false.
 

--- a/abjad/tools/mathtools/NonreducedFraction.py
+++ b/abjad/tools/mathtools/NonreducedFraction.py
@@ -248,6 +248,15 @@ class NonreducedFraction(AbjadObject, fractions.Fraction):
         '''
         return self.reduce() > expr
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(NonreducedFraction, self).__hash__()
+
     def __le__(self, expr):
         r'''Is true when nonreduced fraction is less than or equal to `expr`.
 

--- a/abjad/tools/metertools/MetricAccentKernel.py
+++ b/abjad/tools/metertools/MetricAccentKernel.py
@@ -82,6 +82,15 @@ class MetricAccentKernel(AbjadObject):
 
     ### PRIVATE PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(MetricAccentKernel, self).__hash__()
+
     @property
     def _repr_specification(self):
         return self._storage_format_specification

--- a/abjad/tools/pitchtools/NamedInterval.py
+++ b/abjad/tools/pitchtools/NamedInterval.py
@@ -196,6 +196,15 @@ class NamedInterval(Interval):
         '''
         return float(self._number)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(NamedInterval, self).__hash__()
+
     def __int__(self):
         r'''Returns number of named interval.
 

--- a/abjad/tools/pitchtools/NumberedIntervalClass.py
+++ b/abjad/tools/pitchtools/NumberedIntervalClass.py
@@ -85,6 +85,15 @@ class NumberedIntervalClass(IntervalClass):
         '''
         return float(self._number)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(NumberedIntervalClass, self).__hash__()
+
     def __int__(self):
         r'''Changes numbered interval-class to integer.
 

--- a/abjad/tools/pitchtools/OctaveTranspositionMappingComponent.py
+++ b/abjad/tools/pitchtools/OctaveTranspositionMappingComponent.py
@@ -81,6 +81,15 @@ class OctaveTranspositionMappingComponent(AbjadObject):
             return systemtools.StorageFormatManager.get_storage_format(self)
         return str(self)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(OctaveTranspositionMappingComponent, self).__hash__()
+
     def __ne__(self, expr):
         r'''Is true when octave transposition mapping component does not equal 
         `expr`. Otherwise false.

--- a/abjad/tools/pitchtools/PitchArray.py
+++ b/abjad/tools/pitchtools/PitchArray.py
@@ -97,6 +97,15 @@ class PitchArray(AbjadObject):
         '''
         return vars(self)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(PitchArray, self).__hash__()
+
     def __iadd__(self, arg):
         r'''Adds `arg` to pitch array in place.
 

--- a/abjad/tools/pitchtools/PitchArrayColumn.py
+++ b/abjad/tools/pitchtools/PitchArrayColumn.py
@@ -68,6 +68,15 @@ class PitchArrayColumn(AbjadObject):
         '''
         return vars(self)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(PitchArrayColumn, self).__hash__()
+
     def __ne__(self, arg):
         r'''Is true when pitch array column does not equal `arg`. Otherwise false.
 

--- a/abjad/tools/pitchtools/PitchArrayRow.py
+++ b/abjad/tools/pitchtools/PitchArrayRow.py
@@ -136,6 +136,15 @@ class PitchArrayRow(AbjadObject):
         '''
         return vars(self)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(PitchArrayRow, self).__hash__()
+
     def __iadd__(self, arg):
         r'''Adds `arg` to pitch array row in place.
 

--- a/abjad/tools/pitchtools/PitchRange.py
+++ b/abjad/tools/pitchtools/PitchRange.py
@@ -226,6 +226,15 @@ class PitchRange(AbjadObject):
         except (TypeError, ValueError):
             return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(PitchRange, self).__hash__()
+
     def __illustrate__(self):
         r'''Illustrates pitch range.
 

--- a/abjad/tools/quantizationtools/PitchedQEvent.py
+++ b/abjad/tools/quantizationtools/PitchedQEvent.py
@@ -64,6 +64,15 @@ class PitchedQEvent(QEvent):
 
     ### PUBLIC PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(PitchedQEvent, self).__hash__()
+
     @property
     def attachments(self):
         r'''Attachments of pitched q-event.

--- a/abjad/tools/quantizationtools/QEventProxy.py
+++ b/abjad/tools/quantizationtools/QEventProxy.py
@@ -107,6 +107,15 @@ class QEventProxy(AbjadObject):
                         state[slot] = getattr(self, slot)
         return state
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(QEventProxy, self).__hash__()
+
     def __setstate__(self, state):
         r'''Sets state.
         '''

--- a/abjad/tools/quantizationtools/QEventSequence.py
+++ b/abjad/tools/quantizationtools/QEventSequence.py
@@ -167,6 +167,15 @@ class QEventSequence(AbjadObject):
         '''
         return self._sequence[expr]
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(QEventSequence, self).__hash__()
+
     def __iter__(self):
         r'''Iterates q-event sequence.
 

--- a/abjad/tools/quantizationtools/QGrid.py
+++ b/abjad/tools/quantizationtools/QGrid.py
@@ -179,6 +179,15 @@ class QGrid(AbjadObject):
             '_root_node': self.root_node,
             }
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(QGrid, self).__hash__()
+
     def __setstate__(self, state):
         r'''Sets `state`.
 

--- a/abjad/tools/quantizationtools/QGridLeaf.py
+++ b/abjad/tools/quantizationtools/QGridLeaf.py
@@ -75,6 +75,15 @@ class QGridLeaf(RhythmTreeNode):
 
     ### PRIVATE PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(QGridLeaf, self).__hash__()
+
     @property
     def _pretty_rtm_format_pieces(self):
         return [str(self.preprolated_duration)]

--- a/abjad/tools/quantizationtools/QuantizationJob.py
+++ b/abjad/tools/quantizationtools/QuantizationJob.py
@@ -155,6 +155,15 @@ class QuantizationJob(AbjadObject):
             '_search_tree': self.search_tree,
             }
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(QuantizationJob, self).__hash__()
+
     def __setstate__(self, state):
         r'''Sets state.
 

--- a/abjad/tools/quantizationtools/SearchTree.py
+++ b/abjad/tools/quantizationtools/SearchTree.py
@@ -83,6 +83,15 @@ class SearchTree(AbjadObject):
                         state[slot] = getattr(self, slot)
         return state
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(SearchTree, self).__hash__()
+
     def __setstate__(self, state):
         r'''Sets `state` of search tree.
 

--- a/abjad/tools/quantizationtools/SilentQEvent.py
+++ b/abjad/tools/quantizationtools/SilentQEvent.py
@@ -45,6 +45,15 @@ class SilentQEvent(QEvent):
 
     ### PUBLIC PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(SilentQEvent, self).__hash__()
+
     @property
     def attachments(self):
         r'''Attachments of silen q-event.

--- a/abjad/tools/quantizationtools/TerminalQEvent.py
+++ b/abjad/tools/quantizationtools/TerminalQEvent.py
@@ -27,6 +27,15 @@ class TerminalQEvent(QEvent):
 
     ### SPECIAL METHODS ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(TerminalQEvent, self).__hash__()
+
     def __eq__(self, expr):
         r'''Is true when `expr` is a terminal q-event with offset equal to that of
         this terminal q-event. Otherwise false.

--- a/abjad/tools/rhythmmakertools/BeamSpecifier.py
+++ b/abjad/tools/rhythmmakertools/BeamSpecifier.py
@@ -118,6 +118,15 @@ class BeamSpecifier(AbjadObject):
             format_specification=format_specification,
             )
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(BeamSpecifier, self).__hash__()
+
     def __repr__(self):
         r'''Gets interpreter representation of beam specifier.
 

--- a/abjad/tools/rhythmmakertools/BurnishSpecifier.py
+++ b/abjad/tools/rhythmmakertools/BurnishSpecifier.py
@@ -222,6 +222,15 @@ class BurnishSpecifier(AbjadObject):
             format_specification=format_specification,
             )
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(BurnishSpecifier, self).__hash__()
+
     def __ne__(self, expr):
         r'''Is true when `expr` does not equal burnish specifier.
 

--- a/abjad/tools/rhythmmakertools/DurationSpellingSpecifier.py
+++ b/abjad/tools/rhythmmakertools/DurationSpellingSpecifier.py
@@ -86,6 +86,15 @@ class DurationSpellingSpecifier(AbjadObject):
             format_specification=format_specification,
             )
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(DurationSpellingSpecifier, self).__hash__()
+
     def __repr__(self):
         r'''Gets interpreter representation of duration spelling specifier.
 

--- a/abjad/tools/rhythmmakertools/NoteRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/NoteRhythmMaker.py
@@ -148,6 +148,15 @@ class NoteRhythmMaker(RhythmMaker):
         superclass = super(NoteRhythmMaker, self)
         return superclass.__format__(format_specification=format_specification)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(NoteRhythmMaker, self).__hash__()
+
     def __repr__(self):
         r'''Gets interpreter representation of note rhythm-maker.
 

--- a/abjad/tools/rhythmmakertools/RhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/RhythmMaker.py
@@ -118,6 +118,15 @@ class RhythmMaker(AbjadObject):
                 state[slot] = getattr(self, slot, None)
         return state
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(RhythmMaker, self).__hash__()
+
     def __illustrate__(self, divisions=None):
         r'''Illustrates rhythm-maker.
 

--- a/abjad/tools/rhythmmakertools/TieSpecifier.py
+++ b/abjad/tools/rhythmmakertools/TieSpecifier.py
@@ -49,6 +49,15 @@ class TieSpecifier(AbjadObject):
 
     ### PRIVATE METHODS ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(TieSpecifier, self).__hash__()
+
     def _make_ties(self, music):
         if self.tie_across_divisions:
             self._make_ties_across_divisions(music)

--- a/abjad/tools/rhythmtreetools/RhythmTreeContainer.py
+++ b/abjad/tools/rhythmtreetools/RhythmTreeContainer.py
@@ -238,6 +238,15 @@ class RhythmTreeContainer(RhythmTreeNode, TreeContainer):
                     return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(RhythmTreeContainer, self).__hash__()
+
     def __setitem__(self, i, expr):
         r'''Set `expr` in self at nonnegative integer index `i`, 
         or set `expr` in self at slice i.

--- a/abjad/tools/rhythmtreetools/RhythmTreeLeaf.py
+++ b/abjad/tools/rhythmtreetools/RhythmTreeLeaf.py
@@ -85,6 +85,15 @@ class RhythmTreeLeaf(RhythmTreeNode):
 
     ### PRIVATE PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(RhythmTreeLeaf, self).__hash__()
+
     @property
     def _pretty_rtm_format_pieces(self):
         return [str(self.preprolated_duration)]

--- a/abjad/tools/schemetools/Scheme.py
+++ b/abjad/tools/schemetools/Scheme.py
@@ -127,6 +127,15 @@ class Scheme(AbjadObject):
         '''
         return (self._value,)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Scheme, self).__hash__()
+
     def __str__(self):
         r'''String representation of scheme object.
 

--- a/abjad/tools/schemetools/SchemeMoment.py
+++ b/abjad/tools/schemetools/SchemeMoment.py
@@ -72,6 +72,15 @@ class SchemeMoment(Scheme):
         '''
         return (self._value,)
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(SchemeMoment, self).__hash__()
+
     def __lt__(self, arg):
         r'''Is true when `arg` is a scheme moment with value greater than that of
         this scheme moment.

--- a/abjad/tools/scoretools/NoteHead.py
+++ b/abjad/tools/scoretools/NoteHead.py
@@ -107,6 +107,15 @@ class NoteHead(AbjadObject):
             )
         return args
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(NoteHead, self).__hash__()
+
     def __lt__(self, expr):
         r'''Is true when `expr` is a note-head with written pitch greater than
         that of this note-head. Otherwise false.

--- a/abjad/tools/selectiontools/Selection.py
+++ b/abjad/tools/selectiontools/Selection.py
@@ -91,6 +91,15 @@ class Selection(object):
 #                state[slot] = getattr(self, slot, None)
 #        return state
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Selection, self).__hash__()
+
     def __len__(self):
         r'''Number of components in selection.
 

--- a/abjad/tools/sequencetools/Sequence.py
+++ b/abjad/tools/sequencetools/Sequence.py
@@ -129,6 +129,15 @@ class Sequence(AbjadObject):
         result = type(self)(*result)
         return result
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Sequence, self).__hash__()
+
     def __len__(self):
         r'''Gets length of sequence.
 

--- a/abjad/tools/sievetools/ResidueClass.py
+++ b/abjad/tools/sievetools/ResidueClass.py
@@ -82,6 +82,15 @@ class ResidueClass(BaseResidueClass):
                     return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(ResidueClass, self).__hash__()
+
     def __lt__(self, expr):
         r'''Is true when `expr` is a residue class with module greater than that
         of this residue class. Also true when `expr` is a residue class with

--- a/abjad/tools/timespantools/OffsetTimespanTimeRelation.py
+++ b/abjad/tools/timespantools/OffsetTimespanTimeRelation.py
@@ -132,6 +132,15 @@ class OffsetTimespanTimeRelation(TimeRelation):
 
     ### PUBLIC PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(OffsetTimespanTimeRelation, self).__hash__()
+
     @property
     def is_fully_loaded(self):
         r'''Is true when `timespan` and `offset` are both not none.

--- a/abjad/tools/timespantools/TimeRelation.py
+++ b/abjad/tools/timespantools/TimeRelation.py
@@ -52,6 +52,15 @@ class TimeRelation(AbjadObject):
 
     ### PUBLIC PROPERTIES ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(TimeRelation, self).__hash__()
+
     @property
     def inequality(self):
         r'''Time relation inequality.

--- a/abjad/tools/timespantools/Timespan.py
+++ b/abjad/tools/timespantools/Timespan.py
@@ -195,6 +195,15 @@ class Timespan(BoundedObject):
             return False
         return self.start_offset > expr.start_offset
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Timespan, self).__hash__()
+
     def __le__(self, expr):
         r'''Is true when `expr` start offset is less than or equal to
         timespan start offset.

--- a/abjad/tools/timespantools/TimespanTimespanTimeRelation.py
+++ b/abjad/tools/timespantools/TimespanTimespanTimeRelation.py
@@ -367,6 +367,15 @@ class TimespanTimespanTimeRelation(TimeRelation):
 
     ### PUBLIC METHODS ###
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(TimespanTimespanTimeRelation, self).__hash__()
+
     def get_counttime_components(self, counttime_components):
         r'''Get `counttime_components` that satisfy `time_relation`:
 

--- a/abjad/tools/tonalanalysistools/ChordExtent.py
+++ b/abjad/tools/tonalanalysistools/ChordExtent.py
@@ -51,6 +51,15 @@ class ChordExtent(AbjadObject):
                 return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(ChordExtent, self).__hash__()
+
     def __ne__(self, arg):
         r'''Is true when chord extent does not equal `arg`. Otherwise false.
 

--- a/abjad/tools/tonalanalysistools/ChordInversion.py
+++ b/abjad/tools/tonalanalysistools/ChordInversion.py
@@ -74,6 +74,15 @@ class ChordInversion(AbjadObject):
                 return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(ChordInversion, self).__hash__()
+
     def __ne__(self, arg):
         r'''Is true when chord inversion does not equal `arg`. Otherise false.
 

--- a/abjad/tools/tonalanalysistools/ChordQuality.py
+++ b/abjad/tools/tonalanalysistools/ChordQuality.py
@@ -52,6 +52,15 @@ class ChordQuality(AbjadObject):
                 return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(ChordQuality, self).__hash__()
+
     def __ne__(self, arg):
         r'''Is true when chord quality does not equal `arg`. Otherwise false.
 

--- a/abjad/tools/tonalanalysistools/ChordSuspension.py
+++ b/abjad/tools/tonalanalysistools/ChordSuspension.py
@@ -61,6 +61,15 @@ class ChordSuspension(AbjadObject):
                     return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(ChordSuspension, self).__hash__()
+
     def __ne__(self, arg):
         r'''Is true when `arg` does not equal chord suspension. Otherwise 
         false.

--- a/abjad/tools/tonalanalysistools/Mode.py
+++ b/abjad/tools/tonalanalysistools/Mode.py
@@ -46,6 +46,15 @@ class Mode(AbjadObject):
             return False
         return self.mode_name == arg.mode_name
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(Mode, self).__hash__()
+
     def __len__(self):
         r'''Length of mode.
 

--- a/abjad/tools/tonalanalysistools/RomanNumeral.py
+++ b/abjad/tools/tonalanalysistools/RomanNumeral.py
@@ -90,6 +90,15 @@ class RomanNumeral(AbjadObject):
                                 return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(RomanNumeral, self).__hash__()
+
     def __ne__(self, arg):
         r'''Is true when roman numeral does not equal `arg`. Otherwise false.
 

--- a/abjad/tools/tonalanalysistools/RootedChordClass.py
+++ b/abjad/tools/tonalanalysistools/RootedChordClass.py
@@ -99,6 +99,15 @@ class RootedChordClass(PitchClassSet):
                         return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(RootedChordClass, self).__hash__()
+
     def __ne__(self, arg):
         r'''Is true when rooted chord-class does not equal `arg`. Otherwise 
         false.

--- a/abjad/tools/tonalanalysistools/ScaleDegree.py
+++ b/abjad/tools/tonalanalysistools/ScaleDegree.py
@@ -122,6 +122,15 @@ class ScaleDegree(AbjadObject):
                     return True
         return False
 
+    def __hash__(self):
+        r'''Hashes my class.
+
+        Required to be explicitely re-defined on Python 3 if __eq__ changes.
+
+        Returns integer.
+        '''
+        return super(ScaleDegree, self).__hash__()
+
     def __ne__(self, arg):
         r'''Is true when `arg` does not equal scale degree. Otherwise false.
 


### PR DESCRIPTION
I have now took a completely different approach: As there are 144 files which need this patch, I did an automated patcher (a piece of code to patch the code - talk about metaprogramming ;) ).
The code introduces a docstring like you requested (I can easily change it if something is amiss - the joys of automated patching - just say).

The code also places the **hash** function as best as possible, but in some cases it is not perfect (especially if the class itself is not ordered to start with - a few cases).

Doing this manually would be a lot of grunt work. But I can tweak the automated patcher further if needed (though I doubt I would get a perfect placement for **hash** all the time).

After this patch 142 tests fail of 8886. Of these 35 are string/byte issues (trivial), plenty are sort issues. I continue to believe that no serious problem will occur (on abjad/, did not look at experimental and scoretools/)
