### PR TITLE
Cleaned up Talea API entry.

### DIFF
--- a/abjad/tools/abctools/AbjadObject.py
+++ b/abjad/tools/abctools/AbjadObject.py
@@ -64,7 +64,7 @@ class AbjadObject(AbstractBase):
     def __hash__(self):
         r'''Hashes Abjad object.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/datastructuretools/Cursor.py
+++ b/abjad/tools/datastructuretools/Cursor.py
@@ -91,7 +91,7 @@ class Cursor(AbjadObject):
     def __hash__(self):
         r'''Hashes cursor.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/datastructuretools/CyclicTuple.py
+++ b/abjad/tools/datastructuretools/CyclicTuple.py
@@ -116,7 +116,7 @@ class CyclicTuple(AbjadObject, tuple):
     def __hash__(self):
         r'''Hashes cyclic tuple.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/datastructuretools/PayloadTree.py
+++ b/abjad/tools/datastructuretools/PayloadTree.py
@@ -357,7 +357,7 @@ class PayloadTree(AbjadObject):
     def __hash__(self):
         r'''Hashes payload tree.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/datastructuretools/TypedCollection.py
+++ b/abjad/tools/datastructuretools/TypedCollection.py
@@ -70,7 +70,7 @@ class TypedCollection(AbjadObject):
     def __hash__(self):
         r'''Hashes typed collection.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/durationtools/Duration.py
+++ b/abjad/tools/durationtools/Duration.py
@@ -278,7 +278,7 @@ class Duration(AbjadObject, fractions.Fraction):
     def __hash__(self):
         r'''Hashes duration.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/indicatortools/SpacingIndication.py
+++ b/abjad/tools/indicatortools/SpacingIndication.py
@@ -90,7 +90,7 @@ class SpacingIndication(AbjadObject):
     def __hash__(self):
         r'''Hashes spacing indication.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/lilypondnametools/LilyPondNameManager.py
+++ b/abjad/tools/lilypondnametools/LilyPondNameManager.py
@@ -27,7 +27,7 @@ class LilyPondNameManager(AbjadObject):
     def __hash__(self):
         r'''Hashes LilyPond name manager.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/markuptools/MarkupCommand.py
+++ b/abjad/tools/markuptools/MarkupCommand.py
@@ -194,7 +194,7 @@ class MarkupCommand(AbjadValueObject):
     def __hash__(self):
         r'''Hashes markup command.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/mathtools/Infinity.py
+++ b/abjad/tools/mathtools/Infinity.py
@@ -74,7 +74,7 @@ class Infinity(AbjadObject):
     def __hash__(self):
         r'''Hashes infinity.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/mathtools/NonreducedFraction.py
+++ b/abjad/tools/mathtools/NonreducedFraction.py
@@ -217,7 +217,7 @@ class NonreducedFraction(AbjadObject, fractions.Fraction):
     def __hash__(self):
         r'''Hashes nonreduced fraction.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/mathtools/NonreducedRatio.py
+++ b/abjad/tools/mathtools/NonreducedRatio.py
@@ -97,7 +97,7 @@ class NonreducedRatio(AbjadValueObject):
     def __hash__(self):
         r'''Hashes non-reduced ratio.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/metertools/MetricAccentKernel.py
+++ b/abjad/tools/metertools/MetricAccentKernel.py
@@ -101,7 +101,7 @@ class MetricAccentKernel(AbjadValueObject):
     def __hash__(self):
         r'''Hashes metric accent kernel.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/pitchtools/Accidental.py
+++ b/abjad/tools/pitchtools/Accidental.py
@@ -244,7 +244,7 @@ class Accidental(AbjadObject):
     def __hash__(self):
         r'''Hashes accidental.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/pitchtools/NamedInterval.py
