### PR TITLE
Implement TupletSpellingSpecifier.preferred_denominator

### DIFF
--- a/abjad/tools/rhythmmakertools/RhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/RhythmMaker.py
@@ -73,7 +73,7 @@ class RhythmMaker(AbjadValueObject):
         self._rotation = rotation
         divisions = self._coerce_divisions(divisions)
         selections = self._make_music(divisions, rotation)
-        selections = self._apply_specifiers(selections)
+        selections = self._apply_specifiers(selections, divisions)
         self._check_well_formedness(selections)
         return selections
 
@@ -245,8 +245,11 @@ class RhythmMaker(AbjadValueObject):
             new_selections.append(new_selection)
         return new_selections
 
-    def _apply_specifiers(self, selections):
-        selections = self._apply_tuplet_spelling_specifier(selections)
+    def _apply_specifiers(self, selections, divisions=None):
+        selections = self._apply_tuplet_spelling_specifier(
+            selections,
+            divisions,
+            )
         self._apply_tie_specifier(selections)
         selections = self._apply_logical_tie_masks(selections)
         self._validate_selections(selections)
@@ -257,11 +260,17 @@ class RhythmMaker(AbjadValueObject):
         tie_specifier = self._get_tie_specifier()
         tie_specifier(selections)
 
-    def _apply_tuplet_spelling_specifier(self, selections):
+    
+    def _apply_tuplet_spelling_specifier(self, selections, divisions):
+        # TODO: migrate functionality to TupletSpellingSpecifier.__call__()
         tuplet_spelling_specifier = self._get_tuplet_spelling_specifier()
         tuplet_spelling_specifier._do_simplify_redundant_tuplets(selections)
         selections = self._rewrite_rest_filled_tuplets(selections)
         selections = self._flatten_trivial_tuplets(selections)
+        tuplet_spelling_specifier._apply_preferred_denominator(
+            selections,
+            divisions,
+            )
         return selections
 
     def _check_well_formedness(self, selections):

--- a/abjad/tools/rhythmmakertools/TupletRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/TupletRhythmMaker.py
@@ -369,22 +369,24 @@ class TupletRhythmMaker(RhythmMaker):
                 avoid_dots=tuplet_spelling_specifier.avoid_dots,
                 is_diminution=tuplet_spelling_specifier.is_diminution,
                 )
-            if self.preferred_denominator is None:
+            preferred_denominator = \
+                tuplet_spelling_specifier.preferred_denominator
+            if preferred_denominator is None:
                 pass
-            elif self.preferred_denominator == 'divisions':
+            elif preferred_denominator == 'divisions':
                 tuplet.preferred_denominator = division.numerator
             elif isinstance(
-                self.preferred_denominator, durationtools.Duration):
-                unit_duration = self.preferred_denominator
+                preferred_denominator, durationtools.Duration):
+                unit_duration = preferred_denominator
                 assert unit_duration.numerator == 1
                 duration = inspect_(tuplet).get_duration()
                 denominator = unit_duration.denominator
                 nonreduced_fraction = duration.with_denominator(denominator)
                 tuplet.preferred_denominator = nonreduced_fraction.numerator
-            elif mathtools.is_positive_integer(self.preferred_denominator):
-                tuplet.preferred_denominator = self.preferred_denominator
+            elif mathtools.is_positive_integer(preferred_denominator):
+                tuplet.preferred_denominator = preferred_denominator
             else:
-                raise ValueError(self.preferred_denominator)
+                raise ValueError(preferred_denominator)
             tuplets.append(tuplet)
         selections = [selectiontools.Selection(x) for x in tuplets]
         beam_specifier = self._get_beam_specifier()
@@ -785,8 +787,8 @@ class TupletRhythmMaker(RhythmMaker):
 
             **Example 1.** Tuplet numerators and denominators are reduced to
             numbers that are relatively prime when `preferred_denominator` is
-            set to none. This means that ratios like ``6:4`` and ``10:8`` are
-            not possible:
+            set to none. This means that ratios like ``6:4`` and ``10:8`` do
+            not arise:
 
             ::
 
