### PR TITLE
Improve Sphinx SVG output (Part 2)

### DIFF
--- a/abjad/docs/source/appendices/pitch_conventions.rst
+++ b/abjad/docs/source/appendices/pitch_conventions.rst
@@ -46,8 +46,10 @@ Abjad numbers pitches like this:
 
 ..  abjad::
 
-    lilypond_file = lilypondfiletools.make_basic_lilypond_file(score)
-    lilypond_file.global_staff_size = 15
+    lilypond_file = lilypondfiletools.make_basic_lilypond_file(
+        score,
+        global_staff_size=15,
+        )
     show(lilypond_file)
 
 
@@ -102,8 +104,10 @@ Abjad numbers diatonic pitches like this:
 
 ..  abjad::
 
-    lilypond_file = lilypondfiletools.make_basic_lilypond_file(score)
-    lilypond_file.global_staff_size = 15
+    lilypond_file = lilypondfiletools.make_basic_lilypond_file(
+        score,
+        global_staff_size=15,
+        )
     show(lilypond_file)
 
 

--- a/abjad/docs/source/reference_manual/lilypond_files.rst
+++ b/abjad/docs/source/reference_manual/lilypond_files.rst
@@ -46,12 +46,28 @@ Basic LilyPond files also come equipped with header, layout and paper blocks:
 Setting global staff size and default paper size
 ------------------------------------------------
 
-Set default LilyPond global staff size and paper size like this:
+A LilyPondFile's global staff size and default paper size are immutable.
+Set them during instantiation, or by templating a new LilyPondFile via `new()`:
+
+Via templating:
 
 ..  abjad::
 
-    lilypond_file.global_staff_size = 14
-    lilypond_file.default_paper_size = 'A7', 'portrait'
+    lilypond_file = new(
+        lilypond_file,
+        global_staff_size=14,
+        default_paper_size=('A7', 'portrait'),
+        )
+
+When instantiating:
+
+..  abjad::
+
+    lilypond_file = lilypondfiletools.make_basic_lilypond_file(
+        staff,
+        global_staff_size=14,
+        default_paper_size=('A7', 'portrait'),
+        )
 
 ..  abjad::
 

--- a/abjad/tools/abjadbooktools/SphinxDocumentHandler.py
+++ b/abjad/tools/abjadbooktools/SphinxDocumentHandler.py
@@ -179,8 +179,10 @@ class SphinxDocumentHandler(abctools.AbjadObject):
             view_box = svg_element.getAttribute('viewBox')
             view_box = [float(_) for _ in view_box.split()]
             if delete_attributes:
-                del(svg_element.attributes['height'])
-                del(svg_element.attributes['width'])
+                if 'height' in svg_element.attributes:
+                    del(svg_element.attributes['height'])
+                if 'width' in svg_element.attributes:
+                    del(svg_element.attributes['width'])
             else:
                 height = '{}pt'.format(int(view_box[-1] * 0.6))
                 width = '{}pt'.format(int(view_box[-2] * 0.6))
@@ -227,6 +229,9 @@ class SphinxDocumentHandler(abctools.AbjadObject):
             len(thumbnail_paths),
             ):
             image_name = os.path.basename(path)
+            _, suffix = os.path.splitext(image_name)
+            if suffix == '.svg':
+                continue
             if 'abjadbook' in path:
                 image_name = os.path.join('abjadbook', image_name)
             prefix, suffix = os.path.splitext(image_name)
@@ -947,7 +952,10 @@ class SphinxDocumentHandler(abctools.AbjadObject):
                     paths = relative_target_file_paths[i:i + step]
                     for relative_target_file_path in paths:
                         prefix, suffix = os.path.splitext(relative_target_file_path)
-                        thumbnail_path = '{}-thumbnail{}'.format(prefix, suffix)
+                        if suffix == '.svg':
+                            thumbnail_path = relative_target_file_path
+                        else:
+                            thumbnail_path = '{}-thumbnail{}'.format(prefix, suffix)
                         result = template.format(
                             alt='',
                             cls=' '.join(sorted(css_classes)),
@@ -966,7 +974,10 @@ class SphinxDocumentHandler(abctools.AbjadObject):
                 css_classes.add('abjadbook')
                 for relative_target_file_path in relative_target_file_paths:
                     prefix, suffix = os.path.splitext(relative_target_file_path)
-                    thumbnail_path = '{}-thumbnail{}'.format(prefix, suffix)
+                    if suffix == '.svg':
+                        thumbnail_path = relative_target_file_path
+                    else:
+                        thumbnail_path = '{}-thumbnail{}'.format(prefix, suffix)
                     result = template.format(
                         alt='',
                         cls=' '.join(sorted(css_classes)),
@@ -1013,7 +1024,10 @@ class SphinxDocumentHandler(abctools.AbjadObject):
                     )
             target_path = node['uri']
             prefix, suffix = os.path.splitext(target_path)
-            thumbnail_path = '{}-thumbnail{}'.format(prefix, suffix)
+            if suffix == '.svg':
+                thumbnail_path = target_path
+            else:
+                thumbnail_path = '{}-thumbnail{}'.format(prefix, suffix)
             output = SphinxDocumentHandler._thumbnail_template.format(
                 alt=title,
                 group=group,

--- a/abjad/tools/lilypondfiletools/LilyPondFile.py
+++ b/abjad/tools/lilypondfiletools/LilyPondFile.py
@@ -125,7 +125,7 @@ class LilyPondFile(AbjadObject):
         comments = tuple(comments)
         self._comments = comments
         self._date_time_token = None
-        if not date_time_token == False:
+        if date_time_token is not False:
             self._date_time_token = lilypondfiletools.DateTimeToken()
         self._default_paper_size = default_paper_size
         self._global_staff_size = global_staff_size


### PR DESCRIPTION
This PR mops up failing doctests and problems with SVG thumbnails via the `abjadbook` `:with-thumbnails:` option.