+++ b/abjad/tools/pitchtools/NamedInterval.py
@@ -211,7 +211,7 @@ class NamedInterval(Interval):
     def __hash__(self):
         r'''Hashes named interval.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/pitchtools/NamedInversionEquivalentIntervalClass.py
+++ b/abjad/tools/pitchtools/NamedInversionEquivalentIntervalClass.py
@@ -67,7 +67,7 @@ class NamedInversionEquivalentIntervalClass(NamedIntervalClass):
         return False
 
     def __hash__(self):
-        r'''Required to be explicitly re-defined on Python 3 if
+        r'''Required to be explicitly redefined on Python 3 if
         __eq__ changes
 
         Returns integer.

--- a/abjad/tools/pitchtools/NamedPitch.py
+++ b/abjad/tools/pitchtools/NamedPitch.py
@@ -258,7 +258,7 @@ class NamedPitch(Pitch):
         return False
 
     def __hash__(self):
-        r'''Required to be explicitly re-defined on Python 3 if
+        r'''Required to be explicitly redefined on Python 3 if
         __eq__ changes.
 
         Returns integer.

--- a/abjad/tools/pitchtools/NamedPitchClass.py
+++ b/abjad/tools/pitchtools/NamedPitchClass.py
@@ -184,7 +184,7 @@ class NamedPitchClass(PitchClass):
     def __hash__(self):
         r'''Hashes named pitch-class.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/pitchtools/NumberedIntervalClass.py
+++ b/abjad/tools/pitchtools/NumberedIntervalClass.py
@@ -121,7 +121,7 @@ class NumberedIntervalClass(IntervalClass):
     def __hash__(self):
         r'''Hashes numbered interval-class.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/pitchtools/NumberedPitchClass.py
+++ b/abjad/tools/pitchtools/NumberedPitchClass.py
@@ -175,7 +175,7 @@ class NumberedPitchClass(PitchClass):
     def __hash__(self):
         r'''Hashes numbered pitch-class.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/pitchtools/PitchArray.py
+++ b/abjad/tools/pitchtools/PitchArray.py
@@ -157,7 +157,7 @@ class PitchArray(AbjadObject):
     def __hash__(self):
         r'''Hashes pitch array.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/pitchtools/PitchArrayColumn.py
+++ b/abjad/tools/pitchtools/PitchArrayColumn.py
@@ -90,7 +90,7 @@ class PitchArrayColumn(AbjadObject):
     def __hash__(self):
         r'''Hashes pitch array column.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/pitchtools/PitchArrayRow.py
+++ b/abjad/tools/pitchtools/PitchArrayRow.py
@@ -161,7 +161,7 @@ class PitchArrayRow(AbjadObject):
     def __hash__(self):
         r'''Hashes pitch array row.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/pitchtools/PitchRange.py
+++ b/abjad/tools/pitchtools/PitchRange.py
@@ -175,7 +175,7 @@ class PitchRange(AbjadObject):
     def __hash__(self):
         r'''Hashes pitch range.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/pitchtools/RegistrationComponent.py
+++ b/abjad/tools/pitchtools/RegistrationComponent.py
@@ -71,7 +71,7 @@ class RegistrationComponent(AbjadObject):
     def __hash__(self):
         r'''Hashes registration component.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/quantizationtools/PitchedQEvent.py
+++ b/abjad/tools/quantizationtools/PitchedQEvent.py
@@ -65,7 +65,7 @@ class PitchedQEvent(QEvent):
     def __hash__(self):
         r'''Hashes pitched q-event.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/quantizationtools/QEventProxy.py
+++ b/abjad/tools/quantizationtools/QEventProxy.py
@@ -92,7 +92,7 @@ class QEventProxy(AbjadObject):
     def __hash__(self):
         r'''Hashes q-event proxy.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/quantizationtools/QEventSequence.py
+++ b/abjad/tools/quantizationtools/QEventSequence.py
@@ -171,7 +171,7 @@ class QEventSequence(AbjadObject):
     def __hash__(self):
         r'''Hashes q-event sequence.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/quantizationtools/QGrid.py
+++ b/abjad/tools/quantizationtools/QGrid.py
@@ -165,7 +165,7 @@ class QGrid(AbjadObject):
     def __hash__(self):
         r'''Hashes q-grid.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/quantizationtools/QuantizationJob.py
+++ b/abjad/tools/quantizationtools/QuantizationJob.py
@@ -142,7 +142,7 @@ class QuantizationJob(AbjadObject):
     def __hash__(self):
         r'''Hashes quantization job.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/quantizationtools/SearchTree.py
