### PR TITLE
Python 3: cmp to key

### DIFF
--- a/abjad/tools/agenttools/IterationAgent.py
+++ b/abjad/tools/agenttools/IterationAgent.py
@@ -960,32 +960,12 @@ class IterationAgent(abctools.AbjadObject):
             component_class = scoretools.Leaf
         component_generator = iterate(self._client).by_class(component_class)
         components = list(component_generator)
-        def _backward_sort_helper(component_1, component_2):
-            result = cmp(
-                component_1._get_timespan().stop_offset,
-                component_2._get_timespan().stop_offset)
-            if result == 0:
-                return cmp(
-                    component_1._get_parentage().score_index,
-                    component_2._get_parentage().score_index)
-            else:
-                # note negative result of cmp() is returned
-                # for backward time sort
-                return -result
-        def _forward_sort_helper(component_1, component_2):
-            result = cmp(
-                component_1._get_timespan().start_offset,
-                component_2._get_timespan().start_offset)
-            if result == 0:
-                return cmp(
-                    component_1._get_parentage().score_index,
-                    component_2._get_parentage().score_index)
-            else:
-                return result
         if not reverse:
-            components.sort(_forward_sort_helper)
+            components.sort(key=lambda x: [x._get_timespan().start_offset,
+                                           x._get_parentage().score_index])
         else:
-            components.sort(_backward_sort_helper)
+            components.sort(key=lambda x: [-x._get_timespan().stop_offset,
+                                           x._get_parentage().score_index])
         for component in components:
             yield component
 

--- a/abjad/tools/scoretools/Container.py
+++ b/abjad/tools/scoretools/Container.py
@@ -1246,18 +1246,11 @@ class Container(Component):
         '''
         from abjad.tools import scoretools
         from abjad.tools import spannertools
-        def _offset(x, y):
-            if x._get_timespan().start_offset < y._get_timespan().start_offset:
-                return -1
-            elif y._get_timespan().start_offset < x._get_timespan().start_offset:
-                return 1
-            else:
-                return 0
         self._music.reverse()
         self._update_later(offsets=True)
         spanners = self._get_descendants()._get_spanners()
         for s in spanners:
-            s._components.sort(_offset)
+            s._components.sort(key=lambda x: x._get_timespan().start_offset)
 
     def select_leaves(
         self,


### PR DESCRIPTION
Python 3 does not use cmp, but just key for comparisons. This actually simplifies the code even with Python 2.

I think we are below 100 tests failing on Python 3 now on abjad/. I have to gain some courage to have a look at the needs of the experimental/ directory...
