### PR TITLE
Refactor tuplet simplification

### DIFF
--- a/abjad/tools/agenttools/IterationAgent.py
+++ b/abjad/tools/agenttools/IterationAgent.py
@@ -384,7 +384,7 @@ class IterationAgent(abctools.AbjadObject):
 
         ..  container:: example
 
-            **Example 1.** Iterates leaves: 
+            **Example 1.** Iterates leaves:
 
             ::
 
@@ -634,17 +634,33 @@ class IterationAgent(abctools.AbjadObject):
             prototype = (scoretools.Chord, scoretools.Note)
         if not reverse:
             for leaf in self.by_class(prototype):
+                yielded = False
                 tie_spanners = leaf._get_spanners(spannertools.Tie)
                 if not tie_spanners or \
                     tuple(tie_spanners)[0]._is_my_last_leaf(leaf):
                     logical_tie = leaf._get_logical_tie()
                     if not nontrivial or not logical_tie.is_trivial:
+                        yielded = True
+                        yield logical_tie
+            if not yielded:
+                if tie_spanners and \
+                    tuple(tie_spanners)[0]._is_my_first_leaf(leaf):
+                    logical_tie = leaf._get_logical_tie()
+                    if not nontrivial or not logical_tie.is_trivial:
                         yield logical_tie
         else:
             for leaf in self.by_class(prototype, reverse=True):
+                yielded = False
                 tie_spanners = leaf._get_spanners(spannertools.Tie)
                 if not(tie_spanners) or \
                     tuple(tie_spanners)[0]._is_my_first_leaf(leaf):
+                    logical_tie = leaf._get_logical_tie()
+                    if not nontrivial or not logical_tie.is_trivial:
+                        yielded = True
+                        yield logical_tie
+            if not yielded:
+                if tie_spanners and \
+                    tuple(tie_spanners)[0]._is_my_last_leaf(leaf):
                     logical_tie = leaf._get_logical_tie()
                     if not nontrivial or not logical_tie.is_trivial:
                         yield logical_tie

--- a/abjad/tools/agenttools/IterationAgent.py
+++ b/abjad/tools/agenttools/IterationAgent.py
@@ -550,6 +550,7 @@ class IterationAgent(abctools.AbjadObject):
         nontrivial=False,
         pitched=False,
         reverse=False,
+        parentage_mask=None,
         ):
         r'''Iterates client by logical tie.
 
@@ -626,8 +627,39 @@ class IterationAgent(abctools.AbjadObject):
                 LogicalTie(Note("c'4"), Note("c'16"))
                 LogicalTie(Note("f'4"), Note("f'16"))
 
+        ..  container:: example
+
+            **Example 5.** Iterates logical ties masked by parentage.
+
+            ..  note::
+
+                When iterating logical ties in a container, the yielded logical
+                ties may contain leaves outside that container's parentage. By
+                specifying a parentage mask, composers can constrain the
+                contents of the yielded logical ties to only those leaves
+                actually within the parentage of the container under iteration.
+
+            ::
+
+                >>> staff = Staff("{ c'1 ~ } { c'2 d'2 ~ } { d'1 }")
+                >>> for logical_tie in iterate(staff[1]).by_logical_tie():
+                ...     logical_tie
+                ...
+                LogicalTie(Note("c'1"), Note("c'2"))
+                LogicalTie(Note("d'2"), Note("d'1"))
+
+            ::
+
+                >>> for logical_tie in iterate(staff[1]).by_logical_tie(
+                ...     parentage_mask=staff[1]):
+                ...     logical_tie
+                ...
+                LogicalTie(Note("c'2"),)
+                LogicalTie(Note("d'2"),)
+
         Returns generator.
         '''
+        from abjad.tools import selectiontools
         nontrivial = bool(nontrivial)
         prototype = scoretools.Leaf
         if pitched:
@@ -639,6 +671,13 @@ class IterationAgent(abctools.AbjadObject):
                 if not tie_spanners or \
                     tuple(tie_spanners)[0]._is_my_last_leaf(leaf):
                     logical_tie = leaf._get_logical_tie()
+                    if parentage_mask:
+                        logical_tie = selectiontools.LogicalTie(
+                            x for x in logical_tie
+                            if parentage_mask in x._get_parentage()
+                            )
+                        if not logical_tie:
+                            continue
                     if not nontrivial or not logical_tie.is_trivial:
                         yielded = True
                         yield logical_tie
@@ -646,6 +685,13 @@ class IterationAgent(abctools.AbjadObject):
                 if tie_spanners and \
                     tuple(tie_spanners)[0]._is_my_first_leaf(leaf):
                     logical_tie = leaf._get_logical_tie()
+                    if parentage_mask:
+                        logical_tie = selectiontools.LogicalTie(
+                            x for x in logical_tie
+                            if parentage_mask in x._get_parentage()
+                            )
+                        if not logical_tie:
+                            return
                     if not nontrivial or not logical_tie.is_trivial:
                         yield logical_tie
         else:
@@ -655,6 +701,13 @@ class IterationAgent(abctools.AbjadObject):
                 if not(tie_spanners) or \
                     tuple(tie_spanners)[0]._is_my_first_leaf(leaf):
                     logical_tie = leaf._get_logical_tie()