+++ b/abjad/tools/quantizationtools/SearchTree.py
@@ -63,7 +63,7 @@ class SearchTree(AbjadObject):
     def __hash__(self):
         r'''Hashes search tree.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/quantizationtools/SilentQEvent.py
+++ b/abjad/tools/quantizationtools/SilentQEvent.py
@@ -46,7 +46,7 @@ class SilentQEvent(QEvent):
     def __hash__(self):
         r'''Hashes silent q-event.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/quantizationtools/TerminalQEvent.py
+++ b/abjad/tools/quantizationtools/TerminalQEvent.py
@@ -41,7 +41,7 @@ class TerminalQEvent(QEvent):
     def __hash__(self):
         r'''Hashes terminal q-event.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/rhythmmakertools/BeamSpecifier.py
+++ b/abjad/tools/rhythmmakertools/BeamSpecifier.py
@@ -143,7 +143,7 @@ class BeamSpecifier(AbjadValueObject):
     def __hash__(self):
         r'''Hashes beam specifier.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/rhythmmakertools/BurnishSpecifier.py
+++ b/abjad/tools/rhythmmakertools/BurnishSpecifier.py
@@ -243,7 +243,7 @@ class BurnishSpecifier(AbjadValueObject):
     def __hash__(self):
         r'''Hashes burnish specifier.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/rhythmmakertools/NoteRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/NoteRhythmMaker.py
@@ -166,7 +166,7 @@ class NoteRhythmMaker(RhythmMaker):
     def __hash__(self):
         r'''Hashes note rhythm-maker.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/rhythmmakertools/RhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/RhythmMaker.py
@@ -117,7 +117,7 @@ class RhythmMaker(AbjadValueObject):
     def __hash__(self):
         r'''Hashes rhythm-maker.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/rhythmmakertools/Talea.py
+++ b/abjad/tools/rhythmmakertools/Talea.py
@@ -10,6 +10,8 @@ class Talea(AbjadValueObject):
 
     ..  container:: example
 
+        **Example.**
+
         ::
 
             >>> talea = rhythmmakertools.Talea(
@@ -17,35 +19,8 @@ class Talea(AbjadValueObject):
             ...    denominator=16,
             ...    )
 
-    ..  container:: example
-
-        ::
-
-            >>> talea[2]
-            NonreducedFraction(3, 16)
-
-    ..  container:: example
-
-        ::
-
-            >>> for nonreduced_fraction in talea[3:9]:
-            ...     nonreduced_fraction
-            ...
-            NonreducedFraction(2, 16)
-            NonreducedFraction(4, 16)
-            NonreducedFraction(1, 16)
-            NonreducedFraction(1, 16)
-            NonreducedFraction(2, 16)
-            NonreducedFraction(1, 16)
-
-    ..  container:: example
-
-        Taleas can be instantiated without keyword arguments.
-
-        ::
-
-            >>> talea = rhythmmakertools.Talea([1, 2, 3], 8)
-
+    The medieval plural of 'talea' is 'talee'. Abjad documentation
+    uses 'taleas' instead.
     '''
 
     ### CLASS VARIABLES ###
@@ -77,15 +52,87 @@ class Talea(AbjadValueObject):
         r'''Is true when `expr` is a talea with `counts` and `denominator`
         equal to those of this talea. Otherwise false.
 
+        ..  container:: example
+
+            **Example.**
+
+            ::
+
+                >>> talea_1 = rhythmmakertools.Talea(
+                ...    counts=(1, 2),
+                ...    denominator=16,
+                ...    )
+                >>> talea_2 = rhythmmakertools.Talea(
+                ...    counts=(1, 2),
+                ...    denominator=16,
+                ...    )
+                >>> talea_3 = rhythmmakertools.Talea(
+                ...    counts=(1, 2),
+                ...    denominator=8,
+                ...    )
+
+            ::
+
+                >>> talea_1 == talea_1
+                True
+                >>> talea_1 == talea_2
+                True
+                >>> talea_1 == talea_3
+                False
+                >>> talea_2 == talea_1
+                True
+                >>> talea_2 == talea_2
+                True
+                >>> talea_2 == talea_3
+                False
+                >>> talea_3 == talea_1
+                False
+                >>> talea_3 == talea_2
+                False
+                >>> talea_3 == talea_3
+                True
+
         Returns true or false.
         '''
         from abjad.tools import systemtools
         return systemtools.StorageFormatManager.compare(self, expr)
 
     def __getitem__(self, item):
