### PR TITLE
Scoped indicators can be formatted via _get_lilypond_format_bundle().

### DIFF
--- a/abjad/tools/indicatortools/IndicatorExpression.py
+++ b/abjad/tools/indicatortools/IndicatorExpression.py
@@ -152,6 +152,8 @@ class IndicatorExpression(AbjadValueObject):
         result = []
         if self.is_annotation:
             return result
+        if hasattr(self.indicator, '_get_lilypond_format_bundle'):
+            return self.indicator._get_lilypond_format_bundle(self.component)
         lilypond_format = self.indicator._lilypond_format
         if isinstance(lilypond_format, (tuple, list)):
             result.extend(lilypond_format)

--- a/abjad/tools/indicatortools/MetricModulation.py
+++ b/abjad/tools/indicatortools/MetricModulation.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
-import copy
 from abjad.tools import durationtools
 from abjad.tools import markuptools
 from abjad.tools import mathtools
-from abjad.tools import schemetools
-from abjad.tools.abctools.AbjadObject import AbjadObject
+from abjad.tools.abctools.AbjadValueObject import AbjadValueObject
 from abjad.tools.topleveltools.new import new
-from abjad.tools.topleveltools.override import override
-from abjad.tools.topleveltools.set_ import set_
 
 
-class MetricModulation(AbjadObject):
+class MetricModulation(AbjadValueObject):
     r'''A metric modulation.
 
     ..  container:: example
@@ -550,7 +546,6 @@ class MetricModulation(AbjadObject):
         left_markup=None,
         right_markup=None,
         ):
-        from abjad.tools import indicatortools
         from abjad.tools import markuptools
         from abjad.tools import scoretools
         # TODO: make default scope work
@@ -768,7 +763,6 @@ class MetricModulation(AbjadObject):
         Returns LilyPond file.
         '''
         from abjad.tools import lilypondfiletools
-        from abjad.tools import markuptools
         lilypond_file = lilypondfiletools.make_basic_lilypond_file()
         lilypond_file.header_block.tagline = False
         lilypond_file.items.append(self._get_markup())

--- a/abjad/tools/indicatortools/TimeSignature.py
+++ b/abjad/tools/indicatortools/TimeSignature.py
@@ -145,7 +145,7 @@ class TimeSignature(AbjadValueObject):
         self._multiplier = self.implied_prolation
         self._has_non_power_of_two_denominator = \
             not mathtools.is_nonnegative_integer_power_of_two(
-            self.denominator)
+                self.denominator)
 
     ### SPECIAL METHODS ###
 
@@ -201,8 +201,8 @@ class TimeSignature(AbjadValueObject):
             )
 
     def __eq__(self, arg):
-        r'''Is true when `arg` is a time signature with numerator and 
-        denominator equal to this time signature. Also true when `arg` is a 
+        r'''Is true when `arg` is a time signature with numerator and
+        denominator equal to this time signature. Also true when `arg` is a
         tuple with first and second elements equal to numerator and denominator
         of this time signature. Otherwise false.
 
@@ -680,11 +680,11 @@ class TimeSignature(AbjadValueObject):
         if contents_multiplier == durationtools.Multiplier(1):
             power_of_two_denominator = \
                 mathtools.greatest_power_of_two_less_equal(
-                non_power_of_two_denominator)
+                    non_power_of_two_denominator)
         else:
             power_of_two_denominator = \
                 mathtools.greatest_power_of_two_less_equal(
-                non_power_of_two_denominator, 1)
+                    non_power_of_two_denominator, 1)
 
         # find power_of_two pair
         non_power_of_two_pair = mathtools.NonreducedFraction(self.pair)

--- a/abjad/tools/instrumenttools/Instrument.py
+++ b/abjad/tools/instrumenttools/Instrument.py
@@ -5,10 +5,10 @@ from abjad.tools import markuptools
 from abjad.tools import pitchtools
 from abjad.tools import stringtools
 from abjad.tools.topleveltools import new
-from abjad.tools.abctools.AbjadObject import AbjadObject
+from abjad.tools.abctools.AbjadValueObject import AbjadValueObject
 
 
-class Instrument(AbjadObject):
+class Instrument(AbjadValueObject):
     '''A musical instrument.
     '''
 
@@ -83,34 +83,6 @@ class Instrument(AbjadObject):
 
     ### SPECIAL METHODS ###
 
-    def __copy__(self, *args):
-        r'''Copies instrument.
-
-        Returns new instrument.
-        '''
-        return type(self)(
-            instrument_name=self.instrument_name,
-            short_instrument_name=self.short_instrument_name,
-            instrument_name_markup=self.instrument_name_markup,
-            short_instrument_name_markup=self.short_instrument_name_markup,
-            allowable_clefs=self.allowable_clefs,
-            pitch_range=self.pitch_range,
-            sounding_pitch_of_written_middle_c=self
-                .sounding_pitch_of_written_middle_c,
-            )
-
-    def __eq__(self, arg):
-        r'''Is true when `arg` is an instrument with instrument name and short
-        instrument name equal to those of this instrument. Otherwise false.
-
-        Returns true or false.
-        '''
-        if isinstance(arg, type(self)):
-            if self.instrument_name == arg.instrument_name and \
-                self.short_instrument_name == arg.short_instrument_name:
-                return True
-        return False
-
     def __format__(self, format_specification=''):
         r'''Formats instrument.
 
@@ -123,19 +95,6 @@ class Instrument(AbjadObject):
         if format_specification in ('', 'storage'):
             return systemtools.StorageFormatManager.get_storage_format(self)
         return str(self)
-
-    def __hash__(self):
-        '''Gets hash value instrument.
-
-        Computed on type, instrument name and short instrument name.
-
-        Returns integer.
-        '''
-        return hash((
-            type(self).__name__,
-            self.instrument_name,
-            self.short_instrument_name,
-            ))
 
     def __repr__(self):
         r'''Gets interpreter representation of instrument.

--- a/abjad/tools/systemtools/LilyPondFormatManager.py
+++ b/abjad/tools/systemtools/LilyPondFormatManager.py
@@ -231,8 +231,11 @@ class LilyPondFormatManager(AbjadObject):
         ):
         for scoped_expression in scoped_expressions:
             format_pieces = scoped_expression._get_format_pieces()
-            format_slot = scoped_expression.indicator._format_slot
-            bundle.get(format_slot).indicators.extend(format_pieces)
+            if isinstance(format_pieces, type(bundle)):
+                bundle.update(format_pieces)
+            else:
+                format_slot = scoped_expression.indicator._format_slot
+                bundle.get(format_slot).indicators.extend(format_pieces)
 
     @staticmethod
     def _populate_spanner_format_contributions(


### PR DESCRIPTION
This bypasses the old `_lilypond_format` property.

Doesn't need to be announced.