### PR TITLE
Wellformedness enhancements

### DIFF
--- a/abjad/tools/agenttools/InspectionAgent.py
+++ b/abjad/tools/agenttools/InspectionAgent.py
@@ -106,9 +106,9 @@ class InspectionAgent(abctools.AbjadObject):
         Returns list.
         '''
         from abjad.tools import systemtools
-        manager = systemtools.WellformednessManager(self._client)
+        manager = systemtools.WellformednessManager()
         violators = []
-        for current_violators, total, check_name in manager():
+        for current_violators, total, check_name in manager(self._client):
             violators.extend(current_violators)
         return violators
 
@@ -962,21 +962,15 @@ class InspectionAgent(abctools.AbjadObject):
             return True
         return False
 
-    def is_well_formed(
-        self,
-        #allow_empty_containers=True,
-        ):
+    def is_well_formed(self):
         r'''Is true when client is well-formed.
         Otherwise false.
 
         Returns false.
         '''
         from abjad.tools import systemtools
-        manager = systemtools.WellformednessManager(
-            self._client,
-            #allow_empty_containers=allow_empty_containers,
-            )
-        for violators, total, check_name in manager():
+        manager = systemtools.WellformednessManager()
+        for violators, total, check_name in manager(self._client):
             if violators:
                 return False
         return True
@@ -1103,8 +1097,8 @@ class InspectionAgent(abctools.AbjadObject):
         Returns string.
         '''
         from abjad.tools import systemtools
-        manager = systemtools.WellformednessManager(self._client)
-        triples = manager()
+        manager = systemtools.WellformednessManager()
+        triples = manager(self._client)
         strings = []
         for violators, total, check_name in triples:
             violator_count = len(violators)

--- a/abjad/tools/agenttools/InspectionAgent.py
+++ b/abjad/tools/agenttools/InspectionAgent.py
@@ -964,7 +964,7 @@ class InspectionAgent(abctools.AbjadObject):
 
     def is_well_formed(
         self,
-        allow_empty_containers=True,
+        #allow_empty_containers=True,
         ):
         r'''Is true when client is well-formed.
         Otherwise false.
@@ -974,7 +974,7 @@ class InspectionAgent(abctools.AbjadObject):
         from abjad.tools import systemtools
         manager = systemtools.WellformednessManager(
             self._client,
-            allow_empty_containers=allow_empty_containers,
+            #allow_empty_containers=allow_empty_containers,
             )
         for violators, total, check_name in manager():
             if violators:
@@ -1081,6 +1081,7 @@ class InspectionAgent(abctools.AbjadObject):
                 0 / 1 conflicting clefs
                 0 / 1 discontiguous spanners
                 0 / 5 duplicate ids
+                0 / 1 empty containers
                 0 / 0 intermarked hairpins
                 0 / 0 misdurated measures
                 0 / 0 misfilled measures

--- a/abjad/tools/agenttools/test/test_agenttools_MutationAgent_split.py
+++ b/abjad/tools/agenttools/test/test_agenttools_MutationAgent_split.py
@@ -1674,7 +1674,7 @@ def test_agenttools_MutationAgent_split_29():
         fracture_spanners=False,
         )
 
-    assert inspect_(voice).is_well_formed()
+    assert not len(voice)
 
     voice_1 = result[0][0]
     voice_2 = result[1][0]

--- a/abjad/tools/lilypondnametools/test/test_lilypondproxytools_LilyPondGrobNameManager___setattr__.py
+++ b/abjad/tools/lilypondnametools/test/test_lilypondproxytools_LilyPondGrobNameManager___setattr__.py
@@ -857,7 +857,7 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___37():
         '''
         )
 
-    assert inspect_(score).is_well_formed()
+    assert not len(score)
 
 
 def test_lilypondproxytools_LilyPondGrobNameManager___setattr___38():

--- a/abjad/tools/lilypondnametools/test/test_lilypondproxytools_LilyPondSettingNameManager___setattr__.py
+++ b/abjad/tools/lilypondnametools/test/test_lilypondproxytools_LilyPondSettingNameManager___setattr__.py
@@ -311,7 +311,7 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___13():
         '''
         )
 
-    assert inspect_(staff).is_well_formed()
+    assert not len(staff)
 
     set_(staff).tuplet_full_length = False
 
@@ -324,7 +324,7 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___13():
         '''
         )
 
