### PR TITLE
Fix ajv doctest imports for the IDE.

### DIFF
--- a/abjad/boilerplate/example_score/example_score/__metadata__.py
+++ b/abjad/boilerplate/example_score/example_score/__metadata__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from abjad import *
+
+
+metadata = datastructuretools.TypedOrderedDict(
+    [
+        ('title', {score_title!r}),
+        ('year', {year}),
+        ]
+    )

--- a/abjad/tools/commandlinetools/DoctestScript.py
+++ b/abjad/tools/commandlinetools/DoctestScript.py
@@ -30,7 +30,6 @@ class DoctestScript(CommandlineScript):
     _module_names_for_globs = (
         'abjad',
         'experimental',
-        'ide',
         )
 
     ### PRIVATE METHODS ###
@@ -43,6 +42,11 @@ class DoctestScript(CommandlineScript):
                 globs.update(module.__dict__)
             except:
                 pass
+        try:
+            ide_module = importlib.import_module('ide')
+            globs['ide'] = ide_module
+        except ImportError:
+            pass
         globs['print_function'] = print_function
         return globs
 

--- a/abjad/tools/commandlinetools/test/test_commandlinetools_ManageScoreScript_new.py
+++ b/abjad/tools/commandlinetools/test/test_commandlinetools_ManageScoreScript_new.py
@@ -15,6 +15,7 @@ class Test(ScorePackageScriptTestCase):
         'test_score/setup.cfg',
         'test_score/setup.py',
         'test_score/test_score/__init__.py',
+        'test_score/test_score/__metadata__.py',
         'test_score/test_score/build/.gitignore',
         'test_score/test_score/build/assets/.gitignore',
         'test_score/test_score/build/assets/instrumentation.tex',


### PR DESCRIPTION
This guarantees an attempted import of `ide` into the global namespace for doctests, rather than the contents of `ide` as before.