### PR TITLE
Cleanup install guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,8 @@ Abjad also works with `CPython`_ versions 2.7 and 3.3+, as well as `PyPy`_.
 Install Abjad
 -------------
 
-To install Abjad from `PyPI`_, the Python Package Index, via `pip`_::
+To install the most recent official release of Abjad from `PyPI`_, the Python
+Package Index, via `pip`_::
 
     ~$ sudo pip install abjad
 
@@ -108,10 +109,9 @@ To install `Graphviz`_ on Debian and Ubuntu::
 
     ~$ sudo apt-get install graphviz
 
-To install `Graphviz`_ on OSX via `Homebrew`_ or `MacPorts`_::
+To install `Graphviz`_ on OSX via `Homebrew`_::
 
     ~$ brew install graphviz
-    ~$ sudo port install graphviz
 
 Once you have install `Graphviz`_, test if `Graphviz`_ is callable from your
 command-line by running the following command:
@@ -130,7 +130,7 @@ documentation locally, clone Abjad from the Github repository and install it in
 
     ~$ git clone https://github.com/Abjad/abjad.git
     ~$ cd abjad
-    abjad$ sudo pip install -e ".[development]"
+    abjad$ sudo pip install -e .[development]
 
 Installing Abjad in development mode will install the following `Python`_
 package dependencies.
@@ -156,8 +156,8 @@ To install C compilation tools on Debian and Ubuntu::
     ~$ sudo apt-get install build-essential
 
 To install C compilation tools on OSX, we recommend simply installing XCode
-from the Apple App Store. Alternatively, you can install via `Homebrew`_ or
-`MacPorts`_, although this may take a significant amount of time.
+from the Apple App Store. Alternatively, you can install via `Homebrew`_
+although this may take a significant amount of time.
 
 Additionally, a few non-`Python`_ tools need to be installed in order to
 develop Abjad or build its documentation: `TeXLive`_, `ImageMagick`_, and
@@ -187,11 +187,19 @@ To install `ImageMagick`_ on Debian and Ubuntu::
 
     ~$ sudo apt-get install imagemagick
 
-To install `ImageMagick`_ on OSX, we recommend installing via `Homebrew`_ or
-`MacPorts`_::
+To install `ImageMagick`_ on OSX, we recommend installing via `Homebrew`_::
 
     ~$ brew install imagemagick
-    ~$ sudo port install imagemagick
+
+Once you have install `ImageMagick`_, test if `ImageMagick`_ is callable from
+your command-line by running the following command:
+
+    ~$ convert --version
+    Version: ImageMagick 6.9.1-6 Q16 x86_64 2015-06-22 http://www.imagemagick.org
+    Copyright: Copyright (C) 1999-2015 ImageMagick Studio LLC
+    License: http://www.imagemagick.org/script/license.php
+    Features: Cipher DPC Modules 
+    Delegates (built-in): bzlib freetype jng jpeg ltdl lzma png tiff xml zlib
 
 Abjad and IPython
 -----------------
@@ -200,7 +208,7 @@ Abjad can be used with `IPython`_ to embed notation, graphs and audio into an
 `IPython notebook`_. To work with Abjad in `IPython`_, install Abjad with both
 its **development** and **ipython** extra dependencies::
 
-    ~$ sudo pip install abjad [development, ipython]
+    ~$ sudo pip install abjad[development,ipython]  # NOTE: no spaces in the string after "install"
 
 Capturing MIDI files into an `IPython notebook`_ requires the `fluidsynth`_
 package.
@@ -209,16 +217,18 @@ To install `fluidsynth`_ on Debian or Ubuntu::
 
     ~$ apt-get install fluidsynth
 
-To install `fluidsynth`_ on OSX via `Homebrew`_ or `MacPorts`_::
+To install `fluidsynth`_ on OSX via `Homebrew`_::
 
     ~$ brew install fluidsynth --with-libsndfile
-    ~$ sudo port install fluidsynth
 
 Once all dependencies have been installed, create a new `IPython notebook`_ and
-run the following magic command in a cell to load Abjad's `IPython`_
+run the following "magic" command in a cell to load Abjad's `IPython`_
 extension::
 
     %load_ext abjad.ext.ipython