@@ -794,8 +796,8 @@ class TupletRhythmMaker(RhythmMaker):
                 ...     tuplet_ratios=[(1, 4)],
                 ...     tuplet_spelling_specifier=rhythmmakertools.TupletSpellingSpecifier(
                 ...         avoid_dots=True,
+                ...         preferred_denominator=None,
                 ...         ),
-                ...     preferred_denominator=None,
                 ...     )
 
             ::
@@ -853,7 +855,7 @@ class TupletRhythmMaker(RhythmMaker):
             `preferred_denominator` is set to the string ``'divisions'``. This
             means that the tuplet numerator and denominator are not necessarily
             relatively prime. This also means that ratios like ``6:4`` and
-            ``10:8`` are possible:
+            ``10:8`` may arise:
 
             ::
 
@@ -861,8 +863,8 @@ class TupletRhythmMaker(RhythmMaker):
                 ...     tuplet_ratios=[(1, 4)],
                 ...     tuplet_spelling_specifier=rhythmmakertools.TupletSpellingSpecifier(
                 ...         avoid_dots=True,
+                ...         preferred_denominator='divisions',
                 ...         ),
-                ...     preferred_denominator='divisions',
                 ...     )
 
             ::
@@ -923,8 +925,8 @@ class TupletRhythmMaker(RhythmMaker):
                 ...     tuplet_ratios=[(1, 4)],
                 ...     tuplet_spelling_specifier=rhythmmakertools.TupletSpellingSpecifier(
                 ...         avoid_dots=True,
+                ...         preferred_denominator=Duration(1, 16),
                 ...         ),
-                ...     preferred_denominator=Duration(1, 16),
                 ...     )
 
             ::
@@ -984,8 +986,8 @@ class TupletRhythmMaker(RhythmMaker):
                 ...     tuplet_ratios=[(1, 4)],
                 ...     tuplet_spelling_specifier=rhythmmakertools.TupletSpellingSpecifier(
                 ...         avoid_dots=True,
+                ...         preferred_denominator=Duration(1, 32),
                 ...         ),
-                ...     preferred_denominator=Duration(1, 32),
                 ...     )
 
             ::
@@ -1045,8 +1047,8 @@ class TupletRhythmMaker(RhythmMaker):
                 ...     tuplet_ratios=[(1, 4)],
                 ...     tuplet_spelling_specifier=rhythmmakertools.TupletSpellingSpecifier(
                 ...         avoid_dots=True,
+                ...         preferred_denominator=Duration(1, 64),
                 ...         ),
-                ...     preferred_denominator=Duration(1, 64),
                 ...     )
 
             ::
@@ -1108,8 +1110,8 @@ class TupletRhythmMaker(RhythmMaker):
                 ...     tuplet_ratios=[(1, 4)],
                 ...     tuplet_spelling_specifier=rhythmmakertools.TupletSpellingSpecifier(
                 ...         avoid_dots=True,
+                ...         preferred_denominator=8,
                 ...         ),
-                ...     preferred_denominator=8,
                 ...     )
 
             ::
@@ -1169,8 +1171,8 @@ class TupletRhythmMaker(RhythmMaker):
                 ...     tuplet_ratios=[(1, 4)],
                 ...     tuplet_spelling_specifier=rhythmmakertools.TupletSpellingSpecifier(
                 ...         avoid_dots=True,
+                ...         preferred_denominator=12,
                 ...         ),
-                ...     preferred_denominator=12,
                 ...     )
 
             ::
@@ -1230,8 +1232,8 @@ class TupletRhythmMaker(RhythmMaker):
                 ...     tuplet_ratios=[(1, 4)],
                 ...     tuplet_spelling_specifier=rhythmmakertools.TupletSpellingSpecifier(
                 ...         avoid_dots=True,
+                ...         preferred_denominator=13,
                 ...         ),
-                ...     preferred_denominator=13,
                 ...     )
 
             ::