-        r'''Gets non-reduced fraction at `item` cyclically.
+        r'''Gets nonreduced fraction at `item` cyclically.
 
-        Returns non-reduced fraction or non-reduced fractions.
+        ..  container:: example
+
+            **Example 1.** Gets item at index:
+
+            ::
+
+                >>> talea = rhythmmakertools.Talea(
+                ...    counts=(2, 1, 3, 2, 4, 1, 1),
+                ...    denominator=16,
+                ...    )
+
+            ::
+
+                >>> talea[2]
+                NonreducedFraction(3, 16)
+
+        ..  container:: example
+
+            **Example 2.** Gets items in slice:
+
+            ::
+
+                >>> for nonreduced_fraction in talea[3:9]:
+                ...     nonreduced_fraction
+                ...
+                NonreducedFraction(2, 16)
+                NonreducedFraction(4, 16)
+                NonreducedFraction(1, 16)
+                NonreducedFraction(1, 16)
+                NonreducedFraction(2, 16)
+                NonreducedFraction(1, 16)
+
+        Returns nonreduced fraction or nonreduced fractions.
         '''
         counts = datastructuretools.CyclicTuple(self.counts)
         if isinstance(item, int):
@@ -112,12 +159,17 @@ class Talea(AbjadValueObject):
 
         ..  container:: example
 
+            **Example.**
+
             ::
 
                 >>> talea = rhythmmakertools.Talea(
                 ...    counts=(2, 1, 3, 2, 4, 1, 1),
                 ...    denominator=16,
                 ...    )
+
+            ::
+
                 >>> for duration in talea:
                 ...     duration
                 ...
@@ -138,7 +190,25 @@ class Talea(AbjadValueObject):
     def __len__(self):
         r'''Gets length of talea.
 
-        Returns integer.
+        ..  container:: example
+
+            **Example.**
+
+            ::
+
+                >>> talea = rhythmmakertools.Talea(
+                ...    counts=(2, 1, 3, 2, 4, 1, 1),
+                ...    denominator=16,
+                ...    )
+
+            ::
+
+                >>> len(talea)
+                7
+
+        Defined equal to length of counts.
+
+        Returns nonnegative integer.
         '''
         return len(self.counts)
 
@@ -148,7 +218,25 @@ class Talea(AbjadValueObject):
     def counts(self):
         r'''Gets counts of talea.
 
+        ..  container:: example
+
+            **Example.**
+
+            ::
+
+                >>> talea = rhythmmakertools.Talea(
+                ...    counts=(2, 1, 3, 2, 4, 1, 1),
+                ...    denominator=16,
+                ...    )
+
+            ::
+
+                >>> talea.counts
+                (2, 1, 3, 2, 4, 1, 1)
+
         Set to integers.
+
+        Defaults to `(1,)`.
 
         Returns tuple.
         '''
@@ -158,7 +246,25 @@ class Talea(AbjadValueObject):
     def denominator(self):
         r'''Gets denominator of talea.
 
+        ..  container:: example
+
+            **Example.**
+
+            ::
+
+                >>> talea = rhythmmakertools.Talea(
+                ...    counts=(2, 1, 3, 2, 4, 1, 1),
+                ...    denominator=16,
+                ...    )
+
+            ::
+
+                >>> talea.denominator
+                16
+
         Set to nonnegative integer power of two.
+
+        Defaults to 16.
 
         Returns nonnegative integer power of two.
         '''

--- a/abjad/tools/rhythmmakertools/TaleaRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/TaleaRhythmMaker.py
@@ -147,7 +147,6 @@ class TaleaRhythmMaker(RhythmMaker):
         '_rest_tied_notes',
         '_split_divisions_by_counts',
         '_talea',
-        '_talea_denominator',
         '_tie_split_notes',
         )
 

--- a/abjad/tools/schemetools/SchemeMoment.py
+++ b/abjad/tools/schemetools/SchemeMoment.py
@@ -75,7 +75,7 @@ class SchemeMoment(Scheme):
     def __hash__(self):
         r'''Hashes scheme moment.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/scoretools/NoteHead.py
