### PR TITLE
fixed subprocess running python3 despite parent process running python2

### DIFF
--- a/abjad/tools/documentationtools/Pipe.py
+++ b/abjad/tools/documentationtools/Pipe.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 import select
 import subprocess
+import sys
 import time
 from abjad.tools import abctools
 
@@ -18,7 +19,8 @@ class Pipe(abctools.AbjadObject, subprocess.Popen):
 
     ### INITIALIZER ###
 
-    def __init__(self, executable='python', arguments=('-i',), timeout=0):
+    def __init__(self, executable=None, arguments=('-i',), timeout=0):
+        executable = executable or sys.executable
         self._arguments = arguments
         self._executable = executable
         self._timeout = timeout


### PR DESCRIPTION
Since abjad is only compatible with python2, I installed it using pip for python2:

    pip2 install abjad

This installed the ajv script.
I tried to follow the ajv book tutorial to use ajv with Latex. But when running:

    ajv book test.tex.raw

I got the error message:

    Processing 'test.tex.raw' ...
    ('COMMAND', "__result__ =  persist(documentationtools.make_reference_manual_lilypond_file(measure)).as_ly('/home/myusername/mydirectory/tmpwfX5Zh/test-1.ly')")

    AbjadBookError:

    \begin{lstlisting}
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    NameError: name 'f' is not defined
    \end{lstlisting}

    AbjadBookError:

    \begin{lstlisting}
    >>> show(measure)
    \end{lstlisting}

    AbjadBookError:

    \begin{lstlisting}
    >>> show(measure)
    \end{lstlisting}

    \begin{lstlisting}
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    NameError: name 'persist' is not defined
    \end{lstlisting}

The problem happens because, although the `ajv` command is correctly started using python2 (the `ajv` script starts with `#!/usr/bin/python2`), the subprocess used to execute code between `<abjad>` and `</abjad>` tags runs the "python" command. But, on Arch Linux, and, I believe, on many other distros now, the "python" command points to python3, not python2.

I modified the Pipe.py file to use `sys.executable` as executable by default. This way, unless asked otherwise, the subprocess will use the same python executable as the parent process. This solves the problem.
