### PR TITLE
PLY version set to 3.4 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ keywords = ', '.join(keywords)
 install_requires = [
     'Sphinx >= 1.0.7',
     'configobj >= 4.7.2',
-    'ply >= 3.4',
+    'ply == 3.4',
     'pytest >= 2.1',
     ]
 if sys.version_info[0] == 2:


### PR DESCRIPTION
Abjad does not work with PLY 3.6
It throws FileNotFoundError for:
~/.abjad/parse_tables_LilyPondParser_3-4-3-final-0.pkl
or similar file for other Python versions

Set ply == 3.4 as PLY 3.5 is declared broken
(SEE: http://www.dabeaz.com/ply/)