### PR TITLE
Leaf splitting tests for rests before attaching ties.

### DIFF
--- a/abjad/tools/scoretools/Leaf.py
+++ b/abjad/tools/scoretools/Leaf.py
@@ -424,10 +424,11 @@ class Leaf(Component):
             self._splice(tied_leaves, grow_spanners=True)
             parentage = self._get_parentage()
             if not parentage._get_spanners(spannertools.Tie):
-                tie = spannertools.Tie(
-                    use_messiaen_style_ties=use_messiaen_style_ties,
-                    )
-                attach(tie, all_leaves)
+                if spannertools.Tie._attachment_test(self):
+                    tie = spannertools.Tie(
+                        use_messiaen_style_ties=use_messiaen_style_ties,
+                        )
+                    attach(tie, all_leaves)
             return all_leaves
         else:
             assert isinstance(components[0], scoretools.Tuplet)
@@ -440,10 +441,11 @@ class Leaf(Component):
                 x.written_duration = component.written_duration
             self._splice(tied_leaves, grow_spanners=True)
             if not self._get_spanners(spannertools.Tie):
-                tie = spannertools.Tie(
-                    use_messiaen_style_ties=use_messiaen_style_ties,
-                    )
-                attach(tie, all_leaves)
+                if spannertools.Tie._attachment_test(self):
+                    tie = spannertools.Tie(
+                        use_messiaen_style_ties=use_messiaen_style_ties,
+                        )
+                    attach(tie, all_leaves)
             tuplet_multiplier = tuplet.multiplier
             scoretools.Tuplet(tuplet_multiplier, all_leaves)
             return [tuplet]

--- a/abjad/tools/scoretools/test/test_scoretools_Leaf__set_duration.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Leaf__set_duration.py
@@ -10,8 +10,7 @@ def test_scoretools_Leaf__set_duration_01():
     beam = Beam()
     attach(beam, voice[:2])
 
-    assert systemtools.TestManager.compare(
-        voice,
+    assert format(voice) == stringtools.normalize(
         r'''
         \new Voice {
             c'8 [
@@ -24,8 +23,7 @@ def test_scoretools_Leaf__set_duration_01():
 
     voice[1]._set_duration(Duration(5, 32))
 
-    assert systemtools.TestManager.compare(
-        voice,
+    assert format(voice) == stringtools.normalize(
         r'''
         \new Voice {
             c'8 [
@@ -50,8 +48,7 @@ def test_scoretools_Leaf__set_duration_02():
     beam = Beam()
     attach(beam, voice[:2])
 
-    assert systemtools.TestManager.compare(
-        voice,
+    assert format(voice) == stringtools.normalize(
         r'''
         \new Voice {
             c'8 ~ [
@@ -64,8 +61,7 @@ def test_scoretools_Leaf__set_duration_02():
 
     voice[1]._set_duration(Duration(5, 32))
 
-    assert systemtools.TestManager.compare(
-        voice,
+    assert format(voice) == stringtools.normalize(
         r'''
         \new Voice {
             c'8 ~ [
@@ -89,8 +85,7 @@ def test_scoretools_Leaf__set_duration_03():
     beam = Beam()
     attach(beam, voice[:2])
 
-    assert systemtools.TestManager.compare(
-        voice,
+    assert format(voice) == stringtools.normalize(
         r'''
         \new Voice {
             c'8 [
@@ -103,8 +98,7 @@ def test_scoretools_Leaf__set_duration_03():
 
     voice[1]._set_duration(Duration(3, 16))
 
-    assert systemtools.TestManager.compare(
-        voice,
+    assert format(voice) == stringtools.normalize(
         r'''
         \new Voice {
             c'8 [
@@ -127,8 +121,7 @@ def test_scoretools_Leaf__set_duration_04():
     beam = Beam()
     attach(beam, voice[:2])
 
-    assert systemtools.TestManager.compare(
-        voice,
+    assert format(voice) == stringtools.normalize(
         r'''
         \new Voice {
             c'8 [
@@ -141,8 +134,7 @@ def test_scoretools_Leaf__set_duration_04():
 
     voice[1]._set_duration(Duration(5, 48))
 
-    assert systemtools.TestManager.compare(
-        voice,
+    assert format(voice) == stringtools.normalize(
         r'''
         \new Voice {
             c'8 [
@@ -169,8 +161,7 @@ def test_scoretools_Leaf__set_duration_05():
     beam = Beam()
     attach(beam, voice[:2])
 
-    assert systemtools.TestManager.compare(
-        voice,
+    assert format(voice) == stringtools.normalize(
         r'''
         \new Voice {
             c'8 [
@@ -284,3 +275,39 @@ def test_scoretools_Leaf__set_duration_10():
 
     assert inspect_(note).is_well_formed()
     assert format(note) == "c'8 * 5/3"
+
+
+def test_scoretools_Leaf__set_duration_11():
+    r'''Change rest duration.
+    '''
+
+    voice = Voice("c'8 r8 e'8 f'8")
+    beam = Beam()
+    attach(beam, voice[:3])
+
+    assert format(voice) == stringtools.normalize(
+        r'''
+        \new Voice {
+            c'8 [
+            r8
+            e'8 ]
+            f'8
+        }
+        '''
+        )
+
+    voice[1]._set_duration(Duration(5, 32))
+
+    assert format(voice) == stringtools.normalize(
+        r'''
+        \new Voice {
+            c'8 [
+            r8
+            r32
+            e'8 ]
+            f'8
+        }
+        '''
+        )
+
+    assert inspect_(voice).is_well_formed()

--- a/abjad/tools/spannertools/Spanner.py
+++ b/abjad/tools/spannertools/Spanner.py
@@ -182,7 +182,7 @@ class Spanner(AbjadObject):
     ### PRIVATE METHODS ###
 
     def _append(self, component):
-        assert self._attachment_test(component), repr(component)
+        assert self._attachment_test(component), (repr(component), repr(self))
         if self._contiguity_constraint == 'logical voice':
             components = self[-1:] + [component]
             assert Selection._all_are_contiguous_components_in_same_logical_voice(

--- a/abjad/tools/spannertools/Tie.py
+++ b/abjad/tools/spannertools/Tie.py
@@ -58,7 +58,6 @@ class Tie(Spanner):
     @staticmethod
     def _attachment_test(component):
         from abjad.tools import scoretools
-        rest_prototype = (scoretools.Rest, scoretools.MultimeasureRest)
         pitched_prototype = (scoretools.Note, scoretools.Chord)
         return isinstance(component, pitched_prototype)
 


### PR DESCRIPTION
This PR fixes `Leaf._set_duration()` handling of ties with rests and skips.

Because ties can no longer be attached to rests and skips, `Leaf._set_duration()` tests `Tie._attachment_test()` against the leaf to be resized before attaching any tie.