### PR TITLE
New Abjad Cookbook (Part I)

### DIFF
--- a/abjad/docs/source/cookbook/analyzing_audio.rst
+++ b/abjad/docs/source/cookbook/analyzing_audio.rst
@@ -1,2 +1,6 @@
 Analyzing Audio
 ===============
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/analyzing_audio.rst
+++ b/abjad/docs/source/cookbook/analyzing_audio.rst
@@ -1,0 +1,2 @@
+Analyzing Audio
+===============

--- a/abjad/docs/source/cookbook/creating_complex_rhythms.rst
+++ b/abjad/docs/source/cookbook/creating_complex_rhythms.rst
@@ -1,2 +1,6 @@
 Creating complex rhythms with rhythm-makers
 ===========================================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/creating_custom_symbols.rst
+++ b/abjad/docs/source/cookbook/creating_custom_symbols.rst
@@ -1,2 +1,197 @@
 Creating custom musical symbols with markup
 ===========================================
+
+Building basic shapes with markup
+---------------------------------
+
+..  abjad::
+
+    mallet_stick = Markup.draw_line(0, -6)
+    mallet_head = Markup.filled_box((-1, 1), (-1, 1))
+    square_mallet = Markup.combine(mallet_stick, mallet_head)
+    print(format(square_mallet))
+    show(square_mallet)
+
+..  abjad::
+
+    mallet_stick = Markup.draw_line(0, -6)
+    mallet_head = Markup.filled_box((-1, 1), (-1, 1), blot=1)
+    square_mallet = Markup.combine(mallet_stick, mallet_head)
+    print(format(square_mallet))
+    show(square_mallet)
+
+..  abjad::
+
+    mallet_stick = Markup.draw_line(0, -6)
+    mallet_head = Markup.draw_circle(2, 0.5)
+    round_mallet = Markup.combine(mallet_stick, mallet_head)
+    print(format(round_mallet))
+    show(round_mallet)
+
+..  abjad::
+
+    mallet_stick = Markup.draw_line(0, -5).translate((0, -1))
+    mallet_head = Markup.draw_circle(1, 0.25)
+    round_mallet = Markup.combine(mallet_stick, mallet_head)
+    print(format(round_mallet))
+    show(round_mallet)
+
+..  abjad::
+
+    boxed_mallet = round_mallet.pad_around(1).box()
+    print(format(boxed_mallet))
+    show(boxed_mallet)
+
+..  abjad::
+
+    boxed_mallets = Markup.concat([round_mallet, square_mallet])
+    boxed_mallets = boxed_mallets.pad_around(1).box()
+    print(format(boxed_mallets))
+    show(boxed_mallets)
+
+..  abjad::
+
+    spacing = Markup.hspace(1)
+    boxed_mallets = Markup.concat([round_mallet, spacing, square_mallet])
+    boxed_mallets = boxed_mallets.pad_around(1).box()
+    print(format(boxed_mallets))
+    show(boxed_mallets)
+
+Fonts and alignment
+-------------------
+
+..  abjad::
+
+    flat = Markup.flat()
+    print(format(flat))
+    show(flat)
+
+..  abjad::
+
+    flat = Markup.flat()
+    a_flat = Markup.concat(['A', flat])
+    print(format(a_flat))
+    show(a_flat)
+
+..  abjad::
+
+    a = Markup('A').fontsize(3)
+    flat = Markup.flat()
+    a_flat = Markup.concat([a, flat])
+    print(format(a_flat))
+    show(a_flat)
+
+..  abjad::
+
+    a = Markup('A').fontsize(3)
+    flat = Markup.flat().vcenter()
+    a_flat = Markup.concat([a, flat])
+    print(format(a_flat))
+    show(a_flat)
+
+..  abjad::
+
+    a = Markup('A').fontsize(3).vcenter()
+    flat = Markup.flat().vcenter()
+    a_flat = Markup.concat([a, flat])
+    print(format(a_flat))
+    show(a_flat)
+
+..  abjad::
+
+    a = Markup('A').fontsize(3).override(('font-name', 'Arial')).vcenter()
+    flat = Markup.flat().vcenter()
+    a_flat = Markup.concat([a, flat])
+    print(format(a_flat))
+    show(a_flat)
+
+Working directly with Postscript
+--------------------------------
+
+..  abjad::
+
+    postscript = markuptools.Postscript()
+    postscript = postscript.newpath()
+    postscript = postscript.moveto(0, 0)
+    postscript = postscript.rlineto(0, 6)
+    postscript = postscript.rlineto(10, -2)
+    postscript = postscript.rlineto(0, -2)
+    postscript = postscript.rlineto(-10, -2)
+    postscript = postscript.closepath()
+    postscript = postscript.stroke()
+    outline = Markup.postscript(postscript)
+    print(format(outline))
+    show(outline)
+
+..  abjad::
+
+    show(outline.pad_around(1).box())
+
+..  abjad::
+
+    outline = outline.with_dimensions((0, 10), (0, 6))
+    show(outline.pad_around(1).box())
+
+..  abjad::
+
+    text = Markup('Vib').italic().bold().fontsize(3)
+    show(text)
+
+..  abjad::
+
+    diagram = Markup.combine(text, outline)
+    show(diagram)
+
+..  abjad::
+
+    diagram = Markup.combine(text, outline.vcenter())
+    show(diagram)
+
+..  abjad::
+
+    diagram = Markup.combine(text, outline.vcenter())
+    show(diagram)
+
+..  abjad::
+
+    diagram = Markup.combine(text.vcenter(), outline.vcenter())
+    show(diagram)
+
+..  abjad::
+
+    diagram = Markup.combine(text.vcenter().translate((1, 0)), outline.vcenter())
+    show(diagram)
+    print(format(diagram))
+
+Aligning markup on score components
+-----------------------------------
+
+..  abjad::
+
+    staff = Staff(r"\time 2/4 c'2 d'2 e'2")
+    for leaf in staff:
+        attach(diagram, leaf)
+
+    show(staff)
+
+..  abjad::
+
+    diagram = Markup(diagram, Up)
+    staff = Staff(r"\time 2/4 c'2 d'2 e'2")
+    for leaf in staff:
+        attach(diagram, leaf)
+
+    show(staff)
+
+..  abjad::
+
+    override(staff[1]).text_script.self_alignment_X = Center
+    override(staff[2]).text_script.self_alignment_X = Right
+    show(staff)
+
+..  abjad::
+
+    for leaf in staff:
+        override(leaf).text_script.parent_alignment_X = Center
+
+    show(staff)

