### PR TITLE
Stop instantiating LilyPond parsers

### DIFF
--- a/abjad/tools/markuptools/Markup.py
+++ b/abjad/tools/markuptools/Markup.py
@@ -98,13 +98,13 @@ class Markup(AbjadValueObject):
         direction=None,
         stack_priority=0,
         ):
-        from abjad.tools import lilypondparsertools
         from abjad.tools import markuptools
+        from abjad.tools.topleveltools import parse
         if contents is None:
             new_contents = ('',)
         elif isinstance(contents, str):
             to_parse = r'\markup {{ {} }}'.format(contents)
-            parsed = lilypondparsertools.LilyPondParser()(to_parse)
+            parsed = parse(to_parse)
             if all(isinstance(x, str) for x in parsed.contents):
                 new_contents = (' '.join(parsed.contents),)
             else:

--- a/abjad/tools/scoretools/Chord.py
+++ b/abjad/tools/scoretools/Chord.py
@@ -38,15 +38,15 @@ class Chord(Leaf):
 
     def __init__(self, *args):
         from abjad.ly import drums
-        from abjad.tools import lilypondparsertools
         from abjad.tools import scoretools
+        from abjad.tools.topleveltools import parse
         assert len(args) in (0, 1, 2)
         self._note_heads = scoretools.NoteHeadInventory(
             client=self,
             )
         if len(args) == 1 and isinstance(args[0], str):
             string = '{{ {} }}'.format(args[0])
-            parsed = lilypondparsertools.LilyPondParser()(string)
+            parsed = parse(string)
             assert len(parsed) == 1 and isinstance(parsed[0], Leaf)
             args = [parsed[0]]
         are_cautionary = []
@@ -132,7 +132,7 @@ class Chord(Leaf):
     @property
     def _compact_representation_with_tie(self):
         logical_tie = self._get_logical_tie()
-        if 1 < len(logical_tie) and not self is logical_tie[-1]:
+        if 1 < len(logical_tie) and self is not logical_tie[-1]:
             return '{} ~'.format(self._body[0])
         else:
             return self._body[0]
@@ -300,8 +300,9 @@ class Chord(Leaf):
                 sounding_pitch = pitchtools.NamedPitch('C4')
             interval = pitchtools.NamedPitch('C4') - sounding_pitch
             sounding_pitches = [
-                pitchtools.transpose_pitch_carrier_by_interval(
-                pitch, interval) for pitch in self.written_pitches]
+                pitchtools.transpose_pitch_carrier_by_interval(pitch, interval)
+                for pitch in self.written_pitches
+                ]
             return tuple(sounding_pitches)
 
     def _get_tremolo_reattack_duration(self):

--- a/abjad/tools/scoretools/Container.py
+++ b/abjad/tools/scoretools/Container.py
@@ -402,7 +402,7 @@ class Container(Component):
         from abjad.tools import systemtools
         positional_argument_values = ()
         if len(self):