-    assert inspect_(staff).is_well_formed()
+    assert not len(staff)
 
     del(set_(staff).tuplet_full_length)
 
@@ -335,4 +335,4 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___13():
         '''
         )
 
-    assert inspect_(staff).is_well_formed()
+    assert not len(staff)

--- a/abjad/tools/scoretools/test/test_scoretools_Container___delitem__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container___delitem__.py
@@ -147,7 +147,7 @@ def test_scoretools_Container___delitem___06():
         '''
         )
 
-    assert inspect_(voice).is_well_formed()
+    assert not len(voice)
 
 
 def test_scoretools_Container___delitem___07():

--- a/abjad/tools/scoretools/test/test_scoretools_Tuplet___copy__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Tuplet___copy__.py
@@ -31,4 +31,4 @@ def test_scoretools_Tuplet___copy___01():
         '''
         )
 
-    assert inspect_(tuplet_2).is_well_formed()
+    assert not len(tuplet_2)

--- a/abjad/tools/scoretools/test/test_scoretools_make_empty_piano_score.py
+++ b/abjad/tools/scoretools/test/test_scoretools_make_empty_piano_score.py
@@ -19,7 +19,6 @@ def test_scoretools_make_empty_piano_score_01():
     >>
     '''
 
-    assert inspect_(score).is_well_formed()
     assert format(score) == stringtools.normalize(
         r'''
         \new Score <<

--- a/abjad/tools/selectiontools/test/test_selectiontools_Selection__set_component_parents.py
+++ b/abjad/tools/selectiontools/test/test_selectiontools_Selection__set_component_parents.py
@@ -10,7 +10,6 @@ def test_selectiontools_Selection__set_component_parents_01():
     selection = u[:]
     selection._set_parents(voice)
 
-    assert inspect_(u).is_well_formed()
     assert len(u) == 0
 
     "Container voice now assigned to selection."

--- a/abjad/tools/systemtools/WellformednessManager.py
+++ b/abjad/tools/systemtools/WellformednessManager.py
@@ -20,32 +20,28 @@ class WellformednessManager(AbjadObject):
 
     __documentation_section__ = 'Managers'
 
-    ### INITIALIZER ###
-
-    def __init__(self, expr=None):
-        self.expr = expr
-
     ### SPECIAL METHODS ###
 
-    def __call__(self):
+    def __call__(self, expr=None):
         r'''Calls all wellformedness checks on `expr`.
 
         Returns triples.
         '''
-        if self.expr is None:
+        if expr is None:
             return
         check_names = [x for x in dir(self) if x.startswith('check_')]
         triples = []
         for current_check_name in sorted(check_names):
             current_check = getattr(self, current_check_name)
-            current_violators, current_total = current_check()
+            current_violators, current_total = current_check(expr=expr)
             triple = (current_violators, current_total, current_check_name)
             triples.append(triple)
         return triples
 
     ### PUBLIC METHODS ###
 
-    def check_beamed_quarter_notes(self):
+    @staticmethod
+    def check_beamed_quarter_notes(expr=None):
         r'''Checks to make sure there are no beamed quarter notes.
 
         Returns violators and total.
@@ -59,7 +55,7 @@ class WellformednessManager(AbjadObject):
             spannertools.DuratedComplexBeam,
             spannertools.MultipartBeam,
             )
-        for leaf in iterate(self.expr).by_class(scoretools.Leaf):
+        for leaf in iterate(expr).by_class(scoretools.Leaf):
             total += 1
             parentage = leaf._get_parentage(include_self=True)
             beams = parentage._get_spanners(spannertools.Beam)
@@ -71,7 +67,8 @@ class WellformednessManager(AbjadObject):
                         break
         return violators, total
 
