### PR TITLE
Use hasattr for method check

### DIFF
--- a/abjad/tools/agenttools/PersistenceAgent.py
+++ b/abjad/tools/agenttools/PersistenceAgent.py
@@ -83,7 +83,7 @@ class PersistenceAgent(abctools.AbjadObject):
         from abjad import abjad_configuration
         from abjad.tools import systemtools
         if illustrate_function is None:
-            assert '__illustrate__' in dir(self._client)
+            assert hasattr(self._client, '__illustrate__')
             illustrate_function = self._client.__illustrate__
         illustration = illustrate_function(**kwargs)
         if ly_file_path is None:
@@ -139,7 +139,7 @@ class PersistenceAgent(abctools.AbjadObject):
         '''
         from abjad.tools import lilypondfiletools
         from abjad.tools import systemtools
-        assert '__illustrate__' in dir(self._client)
+        assert hasattr(self._client, '__illustrate__')
         illustration = self._client.__illustrate__(**kwargs)
         assert hasattr(illustration, 'score_block')
         block = lilypondfiletools.Block(name='midi')
@@ -246,7 +246,7 @@ class PersistenceAgent(abctools.AbjadObject):
         '''
         from abjad.tools import systemtools
         if illustrate_function is None:
-            assert '__illustrate__' in dir(self._client)
+            assert hasattr(self._client, '__illustrate__')
         if pdf_file_path is not None:
             pdf_file_path = os.path.expanduser(pdf_file_path)
             without_extension = os.path.splitext(pdf_file_path)[0]
@@ -329,7 +329,7 @@ class PersistenceAgent(abctools.AbjadObject):
         '''
         from abjad.tools import systemtools
         if illustrate_function is None:
-            assert '__illustrate__' in dir(self._client)
+            assert hasattr(self._client, '__illustrate__')
         if png_file_path is not None:
             png_file_path = os.path.expanduser(png_file_path)
             without_extension = os.path.splitext(png_file_path)[0]

--- a/abjad/tools/documentationtools/make_reference_manual_lilypond_file.py
+++ b/abjad/tools/documentationtools/make_reference_manual_lilypond_file.py
@@ -62,7 +62,7 @@ def make_reference_manual_lilypond_file(music=None, **kwargs):
     from abjad.tools import lilypondfiletools
     from abjad.tools import schemetools
 
-    assert '__illustrate__' in dir(music)
+    assert hasattr(music, '__illustrate__')
     lilypond_file = music.__illustrate__(**kwargs)
 
     # header

--- a/abjad/tools/ipythontools/Play.py
+++ b/abjad/tools/ipythontools/Play.py
@@ -47,7 +47,7 @@ class Play(object):
             message += 'cannot render MIDI file to MP3.'
             print(message)
             return
-        assert '__illustrate__' in dir(expr)
+        assert hasattr(expr, '__illustrate__')
         sound_font = self.sound_font
         if not sound_font:
             message = 'sound_font is not specified, please call '

--- a/abjad/tools/ipythontools/Show.py
+++ b/abjad/tools/ipythontools/Show.py
@@ -16,7 +16,7 @@ class Show(object):
         from abjad.tools import systemtools
         from abjad.tools import topleveltools
         from IPython.core.display import display_png
-        assert '__illustrate__' in dir(expr)
+        assert hasattr(expr, '__illustrate__')
         temporary_directory = tempfile.mkdtemp()
         temporary_file_path = os.path.join(
             temporary_directory,

--- a/abjad/tools/topleveltools/graph.py
+++ b/abjad/tools/topleveltools/graph.py
@@ -38,7 +38,7 @@ def graph(
     if isinstance(expr, str):
         graphviz_format = expr
     else:
-        assert '__graph__' in dir(expr)
+        assert hasattr(expr, '__graph__')
         graphviz_graph = expr.__graph__(**kwargs)
         if graph_attributes:
             graph.attributes.update(graph_attributes)

--- a/abjad/tools/topleveltools/play.py
+++ b/abjad/tools/topleveltools/play.py
@@ -26,7 +26,7 @@ def play(expr):
     from abjad import abjad_configuration
     from abjad.tools import systemtools
     from abjad.tools import topleveltools
-    assert '__illustrate__' in dir(expr)
+    assert hasattr(expr, '__illustrate__')
     midi_file_path, abjad_formatting_time, lilypond_rendering_time = \
         topleveltools.persist(expr).as_midi()
     midi_player = abjad_configuration['midi_player']

--- a/abjad/tools/topleveltools/show.py
+++ b/abjad/tools/topleveltools/show.py
@@ -26,7 +26,7 @@ def show(expr, return_timing=False, **kwargs):
     '''
     from abjad.tools import systemtools
     from abjad.tools import topleveltools
-    assert '__illustrate__' in dir(expr)
+    assert expr.__illustrate__
     result = topleveltools.persist(expr).as_pdf(**kwargs)
     pdf_file_path = result[0]
     abjad_formatting_time = result[1]

--- a/abjad/tools/topleveltools/show.py
+++ b/abjad/tools/topleveltools/show.py
@@ -26,7 +26,7 @@ def show(expr, return_timing=False, **kwargs):
     '''
     from abjad.tools import systemtools
     from abjad.tools import topleveltools
-    assert hasattr(expr, "__illustrate__")
+    assert hasattr(expr, '__illustrate__')
     result = topleveltools.persist(expr).as_pdf(**kwargs)
     pdf_file_path = result[0]
     abjad_formatting_time = result[1]

--- a/abjad/tools/topleveltools/show.py
+++ b/abjad/tools/topleveltools/show.py
@@ -26,7 +26,7 @@ def show(expr, return_timing=False, **kwargs):
     '''
     from abjad.tools import systemtools
     from abjad.tools import topleveltools
-    assert expr.__illustrate__
+    assert hasattr(expr, "__illustrate__")
     result = topleveltools.persist(expr).as_pdf(**kwargs)
     pdf_file_path = result[0]
     abjad_formatting_time = result[1]


### PR DESCRIPTION
I ran into an error while running `show()` on an object extending the `lilypondfiletools.LilyPondFile` class.

I thought the same would happen extending other classes in the same way and so thought it would be useful to send through a PR to fix this.

```
>>> show(vln.tools.LilyPondFileTemplate(Note("c'4")))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Python/2.7/site-packages/abjad/tools/topleveltools/show.py", line 41, in show
    assert '__illustrate__' in dir(expr)
AssertionError
```

Because I am extending by composition rather than by inheritance (http://learnpythonthehardway.org/book/ex44.html), the `__illustrate__` method should actually be accessible. However, Abjad errors because it's not listed in `dir(expr)`.

I made a cut down example (if there's an obvious easier way of doing what I am trying lmk!): https://gist.github.com/odub/2450611d5e8e69f2ebcb

Also, having not done this before, let me know if there are practices I should follow for contributing in future. Most obviously:
1) would it be better to make an issue first before fixing?
2) unit test?