### PR TITLE
Fixed LilyPond \language command

### DIFF
--- a/abjad/tools/layouttools/make_spacing_vector.py
+++ b/abjad/tools/layouttools/make_spacing_vector.py
@@ -30,7 +30,7 @@ def make_spacing_vector(
         % 2011-04-07 15:19
 
         \version "2.13.44"
-        \include "english.ly"
+        \language "english"
 
         \paper {
             system-system-spacing = #'(

--- a/abjad/tools/lilypondfiletools/LilyPondFile.py
+++ b/abjad/tools/lilypondfiletools/LilyPondFile.py
@@ -37,7 +37,7 @@ class LilyPondFile(AbjadObject):
             % Parts shown here for positioning.
 
             \version "2.19.0"
-            \include "english.ly"
+            \language "english"
 
             \include "external-settings-file-1.ly"
             \include "external-settings-file-2.ly"

--- a/scoremanager/scores/red_example_score/stylesheets/sargasso-stylesheet.ily
+++ b/scoremanager/scores/red_example_score/stylesheets/sargasso-stylesheet.ily
@@ -1,5 +1,5 @@
 \version "2.15.13"
-\include "english.ly"
+\language "english"
 
 #(set-default-paper-size "letter" 'portrait)
 #(set-global-staff-size 14)


### PR DESCRIPTION
I found remaining wrong uses of the LilyPond language selection.

I searched the code base with `grep -r 'include "english.ly"' .` and fixed all.
