### PR TITLE
Added new StorageFormatSpecifier.include_abjad_namespace property. NEW.

### DIFF
--- a/abjad/tools/systemtools/StorageFormatManager.py
+++ b/abjad/tools/systemtools/StorageFormatManager.py
@@ -209,7 +209,9 @@ class StorageFormatManager(AbjadObject):
         class_name = type(specification.instance).__name__
         if as_storage_format:
             tools_package_name = specification.tools_package_name
-            class_name_prefix = '{}.{}'.format(tools_package_name, class_name)
+            class_name_prefix = '{}.{}'
+            class_name_prefix = class_name_prefix.format(
+                tools_package_name, class_name)
         else:
             class_name_prefix = class_name
 
@@ -550,8 +552,8 @@ class StorageFormatManager(AbjadObject):
         return '.'.join(parts)
 
     @staticmethod
-    def get_tools_package_qualified_class_name(subject):
-        r'''Gets tools-package qualified class name of `subject`.
+    def get_tools_package_qualified_class_name(object_):
+        r'''Gets tools-package qualified class name of `object_`.
 
         ::
 
@@ -562,11 +564,11 @@ class StorageFormatManager(AbjadObject):
         Returns string.
         '''
         tools_package_name = StorageFormatManager.get_tools_package_name(
-            subject)
-        if StorageFormatManager.is_instance(subject):
-            class_name = type(subject).__name__
+            object_)
+        if StorageFormatManager.is_instance(object_):
+            class_name = type(object_).__name__
         else:
-            class_name = subject.__name__
+            class_name = object_.__name__
         return '{}.{}'.format(tools_package_name, class_name)
 
     @staticmethod

--- a/abjad/tools/systemtools/StorageFormatSpecification.py
+++ b/abjad/tools/systemtools/StorageFormatSpecification.py
@@ -12,6 +12,7 @@ class StorageFormatSpecification(AbjadObject):
 
     __slots__ = (
         '_body_text',
+        '_include_abjad_namespace',
         '_instance',
         '_is_bracketed',
         '_is_indented',
@@ -29,6 +30,7 @@ class StorageFormatSpecification(AbjadObject):
         self,
         instance=None,
         body_text=None,
+        include_abjad_namespace=None,
         is_bracketed=False,
         is_indented=True,
         keyword_argument_callables=None,
@@ -44,6 +46,7 @@ class StorageFormatSpecification(AbjadObject):
             body_text = str(body_text)
         self._body_text = body_text
 
+        self._include_abjad_namespace = bool(include_abjad_namespace)
         self._is_bracketed = bool(is_bracketed)
         self._is_indented = bool(is_indented)
 
@@ -89,6 +92,14 @@ class StorageFormatSpecification(AbjadObject):
         Returns string.
         '''
         return self._instance
+
+    @property
+    def include_abjad_namespace(self):
+        r'''Is true when storage specification includes Abjad namespace.
+
+        Returns true or false.
+        '''
+        return self._include_abjad_namespace
 
     @property
     def is_bracketed(self):
@@ -172,8 +183,13 @@ class StorageFormatSpecification(AbjadObject):
         Returns string.
         '''
         from abjad.tools import systemtools
+        tools_package_name = None
         if self._tools_package_name is not None:
-            return self._tools_package_name
+            tools_package_name = self._tools_package_name
         if self.instance is not None:
-            return systemtools.StorageFormatManager.get_tools_package_name(
+            tools_package_name = \
+                systemtools.StorageFormatManager.get_tools_package_name(
                 self.instance)
+        if tools_package_name and self.include_abjad_namespace:
+            tools_package_name = 'abjad.' + tools_package_name
+        return tools_package_name

--- a/abjad/tools/test/test_abjad___format__.py
+++ b/abjad/tools/test/test_abjad___format__.py
@@ -61,6 +61,7 @@ def test_abjad___format___02(class_):
     environment.update(abjad.demos.__dict__)
     environment['abjadbooktools'] = importlib.import_module(
         'abjad.tools.abjadbooktools')
+    environment['abjad'] = abjad
     instance_one = class_()
     instance_one_format = format(instance_one, 'storage')
     assert isinstance(instance_one_format, str)


### PR DESCRIPTION
Developers can now say things like this:

    @property
    def _storage_format_specification(self):
        from abjad.tools import systemtools
        ...
        return systemtools.StorageFormatSpecification(
            self,
            include_abjad_namespace=True, # <== NEW
            keyword_argument_names=keyword_argument_names,
            positional_argument_values=positional_argument_values,
            )

This causes the Abjad namespace to be preprended to tools package names in
storage format output:

    >>> dictionary = datastructuretools.TypedOrderedDict([
    ...     ('color', 'red'),
    ...     ('directive', Markup(r'\italic Allegretto')),
    ...     ])

    >>> print(format(dictionary))
    abjad.datastructuretools.TypedOrderedDict( # <== NEW
        [
            ('color', 'red'),
            (
                'directive',
                markuptools.Markup(
                    contents=(
                        markuptools.MarkupCommand(
                            'italic',
                            'Allegretto'
                            ),
                        ),
                    ),
                ),
            ]
        )

EXPLANATION. The purpose of the commit is to allow
datastructuretools.TypedOrderedDict to output its storage format in this new
way. (This change will be made in the next commit.)

The reason for doing this is to allow 'import abjad' at the head of all score
package __metadata.__py files.

NOTE. It probably makes very good sense to set include_abjad_namespace to true
by default for ALL classes in the system! This will involve updating dozens of
doctests. But this will then make the evaluation of storage format output quite
straightforward.

I think the new realization is that storage format output is almost always
produced for *external* storage. That is, true client code makes use of storage
format output. And it makes sense for client code to use 'import abjad' rather
than 'from abjad import *'. So it correspondingly will make sense to turn
include_abjad_namespace on by default for all Abjad classes. (Such a change
will not happen in a near term commit but would happen later.)