+
+Once loaded, notation and MIDI files can be embedded in your notebook whenever
+you use `show(...)` and `play(...)` on valid Abjad objects.
 
 Virtual environments
 --------------------
@@ -231,23 +241,47 @@ packages. They also allow you to install Python packages without ``sudo``. The
 and the `virtualenvwrapper`_ package provides additional tools which make
 working with virtual environments incredibly easy::
 
-    ~$ pip install virtualenv virtualenvwrapper
+    ~$ pip install virtualenvwrapper
     ...
-    ~$ export WORKON_HOME=~/Envs
+    ~$ export WORKON_HOME=~/.virtualenvs
     ~$ mkdir -p $WORKON_HOME
-    ~$ source /usr/local/bin/virtualenvwrapper.sh
+    ~$ source `which virtualenvwrapper.sh`
     ~$ mkvirtualenv abjad
     ...
     ~(abjad)$ pip install abjad
 
-If you have `virtualenvwrapper`_ installed, create a virtual environment and
-install Abjad into that instead::
+..  note::
+
+    The location your virtual environment files are stored in could be
+    anywhere. Because you are unlikely to need to access them directly, we
+    suggest the `.`-prepended path `.virtualenvs`.
+
+..  note::
+
+    On OSX 10.11 (El Capitan) it may be necessary to install
+    `virtualenvwrapper` via alternate instructions::
+
+        ~$ pip install virtualenvwrapper --ignore-installed six
+
+    See
+    [here](http://stackoverflow.com/questions/32086631/cant-install-virtualenvwrapper-on-osx-10-11-el-capitan)
+    for details.
+
+Once you have `virtualenvwrapper`_ installed, create a virtual environment and
+install Abjad into the newly create virtual environment.
 
     ~$ mkvirtualenv abjad
     ...
     ~(abjad)$ git clone https://github.com/Abjad/abjad.git
     ~(abjad)$ cd abjad
-    abjad(abjad)$ pip install -e ".[development]"
+    abjad(abjad)$ pip install -e .[development]  # NOTE: no spaces between "." and "[development]"
+
+To make the virtual environment configuration sticky from terminal session to
+terminal session, add the following lines to your `~/.profile`,
+`~/.bash_profile` or similar shell configuration file::
+
+    export WORKON_HOME=$HOME/.virtualenvs
+    source `which virtualenvwrapper.sh`
 
 Configuring Abjad
 -----------------
@@ -308,7 +342,6 @@ you might want to set your ``pdf_viewer`` to ``evince`` and your
 ..  _ImageMagick: http://www.imagemagick.org/script/index.php
 ..  _LaTeX: https://tug.org/
 ..  _LilyPond: http://lilypond.org/
-..  _MacPorts: https://www.macports.org/
 ..  _MacTeX: https://tug.org/mactex/
 ..  _PyPDF2: http://pythonhosted.org/PyPDF2/
 ..  _PyPI: https://pypi.python.org/pypi/Abjad

--- a/README.rst
+++ b/README.rst
@@ -50,12 +50,26 @@ Package Index, via `pip`_::
 
     ~$ sudo pip install abjad
 
+..  note::
+
+    Abjad supports Python 2.7 and above. Python 2.7.9 and above provide `pip`_
+    out-of-the-box. For earlier versions of Python 2.7, you may need to install
+    `pip`_ yourself. While you can use the old ``easy_install`` tool (``sudo
+    easy_install pip``), we strongly recommend the `pip`_-installation
+    instructions found here: https://pip.pypa.io/en/stable/installing/.
+
 To install the cutting-edge version Abjad from its `GitHub`_ repository, via
 `git <https://git-scm.com/>`_ and `pip`_::
 
     ~$ git clone https://github.com/Abjad/abjad.git 
     ~$ cd abjad
     abjad$ sudo pip install .
+
+..  caution::
+
+    We strongly encourage you to *not* install Abjad globally via ``sudo pip
+    install``, but to use a :ref:`virtual environment <virtual-environments>`
+    instead.
 
 Install LilyPond
 ````````````````
@@ -121,6 +135,10 @@ command-line by running the following command:
     ~$ dot -V
     dot - graphviz version 2.38.0 (20140413.2041)
 
+All of the graph images in Abjad's API documentation were created via
+`graphviz`_. See :py:func:`~abjad.tools.topleveltools.graph` for more
+details.
+
 Development installation
 ------------------------
 
@@ -130,17 +148,14 @@ documentation locally, clone Abjad from the Github repository and install it in
 
     ~$ git clone https://github.com/Abjad/abjad.git
     ~$ cd abjad
-    abjad$ sudo pip install -e .[development]
+    abjad$ sudo pip install -e .[development]  # NOTE: no spaces in the string after "install"
 
 Installing Abjad in development mode will install the following `Python`_
-package dependencies.
+package dependencies (along with their own dependencies):
 
 -   `pytest`_, for running Abjad's test suite
 
 -   `Sphinx`_, for building Abjad's documentation
-
--   `sphinx_rtd_theme <https://pypi.python.org/pypi/sphinx_rtd_theme>`_, for
-    theming Abjad's HTML documentation
 
 -   `PyPDF2`_, for performing preprocessing on `LaTeX`_ source with Abjad's
     ``ajv book`` tool
@@ -230,6 +245,8 @@ extension::
 Once loaded, notation and MIDI files can be embedded in your notebook whenever
 you use `show(...)` and `play(...)` on valid Abjad objects.
 
+..  _virtual-environments:
+
 Virtual environments
 --------------------
 
@@ -239,27 +256,17 @@ you to isolate `Python`_ packages from your systems global collection of
 packages. They also allow you to install Python packages without ``sudo``. The
 `virtualenv`_ package provides tools for creating Python virtual environments,
 and the `virtualenvwrapper`_ package provides additional tools which make
-working with virtual environments incredibly easy::
+working with virtual environments incredibly easy.
 
-    ~$ pip install virtualenvwrapper
+Let's install `virtualenvwrapper`_::
+
+    ~$ sudo pip install virtualenvwrapper
     ...
-    ~$ export WORKON_HOME=~/.virtualenvs
-    ~$ mkdir -p $WORKON_HOME
-    ~$ source `which virtualenvwrapper.sh`
-    ~$ mkvirtualenv abjad
-    ...
-    ~(abjad)$ pip install abjad
-
-..  note::
-
-    The location your virtual environment files are stored in could be
-    anywhere. Because you are unlikely to need to access them directly, we
-    suggest the `.`-prepended path `.virtualenvs`.
 
 ..  note::
 
     On OSX 10.11 (El Capitan) it may be necessary to install
-    `virtualenvwrapper` via alternate instructions::
+    `virtualenvwrapper`_ via alternate instructions::
 
         ~$ pip install virtualenvwrapper --ignore-installed six
 
@@ -267,21 +274,69 @@ working with virtual environments incredibly easy::
     [here](http://stackoverflow.com/questions/32086631/cant-install-virtualenvwrapper-on-osx-10-11-el-capitan)
     for details.
 
-Once you have `virtualenvwrapper`_ installed, create a virtual environment and
-install Abjad into the newly create virtual environment.
+Next, set an environment variable in your shell naming the directory you want
+the virtual environment files to be stored in, then create that directory if it
+doesn't already exist::
+
+    ~$ export WORKON_HOME=~/.virtualenvs
+    ~$ mkdir -p $WORKON_HOME
+
+..  note::
+
+    The location your virtual environment files are stored in could be
+    anywhere. Because you are unlikely to need to access them directly, we
+    suggest the `.`-prepended path ``.virtualenvs``.
+
+With the virtual environment directory created, "source" `virtualenvwrapper`_'s
+script. This script teaches your shell about how to create, activate and delete
+virtual environments::
+
+    ~$ source `which virtualenvwrapper.sh`
+
+Finally, you can create a virtual environment via the ``mkvirtualenv`` command.
+This will both create the fresh environment and "activate" it. Once activated,
+you can install Python packages within that environment, safe in the knowledge
+that they won't interfere with Python packages installed anywhere else on your
+system::
+
+    ~$ mkvirtualenv abjad
+    ...
+    ~(abjad)$ pip install abjad  # "(abjad)" indicates the name of the virtualenv
+    ...
+
+You can also deactivate the current virtual environment via the ``deactivate``
+command, or switch to a different environment via the ``workon <virtualenv
+name>`` command::
+
+    ~(abjad)$ deactivate
+    ~$ workon my-new-score
+    ~(my-new-score)$
+
+To make the virtual environment configuration sticky from terminal session to
+terminal session, add the following lines to your ``~/.profile``,
+``~/.bash_profile`` or similar shell configuration file::
+
+    export WORKON_HOME=$HOME/.virtualenvs
+    source `which virtualenvwrapper.sh`
+
+Development installation within a virtualenv
+````````````````````````````````````````````
+
+To recap, a complete development installation of Abjad within a virtual
+environment requires the following steps:
+
+- Create and activate a new virtual environment
+- Clone Abjad somewhere and ``cd`` into the root of the cloned repository
+- Install Abjad and its development / IPython dependencies
+
+::
 
     ~$ mkvirtualenv abjad
     ...
     ~(abjad)$ git clone https://github.com/Abjad/abjad.git
     ~(abjad)$ cd abjad
-    abjad(abjad)$ pip install -e .[development]  # NOTE: no spaces between "." and "[development]"
-
-To make the virtual environment configuration sticky from terminal session to
-terminal session, add the following lines to your `~/.profile`,
-`~/.bash_profile` or similar shell configuration file::
-
-    export WORKON_HOME=$HOME/.virtualenvs
-    source `which virtualenvwrapper.sh`
+    abjad(abjad)$ pip install -e .[development,ipython]  # NOTE: no spaces between "." and "[development,ipython]"
+    ...
 
 Configuring Abjad
 -----------------

--- a/abjad/docs/Makefile
+++ b/abjad/docs/Makefile
@@ -151,3 +151,6 @@ doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+
+upload:
+	rsync -avzP --delete build/html/ root@mbrsi.org:/home/mbrsi/subdomains/abjad

--- a/abjad/docs/source/installation.rst
+++ b/abjad/docs/source/installation.rst
@@ -8,9 +8,18 @@ Abjad also works with `CPython`_ versions 2.7 and 3.3+, as well as `PyPy`_.
 Install Abjad
 -------------
 
-To install Abjad from `PyPI`_, the Python Package Index, via `pip`_::
+To install the most recent official release of Abjad from `PyPI`_, the Python
+Package Index, via `pip`_::
 
     ~$ sudo pip install abjad
+
+..  note::
+
+    Abjad supports Python 2.7 and above. Python 2.7.9 and above provide `pip`_
+    out-of-the-box. For earlier versions of Python 2.7, you may need to install
+    `pip`_ yourself. While you can use the old ``easy_install`` tool (``sudo
+    easy_install pip``), we strongly recommend the `pip`_-installation
+    instructions found here: https://pip.pypa.io/en/stable/installing/.
 
 To install the cutting-edge version Abjad from its `GitHub`_ repository, via
 `git <https://git-scm.com/>`_ and `pip`_::
@@ -18,6 +27,12 @@ To install the cutting-edge version Abjad from its `GitHub`_ repository, via
     ~$ git clone https://github.com/Abjad/abjad.git 
     ~$ cd abjad
     abjad$ sudo pip install .
+
+..  caution::
+
+    We strongly encourage you to *not* install Abjad globally via ``sudo pip
+    install``, but to use a :ref:`virtual environment <virtual-environments>`
+    instead.
 
 Install LilyPond
 ````````````````
@@ -71,10 +86,9 @@ To install `Graphviz`_ on Debian and Ubuntu::
 
     ~$ sudo apt-get install graphviz
 
-To install `Graphviz`_ on OSX via `Homebrew`_ or `MacPorts`_::
+To install `Graphviz`_ on OSX via `Homebrew`_::
 
     ~$ brew install graphviz
-    ~$ sudo port install graphviz
 
 Once you have install `Graphviz`_, test if `Graphviz`_ is callable from your
 command-line by running the following command:
@@ -83,6 +97,10 @@ command-line by running the following command:
 
     ~$ dot -V
     dot - graphviz version 2.38.0 (20140413.2041)
+
+All of the graph images in Abjad's API documentation were created via
+`graphviz`_. See :py:func:`~abjad.tools.topleveltools.graph` for more
+details.
 
 Development installation
 ------------------------
@@ -93,17 +111,14 @@ documentation locally, clone Abjad from the Github repository and install it in
 
     ~$ git clone https://github.com/Abjad/abjad.git
     ~$ cd abjad
-    abjad$ sudo pip install -e ".[development]"
+    abjad$ sudo pip install -e .[development]  # NOTE: no spaces in the string after "install"
 
 Installing Abjad in development mode will install the following `Python`_
-package dependencies.
+package dependencies (along with their own dependencies):
 
 -   `pytest`_, for running Abjad's test suite
 
 -   `Sphinx`_, for building Abjad's documentation
-
--   `sphinx_rtd_theme <https://pypi.python.org/pypi/sphinx_rtd_theme>`_, for
-    theming Abjad's HTML documentation
 
 -   `PyPDF2`_, for performing preprocessing on `LaTeX`_ source with Abjad's
     ``ajv book`` tool
@@ -119,8 +134,8 @@ To install C compilation tools on Debian and Ubuntu::
     ~$ sudo apt-get install build-essential
 
 To install C compilation tools on OSX, we recommend simply installing XCode
-from the Apple App Store. Alternatively, you can install via `Homebrew`_ or
-`MacPorts`_, although this may take a significant amount of time.
+from the Apple App Store. Alternatively, you can install via `Homebrew`_
+although this may take a significant amount of time.
 
 Additionally, a few non-`Python`_ tools need to be installed in order to
 develop Abjad or build its documentation: `TeXLive`_, `ImageMagick`_, and
@@ -150,11 +165,19 @@ To install `ImageMagick`_ on Debian and Ubuntu::
 
     ~$ sudo apt-get install imagemagick
 
-To install `ImageMagick`_ on OSX, we recommend installing via `Homebrew`_ or
-`MacPorts`_::
+To install `ImageMagick`_ on OSX, we recommend installing via `Homebrew`_::
 
     ~$ brew install imagemagick
-    ~$ sudo port install imagemagick
+
+Once you have install `ImageMagick`_, test if `ImageMagick`_ is callable from
+your command-line by running the following command:
+
+    ~$ convert --version
+    Version: ImageMagick 6.9.1-6 Q16 x86_64 2015-06-22 http://www.imagemagick.org
+    Copyright: Copyright (C) 1999-2015 ImageMagick Studio LLC
+    License: http://www.imagemagick.org/script/license.php
+    Features: Cipher DPC Modules 
+    Delegates (built-in): bzlib freetype jng jpeg ltdl lzma png tiff xml zlib
 
 Abjad and IPython
 -----------------
@@ -163,7 +186,7 @@ Abjad can be used with `IPython`_ to embed notation, graphs and audio into an
 `IPython notebook`_. To work with Abjad in `IPython`_, install Abjad with both
 its **development** and **ipython** extra dependencies::
 
-    ~$ sudo pip install abjad [development, ipython]
+    ~$ sudo pip install abjad[development,ipython]  # NOTE: no spaces in the string after "install"
 
 Capturing MIDI files into an `IPython notebook`_ requires the `fluidsynth`_
 package.
@@ -172,16 +195,20 @@ To install `fluidsynth`_ on Debian or Ubuntu::
 
     ~$ apt-get install fluidsynth
 
-To install `fluidsynth`_ on OSX via `Homebrew`_ or `MacPorts`_::
+To install `fluidsynth`_ on OSX via `Homebrew`_::
 
     ~$ brew install fluidsynth --with-libsndfile
-    ~$ sudo port install fluidsynth
 
 Once all dependencies have been installed, create a new `IPython notebook`_ and
-run the following magic command in a cell to load Abjad's `IPython`_
+run the following "magic" command in a cell to load Abjad's `IPython`_
 extension::
 
     %load_ext abjad.ext.ipython
+
+Once loaded, notation and MIDI files can be embedded in your notebook whenever
+you use `show(...)` and `play(...)` on valid Abjad objects.
+
+..  _virtual-environments:
 
 Virtual environments
 --------------------
@@ -192,25 +219,87 @@ you to isolate `Python`_ packages from your systems global collection of
 packages. They also allow you to install Python packages without ``sudo``. The
 `virtualenv`_ package provides tools for creating Python virtual environments,
 and the `virtualenvwrapper`_ package provides additional tools which make
-working with virtual environments incredibly easy::
+working with virtual environments incredibly easy.
 
-    ~$ pip install virtualenv virtualenvwrapper
+Let's install `virtualenvwrapper`_::
+
+    ~$ sudo pip install virtualenvwrapper
     ...
-    ~$ export WORKON_HOME=~/Envs
+
+..  note::
+
+    On OSX 10.11 (El Capitan) it may be necessary to install
+    `virtualenvwrapper`_ via alternate instructions::
+
+        ~$ pip install virtualenvwrapper --ignore-installed six
+
+    See
+    [here](http://stackoverflow.com/questions/32086631/cant-install-virtualenvwrapper-on-osx-10-11-el-capitan)
+    for details.
+
+Next, set an environment variable in your shell naming the directory you want
+the virtual environment files to be stored in, then create that directory if it
+doesn't already exist::
+
+    ~$ export WORKON_HOME=~/.virtualenvs
     ~$ mkdir -p $WORKON_HOME
-    ~$ source /usr/local/bin/virtualenvwrapper.sh
+
+..  note::
+
+    The location your virtual environment files are stored in could be
+    anywhere. Because you are unlikely to need to access them directly, we
+    suggest the `.`-prepended path ``.virtualenvs``.
+
+With the virtual environment directory created, "source" `virtualenvwrapper`_'s
+script. This script teaches your shell about how to create, activate and delete
+virtual environments::
+
+    ~$ source `which virtualenvwrapper.sh`
+
+Finally, you can create a virtual environment via the ``mkvirtualenv`` command.
+This will both create the fresh environment and "activate" it. Once activated,
+you can install Python packages within that environment, safe in the knowledge
+that they won't interfere with Python packages installed anywhere else on your
+system::
+
     ~$ mkvirtualenv abjad
     ...
-    ~(abjad)$ pip install abjad
+    ~(abjad)$ pip install abjad  # "(abjad)" indicates the name of the virtualenv
+    ...
 
-If you have `virtualenvwrapper`_ installed, create a virtual environment and
-install Abjad into that instead::
+You can also deactivate the current virtual environment via the ``deactivate``
+command, or switch to a different environment via the ``workon <virtualenv
+name>`` command::
+
+    ~(abjad)$ deactivate
+    ~$ workon my-new-score
+    ~(my-new-score)$
+
+To make the virtual environment configuration sticky from terminal session to
+terminal session, add the following lines to your ``~/.profile``,
+``~/.bash_profile`` or similar shell configuration file::
+
+    export WORKON_HOME=$HOME/.virtualenvs
+    source `which virtualenvwrapper.sh`
+
+Development installation within a virtualenv
+````````````````````````````````````````````
+
+To recap, a complete development installation of Abjad within a virtual
+environment requires the following steps:
+
+- Create and activate a new virtual environment
+- Clone Abjad somewhere and ``cd`` into the root of the cloned repository
+- Install Abjad and its development / IPython dependencies
+
+::
 
     ~$ mkvirtualenv abjad
     ...
     ~(abjad)$ git clone https://github.com/Abjad/abjad.git
     ~(abjad)$ cd abjad
-    abjad(abjad)$ pip install -e ".[development]"
+    abjad(abjad)$ pip install -e .[development,ipython]  # NOTE: no spaces between "." and "[development,ipython]"
+    ...
 
 Configuring Abjad
 -----------------
@@ -271,7 +360,6 @@ you might want to set your ``pdf_viewer`` to ``evince`` and your
 ..  _ImageMagick: http://www.imagemagick.org/script/index.php
 ..  _LaTeX: https://tug.org/
 ..  _LilyPond: http://lilypond.org/
-..  _MacPorts: https://www.macports.org/
 ..  _MacTeX: https://tug.org/mactex/
 ..  _PyPDF2: http://pythonhosted.org/PyPDF2/
 ..  _PyPI: https://pypi.python.org/pypi/Abjad

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ extras_require = {
     'development': [
         'pytest',
         'sphinx>=1.3.1',
+        'sphinx-rtd-theme',
         'PyPDF2',
         ],
     'ipython': [


### PR DESCRIPTION
This PR addresses various problems in the installation instructions.

- `pip` installation (should be unnecessary on any system supporting Abjad)
- removing mentions of MacPorts
- correcting optional dependency installation
- improving `virtualenv` and `virtualenvwrapper` instructions
- caveats about OSX El Capitan

Closes #543.