### PR TITLE
Fixed TaleaRhythmMaker.beam_specifier doc string.

### DIFF
--- a/abjad/tools/rhythmmakertools/TaleaRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/TaleaRhythmMaker.py
@@ -689,8 +689,6 @@ class TaleaRhythmMaker(RhythmMaker):
     def beam_specifier(self):
         r'''Gets beam specifier.
 
-        Three beam specifier configurations are available.
-
         ..  container:: example
 
             **Example 1.** Beams each division:


### PR DESCRIPTION
This closes #688.

No change to public functionality.