### PR TITLE
Extend leaf multiplier behavior.

### DIFF
--- a/abjad/tools/mathtools/NonreducedRatio.py
+++ b/abjad/tools/mathtools/NonreducedRatio.py
@@ -53,6 +53,8 @@ class NonreducedRatio(AbjadValueObject):
 
         Returns true or false.
         '''
+        if not isinstance(expr, type(self)):
+            return False
         expr = type(self)(expr)
         return self.numbers == expr.numbers
 

--- a/abjad/tools/mathtools/difference_series.py
+++ b/abjad/tools/mathtools/difference_series.py
@@ -2,19 +2,25 @@
 
 
 def difference_series(sequence):
-    r'''Difference series of `sequence`.
+    r'''Gets difference series of `sequence`.
+
+    **Example 1.** Monotonically increasing:
 
     ::
 
         >>> mathtools.difference_series([1, 1, 2, 3, 5, 5, 6])
         [0, 1, 1, 2, 0, 1]
 
+    **Example 2.** Alternating direction:
+
+    ::
+
+        >>> mathtools.difference_series([9, 6, 8, 5, 7, 4, 6])
+        [-3, 2, -3, 2, -3, 2]
+
     Returns list.
     '''
-
     result = []
-
     for i, n in enumerate(sequence[1:]):
         result.append(n - sequence[i])
-
     return result

--- a/abjad/tools/mathtools/test/test_mathtools_Ratio___eq__.py
+++ b/abjad/tools/mathtools/test/test_mathtools_Ratio___eq__.py
@@ -17,10 +17,3 @@ def test_mathtools_Ratio___eq___01():
     assert not ratio_3 == ratio_1
     assert not ratio_3 == ratio_2
     assert ratio_3 == ratio_3
-
-
-def test_mathtools_Ratio___eq___02():
-    r'''Comparison works with tuples.
-    '''
-
-    assert mathtools.Ratio((1, 2, 1)) == (1, 2, 1)

--- a/abjad/tools/rhythmmakertools/AccelerandoRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/AccelerandoRhythmMaker.py
@@ -753,10 +753,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
             tuplet = scoretools.Tuplet((1, 1), notes)
             selection = selectiontools.Selection([tuplet])
             return selection
-        durations = [
-            durationtools.Duration(int(round(_ * 2**10)), 2**10)
-            for _ in durations
-            ]
+        durations = class_._round_durations(durations, 2**10)
         notes = []
         for i, duration in enumerate(durations):
             written_duration = interpolation_specifier.written_duration
@@ -808,6 +805,15 @@ class AccelerandoRhythmMaker(RhythmMaker):
         beam_specifier(selections)
         selections = self._apply_division_masks(selections, rotation)
         return selections
+
+    @staticmethod
+    def _round_durations(durations, denominator):
+        durations_ = []
+        for duration in durations:
+            numerator = int(round(duration * denominator))
+            duration_ = durationtools.Duration(numerator, denominator)
+            durations_.append(duration_)
+        return durations_
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjad/tools/scoretools/Leaf.py
+++ b/abjad/tools/scoretools/Leaf.py
@@ -76,7 +76,11 @@ class Leaf(Component):
     def _formatted_duration(self):
         duration_string = self.written_duration.lilypond_duration_string
         multiplier = None
-        multipliers = self._get_indicators(durationtools.Multiplier)
+        multiplier_prototype = (
+            durationtools.Multiplier,
+            mathtools.NonreducedFraction,
+            )
+        multipliers = self._get_indicators(multiplier_prototype)
         if not multipliers:
             pass
         elif len(multipliers) == 1:
@@ -93,11 +97,15 @@ class Leaf(Component):
     @property
     def _multiplied_duration(self):
         if self.written_duration:
-            if self._get_indicators(durationtools.Multiplier):
-                multipliers = self._get_indicators(
-                    durationtools.Multiplier)
+            multiplier_prototype = (
+                durationtools.Multiplier,
+                mathtools.NonreducedFraction,
+                )
+            if self._get_indicators(multiplier_prototype):
+                multipliers = self._get_indicators(multiplier_prototype)
                 if 1 == len(multipliers):
                     multiplier = multipliers[0]
+                    multiplier = durationtools.Duration(multiplier)
                 elif 1 < len(multipliers):
                     message = 'more than one duration multiplier.'
                     raise ValueError(message)


### PR DESCRIPTION
OLD. Previously you could only attach Multiplier objects to leaves:

    >>> attach(Multiplier(3, 2), Note("c'4"))

NEW. Now you may also attach NonreducedFraction object to leaves:

    >>> attach(NonreducedFraction(6, 4), Note("c'4"))

The mathematical behavior of NonreducedFraction multipliers is the same as
Multiplier multipliers.

The difference lies in LilyPond output. Use NonreducedFraction objects as leaf
duration multipliers when you want LilyPond output to contain fractions that
are not reduced (eg, for easy visual comparison of many multipliers with the
same denominator).