--- a/abjad/tools/rhythmmakertools/TupletSpellingSpecifier.py
+++ b/abjad/tools/rhythmmakertools/TupletSpellingSpecifier.py
@@ -16,6 +16,7 @@ class TupletSpellingSpecifier(AbjadValueObject):
         '_rewrite_rest_filled_tuplets',
         '_flatten_trivial_tuplets',
         '_is_diminution',
+        '_preferred_denominator',
         '_simplify_redundant_tuplets',
         '_use_note_duration_bracket',
         )
@@ -25,9 +26,10 @@ class TupletSpellingSpecifier(AbjadValueObject):
     def __init__(
         self,
         avoid_dots=False,
-        rewrite_rest_filled_tuplets=False,
         flatten_trivial_tuplets=False,
         is_diminution=True,
+        preferred_denominator=None,
+        rewrite_rest_filled_tuplets=False,
         simplify_redundant_tuplets=False,
         use_note_duration_bracket=False,
         ):
@@ -35,9 +37,10 @@ class TupletSpellingSpecifier(AbjadValueObject):
         #       That would allow for all keywords to default to None,
         #       and therefore a single-line storage format.
         self._avoid_dots = bool(avoid_dots)
-        self._rewrite_rest_filled_tuplets = bool(rewrite_rest_filled_tuplets)
         self._flatten_trivial_tuplets = bool(flatten_trivial_tuplets)
         self._is_diminution = bool(is_diminution)
+        self._preferred_denominator = preferred_denominator
+        self._rewrite_rest_filled_tuplets = bool(rewrite_rest_filled_tuplets)
         self._simplify_redundant_tuplets = bool(simplify_redundant_tuplets)
         self._use_note_duration_bracket = bool(use_note_duration_bracket)
 
@@ -90,6 +93,18 @@ class TupletSpellingSpecifier(AbjadValueObject):
         Returns true or false.
         '''
         return self._is_diminution
+
+    @property
+    def preferred_denominator(self):
+        r'''Gets preferred denominator.
+
+        Defaults to none.
+
+        Set to ``'divisions'``, duration, integer or none.
+
+        Returns ``'divisions'``, duration, integer or none.
+        '''
+        return self._preferred_denominator
 
     @property
     def rewrite_rest_filled_tuplets(self):

--- a/abjad/tools/scoretools/Tuplet.py
+++ b/abjad/tools/scoretools/Tuplet.py
@@ -232,11 +232,8 @@ class Tuplet(Container):
             ])
         return node
 
-    # TODO: hoist to Tuplet and make work for all tuplet instances
     def _fix(self):
         from abjad.tools import scoretools
-        if not isinstance(self, scoretools.FixedDurationTuplet):
-            return
         # find tuplet multiplier
         integer_exponent = int(math.log(self.multiplier, 2))
         leaf_multiplier = durationtools.Multiplier(2) ** integer_exponent
@@ -246,6 +243,11 @@ class Tuplet(Container):
                 old_written_duration = component.written_duration
                 new_written_duration = leaf_multiplier * old_written_duration
                 component._set_duration(new_written_duration)
+        # adjust tuplet multiplier (for non-fixed-duration tuplets)
+        if self.__class__ is Tuplet:
+            numerator, denominator = leaf_multiplier.pair
+            multiplier = durationtools.Multiplier(denominator, numerator)
+            self.multiplier *= multiplier
 
     def _format_after_slot(self, bundle):
         result = []


### PR DESCRIPTION
Recall that Tuplet.preferred_denominator has existed for a long time.

OLD. TupletSpellingSpecifier implemented no preferred_denominator property.
This meant that most rhythm-makers were unable to access the
Tuplet.preferred_denominator property. (The exception was the
TupletRhythmMaker.preferred_denominator property, which was implemented only on
TupletRhythmMaker).

NEW. TupletSpellingSpecifier.preferred_denominator now exists. This means that
all rhythm-makers will be able to access the Tuplet.preferred_denominator
property. Note that as of this commit, only TupletRhythmMaker has integrated
the TupletSpellingSpecifier.preferred_denominator property.

Note that a future commit will be a breaking commit that will remove the old
TupletRhythmMaker.preferred_denominator poperty in favor of the new
TupletSpellingSpecifier.preferred_denominator property.