-    def check_conflicting_clefs(self):
+    @staticmethod
+    def check_conflicting_clefs(expr=None):
         r'''Checks for conflicting clefs.
 
         Conflicting clefs defined equal to the situation in which a first clef
@@ -158,7 +155,7 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import inspect_
         from abjad.tools.topleveltools import iterate
         violators = []
-        containers = iterate(self.expr).by_class(scoretools.Container)
+        containers = iterate(expr).by_class(scoretools.Container)
         total_containers = 0
         for container in containers:
             total_containers += 1
@@ -174,7 +171,8 @@ class WellformednessManager(AbjadObject):
                 current_component = first_child
         return violators, total_containers
 
-    def check_discontiguous_spanners(self):
+    @staticmethod
+    def check_discontiguous_spanners(expr=None):
         r'''Checks for discontiguous spanners.
 
         There are now two different types of spanner.
@@ -188,7 +186,7 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.selectiontools import Selection
         violators = []
         total = 0
-        for spanner in self.expr._get_descendants()._get_spanners():
+        for spanner in expr._get_descendants()._get_spanners():
             if spanner._contiguity_constraint == 'logical voice':
                 if not Selection._all_are_contiguous_components_in_same_logical_voice(
                     spanner[:]):
@@ -196,7 +194,8 @@ class WellformednessManager(AbjadObject):
             total += 1
         return violators, total
 
-    def check_duplicate_ids(self):
+    @staticmethod
+    def check_duplicate_ids(expr=None):
         r'''Checks to make sure there are no components with duplicated IDs.
 
         Returns violators and total.
@@ -204,7 +203,7 @@ class WellformednessManager(AbjadObject):
         from abjad.tools import sequencetools
         from abjad.tools.topleveltools import iterate
         violators = []
-        components = iterate(self.expr).by_class()
+        components = iterate(expr).by_class()
         total_ids = [id(x) for x in components]
         unique_ids = sequencetools.remove_repeated_elements(total_ids)
         if len(unique_ids) < len(total_ids):
@@ -214,7 +213,8 @@ class WellformednessManager(AbjadObject):
                         if id(x) == current_id])
         return violators, len(total_ids)
 
-    def check_empty_containers(self):
+    @staticmethod
+    def check_empty_containers(expr=None):
         r'''Checks to make sure there are no empty containers in score.
 
         Returns violators and total.
@@ -223,14 +223,15 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import iterate
         violators = []
         bad, total = 0, 0
-        for component in iterate(self.expr).by_class(scoretools.Container):
+        for component in iterate(expr).by_class(scoretools.Container):
             if len(component) == 0:
                 violators.append(component)
                 bad += 1
             total += 1
         return violators, total
 
-    def check_intermarked_hairpins(self):
+    @staticmethod
+    def check_intermarked_hairpins(expr=None):
         r'''Checks to make sure there are no hairpins in score with intervening
         dynamic marks.
 
@@ -241,7 +242,7 @@ class WellformednessManager(AbjadObject):
         violators = []
         total, bad = 0, 0
         prototype = (spannertools.Hairpin,)
-        hairpins = self.expr._get_descendants()._get_spanners(prototype)
+        hairpins = expr._get_descendants()._get_spanners(prototype)
         for hairpin in hairpins:
             if 2 < len(hairpin._get_leaves()):
                 for leaf in hairpin._get_leaves()[1:-1]:
@@ -252,7 +253,8 @@ class WellformednessManager(AbjadObject):
             total += 1
         return violators, total
 
-    def check_misdurated_measures(self):
+    @staticmethod
+    def check_misdurated_measures(expr=None):
         r'''Checks to make sure there are no misdurated measures in score.
 
         Returns violators and total.
@@ -261,7 +263,7 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import iterate
         violators = []
         total, bad = 0, 0
-        for measure in iterate(self.expr).by_class(scoretools.Measure):
+        for measure in iterate(expr).by_class(scoretools.Measure):
             time_signature = measure.time_signature
             if time_signature is not None:
                 if measure._preprolated_duration != time_signature.duration:
@@ -270,7 +272,8 @@ class WellformednessManager(AbjadObject):
             total += 1
         return violators, total
 