+++ b/abjad/tools/scoretools/NoteHead.py
@@ -116,7 +116,7 @@ class NoteHead(AbjadObject):
     def __hash__(self):
         r'''Hashes note-head.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/selectiontools/Selection.py
+++ b/abjad/tools/selectiontools/Selection.py
@@ -103,7 +103,7 @@ class Selection(object):
     def __hash__(self):
         r'''Hashes selection.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/sequencetools/Sequence.py
+++ b/abjad/tools/sequencetools/Sequence.py
@@ -122,7 +122,7 @@ class Sequence(AbjadObject):
     def __hash__(self):
         r'''Hashes sequence.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/timespantools/OffsetTimespanTimeRelation.py
+++ b/abjad/tools/timespantools/OffsetTimespanTimeRelation.py
@@ -141,7 +141,7 @@ class OffsetTimespanTimeRelation(TimeRelation):
     def __hash__(self):
         r'''Hashes time relation.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/timespantools/TimeRelation.py
+++ b/abjad/tools/timespantools/TimeRelation.py
@@ -61,7 +61,7 @@ class TimeRelation(AbjadObject):
     def __hash__(self):
         r'''Hashes time relation.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/timespantools/Timespan.py
+++ b/abjad/tools/timespantools/Timespan.py
@@ -205,7 +205,7 @@ class Timespan(BoundedObject):
     def __hash__(self):
         r'''Hashes timespan.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/timespantools/TimespanTimespanTimeRelation.py
+++ b/abjad/tools/timespantools/TimespanTimespanTimeRelation.py
@@ -310,7 +310,7 @@ class TimespanTimespanTimeRelation(TimeRelation):
     def __hash__(self):
         r'''Hashes time relation.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/tonalanalysistools/ChordExtent.py
+++ b/abjad/tools/tonalanalysistools/ChordExtent.py
@@ -54,7 +54,7 @@ class ChordExtent(AbjadObject):
     def __hash__(self):
         r'''Hashes chord extent.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/tonalanalysistools/ChordInversion.py
+++ b/abjad/tools/tonalanalysistools/ChordInversion.py
@@ -77,7 +77,7 @@ class ChordInversion(AbjadObject):
     def __hash__(self):
         r'''Hashes chord inversion.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/tonalanalysistools/ChordQuality.py
+++ b/abjad/tools/tonalanalysistools/ChordQuality.py
@@ -55,7 +55,7 @@ class ChordQuality(AbjadObject):
     def __hash__(self):
         r'''Hashes chord quality.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/tonalanalysistools/ChordSuspension.py
+++ b/abjad/tools/tonalanalysistools/ChordSuspension.py
@@ -64,7 +64,7 @@ class ChordSuspension(AbjadObject):
     def __hash__(self):
         r'''Hashes chord suspension.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/tonalanalysistools/Mode.py
+++ b/abjad/tools/tonalanalysistools/Mode.py
@@ -49,7 +49,7 @@ class Mode(AbjadObject):
     def __hash__(self):
         r'''Hashes mode.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/tonalanalysistools/RomanNumeral.py
+++ b/abjad/tools/tonalanalysistools/RomanNumeral.py
@@ -93,7 +93,7 @@ class RomanNumeral(AbjadObject):
     def __hash__(self):
         r'''Hashes roman numeral.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/tonalanalysistools/RootedChordClass.py
+++ b/abjad/tools/tonalanalysistools/RootedChordClass.py
@@ -102,7 +102,7 @@ class RootedChordClass(PitchClassSet):
     def __hash__(self):
         r'''Hashes rooted chord-class.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''

--- a/abjad/tools/tonalanalysistools/ScaleDegree.py
+++ b/abjad/tools/tonalanalysistools/ScaleDegree.py
@@ -125,7 +125,7 @@ class ScaleDegree(AbjadObject):
     def __hash__(self):
         r'''Hashes scale degree.
 
-        Required to be explicitly re-defined on Python 3 if __eq__ changes.
+        Required to be explicitly redefined on Python 3 if __eq__ changes.
 
         Returns integer.
         '''


### PR DESCRIPTION
Removed unused TaleaRhythmMaker private property.

Respelled 're-defined' as 'redefined' in all __hash__ docstrings.

No change to public functionality.

This closes #669.