--- a/abjad/docs/source/cookbook/creating_floating_time_signatures.rst
+++ b/abjad/docs/source/cookbook/creating_floating_time_signatures.rst
@@ -1,2 +1,6 @@
 Creating floating time signatures
 =================================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/creating_fragmented_scores.rst
+++ b/abjad/docs/source/cookbook/creating_fragmented_scores.rst
@@ -1,2 +1,6 @@
 Creating fragmented scores
 ==========================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/creating_graphs.rst
+++ b/abjad/docs/source/cookbook/creating_graphs.rst
@@ -27,7 +27,6 @@ Key points:
             attributes=dict(
                 bgcolor='transparent',
                 color='lightslategrey',
-                fontname='Arial',
                 output_order='edgesfirst',
                 overlap='prism',
                 penwidth=2,
@@ -94,6 +93,63 @@ Key points:
 
     context_graph = create_context_graph()
     graph(context_graph)
+
+Graph basics
+------------
+
+..  abjad::
+
+    my_graph = documentationtools.GraphvizGraph()
+
+..  abjad::
+
+    node_a = documentationtools.GraphvizNode(name='A', attributes={'label': 'A'})
+    node_b = documentationtools.GraphvizNode(name='B', attributes={'label': 'B'})
+    node_c = documentationtools.GraphvizNode(name='C', attributes={'label': 'C'})
+    node_d = documentationtools.GraphvizNode(name='D', attributes={'label': 'D'})
+
+..  abjad::
+
+    my_graph.extend([node_a, node_b, node_c, node_d])
+    graph(my_graph)
+
+..  abjad::
+
+    my_graph['B'].attributes['shape'] = 'diamond'
+    graph(my_graph)
+
+..  abjad::
+
+    ab_edge = my_graph['A'].attach(my_graph['B'])
+    bc_edge = my_graph['B'].attach(my_graph['C'])
+    bd_edge = my_graph['B'].attach(my_graph['D'])
+    graph(my_graph)
+
+..  abjad::
+
+    bc_edge.attributes['style'] = 'dotted'
+    bd_edge.attributes['style'] = 'dashed'
+    my_graph.attributes['bgcolor'] = 'transparent'
+    my_graph.node_attributes.update(
+        fontname='Arial',
+        penwidth=2,
+        )
+    my_graph.edge_attributes.update(
+        color='grey',
+        penwidth=2,
+        )
+    graph(my_graph)
+    print(format(my_graph, 'graphviz'))
+
+Collecting data for the graph
+-----------------------------
+
+..  abjad::
+
+    for context in lilypondnametools.LilyPondContext.list_all_contexts():
+        print(context.name)
+        for child_context in context.accepts:
+            print('\t' + child_context.name)
 
 Populating the graph
 --------------------
@@ -202,7 +258,6 @@ Configuring the graph's attributes
     context_graph.attributes.update(
         bgcolor='transparent',
         color='lightslategrey',
-        fontname='Arial',
         penwidth=2,
         style=('dotted', 'rounded'),
         truecolor=True,

--- a/abjad/docs/source/cookbook/creating_tables_of_chords.rst
+++ b/abjad/docs/source/cookbook/creating_tables_of_chords.rst
@@ -1,2 +1,6 @@
 Creating tables of chords
 =========================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/creating_texture_music.rst
+++ b/abjad/docs/source/cookbook/creating_texture_music.rst
@@ -1,2 +1,6 @@
 Creating texture music with timespans
 =====================================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/index.rst
+++ b/abjad/docs/source/cookbook/index.rst
@@ -25,6 +25,8 @@ The new Abjad cookbook
     working_with_stylesheets
     preparing_complex_documents
     templating_and_persisting
+    analyzing_audio
+    outputting_midi
     creating_graphs
 
 The old Abjad cookbook

--- a/abjad/docs/source/cookbook/interpolating_between_chords.rst
+++ b/abjad/docs/source/cookbook/interpolating_between_chords.rst
@@ -1,2 +1,6 @@
 Interpolating between chords
 ============================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/mapping_lists_to_rhythms.rst
+++ b/abjad/docs/source/cookbook/mapping_lists_to_rhythms.rst
@@ -1,5 +1,6 @@
 Mapping lists to rhythms
 ========================
+
 Let's say you have a list of numbers that you want to convert into rhythmic
 notation.  This is very easy to do. There are a number of related topics
 that are presented separately as other tutorials.

--- a/abjad/docs/source/cookbook/mapping_patterns_to_notation.rst
+++ b/abjad/docs/source/cookbook/mapping_patterns_to_notation.rst
@@ -1,2 +1,6 @@
 Mapping patterns to notation
 ============================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/modeling_texture_music.rst
+++ b/abjad/docs/source/cookbook/modeling_texture_music.rst
@@ -1,2 +1,6 @@
 Modeling texture music with timespans
 =====================================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/outputting_midi.rst
+++ b/abjad/docs/source/cookbook/outputting_midi.rst
@@ -1,0 +1,2 @@
+Outputting High-quality MIDI
+============================

--- a/abjad/docs/source/cookbook/outputting_midi.rst
+++ b/abjad/docs/source/cookbook/outputting_midi.rst
@@ -1,2 +1,6 @@
 Outputting High-quality MIDI
 ============================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/preparing_complex_documents.rst
+++ b/abjad/docs/source/cookbook/preparing_complex_documents.rst
@@ -1,2 +1,6 @@
 Preparing complex documents with Abjad, LilyPond and LaTeX
 ==========================================================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/selecting_musical_objects.rst
+++ b/abjad/docs/source/cookbook/selecting_musical_objects.rst
@@ -1,2 +1,6 @@
 Selecting musical objects morphophologically
 ============================================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/setting_up_a_new_score_project.rst
+++ b/abjad/docs/source/cookbook/setting_up_a_new_score_project.rst
@@ -1,2 +1,6 @@
 Setting up a new score project
 ==============================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/splitting_and_fusing.rst
+++ b/abjad/docs/source/cookbook/splitting_and_fusing.rst
@@ -1,2 +1,6 @@
 Splitting and fusing musical objects
 ====================================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/swapping_objects.rst
+++ b/abjad/docs/source/cookbook/swapping_objects.rst
@@ -1,2 +1,6 @@
 Swapping objects in and out of scores
 =====================================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/templating_and_persisting.rst
+++ b/abjad/docs/source/cookbook/templating_and_persisting.rst
@@ -1,2 +1,6 @@
 Templating and persisting complex objects
 =========================================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/typesetting_parametric_staves.rst
+++ b/abjad/docs/source/cookbook/typesetting_parametric_staves.rst
@@ -1,2 +1,6 @@
 Typesetting parametric staves
 =============================
+
+..  note::
+
+    Documentation coming soon.

--- a/abjad/docs/source/cookbook/working_with_lists_of_numbers.rst
+++ b/abjad/docs/source/cookbook/working_with_lists_of_numbers.rst
@@ -4,7 +4,6 @@ Working with lists of numbers
 Python provides a built-in ``list`` type that you can use to carry around
 almost anything.
 
-
 Creating lists
 --------------
 

--- a/abjad/docs/source/cookbook/working_with_score_templates.rst
+++ b/abjad/docs/source/cookbook/working_with_score_templates.rst
@@ -1,2 +1,91 @@
 Working with score templates and LilyPond concatentation
 ========================================================
+
+..  abjad::
+
+    template = templatetools.TwoStaffPianoScoreTemplate()
+    score = template()
+    print(format(score))
+
+Creating a basic score template
+-------------------------------
+
+..  abjad::
+    :strip-prompt:
+
+    class StringTrioScoreTemplate(abctools.AbjadObject):
+
+        def __call__(self):
+
+            violin_voice = scoretools.Voice(name='Violin Voice')
+            violin_staff = scoretools.Staff([violin_voice], name='Violin Staff')
+            clef = indicatortools.Clef('treble')
+            attach(clef, violin_staff)
+            instrument = instrumenttools.Violin()
+            attach(instrument, violin_staff)
+
+            viola_voice = scoretools.Voice(name='Viola Voice')
+            viola_staff = scoretools.Staff([viola_voice], name='Viola Staff')
+            clef = indicatortools.Clef('alto')
+            attach(clef, viola_staff)
+            instrument = instrumenttools.Viola()
+            attach(instrument, viola_staff)
+
+            cello_voice = scoretools.Voice(name='Cello Voice')
+            cello_staff = scoretools.Staff([cello_voice], name='Cello Staff')
+            clef = indicatortools.Clef('bass')
+            attach(clef, cello_staff)
+            instrument = instrumenttools.Cello()
+            attach(instrument, cello_staff)
+
+            staff_group = scoretools.StaffGroup(
+                [violin_staff, viola_staff, cello_staff],
+                name='String Trio Staff Group',
+                )
+
+            score = scoretools.Score(
+                [staff_group],
+                name='String Trio Score',
+                )
+
+            return score
+
+..  abjad::
+
+    template = StringTrioScoreTemplate()
+    score = template()
+    print(format(score))
+    score['Violin Voice'].extend("c'2 d'2 e'2 f'2")
+    score['Viola Voice'].extend("c'2 d'2 e'2 f'2")
+    score['Cello Voice'].extend("c'2 d'2 e'2 f'2")
+    show(score)
+
+Context concatenation
+---------------------
+
+..  abjad::
+
+    score_one = template()
+    score_two = template()
+
+..  abjad::
+
+    score_one['Violin Voice'].extend("c'8 d'8 e'8 f'8")
+    score_one['Viola Voice'].extend("c8 d8 e8 f8")
+    score_one['Cello Voice'].extend("c,8 d,8 e,8 f,8")
+    show(score_one)
+
+..  abjad::
+
+    score_two['Violin Voice'].extend("g'8 a'8 b'8 c''8")
+    score_two['Viola Voice'].extend("g8 a8 b8 c'8")
+    score_two['Cello Voice'].extend("g,8 a,8 b,8 c8")
+    show(score_two)
+
+..  abjad::
+
+    lilypond_file = lilypondfiletools.make_basic_lilypond_file()
+    both_scores = [score_one, score_two]
+    lilypond_file.score_block.items.append(both_scores)
+    show(lilypond_file)
+    print(format(lilypond_file))

--- a/abjad/tools/abjadbooktools/LilyPondOutputProxy.py
+++ b/abjad/tools/abjadbooktools/LilyPondOutputProxy.py
@@ -87,6 +87,9 @@ class LilyPondOutputProxy(ImageOutputProxy):
                 payload)
         lilypond_file = payload
         assert isinstance(lilypond_file, lilypondfiletools.LilyPondFile)
+        if lilypond_file.header_block is None:
+            header_block = lilypondfiletools.Block(name='header')
+            lilypond_file.items.insert(0, header_block)
         lilypond_file.header_block.tagline = False
         lilypond_file._date_time_token = None
         token = lilypondfiletools.LilyPondVersionToken(

--- a/abjad/tools/documentationtools/GraphvizNode.py
+++ b/abjad/tools/documentationtools/GraphvizNode.py
@@ -46,6 +46,36 @@ class GraphvizNode(GraphvizMixin, TreeContainer):
         result = '\n'.join(result)
         return result
 
+    ### PUBLIC METHODS ###
+
+    def attach(self, other):
+        r'''Attaches node to attachable Graphviz object.
+
+        ::
+
+            >>> my_graph = documentationtools.GraphvizGraph()
+            >>> node_one = documentationtools.GraphvizNode(attributes={'label': 'One'})
+            >>> node_two = documentationtools.GraphvizNode(attributes={'label': 'Two'})
+            >>> my_graph.extend([node_one, node_two])
+            >>> edge = node_one.attach(node_two)
+            >>> graph(my_graph)  # doctest: +SKIP
+
+        ..  doctest::
+
+            >>> print(str(my_graph))
+            digraph G {
+                node_0 [label=One];
+                node_1 [label=Two];
+                node_0 -> node_1;
+            }
+
+        Returns GraphvizEdge.
+        '''
+        from abjad.tools import documentationtools
+        edge = documentationtools.GraphvizEdge()
+        edge.attach(self, other)
+        return edge
+
     ### PRIVATE PROPERTIES ###
 
     @property

--- a/abjad/tools/lilypondfiletools/ContextBlock.py
+++ b/abjad/tools/lilypondfiletools/ContextBlock.py
@@ -70,8 +70,7 @@ class ContextBlock(Block):
 
     ### PRIVATE PROPERTIES ###
 
-    @property
-    def _format_pieces(self):
+    def _get_format_pieces(self):
         from abjad.tools import systemtools
         indent = systemtools.LilyPondFormatManager.indent
         result = []
@@ -121,10 +120,6 @@ class ContextBlock(Block):
                 result.append(string)
             elif '_get_format_pieces' in dir(item):
                 pieces = item._get_format_pieces()
-                pieces = [indent + item for item in pieces]
-                result.extend(pieces)
-            elif '_format_pieces' in dir(item):
-                pieces = item._format_pieces
                 pieces = [indent + item for item in pieces]
                 result.extend(pieces)
             else:

--- a/abjad/tools/lilypondfiletools/LilyPondDimension.py
+++ b/abjad/tools/lilypondfiletools/LilyPondDimension.py
@@ -53,15 +53,16 @@ class LilyPondDimension(abctools.AbjadObject):
             return systemtools.StorageFormatManager.get_storage_format(self)
         return str(self)
 
+    ### PRIVATE METHODS ###
+
+    def _get_format_pieces(self):
+        return [r'{}\{}'.format(self.value, self.unit)]
+
     ### PRIVATE PROPERTIES ###
 
     @property
-    def _format_pieces(self):
-        return [r'{}\{}'.format(self.value, self.unit)]
-
-    @property
     def _lilypond_format(self):
-        return '\n'.join(self._format_pieces)
+        return '\n'.join(self._get_format_pieces())
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjad/tools/lilypondfiletools/LilyPondFile.py
+++ b/abjad/tools/lilypondfiletools/LilyPondFile.py
@@ -265,8 +265,7 @@ class LilyPondFile(AbjadObject):
 
     ### PRIVATE PROPERTIES ###
 
-    @property
-    def _format_pieces(self):
+    def _get_format_pieces(self):
         result = []
         if self.date_time_token is not None:
             string = '% {}'.format(self.date_time_token)
@@ -289,6 +288,8 @@ class LilyPondFile(AbjadObject):
         result.extend(self._formatted_scheme_settings)
         result.extend(self._formatted_blocks)
         return result
+
+    ### PRIVATE PROPERTIES ###
 
     @property
     def _formatted_blocks(self):
@@ -352,7 +353,7 @@ class LilyPondFile(AbjadObject):
 
     @property
     def _lilypond_format(self):
-        return '\n\n'.join(self._format_pieces)
+        return '\n\n'.join(self._get_format_pieces())
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjad/tools/markuptools/Markup.py
+++ b/abjad/tools/markuptools/Markup.py
@@ -866,6 +866,41 @@ class Markup(AbjadValueObject):
         return Markup(contents=command)
 
     @staticmethod
+    def draw_circle(radius, thickness, filled=False):
+        r'''LilyPond ``\draw-circle`` markup command.
+
+        ..  container:: example
+
+            ::
+
+                >>> markup = Markup.draw_circle(10, 1.5)
+
+            ::
+
+                >>> print(format(markup))
+                \markup {
+                    \draw-circle
+                        #10
+                        #1.5
+                        ##f
+                    }
+
+            ::
+
+                >>> show(markup) # doctest: +SKIP
+
+        Returns new markup
+        '''
+        from abjad.tools import markuptools
+        command = markuptools.MarkupCommand(
+            'draw-circle',
+            radius,
+            thickness,
+            filled,
+            )
+        return Markup(contents=command)
+
+    @staticmethod
     def draw_line(x, y):
         r'''LilyPond ``\draw-line`` markup command.
 
@@ -930,7 +965,7 @@ class Markup(AbjadValueObject):
         return new(self, contents=command)
 
     @staticmethod
-    def filled_box(x_extent, y_extent, blot):
+    def filled_box(x_extent, y_extent, blot=0):
         r'''LilyPond ``filled-box`` markup command.
 
         ..  container:: example

--- a/abjad/tools/markuptools/Markup.py
+++ b/abjad/tools/markuptools/Markup.py
@@ -266,10 +266,6 @@ class Markup(AbjadValueObject):
     ### PRIVATE PROPERTIES ###
 
     @property
-    def _format_pieces(self):
-        return self._get_format_pieces()
-
-    @property
     def _lilypond_format(self):
         return '\n'.join(self._get_format_pieces())
 

--- a/abjad/tools/markuptools/MarkupCommand.py
+++ b/abjad/tools/markuptools/MarkupCommand.py
@@ -236,10 +236,6 @@ class MarkupCommand(AbjadValueObject):
         return string
 
     def _get_format_pieces(self):
-        from abjad.tools import lilypondfiletools
-        from abjad.tools import scoretools
-        from abjad.tools import systemtools
-        indent = systemtools.LilyPondFormatManager.indent
         def recurse(iterable):
             result = []
             for x in iterable:
@@ -247,14 +243,10 @@ class MarkupCommand(AbjadValueObject):
                     result.append('{')
                     result.extend(recurse(x))
                     result.append('}')
-                elif isinstance(x, type(self)):
-                    result.extend(x._get_format_pieces())
                 elif isinstance(x, schemetools.Scheme):
                     result.append(format(x))
-                elif isinstance(x, scoretools.Component):
-                    result.extend(x._format_pieces)
-                elif isinstance(x, lilypondfiletools.Block):
-                    result.extend(x._format_pieces)
+                elif hasattr(x, '_get_format_pieces'):
+                    result.extend(x._get_format_pieces())
                 elif isinstance(x, str) and '\n' in x:
                     result.append('#"')
                     result.extend(x.splitlines())
@@ -269,6 +261,8 @@ class MarkupCommand(AbjadValueObject):
                     else:
                         result.append('#{}'.format(formatted))
             return ['{}{}'.format(indent, x) for x in result]
+        from abjad.tools import systemtools
+        indent = systemtools.LilyPondFormatManager.indent
         parts = [r'\{}'.format(self.command)]
         parts.extend(recurse(self.args))
         return parts

--- a/abjad/tools/scoretools/Component.py
+++ b/abjad/tools/scoretools/Component.py
@@ -150,10 +150,6 @@ class Component(AbjadObject):
     ### PRIVATE PROPERTIES ###
 
     @property
-    def _format_pieces(self):
-        return self._format_component(pieces=True)
-
-    @property
     def _lilypond_format(self):
         self._update_now(indicators=True)
         return self._format_component()
@@ -431,6 +427,9 @@ class Component(AbjadObject):
         for source, contributions in method(bundle):
             result.extend(contributions)
         return result
+
+    def _get_format_pieces(self):
+        return self._format_component(pieces=True)
 
     def _get_grace_containers(self, kind=None):
         from abjad.tools import scoretools

--- a/abjad/tools/scoretools/Context.py
+++ b/abjad/tools/scoretools/Context.py
@@ -109,10 +109,6 @@ class Context(Container):
     ### PRIVATE PROPERTIES ###
 
     @property
-    def _format_pieces(self):
-        return self._format_component(pieces=True)
-
-    @property
     def _lilypond_format(self):
         self._update_now(indicators=True)
         return self._format_component()
@@ -209,6 +205,9 @@ class Context(Container):
             string = r'\remove {}'.format(engraver)
             result.append(string)
         return result
+
+    def _get_format_pieces(self):
+        return self._format_component(pieces=True)
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjad/tools/scoretools/Leaf.py
+++ b/abjad/tools/scoretools/Leaf.py
@@ -73,10 +73,6 @@ class Leaf(Component):
         raise MissingTempoError
 
     @property
-    def _format_pieces(self):
-        return self._lilypond_format.split('\n')
-
-    @property
     def _formatted_duration(self):
         duration_string = self.written_duration.lilypond_duration_string
         multiplier = None
@@ -281,6 +277,9 @@ class Leaf(Component):
         result.append(self._format_after_grace_opening())
         result.append(('spanners', bundle.opening.spanners))
         return result
+
+    def _get_format_pieces(self):
+        return self._lilypond_format.split('\n')
 
     def _get_leaf(self, n=0):
         from abjad.tools import scoretools


### PR DESCRIPTION
This PR adds some additional content to the new Abjad cookbook, along with miscellaneous fixes, including:

- Adding `GraphvizNode.attach()`
- Adding `Markup.draw_circle()`
- Replacing all `_format_pieces` properties with `_get_format_pieces()` methods.