### PR TITLE
Equipped Sequence.partition_by_counts() with reversed_ keyword. NEW.

### DIFF
--- a/abjad/tools/sequencetools/Sequence.py
+++ b/abjad/tools/sequencetools/Sequence.py
@@ -673,7 +673,13 @@ class Sequence(AbjadObject):
         except TypeError:
             return False
 
-    def partition_by_counts(self, counts, cyclic=False, overhang=False):
+    def partition_by_counts(
+        self,
+        counts,
+        cyclic=False,
+        overhang=False,
+        reversed_=False,
+        ):
         r'''Partitions sequence by `counts`.
 
         ..  container:: example
@@ -682,28 +688,32 @@ class Sequence(AbjadObject):
 
             ::
 
-                >>> sequence_ = Sequence(range(10))
-                >>> sequence_.partition_by_counts(
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
                 ...     [3],
                 ...     cyclic=False,
                 ...     overhang=False,
                 ...     )
-                Sequence((Sequence((0, 1, 2)),))
+                >>> for part in parts:
+                ...     part
+                Sequence((0, 1, 2))
 
         ..  container:: example
 
-            **Example 2.** Partitions sequence once by counts without
-            overhang:
+            **Example 2.** Partitions sequence once by counts without overhang:
 
             ::
 
                 >>> sequence_ = Sequence(range(16))
-                >>> sequence_.partition_by_counts(
+                >>> parts = sequence_.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=False,
                 ...     overhang=False,
                 ...     )
-                Sequence((Sequence((0, 1, 2, 3)), Sequence((4, 5, 6))))
+                >>> for part in parts:
+                ...     part
+                Sequence((0, 1, 2, 3))
+                Sequence((4, 5, 6))
 
         ..  container:: example
 
@@ -712,13 +722,19 @@ class Sequence(AbjadObject):
 
             ::
 
-                >>> sequence_ = Sequence(range(10))
-                >>> sequence_.partition_by_counts(
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
                 ...     [3],
                 ...     cyclic=True,
                 ...     overhang=False,
                 ...     )
-                Sequence((Sequence((0, 1, 2)), Sequence((3, 4, 5)), Sequence((6, 7, 8))))
+                >>> for part in parts:
+                ...     part
+                Sequence((0, 1, 2))
+                Sequence((3, 4, 5))
+                Sequence((6, 7, 8))
+                Sequence((9, 10, 11))
+                Sequence((12, 13, 14))
 
         ..  container:: example
 
@@ -728,12 +744,12 @@ class Sequence(AbjadObject):
             ::
 
                 >>> sequence_ = Sequence(range(16))
-                >>> result = sequence_.partition_by_counts(
+                >>> parts = sequence_.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=True,
                 ...     overhang=False,
                 ...     )
-                >>> for part in result:
+                >>> for part in parts:
                 ...     part
                 Sequence((0, 1, 2, 3))
                 Sequence((4, 5, 6))
@@ -747,13 +763,16 @@ class Sequence(AbjadObject):
             ::
 
                 
-                >>> sequence_ = Sequence(range(10))
-                >>> sequence_.partition_by_counts(
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
                 ...     [3],
                 ...     cyclic=False,
                 ...     overhang=True,
                 ...     )
-                Sequence((Sequence((0, 1, 2)), Sequence((3, 4, 5, 6, 7, 8, 9))))
+                >>> for part in parts:
+                ...     part
+                Sequence((0, 1, 2))
+                Sequence((3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
 
         ..  container:: example
 
@@ -762,12 +781,12 @@ class Sequence(AbjadObject):
             ::
 
                 >>> sequence_ = Sequence(range(16))
-                >>> result = sequence_.partition_by_counts(
+                >>> parts = sequence_.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=False,
                 ...     overhang=True,
                 ...     )
-                >>> for part in result:
+                >>> for part in parts:
                 ...     part
                 Sequence((0, 1, 2, 3))
                 Sequence((4, 5, 6))
@@ -780,18 +799,20 @@ class Sequence(AbjadObject):
 
             ::
 
-                >>> sequence_ = Sequence(range(10))
-                >>> result = sequence_.partition_by_counts(
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
                 ...     [3],
                 ...     cyclic=True,
                 ...     overhang=True,
                 ...     )
-                >>> for part in result:
+                >>> for part in parts:
                 ...     part
                 Sequence((0, 1, 2))
                 Sequence((3, 4, 5))
                 Sequence((6, 7, 8))
-                Sequence((9,))
+                Sequence((9, 10, 11))
+                Sequence((12, 13, 14))
+                Sequence((15,))
 
         ..  container:: example
 
@@ -801,12 +822,12 @@ class Sequence(AbjadObject):
             ::
 
                 >>> sequence_ = Sequence(range(16))
-                >>> result = sequence_.partition_by_counts(
+                >>> parts = sequence_.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=True,
                 ...     overhang=True,
                 ...     )
-                >>> for part in result:
+                >>> for part in parts:
                 ...     part
                 Sequence((0, 1, 2, 3))
                 Sequence((4, 5, 6))
@@ -814,35 +835,209 @@ class Sequence(AbjadObject):
                 Sequence((11, 12, 13))
                 Sequence((14, 15))
 
+
+
+
+
+
         ..  container:: example
 
-            **Example 9.** Partitions sequence once by counts and asserts
-            that sequence partitions exactly (with no overhang):
+            **Example 9.** Reversed-partitions sequence once by counts without
+            overhang:
+
+            ::
+
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
+                ...     [3],
+                ...     cyclic=False,
+                ...     overhang=False,
+                ...     reversed_=True,
+                ...     )
+                >>> for part in parts:
+                ...     part
+                Sequence((13, 14, 15))
+
+        ..  container:: example
+
+            **Example 10.** Reverse-partitions sequence once by counts without
+            overhang:
+
+            ::
+
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
+                ...     [4, 3],
+                ...     cyclic=False,
+                ...     overhang=False,
+                ...     reversed_=True,
+                ...     )
+                >>> for part in parts:
+                ...     part
+                Sequence((9, 10, 11))
+                Sequence((12, 13, 14, 15))
+
+        ..  container:: example
+
+            **Example 11.** Reverse-partitions sequence cyclically by counts
+            without overhang:
+
+            ::
+
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
+                ...     [3],
+                ...     cyclic=True,
+                ...     overhang=False,
+                ...     reversed_=True,
+                ...     )
+                >>> for part in parts:
+                ...     part
+                Sequence((1, 2, 3))
+                Sequence((4, 5, 6))
+                Sequence((7, 8, 9))
+                Sequence((10, 11, 12))
+                Sequence((13, 14, 15))
+
+        ..  container:: example
+
+            **Example 12.** Reverse-partitions sequence cyclically by counts
+            without overhang:
+
+            ::
+
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
+                ...     [4, 3],
+                ...     cyclic=True,
+                ...     overhang=False,
+                ...     reversed_=True,
+                ...     )
+                >>> for part in parts:
+                ...     part
+                Sequence((2, 3, 4))
+                Sequence((5, 6, 7, 8))
+                Sequence((9, 10, 11))
+                Sequence((12, 13, 14, 15))
+
+        ..  container:: example
+
+            **Example 13.** Reverse-partitions sequence once by counts with
+            overhang:
+
+            ::
+
+                
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
+                ...     [3],
+                ...     cyclic=False,
+                ...     overhang=True,
+                ...     reversed_=True,
+                ...     )
+                >>> for part in parts:
+                ...     part
+                Sequence((0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+                Sequence((13, 14, 15))
+
+        ..  container:: example
+
+            **Example 14.** Reverse-partitions sequence once by counts with
+            overhang:
+
+            ::
+
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
+                ...     [4, 3],
+                ...     cyclic=False,
+                ...     overhang=True,
+                ...     reversed_=True,
+                ...     )
+                >>> for part in parts:
+                ...     part
+                Sequence((0, 1, 2, 3, 4, 5, 6, 7, 8))
+                Sequence((9, 10, 11))
+                Sequence((12, 13, 14, 15))
+
+        ..  container:: example
+
+            **Example 15.** Reverse-partitions sequence cyclically by counts
+            with overhang:
+
+            ::
+
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
+                ...     [3],
+                ...     cyclic=True,
+                ...     overhang=True,
+                ...     reversed_=True,
+                ...     )
+                >>> for part in parts:
+                ...     part
+                Sequence((0,))
+                Sequence((1, 2, 3))
+                Sequence((4, 5, 6))
+                Sequence((7, 8, 9))
+                Sequence((10, 11, 12))
+                Sequence((13, 14, 15))
+
+        ..  container:: example
+
+            **Example 16.** Reverse-partitions sequence cyclically by counts
+            with overhang:
+
+            ::
+
+                >>> sequence_ = Sequence(range(16))
+                >>> parts = sequence_.partition_by_counts(
+                ...     [4, 3],
+                ...     cyclic=True,
+                ...     overhang=True,
+                ...     reversed_=True,
+                ...     )
+                >>> for part in parts:
+                ...     part
+                Sequence((0, 1))
+                Sequence((2, 3, 4))
+                Sequence((5, 6, 7, 8))
+                Sequence((9, 10, 11))
+                Sequence((12, 13, 14, 15))
+
+        ..  container:: example
+
+            **Example 17.** Partitions sequence once by counts and asserts that
+            sequence partitions exactly (with no overhang):
 
             ::
 
                 >>> sequence_ = Sequence(range(10))
-                >>> sequence_.partition_by_counts(
+                >>> parts = sequence_.partition_by_counts(
                 ...     [2, 3, 5],
                 ...     cyclic=False,
                 ...     overhang=Exact,
                 ...     )
-                Sequence((Sequence((0, 1)), Sequence((2, 3, 4)), Sequence((5, 6, 7, 8, 9))))
+                >>> for part in parts:
+                ...     part
+                Sequence((0, 1))
+                Sequence((2, 3, 4))
+                Sequence((5, 6, 7, 8, 9))
 
         ..  container:: example
 
-            **Example 10.** Partitions sequence cyclically by counts and
+            **Example 18.** Partitions sequence cyclically by counts and
             asserts that sequence partitions exactly:
 
             ::
 
                 >>> sequence_ = Sequence(range(10))
-                >>> result = sequence_.partition_by_counts(
+                >>> parts = sequence_.partition_by_counts(
                 ...     [2],
                 ...     cyclic=True,
                 ...     overhang=Exact,
                 ...     )
-                >>> for part in result:
+                >>> for part in parts:
                 ...     part
                 Sequence((0, 1))
                 Sequence((2, 3))
@@ -854,17 +1049,20 @@ class Sequence(AbjadObject):
 
         ..  container:: example
 
-            **Example 11.** Partitions string:
+            **Example 19.** Partitions string:
 
             ::
 
                 >>> sequence_ = Sequence('some text')
-                >>> sequence_.partition_by_counts(
+                >>> parts = sequence_.partition_by_counts(
                 ...     [3],
                 ...     cyclic=False,
                 ...     overhang=True,
                 ...     )
-                Sequence((Sequence(('s', 'o', 'm')), Sequence(('e', ' ', 't', 'e', 'x', 't'))))
+                >>> for part in parts:
+                ...     part
+                Sequence(('s', 'o', 'm'))
+                Sequence(('e', ' ', 't', 'e', 'x', 't'))
 
         Returns nested sequence.
         '''