+                    if parentage_mask:
+                        logical_tie = selectiontools.LogicalTie(
+                            x for x in logical_tie
+                            if parentage_mask in x._get_parentage()
+                            )
+                        if not logical_tie:
+                            continue
                     if not nontrivial or not logical_tie.is_trivial:
                         yielded = True
                         yield logical_tie
@@ -662,6 +715,13 @@ class IterationAgent(abctools.AbjadObject):
                 if tie_spanners and \
                     tuple(tie_spanners)[0]._is_my_last_leaf(leaf):
                     logical_tie = leaf._get_logical_tie()
+                    if parentage_mask:
+                        logical_tie = selectiontools.LogicalTie(
+                            x for x in logical_tie
+                            if parentage_mask in x._get_parentage()
+                            )
+                        if not logical_tie:
+                            return
                     if not nontrivial or not logical_tie.is_trivial:
                         yield logical_tie
 

--- a/abjad/tools/agenttools/IterationAgent.py
+++ b/abjad/tools/agenttools/IterationAgent.py
@@ -664,6 +664,7 @@ class IterationAgent(abctools.AbjadObject):
         prototype = scoretools.Leaf
         if pitched:
             prototype = (scoretools.Chord, scoretools.Note)
+        leaf, yielded = None, False
         if not reverse:
             for leaf in self.by_class(prototype):
                 yielded = False
@@ -681,7 +682,7 @@ class IterationAgent(abctools.AbjadObject):
                     if not nontrivial or not logical_tie.is_trivial:
                         yielded = True
                         yield logical_tie
-            if not yielded:
+            if leaf is not None and not yielded:
                 if tie_spanners and \
                     tuple(tie_spanners)[0]._is_my_first_leaf(leaf):
                     logical_tie = leaf._get_logical_tie()
@@ -711,7 +712,7 @@ class IterationAgent(abctools.AbjadObject):
                     if not nontrivial or not logical_tie.is_trivial:
                         yielded = True
                         yield logical_tie
-            if not yielded:
+            if leaf is not None and not yielded:
                 if tie_spanners and \
                     tuple(tie_spanners)[0]._is_my_last_leaf(leaf):
                     logical_tie = leaf._get_logical_tie()

--- a/abjad/tools/agenttools/test/test_agenttools_IterationAgent_by_logical_tie.py
+++ b/abjad/tools/agenttools/test/test_agenttools_IterationAgent_by_logical_tie.py
@@ -127,3 +127,18 @@ def test_agenttools_IterationAgent_by_logical_tie_09():
     assert logical_ties[0][1] is staff[1][0]
     assert logical_ties[1][0] is staff[1][1]
     assert logical_ties[1][1] is staff[2][0]
+
+
+def test_agenttools_IterationAgent_by_logical_tie_10():
+
+    staff = Staff("{ c'4 d'4 ~ } { d'4 e'4 ~ } { e'4 f'4 }")
+
+    logical_ties = list(iterate(staff[1])
+        .by_logical_tie(parentage_mask=staff[1])
+        )
+
+    assert len(logical_ties) == 2
+    assert len(logical_ties[0]) == 1
+    assert len(logical_ties[1]) == 1
+    assert logical_ties[0][0] is staff[1][0]
+    assert logical_ties[1][0] is staff[1][1]

--- a/abjad/tools/agenttools/test/test_agenttools_IterationAgent_by_logical_tie.py
+++ b/abjad/tools/agenttools/test/test_agenttools_IterationAgent_by_logical_tie.py
@@ -112,3 +112,18 @@ def test_agenttools_IterationAgent_by_logical_tie_08():
 
     assert logical_ties[0] == selectiontools.LogicalTie(staff[:2])
     assert logical_ties[1] == selectiontools.LogicalTie(staff[3:5])
+
+
+def test_agenttools_IterationAgent_by_logical_tie_09():
+
+    staff = Staff("{ c'4 d'4 ~ } { d'4 e'4 ~ } { e'4 f'4 }")
+
+    logical_ties = list(iterate(staff[1]).by_logical_tie())
+
+    assert len(logical_ties) == 2
+    assert len(logical_ties[0]) == 2
+    assert len(logical_ties[1]) == 2
+    assert logical_ties[0][0] is staff[0][1]
+    assert logical_ties[0][1] is staff[1][0]
+    assert logical_ties[1][0] is staff[1][1]
+    assert logical_ties[1][1] is staff[2][0]

--- a/abjad/tools/agenttools/test/test_agenttools_IterationAgent_by_logical_tie.py
+++ b/abjad/tools/agenttools/test/test_agenttools_IterationAgent_by_logical_tie.py
@@ -142,3 +142,10 @@ def test_agenttools_IterationAgent_by_logical_tie_10():
     assert len(logical_ties[1]) == 1
     assert logical_ties[0][0] is staff[1][0]
     assert logical_ties[1][0] is staff[1][1]
+
+
+def test_agenttools_IterationAgent_by_logical_tie_11():
+    r'''No logical ties, but no errors either.'''
+    staff = Staff()
+    logical_ties = list(iterate(staff).by_logical_tie())
+    assert len(logical_ties) == 0


### PR DESCRIPTION
This PR:

- lets `Tuplet._simplify_redundant_tuplet()` take logical ties into account
- adds a `parentage_mask` keyword to `IterationAgent.by_logical_tie()`
- makes `IterationAgent.by_logical_tie()` always yield all valid logical ties

Closes #654.