-    def check_misfilled_measures(self):
+    @staticmethod
+    def check_misfilled_measures(expr=None):
         r'''Checks that time signature duration equals measure contents
         duration for every measure.
 
@@ -280,14 +283,15 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import iterate
         violators = []
         total, bad = 0, 0
-        for measure in iterate(self.expr).by_class(scoretools.Measure):
+        for measure in iterate(expr).by_class(scoretools.Measure):
             if measure.is_misfilled:
                 violators.append(measure)
                 bad += 1
             total += 1
         return violators, total
 
-    def check_mismatched_enchained_hairpins(self):
+    @staticmethod
+    def check_mismatched_enchained_hairpins(expr=None):
         r'''Checks mismatched enchained hairpins.
 
         ..  container:: example
@@ -334,7 +338,7 @@ class WellformednessManager(AbjadObject):
         violators = []
         all_hairpins = set()
         prototype = spannertools.Hairpin
-        for leaf in iterate(self.expr).by_leaf():
+        for leaf in iterate(expr).by_leaf():
             hairpins = leaf._get_spanners(prototype)
             hairpins = list(hairpins)
             all_hairpins.update(hairpins)
@@ -366,7 +370,8 @@ class WellformednessManager(AbjadObject):
         total = len(all_hairpins)
         return violators, total
 
-    def check_mispitched_ties(self):
+    @staticmethod
+    def check_mispitched_ties(expr=None):
         r'''Checks for mispitched notes.
 
         ..  container:: example
@@ -448,7 +453,7 @@ class WellformednessManager(AbjadObject):
         violators = set()
         all_spanners = set()
         pitched_prototype = (scoretools.Note, scoretools.Chord)
-        for leaf in iterate(self.expr).by_class(pitched_prototype):
+        for leaf in iterate(expr).by_class(pitched_prototype):
             spanners = leaf._get_spanners(spannertools.Tie)
             if not spanners:
                 continue
@@ -468,7 +473,8 @@ class WellformednessManager(AbjadObject):
         total = len(all_spanners)
         return violators, total
 
-    def check_misrepresented_flags(self):
+    @staticmethod
+    def check_misrepresented_flags(expr=None):
         r'''Checks to make sure there are no misrepresented flags in score.
 
         Returns violators and total.
@@ -478,7 +484,7 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import set_
         violators = []
         total = 0
-        for leaf in iterate(self.expr).by_class(scoretools.Leaf):
+        for leaf in iterate(expr).by_class(scoretools.Leaf):
             total += 1
             flags = leaf.written_duration.flag_count
             left = getattr(set_(leaf), 'stem_left_beam_count', None)
@@ -495,7 +501,8 @@ class WellformednessManager(AbjadObject):
                         violators.append(leaf)
         return violators, total
 
-    def check_missing_parents(self):
+    @staticmethod
+    def check_missing_parents(expr=None):
         r'''Checks to make sure there are no components in score with missing
         parent.
 
@@ -504,7 +511,7 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import iterate
         violators = []
         total = 0
-        components = iterate(self.expr).by_class()
+        components = iterate(expr).by_class()
         for i, component in enumerate(components):
             if 0 < i:
                 if component._parent is None:
@@ -512,7 +519,8 @@ class WellformednessManager(AbjadObject):
         total = i + 1
         return violators, total
 
-    def check_nested_measures(self):
+    @staticmethod
+    def check_nested_measures(expr=None):
         r'''Checks to make sure there are no nested measures in score.
 
         Returns violators and total.
@@ -521,14 +529,15 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import iterate
         violators = []
         total = 0
-        for measure in iterate(self.expr).by_class(scoretools.Measure):
+        for measure in iterate(expr).by_class(scoretools.Measure):
             parentage = measure._get_parentage(include_self=False)
             if parentage.get_first(scoretools.Measure):
                 violators.append(measure)
             total += 1
         return violators, total
 
-    def check_overlapping_beams(self):
+    @staticmethod
+    def check_overlapping_beams(expr=None):
         r'''Checks to make sure there are no overlapping beams in score.
 
         Returns violators and total.
@@ -539,7 +548,7 @@ class WellformednessManager(AbjadObject):
         violators = []
         prototype = (spannertools.Beam,)
         all_beams = set()
-        for leaf in iterate(self.expr).by_class(scoretools.Leaf):
+        for leaf in iterate(expr).by_class(scoretools.Leaf):
             beams = leaf._get_spanners(prototype)
             all_beams.update(beams)
             if 1 < len(beams):
@@ -549,7 +558,8 @@ class WellformednessManager(AbjadObject):
         total = len(all_beams)
         return violators, total
 
-    def check_overlapping_glissandi(self):
+    @staticmethod
+    def check_overlapping_glissandi(expr=None):
         r'''Checks to make sure there are no overlapping glissandi in score.
 
         Returns violators and total.