@@ -876,6 +1074,7 @@ class Sequence(AbjadObject):
             counts,
             cyclic=cyclic,
             overhang=overhang,
+            reversed_=reversed_,
             )
         parts = [type(self)(_) for _ in parts]
         sequence = type(self)(parts)

--- a/abjad/tools/sequencetools/partition_sequence_by_counts.py
+++ b/abjad/tools/sequencetools/partition_sequence_by_counts.py
@@ -9,12 +9,13 @@ def partition_sequence_by_counts(
     counts,
     cyclic=False,
     overhang=False,
+    reversed_=False,
     ):
     r'''Partitions `sequence` by `counts`.
 
     ..  container:: example
 
-        **Example 1a.** Partitions sequence once by counts without overhang:
+        **Example 1.** Partitions sequence once by counts without overhang:
 
         ::
 
@@ -26,7 +27,7 @@ def partition_sequence_by_counts(
             ...     )
             [[0, 1, 2]]
 
-        **Example 1b.** Partitions sequence once by counts without overhang:
+        **Example 2.** Partitions sequence once by counts without overhang:
 
         ::
 
@@ -40,7 +41,7 @@ def partition_sequence_by_counts(
 
     ..  container:: example
 
-        **Example 2a.** Partitions sequence cyclically by counts without
+        **Example 3.** Partitions sequence cyclically by counts without
         overhang:
 
         ::
@@ -53,7 +54,7 @@ def partition_sequence_by_counts(
             ...     )
             [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
 
-        **Example 2b.** Partitions sequence cyclically by counts without
+        **Example 4.** Partitions sequence cyclically by counts without
         overhang:
 
         ::
@@ -68,7 +69,7 @@ def partition_sequence_by_counts(
 
     ..  container:: example
 
-        **Example 3a.** Partitions sequence once by counts with overhang:
+        **Example 5.** Partitions sequence once by counts with overhang:
 
         ::
 
@@ -80,7 +81,7 @@ def partition_sequence_by_counts(
             ...     )
             [[0, 1, 2], [3, 4, 5, 6, 7, 8, 9]]
 
-        **Example 3b.** Partitions sequence once by counts with overhang:
+        **Example 6.** Partitions sequence once by counts with overhang:
 
         ::
 
@@ -94,7 +95,7 @@ def partition_sequence_by_counts(
 
     ..  container:: example
 
-        **Example 4a.** Partitions sequence cyclically by counts with overhang:
+        **Example 7.** Partitions sequence cyclically by counts with overhang:
 
         ::
 
@@ -106,7 +107,7 @@ def partition_sequence_by_counts(
             ...     )
             [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
 
-        **Example 4b.** Partitions sequence cyclically by counts with overhang:
+        **Example 8.** Partitions sequence cyclically by counts with overhang:
 
         ::
 
@@ -120,7 +121,7 @@ def partition_sequence_by_counts(
 
     ..  container:: example
 
-        **Example 5a.** Partitions sequence once by counts and asserts
+        **Example 9.** Partitions sequence once by counts and asserts
         that sequence partitions exactly (with no overhang):
 
         ::
@@ -133,7 +134,7 @@ def partition_sequence_by_counts(
             ...     )
             [[0, 1], [2, 3, 4], [5, 6, 7, 8, 9]]
 
-        **Example 5b.** Partitions sequence cyclically by counts and asserts
+        **Example 10.** Partitions sequence cyclically by counts and asserts
         that sequence partitions exactly (with no overhang):
 
         ::
@@ -148,7 +149,7 @@ def partition_sequence_by_counts(
 
     ..  container:: example
 
-        **Example 6a.** Partitions list:
+        **Example 11.** Partitions list:
 
         ::
 
@@ -160,7 +161,7 @@ def partition_sequence_by_counts(
             ...     )
             [[0, 1, 2], [3, 4, 5, 6, 7, 8, 9]]
 
-        **Example 6b.** Partitions tuple:
+        **Example 12.** Partitions tuple:
 
         ::
 
@@ -172,7 +173,7 @@ def partition_sequence_by_counts(
             ...     )
             [(0, 1, 2), (3, 4, 5, 6, 7, 8, 9)]
 
-        **Example 6c.** Partitions string:
+        **Example 13.** Partitions string:
 
         ::
 
@@ -183,6 +184,60 @@ def partition_sequence_by_counts(
             ...     overhang=True,
             ...     )
             ['som', 'e text']
+
+    ..  container:: example
+
+        **Example 14.** Reverses cyclic partition with overhang:
+
+        ::
+
+            >>> sequencetools.partition_sequence_by_counts(
+            ...     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ...     [3],
+            ...     cyclic=True,
+            ...     overhang=True,
+            ...     reversed_=True,
+            ...     )
+            [[0], [1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+        **Example 15.** Reverses cyclic partition without overhang:
+
+        ::
+
+            >>> sequencetools.partition_sequence_by_counts(
+            ...     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ...     [3],
+            ...     cyclic=True,
+            ...     overhang=False,
+            ...     reversed_=True,
+            ...     )
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+        **Example 16.** Reverses acyclic partition with overhang:
+
+        ::
+
+            >>> sequencetools.partition_sequence_by_counts(
+            ...     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ...     [3],
+            ...     cyclic=False,
+            ...     overhang=True,
+            ...     reversed_=True,
+            ...     )
+            [[0, 1, 2, 3, 4, 5, 6], [7, 8, 9]]
+
+        **Example 17.** Reverses acyclic partition without overhang:
+
+        ::
+
+            >>> sequencetools.partition_sequence_by_counts(
+            ...     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ...     [3],
+            ...     cyclic=False,
+            ...     overhang=False,
+            ...     reversed_=True,
+            ...     )
+            [[7, 8, 9]]
 
     Returns list of objects with type equal to that of `sequence`.
     '''