-            positional_argument_values=(
+            positional_argument_values = (
                 self._contents_summary,
                 )
         keyword_argument_names = ()
@@ -652,7 +652,7 @@ class Container(Component):
         Note that setting
         withdraw_components_in_expr_from_crossing_spanners=False constitutes a
         composer-unsafe use of this method.
-        
+
         Only private methods should set this keyword.
         '''
         from abjad.tools import scoretools
@@ -695,10 +695,12 @@ class Container(Component):
             raise Exception(message)
         if self._check_for_cycles(expr):
             raise ParentageError('Attempted to induce cycles.')
-        if (i.start == i.stop and 
+        if (
+            i.start == i.stop and
             i.start is not None and
             i.stop is not None and
-            i.start <= -len(self)):
+            i.start <= -len(self)
+            ):
             start, stop = 0, 0
         else:
             start, stop, stride = i.indices(len(self))
@@ -823,10 +825,9 @@ class Container(Component):
             return
         assert isinstance(expr, bool), repr(expr)
         prototype = scoretools.Context
-        if expr == True:
-            if not all(isinstance(x, prototype) for x in self):
-                message = 'simultaneous containers must contain only contexts.'
-                raise ValueError(message)
+        if expr and not all(isinstance(x, prototype) for x in self):
+            message = 'simultaneous containers must contain only contexts.'
+            raise ValueError(message)
         self._is_simultaneous = expr
         self._update_later(offsets=True)
 
@@ -869,7 +870,7 @@ class Container(Component):
 
             ::
 
-                >>> container.name 
+                >>> container.name
                 'Special'
 
             Container name does not appear in LilyPond output:
@@ -935,7 +936,7 @@ class Container(Component):
             self.is_simultaneous = parsed.is_simultaneous
             if (parsed.is_simultaneous or
                 not Selection._all_are_contiguous_components_in_same_logical_voice(
-                parsed[:])):
+                    parsed[:])):
                 while len(parsed):
                     self.append(parsed.pop(0))
             else:
@@ -964,6 +965,7 @@ class Container(Component):
         from abjad.tools import lilypondfiletools
         from abjad.tools import lilypondparsertools
         from abjad.tools import rhythmtreetools
+        from abjad.tools.topleveltools import parse
         user_input = string.strip()
         if user_input.startswith('abj:'):
             parser = lilypondparsertools.ReducedLyParser()
@@ -973,10 +975,12 @@ class Container(Component):
         elif user_input.startswith('rtm:'):
             parsed = rhythmtreetools.parse_rtm_syntax(user_input[4:])
         else:
-            if (not user_input.startswith('<<') or
-                not user_input.endswith('>>')):
+            if (
+                not user_input.startswith('<<') or
+                not user_input.endswith('>>')
+                ):
                 user_input = '{{ {} }}'.format(user_input)
-            parsed = lilypondparsertools.LilyPondParser()(user_input)
+            parsed = parse(user_input)
             if isinstance(parsed, lilypondfiletools.LilyPondFile):
                 parsed = Container(parsed.items[:])
             assert isinstance(parsed, Container)
@@ -985,11 +989,7 @@ class Container(Component):
     def _scale(self, multiplier):
         self._scale_contents(multiplier)
 
-    def _split_at_index(
-        self, 
-        i, 
-        fracture_spanners=False,
-        ):
+    def _split_at_index(self, i, fracture_spanners=False):
         r'''Splits container to the left of index `i`.
 
         Preserves tuplet multiplier when container is a tuplet.
@@ -1003,7 +1003,6 @@ class Container(Component):
         from abjad.tools import indicatortools
         from abjad.tools import scoretools
         from abjad.tools import selectiontools
-        from abjad.tools import spannertools
         # partition my music
         left_music = self[:i]
         right_music = self[i:]
@@ -1203,10 +1202,14 @@ class Container(Component):
         right_logical_tie._fuse_leaves_by_immediate_parent()
         # reapply tie here if crawl above killed tie applied to leaves
         if did_split_leaf:
-            if (tie_split_notes and
-                isinstance(leaf_left_of_split, scoretools.Note)):
-                if (leaf_left_of_split._get_parentage().root is
-                    leaf_right_of_split._get_parentage().root):
+            if (
+                tie_split_notes and
+                isinstance(leaf_left_of_split, scoretools.Note)
+                ):
+                if (
+                    leaf_left_of_split._get_parentage().root is
+                    leaf_right_of_split._get_parentage().root
+                    ):
                     leaves_around_split = \
                         (leaf_left_of_split, leaf_right_of_split)
                     selection = selectiontools.Selection(
@@ -1613,8 +1616,6 @@ class Container(Component):
 
         Returns none.
         '''
-        from abjad.tools import scoretools
-        from abjad.tools import spannertools
         self._music.reverse()
         self._update_later(offsets=True)
         spanners = self._get_descendants()._get_spanners()

--- a/abjad/tools/scoretools/Note.py
+++ b/abjad/tools/scoretools/Note.py
@@ -39,12 +39,12 @@ class Note(Leaf):
 
     def __init__(self, *args):
         from abjad.ly import drums
-        from abjad.tools import lilypondparsertools
         from abjad.tools import scoretools
+        from abjad.tools.topleveltools import parse
         assert len(args) in (0, 1, 2)
         if len(args) == 1 and isinstance(args[0], str):
             string = '{{ {} }}'.format(args[0])
-            parsed = lilypondparsertools.LilyPondParser()(string)
+            parsed = parse(string)
             assert len(parsed) == 1 and isinstance(parsed[0], Leaf)
             args = [parsed[0]]
         is_cautionary = False
@@ -130,7 +130,7 @@ class Note(Leaf):
     @property
     def _compact_representation_with_tie(self):
         logical_tie = self._get_logical_tie()
-        if 1 < len(logical_tie) and not self is logical_tie[-1]:
+        if 1 < len(logical_tie) and self is not logical_tie[-1]:
             return '{} ~'.format(self._body[0])
         else:
             return self._body[0]

--- a/abjad/tools/scoretools/Rest.py
+++ b/abjad/tools/scoretools/Rest.py
@@ -35,11 +35,11 @@ class Rest(Leaf):
     ### INITIALIZER ###
 
     def __init__(self, written_duration=None):
-        from abjad.tools import lilypondparsertools
+        from abjad.tools.topleveltools import parse
         original_input = written_duration
         if isinstance(written_duration, str):
             string = '{{ {} }}'.format(written_duration)
-            parsed = lilypondparsertools.LilyPondParser()(string)
+            parsed = parse(string)
             assert len(parsed) == 1 and isinstance(parsed[0], Leaf)
             written_duration = parsed[0]
         if isinstance(written_duration, Leaf):

--- a/abjad/tools/scoretools/Skip.py
+++ b/abjad/tools/scoretools/Skip.py
@@ -30,12 +30,12 @@ class Skip(Leaf):
     ### INITIALIZER ###
 
     def __init__(self, *args):
-        from abjad.tools import lilypondparsertools
+        from abjad.tools.topleveltools import parse
         input_leaf = None
         written_duration = None
         if len(args) == 1 and isinstance(args[0], str):
             string = '{{ {} }}'.format(args[0])
-            parsed = lilypondparsertools.LilyPondParser()(string)
+            parsed = parse(string)
             assert len(parsed) == 1 and isinstance(parsed[0], Leaf)
             input_leaf = parsed[0]
             written_duration = input_leaf.written_duration

--- a/abjad/tools/topleveltools/parse.py
+++ b/abjad/tools/topleveltools/parse.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 
+_lilypond_parsers_by_language = {}
+
+
 def parse(arg, language='english'):
     r'''Parses `arg` as LilyPond string.
 
@@ -34,9 +37,11 @@ def parse(arg, language='english'):
     '''
     from abjad.tools import rhythmtreetools
     from abjad.tools import lilypondparsertools
-
     if arg.startswith('abj:'):
         return lilypondparsertools.parse_reduced_ly_syntax(arg[4:])
     elif arg.startswith('rtm:'):
         return rhythmtreetools.parse_rtm_syntax(arg[4:])
-    return lilypondparsertools.LilyPondParser(default_language=language)(arg)
+    if language not in _lilypond_parsers_by_language:
+        parser = lilypondparsertools.LilyPondParser(default_language=language)
+        _lilypond_parsers_by_language[language] = parser
+    return _lilypond_parsers_by_language[language](arg)


### PR DESCRIPTION
This PR refactors Abjad such that the English-language LilyPondParser is only instantiated once.

This saves quite a bit of computation, bringing the instantiation of 1000 notes from ~22 seconds down to ~2. It also drops the py.test suite time from ~222 seconds down to ~160.