@@ -559,7 +569,7 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import iterate
         violators = []
         prototype = (spannertools.Glissando,)
-        for leaf in iterate(self.expr).by_class(scoretools.Leaf):
+        for leaf in iterate(expr).by_class(scoretools.Leaf):
             glissandi = leaf._get_spanners(prototype)
             glissandi = list(glissandi)
             if 1 < len(glissandi):
@@ -579,11 +589,12 @@ class WellformednessManager(AbjadObject):
                 for glissando in glissandi:
                     if glissando not in violators:
                         violators.append(glissando)
-        total = self.expr._get_descendants()._get_spanners(prototype)
+        total = expr._get_descendants()._get_spanners(prototype)
         total = len(total)
         return violators, total
 
-    def check_overlapping_hairpins(self):
+    @staticmethod
+    def check_overlapping_hairpins(expr=None):
         r'''Checks to make sure there are no overlapping hairpins in score.
 
         ..  container:: example
@@ -629,7 +640,7 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import iterate
         violators = []
         prototype = spannertools.Hairpin
-        for leaf in iterate(self.expr).by_leaf():
+        for leaf in iterate(expr).by_leaf():
             hairpins = leaf._get_spanners(prototype)
             hairpins = list(hairpins)
             if 1 < len(hairpins):
@@ -649,11 +660,12 @@ class WellformednessManager(AbjadObject):
                 for hairpin in hairpins:
                     if hairpin not in violators:
                         violators.append(hairpin)
-        total = self.expr._get_descendants()._get_spanners(prototype)
+        total = expr._get_descendants()._get_spanners(prototype)
         total = len(total)
         return violators, total
 
-    def check_overlapping_octavation_spanners(self):
+    @staticmethod
+    def check_overlapping_octavation_spanners(expr=None):
         r'''Checks to make sure there are no overlapping octavation spanners in
         score.
 
@@ -664,16 +676,17 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import iterate
         violators = []
         prototype = (spannertools.OctavationSpanner, )
-        for leaf in iterate(self.expr).by_class(scoretools.Leaf):
+        for leaf in iterate(expr).by_class(scoretools.Leaf):
             spanners = leaf._get_descendants()._get_spanners(prototype)
             if 1 < len(spanners):
                 for spanner in spanners:
                     if spanner not in violators:
                         violators.append(spanner)
-        total = self.expr._get_descendants()._get_spanners(prototype)
+        total = expr._get_descendants()._get_spanners(prototype)
         return violators, len(total)
 
-    def check_overlapping_ties(self):
+    @staticmethod
+    def check_overlapping_ties(expr=None):
         r'''Checks to make sure there are no overlapping ties in score.
 
         ..  container:: example
@@ -717,14 +730,15 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import iterate
         total = set()
         violators = set()
-        for leaf in iterate(self.expr).by_leaf():
+        for leaf in iterate(expr).by_leaf():
             spanners = leaf._get_spanners(spannertools.Tie)
             total.update(spanners)
             if 1 < len(spanners):
                 violators.update(spanners)
         return violators, len(total)
 
-    def check_short_hairpins(self):
+    @staticmethod
+    def check_short_hairpins(expr=None):
         r'''Checks to make sure that hairpins span at least two leaves.
 
         Returns violators and total.
@@ -733,14 +747,15 @@ class WellformednessManager(AbjadObject):
         violators = []
         total = 0
         prototype = (spannertools.Hairpin,)
-        hairpins = self.expr._get_descendants()._get_spanners(prototype)
+        hairpins = expr._get_descendants()._get_spanners(prototype)
         for hairpin in hairpins:
             if len(hairpin._get_leaves()) <= 1:
                 violators.append(hairpin)
             total += 1
         return violators, total
 