@@ -196,6 +251,11 @@ def partition_sequence_by_counts(
         message = 'must be iterable: {!r}.'
         message = message.format(counts)
         raise TypeError(message)
+
+    sequence_type = type(sequence)
+    if reversed_:
+        sequence = reversed(sequence)    
+        sequence = sequence_type(sequence)
 
     if overhang == Exact:
         result_with_overhang = partition_sequence_by_counts(
@@ -216,7 +276,6 @@ def partition_sequence_by_counts(
             message = 'sequence does not partition exactly.'
             raise Exception(message)
 
-    #sequence_type = type(sequence)
     result = []
     if cyclic:
         if overhang:
@@ -239,5 +298,14 @@ def partition_sequence_by_counts(
     for start, stop in mathtools.cumulative_sums_pairwise(counts):
         part = sequence[start:stop]
         result.append(part)
+
+    if reversed_:
+        result_ = []
+        for part in reversed(result):
+            part_type = type(part)
+            part = reversed(part)
+            part = part_type(part)
+            result_.append(part)
+        result = result_
 
     return result


### PR DESCRIPTION
NEW. New functionality.

Example: reverse-partitions sequence once without overhang:

    >>> sequence_ = Sequence(range(16))
    >>> parts = sequence_.partition_by_counts(
    ...     [4, 3],
    ...     cyclic=False,
    ...     overhang=False,
    ...     reversed_=True,
    ...     )
    >>> for part in parts:
    ...     part
    Sequence((9, 10, 11))
    Sequence((12, 13, 14, 15))

Example: reverse-partitions sequence cyclically without overhang:

    >>> sequence_ = Sequence(range(16))
    >>> parts = sequence_.partition_by_counts(
    ...     [4, 3],
    ...     cyclic=True,
    ...     overhang=False,
    ...     reversed_=True,
    ...     )
    >>> for part in parts:
    ...     part
    Sequence((2, 3, 4))
    Sequence((5, 6, 7, 8))
    Sequence((9, 10, 11))
    Sequence((12, 13, 14, 15))

Example: reverse-partitions sequence once with overhang:

    >>> sequence_ = Sequence(range(16))
    >>> parts = sequence_.partition_by_counts(
    ...     [4, 3],
    ...     cyclic=False,
    ...     overhang=True,
    ...     reversed_=True,
    ...     )
    >>> for part in parts:
    ...     part
    Sequence((0, 1, 2, 3, 4, 5, 6, 7, 8))
    Sequence((9, 10, 11))
    Sequence((12, 13, 14, 15))

Example: reverse-partitions sequence cyclically with overhang:

    >>> sequence_ = Sequence(range(16))
    >>> parts = sequence_.partition_by_counts(
    ...     [4, 3],
    ...     cyclic=True,
    ...     overhang=True,
    ...     reversed_=True,
    ...     )
    >>> for part in parts:
    ...     part
    Sequence((0, 1))
    Sequence((2, 3, 4))
    Sequence((5, 6, 7, 8))
    Sequence((9, 10, 11))
    Sequence((12, 13, 14, 15))

More examples included in the Sequence API entry.