### PR TITLE
Add timestamp to PackageGitCommitToken output.

### DIFF
--- a/abjad/tools/lilypondfiletools/PackageGitCommitToken.py
+++ b/abjad/tools/lilypondfiletools/PackageGitCommitToken.py
@@ -14,8 +14,14 @@ class PackageGitCommitToken(AbjadValueObject):
 
         ::
 
-            >>> lilypondfiletools.PackageGitCommitToken() # doctest: +SKIP
+            >>> token = lilypondfiletools.PackageGitCommitToken()
+            >>> token
             PackageGitCommitToken('abjad')
+
+        ::
+
+            >>> print(format(token))  # doctest: +SKIP
+            package "abjad" @ b6a48a7 [implement-lpf-git-token] (2016-02-02 13:36:25)
 
     '''
 
@@ -39,7 +45,7 @@ class PackageGitCommitToken(AbjadValueObject):
 
             >>> token = lilypondfiletools.PackageGitCommitToken('abjad')
             >>> print(format(token)) # doctest: +SKIP
-            "abjad" revision: 47d96e12550ade33a38036f05430372d2521b8b9
+            package "abjad" @ b6a48a7 [implement-lpf-git-token] (2016-02-02 13:36:25)
 
         Return string.
         '''
@@ -77,6 +83,7 @@ class PackageGitCommitToken(AbjadValueObject):
             command,
             shell=True,
             stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             )
         process.wait()
         if process.returncode:
@@ -95,7 +102,7 @@ class PackageGitCommitToken(AbjadValueObject):
             git_branch = self._get_git_branch()
             git_hash = self._get_git_hash()
             timestamp = self._get_commit_timestamp(git_hash)
-            print(git_branch, git_hash, timestamp)
+            #print(git_branch, git_hash, timestamp)
         date, time, _ = timestamp.split()
         return 'package "{}" @ {} [{}] ({} {})'.format(
             self._package_name,

--- a/abjad/tools/lilypondfiletools/PackageGitCommitToken.py
+++ b/abjad/tools/lilypondfiletools/PackageGitCommitToken.py
@@ -14,9 +14,9 @@ class PackageGitCommitToken(AbjadValueObject):
 
         ::
 
-            >>> token = lilypondfiletools.PackageGitCommitToken()
+            >>> token = lilypondfiletools.PackageGitCommitToken('abjad')
             >>> token
-            PackageGitCommitToken('abjad')
+            PackageGitCommitToken(package_name='abjad')
 
         ::
 


### PR DESCRIPTION
This PR adds a token class which can be inserted into the `comments` list of a `LilyPondFile` providing information about the state of a named repository:

```
>>> token = lilypondfiletools.PackageGitCommitToken()
>>> token
PackageGitCommitToken('abjad')
```

```
>>> print(format(token))
package "abjad" @ b6a48a7 [implement-lpf-git-token] (2016-02-02 13:36:25)
```

Why is this useful? It lets composers enumerate all of the packages important to the creation of a given score artifact, and embed that information in the score as a comment. This makes it easier to step back towards the last known working environment necessary to create that score artifact.