-    def check_tied_rests(self):
+    @staticmethod
+    def check_tied_rests(expr=None):
         r'''Checks to make sure there are no tied rests.
 
         Returns violators and total.
@@ -751,7 +766,7 @@ class WellformednessManager(AbjadObject):
         from abjad.tools.topleveltools import iterate
         violators = []
         total = 0
-        for rest in iterate(self.expr).by_class(scoretools.Rest):
+        for rest in iterate(expr).by_class(scoretools.Rest):
             if inspect_(rest).has_spanner(spannertools.Tie):
                 violators.append(rest)
             total += 1

--- a/abjad/tools/systemtools/WellformednessManager.py
+++ b/abjad/tools/systemtools/WellformednessManager.py
@@ -4,6 +4,16 @@ from abjad.tools.abctools import AbjadObject
 
 class WellformednessManager(AbjadObject):
     r'''Wellformedness manager.
+
+    ..  container:: example
+
+        **Example.**
+
+        ::
+
+            >>> systemtools.WellformednessManager()
+            WellformednessManager()
+
     '''
 
     ### CLASS VARIABLES ###
@@ -12,25 +22,21 @@ class WellformednessManager(AbjadObject):
 
     ### INITIALIZER ###
 
-    def __init__(self, expr=None, allow_empty_containers=True):
+    def __init__(self, expr=None):
         self.expr = expr
-        self.allow_empty_containers = allow_empty_containers
 
     ### SPECIAL METHODS ###
 
     def __call__(self):
         r'''Calls all wellformedness checks on `expr`.
 
-        Returns something.
+        Returns triples.
         '''
         if self.expr is None:
             return
         check_names = [x for x in dir(self) if x.startswith('check_')]
         triples = []
         for current_check_name in sorted(check_names):
-            if self.allow_empty_containers:
-                if current_check_name == 'check_empty_containers':
-                    continue
             current_check = getattr(self, current_check_name)
             current_violators, current_total = current_check()
             triple = (current_violators, current_total, current_check_name)
@@ -301,6 +307,7 @@ class WellformednessManager(AbjadObject):
                 0 /	1 conflicting clefs
                 0 /	2 discontiguous spanners
                 0 /	5 duplicate ids
+                0 /     1 empty containers
                 0 /	2 intermarked hairpins
                 0 /	0 misdurated measures
                 0 /	0 misfilled measures
@@ -379,6 +386,7 @@ class WellformednessManager(AbjadObject):
                 0 /	1 conflicting clefs
                 0 /	1 discontiguous spanners
                 0 /	3 duplicate ids
+                0 /     1 empty containers
                 0 /	0 intermarked hairpins
                 0 /	0 misdurated measures
                 0 /	0 misfilled measures
@@ -412,6 +420,7 @@ class WellformednessManager(AbjadObject):
                 0 /	1 conflicting clefs
                 0 /	1 discontiguous spanners
                 0 /	3 duplicate ids
+                0 /     1 empty containers
                 0 /	0 intermarked hairpins
                 0 /	0 misdurated measures
                 0 /	0 misfilled measures
@@ -594,6 +603,7 @@ class WellformednessManager(AbjadObject):
                 0 /	1 conflicting clefs
                 0 /	2 discontiguous spanners
                 0 /	5 duplicate ids
+                0 /     1 empty containers
                 0 /	2 intermarked hairpins
                 0 /	0 misdurated measures
                 0 /	0 misfilled measures
@@ -683,6 +693,7 @@ class WellformednessManager(AbjadObject):
                 0 /	1 conflicting clefs
                 0 /	2 discontiguous spanners
                 0 /	5 duplicate ids
+                0 /     1 empty containers
                 0 /	0 intermarked hairpins
                 0 /	0 misdurated measures
                 0 /	0 misfilled measures


### PR DESCRIPTION
OLD:

    >>> manager = systemtools.WellformednessManager(expr)
    >>> manager()

NEW:

    >>> manager = systemtools.WellformednessManager()
    >>> manager(expr)

Also new: all 20 wellformedness checks are now available as static methods:

NEW:

    >>> manager.check_overlapping_ties(expr)

CHANGE MANAGEMENT. The change in initialization (versus call) probably doesn't
need to be pushed to the user base. Because user access to the wellformedness
checks is encapsulated behind inspect_(expr).is_well_formed() and
inspect_(expr).tabulate_wellformedness_violations(). Both methods remain the
same.