### PR TITLE
Implemented IndicatorExpression.synthetic_offset

### DIFF
--- a/abjad/tools/agenttools/test/test_agenttools_InspectionAgent_get_effective.py
+++ b/abjad/tools/agenttools/test/test_agenttools_InspectionAgent_get_effective.py
@@ -423,3 +423,11 @@ def test_agenttools_InspectionAgent_get_effective_21():
     assert inspect_(staff[4]).get_effective(str, n=-1) == 'blue'
     assert inspect_(staff[4]).get_effective(str, n=0) == 'yellow'
     assert inspect_(staff[4]).get_effective(str, n=1) is None
+
+
+def test_agenttools_InspectionAgent_get_effective_22():
+    staff = Staff("c'8 d'8 e'8 f'8")
+    attach('red', staff[-1], scope=Staff, synthetic_offset=-1)
+    attach('blue', staff[0], scope=Staff)
+    assert inspect_(staff).get_effective(str) == 'blue'
+    assert inspect_(staff).get_effective(str, n=-1) == 'red'

--- a/abjad/tools/topleveltools/attach.py
+++ b/abjad/tools/topleveltools/attach.py
@@ -7,6 +7,7 @@ def attach(
     scope=None,
     is_annotation=None,
     name=None,
+    synthetic_offset=None,
     ):
     r'''Attaches `indicator` to `component_expression`.
 
@@ -45,6 +46,7 @@ def attach(
         is_annotation = is_annotation or indicator.is_annotation
         name = name or indicator.name
         scope = scope or indicator.scope
+        synthetic_offset = synthetic_offset or indicator.synthetic_offset
         indicator._detach()
         indicator = indicator.indicator
 
@@ -57,5 +59,6 @@ def attach(
         is_annotation=is_annotation,
         name=name,
         scope=scope,
+        synthetic_offset=synthetic_offset,
         )
     expression._bind_to_component(component)


### PR DESCRIPTION
This PR implements a new `IndicatorExpression.synthetic_offset` property.

Composers can specify an optional synthetic offset for an indicator during attachment by using the `synthetic_offset` keyword to `attach()`. The resulting indicator expression's synthetic offset will be used instead of the expression's component's start offset when sorting to determine effective indicators.

Why is this useful? It allows composers to attach indicators to a score which effectively start _before_ the score starts. When composing score in segments, composers can simply attach to one segment all those indicators that were effective at the end of the previous segment.