### PR TITLE
Proofread ‘For beginners’ section of docs

### DIFF
--- a/abjad/docs/source/for_beginners/abjad_hello_world_at_the_interpreter.rst
+++ b/abjad/docs/source/for_beginners/abjad_hello_world_at_the_interpreter.rst
@@ -28,7 +28,7 @@ If Abjad is installed on your system then Python will silently load Abjad.
 If Abjad isn't installed on your system then Python will raise
 an import error.
 
-Go to ``www.projectabjad.org`` and follow the instructions there
+Go to http://projectabjad.org/ and follow the instructions there
 to install Abjad if necessary.
 
 

--- a/abjad/docs/source/for_beginners/abjad_hello_world_at_the_interpreter.rst
+++ b/abjad/docs/source/for_beginners/abjad_hello_world_at_the_interpreter.rst
@@ -55,4 +55,4 @@ Type ``quit()`` or ``ctrl+D`` when you're done.
 
 Working with the interpreter is a good way to test out small bits of code in
 Abjad. As your scores become more complex you will want to organize the code
-your write with Abjad in files. This is the topic of the next tutorial.
+you write with Abjad in files. This is the topic of the next tutorial.

--- a/abjad/docs/source/for_beginners/abjad_hello_world_in_a_file.rst
+++ b/abjad/docs/source/for_beginners/abjad_hello_world_in_a_file.rst
@@ -49,4 +49,4 @@ Working with files in Abjad means that you do these things::
 These steps make up a type of edit-interpret loop.
 
 This way of working with Abjad remains the same
-no matter how complex the scores you build.
+no matter how complex the scores you build become.

--- a/abjad/docs/source/for_beginners/abjad_hello_world_in_a_file.rst
+++ b/abjad/docs/source/for_beginners/abjad_hello_world_in_a_file.rst
@@ -47,8 +47,6 @@ Repeating the process
 
 Working with files in Abjad means that you do these things:
 
-::
-
     1. edit a file
     2. interpret the file
 

--- a/abjad/docs/source/for_beginners/abjad_hello_world_in_a_file.rst
+++ b/abjad/docs/source/for_beginners/abjad_hello_world_in_a_file.rst
@@ -11,7 +11,9 @@ Use your text editor to create a new file called ``hello_world.py``.
 If you have ``hello_world.py`` left over from earlier you should delete it
 and create a new file.
 
-Type the following lines of code into ``hello_world.py``::
+Type the following lines of code into ``hello_world.py``:
+
+::
 
     from abjad import *
 
@@ -25,7 +27,9 @@ Save ``hello_world.py`` and quit your text editor.
 Interpreting the file
 ---------------------
 
-Call Python on ``hello_world.py``::
+Call Python on ``hello_world.py``:
+
+::
 
     $ python hello_world.py
 
@@ -41,7 +45,9 @@ Python reads ``hello_world.py`` and shows the score you've created.
 Repeating the process
 ---------------------
 
-Working with files in Abjad means that you do these things::
+Working with files in Abjad means that you do these things:
+
+::
 
     1. edit a file
     2. interpret the file

--- a/abjad/docs/source/for_beginners/index.rst
+++ b/abjad/docs/source/for_beginners/index.rst
@@ -17,7 +17,7 @@ to list the contents of directories and how to copy files. You should know
 enough about environment variables to make sure that your operating system
 knows where Abjad is installed. You might also consider installing any OS
 updates on your computer, too, since you'll need Python 2.7 or Python 3.3+ to
-run Abjad. When you start building score with Abjad you'll find the system to
+run Abjad. When you start building scores with Abjad you'll find the system to
 be almost entirely platform-independent.
 
 
@@ -29,7 +29,7 @@ some time picking out a text editor before you begin. If this is your first
 time programming you might want to Google and read what other programmers have
 to say on the matter. Or you could ask a programmer friend about the editor she
 prefers. Linux programmers sometimes like ``vi`` or ``emacs``. Macintosh
-programmers might prefer ``TextMate``. Whatever your choice make sure you set
+programmers might prefer ``TextMate``. Whatever your choice, make sure
 your editor is set to produce plain text files before you start.
 
 
@@ -40,7 +40,7 @@ To work with Abjad you'll need a terminal window. The way that you open the
 terminal window depends on your computer. If you're using MacOS X you can
 navigate from ``Applications`` to ``Utilities`` and then click on ``Terminal``.
 Linux and Windows house the terminal elsewhere. Regardless of the terminal
-client you chose the purpose of the terminal is to let you type commands to
+client you choose, the purpose of the terminal is to let you type commands to
 your computer's operating system.
 
 
@@ -49,8 +49,8 @@ Where to save your work
 
 Where you choose to save the files you create with Abjad is up to you.
 Eventually you'll want to create a dedicated set of directories to organize
-your work. But for now you can  create the files described in the tutorials on
-your desktop, in your documents folder or anywhere else you like.
+your work. But for now you can create the files described in the tutorials on
+your desktop, in your documents folder, or anywhere else you like.
 
 Introducing LilyPond
 --------------------

--- a/abjad/docs/source/for_beginners/lilypond_hello_world.rst
+++ b/abjad/docs/source/for_beginners/lilypond_hello_world.rst
@@ -5,7 +5,9 @@ Working with Abjad means working with LilyPond.
 
 To start we'll need to make sure LilyPond is installed.
 
-Open the terminal and type ``lilypond --version``::
+Open the terminal and type ``lilypond --version``:
+
+::
 
     $ lilypond --version
     GNU LilyPond 2.17.3
@@ -44,7 +46,9 @@ Writing the file
 Change to whatever directory you'd like and then use your text editor
 to create a new file called ``hello_world.ly``.
 
-Type the following lines of LilyPond input into ``hello_world.ly``::
+Type the following lines of LilyPond input into ``hello_world.ly``:
+
+::
 
     \version "2.17.3"
     \language "english"
@@ -55,7 +59,9 @@ Type the following lines of LilyPond input into ``hello_world.ly``::
 
 Save ``hello_world.ly`` and quit your text editor when you're done.
 
-Note the following::
+Note the following:
+
+::
 
     1. You can use either spaces or tabs while you type.
     2. The version string you type must match the LilyPond version you found above.
@@ -68,7 +74,9 @@ Note the following::
 Interpreting the file
 ---------------------
 
-Call LilyPond on ``hello_world.ly``::
+Call LilyPond on ``hello_world.ly``:
+
+::
 
     $ lilypond hello_world.ly
     GNU LilyPond 2.17.3
@@ -90,7 +98,9 @@ Open the ``hello_world.pdf`` file LilyPond creates.
 You can do this by clicking on the file.
 Or you can open the file from the command line.
 
-If you're using MacOS X you can open ``hello_world.pdf`` like this::
+If you're using MacOS X you can open ``hello_world.pdf`` like this:
+
+::
 
     $ open hello_world.pdf
 
@@ -106,7 +116,9 @@ Your operating system shows the score you created.
 Repeating the process
 ---------------------
 
-Working with LilyPond means doing these things::
+Working with LilyPond means doing these things:
+
+::
 
     1. edit a LilyPond input file
     2. interpet the input file

--- a/abjad/docs/source/for_beginners/lilypond_hello_world.rst
+++ b/abjad/docs/source/for_beginners/lilypond_hello_world.rst
@@ -27,7 +27,7 @@ If the terminal tells you that LilyPond is not found, then
 either LilyPond isn't installed on your computer or else
 your computer doesn't know where LilyPond is installed.
 
-If you haven't installed LilyPond, go to www.lilypond.org
+If you haven't installed LilyPond, go to http://lilypond.org/
 and download the current version of LilyPond for your operating system.
 
 If your computer doesn't know where LilyPond is installed,

--- a/abjad/docs/source/for_beginners/lilypond_hello_world.rst
+++ b/abjad/docs/source/for_beginners/lilypond_hello_world.rst
@@ -25,7 +25,7 @@ If the terminal tells you that LilyPond is not found, then
 either LilyPond isn't installed on your computer or else
 your computer doesn't know where LilyPond is installed.
 
-If you haven't installed LilyPond, go to ``www.lilypond.org``
+If you haven't installed LilyPond, go to www.lilypond.org
 and download the current version of LilyPond for your operating system.
 
 If your computer doesn't know where LilyPond is installed,

--- a/abjad/docs/source/for_beginners/lilypond_hello_world.rst
+++ b/abjad/docs/source/for_beginners/lilypond_hello_world.rst
@@ -61,8 +61,6 @@ Save ``hello_world.ly`` and quit your text editor when you're done.
 
 Note the following:
 
-::
-
     1. You can use either spaces or tabs while you type.
     2. The version string you type must match the LilyPond version you found above.
     3. The English language command tells LilyPond to use English note names.
@@ -117,8 +115,6 @@ Repeating the process
 ---------------------
 
 Working with LilyPond means doing these things:
-
-::
 
     1. edit a LilyPond input file
     2. interpet the input file

--- a/abjad/docs/source/for_beginners/lilypond_hello_world.rst
+++ b/abjad/docs/source/for_beginners/lilypond_hello_world.rst
@@ -21,20 +21,21 @@ Open the terminal and type ``lilypond --version``::
     information.
 
 LilyPond responds with version and copyright information.
-If the terminal tells you that LilyPond is not found then
+If the terminal tells you that LilyPond is not found, then
 either LilyPond isn't installed on your computer or else
 your computer doesn't know where LilyPond is installed.
 
-If you haven't installed LilyPond go to ``www.lilypond.org``
+If you haven't installed LilyPond, go to ``www.lilypond.org``
 and download the current version of LilyPond for your operating system.
 
-If your computer doesn't know where LilyPond is installed
+If your computer doesn't know where LilyPond is installed,
 then you'll have to tell your computer where LilyPond is.
 Doing this depends on your operating system.
-If you're running MacOS X or Linux then you need to make sure that the
+If you're running MacOS X or Linux, then you need to make sure that the
 location of the LilyPond binary is present in your ``PATH``
 environment variable.
-If you don't know how to add things to your path you should Google or ask a friend.
+If you don't know how to add things to your path, you should
+Google or ask a friend.
 
 
 Writing the file

--- a/abjad/docs/source/for_beginners/more_about_abjad.rst
+++ b/abjad/docs/source/for_beginners/more_about_abjad.rst
@@ -6,7 +6,7 @@ How it works
 ------------
 
 How does Python suddenly know what musical notes are?
-And how to make musical score?
+And how to make a musical score?
 
 Use Python's ``dir()`` built-in to get a sense of the answer:
 

--- a/abjad/docs/source/for_beginners/more_about_abjad.rst
+++ b/abjad/docs/source/for_beginners/more_about_abjad.rst
@@ -16,9 +16,9 @@ Use Python's ``dir()`` built-in to get a sense of the answer:
     dir()
 
 Calling ``from abjad import *`` causes Python to load hundreds or thousands of
-lines of Abjad's code into the global namespace for you to use.  Abjad's code
+lines of Abjad's code into the global namespace for you to use. Abjad's code
 is organized into a collection of several dozen different score-related
-packages.  These packages comprise hundreds of classes that model things like
+packages. These packages comprise hundreds of classes that model things like
 notes and rests and more than a thousand functions that let you do things like
 transpose music or change the way beams look in your score.
 
@@ -68,7 +68,7 @@ Notice:
     in the last tutorial.
 
 When you called ``show(note)`` Abjad created the LilyPond input file shown
-above.  Abjad then called LilyPond on that ``.ly`` file to create a PDF.
+above. Abjad then called LilyPond on that ``.ly`` file to create a PDF.
 
 (Quit your text editor in the usual way to return to the Python interpreter.)
 

--- a/abjad/docs/source/for_beginners/more_about_abjad.rst
+++ b/abjad/docs/source/for_beginners/more_about_abjad.rst
@@ -36,7 +36,9 @@ The ``systemtools`` package implements I/O functions that help you work with the
 files you create in Abjad.
 
 Use ``systemtools.open_last_ly()`` to see the last LilyPond input file created
-in Abjad::
+in Abjad:
+
+::
 
     % Abjad revision 12452
     % 2013-10-22 13:32
@@ -73,7 +75,9 @@ above. Abjad then called LilyPond on that ``.ly`` file to create a PDF.
 (Quit your text editor in the usual way to return to the Python interpreter.)
 
 Now use ``systemtools.open_last_log()`` to see the output LilyPond created as
-it ran::
+it ran:
+
+::
 
     GNU LilyPond 2.17.3
     Processing `7721.ly'

--- a/abjad/docs/source/for_beginners/more_about_lilypond.rst
+++ b/abjad/docs/source/for_beginners/more_about_lilypond.rst
@@ -6,21 +6,21 @@ Abjad extends LilyPond
 
 `LilyPond`_ is an open-source music notation package
 invented by Han-Wen Nienhuys and Jan Niewenhuizen and extended by an
-international team of developers and musicians.  LilyPond differs from other
-music engraving programs in a number of ways.  LilyPond separates musical
-content from page layout.  LilyPond affords typographic control over almost
-everything.  And LilyPond implements a powerfully correct model of the musical
+international team of developers and musicians. LilyPond differs from other
+music engraving programs in a number of ways. LilyPond separates musical
+content from page layout. LilyPond affords typographic control over almost
+everything. And LilyPond implements a powerfully correct model of the musical
 score.
 
 You can start working with Abjad right away because Abjad creates LilyPond
-files for you automatically.  But you will work with Abjad faster and more
+files for you automatically. But you will work with Abjad faster and more
 effectively if you understand the structure of the LilyPond files Abjad
-creates.  For this reason we recommend new users spend a couple of days
+creates. For this reason we recommend new users spend a couple of days
 learning LilyPond first.
 
 Start by reading about `text input <http://lilypond.org/text-input.html>`_ in
-LilyPond.  Then work through the `LilyPond tutorial
-<http://www.lilypond.org/doc/v2.19/Documentation/learning/tutorial>`_.  You can
+LilyPond. Then work through the `LilyPond tutorial
+<http://www.lilypond.org/doc/v2.19/Documentation/learning/tutorial>`_. You can
 test your understanding of LilyPond by using the program to engrave the first
 few phrases of a Bach chorale. Once you can engrave a chorale in LilyPond
 you'll understand the way Abjad works with LilyPond behind the scenes.

--- a/abjad/docs/source/for_beginners/more_about_lilypond.rst
+++ b/abjad/docs/source/for_beginners/more_about_lilypond.rst
@@ -19,7 +19,7 @@ creates.  For this reason we recommend new users spend a couple of days
 learning LilyPond first.
 
 Start by reading about `text input <http://lilypond.org/text-input.html>`_ in
-LilyPond.  Then work the `LilyPond tutorial
+LilyPond.  Then work through the `LilyPond tutorial
 <http://www.lilypond.org/doc/v2.19/Documentation/learning/tutorial>`_.  You can
 test your understanding of LilyPond by using the program to engrave the first
 few phrases of a Bach chorale. Once you can engrave a chorale in LilyPond

--- a/abjad/docs/source/for_beginners/more_about_python.rst
+++ b/abjad/docs/source/for_beginners/more_about_python.rst
@@ -44,7 +44,7 @@ Now let's define the variable ``x``::
     >>> x = 10
 
 Which lets us do things with ``x``::
-    
+
     >>> x ** 2
     100
 
@@ -62,27 +62,27 @@ Now type ``__builtins__`` at the prompt::
 
 Python responds and tells us that ``__builtins__`` is the name of a module.
 
-A module is file full of Python code that somebody has written to provide new functionality.
+A module is a file full of Python code that somebody has written to provide new functionality.
 
 Use ``dir()`` to inspect the contents of ``__builtins__``::
 
     >>> dir(__builtins__)
-    ['ArithmeticError', 'AssertionError', 'AttributeError', 'BaseException', 'BufferError', 'BytesWarning', 
-    'DeprecationWarning', 'EOFError', 'Ellipsis', 'EnvironmentError', 'Exception', 'False', 'FloatingPointError', 
-    'FutureWarning', 'GeneratorExit', 'IOError', 'ImportError', 'ImportWarning', 'IndentationError', 
-    'IndexError', 'KeyError', 'KeyboardInterrupt', 'LookupError', 'MemoryError', 'NameError', 'None', 
-    'NotImplemented', 'NotImplementedError', 'OSError', 'OverflowError', 'PendingDeprecationWarning', 
-    'ReferenceError', 'RuntimeError', 'RuntimeWarning', 'StandardError', 'StopIteration', 'SyntaxError', 
-    'SyntaxWarning', 'SystemError', 'SystemExit', 'TabError', 'True', 'TypeError', 'UnboundLocalError', 
-    'UnicodeDecodeError', 'UnicodeEncodeError', 'UnicodeError', 'UnicodeTranslateError', 'UnicodeWarning', 
-    'UserWarning', 'ValueError', 'Warning', 'ZeroDivisionError', '_', '__debug__', '__doc__', '__import__', 
-    '__name__', '__package__', 'abs', 'all', 'any', 'apply', 'basestring', 'bin', 'bool', 'buffer', 
-    'bytearray', 'bytes', 'callable', 'chr', 'classmethod', 'cmp', 'coerce', 'compile', 'complex', 'copyright', 
-    'credits', 'delattr', 'dict', 'dir', 'divmod', 'enumerate', 'eval', 'execfile', 'exit', 'file', 'filter', 
-    'float', 'format', 'frozenset', 'getattr', 'globals', 'hasattr', 'hash', 'help', 'hex', 'id', 'input', 'int', 
-    'intern', 'isinstance', 'issubclass', 'iter', 'len', 'license', 'list', 'locals', 'long', 'map', 'max', 
-    'memoryview', 'min', 'next', 'object', 'oct', 'open', 'ord', 'pow', 'print', 'property', 'quit', 'range', 
-    'raw_input', 'reduce', 'reload', 'repr', 'reversed', 'round', 'set', 'setattr', 'slice', 'sorted', 
+    ['ArithmeticError', 'AssertionError', 'AttributeError', 'BaseException', 'BufferError', 'BytesWarning',
+    'DeprecationWarning', 'EOFError', 'Ellipsis', 'EnvironmentError', 'Exception', 'False', 'FloatingPointError',
+    'FutureWarning', 'GeneratorExit', 'IOError', 'ImportError', 'ImportWarning', 'IndentationError',
+    'IndexError', 'KeyError', 'KeyboardInterrupt', 'LookupError', 'MemoryError', 'NameError', 'None',
+    'NotImplemented', 'NotImplementedError', 'OSError', 'OverflowError', 'PendingDeprecationWarning',
+    'ReferenceError', 'RuntimeError', 'RuntimeWarning', 'StandardError', 'StopIteration', 'SyntaxError',
+    'SyntaxWarning', 'SystemError', 'SystemExit', 'TabError', 'True', 'TypeError', 'UnboundLocalError',
+    'UnicodeDecodeError', 'UnicodeEncodeError', 'UnicodeError', 'UnicodeTranslateError', 'UnicodeWarning',
+    'UserWarning', 'ValueError', 'Warning', 'ZeroDivisionError', '_', '__debug__', '__doc__', '__import__',
+    '__name__', '__package__', 'abs', 'all', 'any', 'apply', 'basestring', 'bin', 'bool', 'buffer',
+    'bytearray', 'bytes', 'callable', 'chr', 'classmethod', 'cmp', 'coerce', 'compile', 'complex', 'copyright',
+    'credits', 'delattr', 'dict', 'dir', 'divmod', 'enumerate', 'eval', 'execfile', 'exit', 'file', 'filter',
+    'float', 'format', 'frozenset', 'getattr', 'globals', 'hasattr', 'hash', 'help', 'hex', 'id', 'input', 'int',
+    'intern', 'isinstance', 'issubclass', 'iter', 'len', 'license', 'list', 'locals', 'long', 'map', 'max',
+    'memoryview', 'min', 'next', 'object', 'oct', 'open', 'ord', 'pow', 'print', 'property', 'quit', 'range',
+    'raw_input', 'reduce', 'reload', 'repr', 'reversed', 'round', 'set', 'setattr', 'slice', 'sorted',
     'staticmethod', 'str', 'sum', 'super', 'tuple', 'type', 'unichr', 'unicode', 'vars', 'range', 'zip']
 
 Python responds with a list of many names.
@@ -112,7 +112,7 @@ resembles C, C++ and Java.
 
 To get the most out of Abjad you need to know (or learn) the basics of
 programming in Python.  Abjad extends Python because it makes no sense to
-reinvent the wheel modern programming langauges have developed to find, sort,
+reinvent the wheel modern programming languages have developed to find, sort,
 store, model and encapsulate information.  Abjad simply piggy-backs on the ways
 of doing these things that Python provides.  So to use Abjad effectively you
 need to know the way these things are done in Python.

--- a/abjad/docs/source/for_beginners/more_about_python.rst
+++ b/abjad/docs/source/for_beginners/more_about_python.rst
@@ -11,12 +11,16 @@ Doing many things
 
 You can use the Python interpreter to do many things.
 
-Simple math like addition looks like this::
+Simple math like addition looks like this:
+
+::
 
     >>> 2 + 2
     4
 
-Exponentiation looks like this::
+Exponentiation looks like this:
+
+::
 
     >>> 2 ** 38
     274877906944
@@ -31,7 +35,9 @@ But the Python interpreter's input-output loop makes it easy to see what Python 
 Looking around
 --------------
 
-Use ``dir()`` to see the things the Python interpreter knows about::
+Use ``dir()`` to see the things the Python interpreter knows about:
+
+::
 
     >>> dir()
     ['__builtins__', '__doc__', '__name__', '__package__']
@@ -39,23 +45,31 @@ Use ``dir()`` to see the things the Python interpreter knows about::
 These four things are the only elements that Python loads into the so-called
 global namespace when you start the interpreter.
 
-Now let's define the variable ``x``::
+Now let's define the variable ``x``:
+
+::
 
     >>> x = 10
 
-Which lets us do things with ``x``::
+Which lets us do things with ``x``:
+
+::
 
     >>> x ** 2
     100
 
-When we call ``dir()`` now we see that the global namespace has changed::
+When we call ``dir()`` now we see that the global namespace has changed:
+
+::
 
     >>> dir()
     ['__builtins__', '__doc__', '__name__', '__package__', 'x']
 
 Using ``dir()`` is a good way to check the variables Python knows about when it runs.
 
-Now type ``__builtins__`` at the prompt::
+Now type ``__builtins__`` at the prompt:
+
+::
 
     >>> __builtins__
     <module '__builtin__' (built-in)>
@@ -64,7 +78,9 @@ Python responds and tells us that ``__builtins__`` is the name of a module.
 
 A module is a file full of Python code that somebody has written to provide new functionality.
 
-Use ``dir()`` to inspect the contents of ``__builtins__``::
+Use ``dir()`` to inspect the contents of ``__builtins__``:
+
+::
 
     >>> dir(__builtins__)
     ['ArithmeticError', 'AssertionError', 'AttributeError', 'BaseException', 'BufferError', 'BytesWarning',
@@ -88,7 +104,9 @@ Use ``dir()`` to inspect the contents of ``__builtins__``::
 Python responds with a list of many names.
 
 Use Python's ``len()`` command together with the last-output character ``_``
-to find out how many names ``__builtins__`` contains::
+to find out how many names ``__builtins__`` contains:
+
+::
 
     >>> len(_)
     144

--- a/abjad/docs/source/for_beginners/more_about_python.rst
+++ b/abjad/docs/source/for_beginners/more_about_python.rst
@@ -105,27 +105,27 @@ Abjad extends Python
 
 `Python`_ is an open-source programming language invented by Guido van Rossum
 and further developed by a team of programmers working in many countries around
-the world.  Python is used to provision servers, process text, develop
+the world. Python is used to provision servers, process text, develop
 distributed systems and do much more besides. The dynamic language and
 interpreter features of Python are similar to Ruby while the syntax of Python
 resembles C, C++ and Java.
 
 To get the most out of Abjad you need to know (or learn) the basics of
-programming in Python.  Abjad extends Python because it makes no sense to
+programming in Python. Abjad extends Python because it makes no sense to
 reinvent the wheel modern programming languages have developed to find, sort,
-store, model and encapsulate information.  Abjad simply piggy-backs on the ways
-of doing these things that Python provides.  So to use Abjad effectively you
+store, model and encapsulate information. Abjad simply piggy-backs on the ways
+of doing these things that Python provides. So to use Abjad effectively you
 need to know the way these things are done in Python.
 
-Start with the `Python tutorial <http://docs.python.org/tutorial/>`_.  The
+Start with the `Python tutorial <http://docs.python.org/tutorial/>`_. The
 tutorial is structured in 15 chapters and you should work through the first 12.
 This will take a day or two and you'll be able to use all the information you
-read in the Python tutorial in Abjad.  If you're an experienced programmer you
-should skip chapters 1 - 3 but read 4 - 12.  When you're done you can give
-yourself the equivalent of the chorale test suggested above.  First open a file
-and define a couple of classes and functions in it.  Then open a second file
+read in the Python tutorial in Abjad. If you're an experienced programmer you
+should skip chapters 1 - 3 but read 4 - 12. When you're done you can give
+yourself the equivalent of the chorale test suggested above. First open a file
+and define a couple of classes and functions in it. Then open a second file
 and write some code to first import and then do stuff with the classes and
-functions you defined in the first file.  Once you can easily do this without
+functions you defined in the first file. Once you can easily do this without
 looking at the Python docs you'll be in a much better position to work with
 Abjad.
 

--- a/abjad/docs/source/for_beginners/python_hello_world_at_the_interpreter.rst
+++ b/abjad/docs/source/for_beginners/python_hello_world_at_the_interpreter.rst
@@ -14,10 +14,10 @@ Open the terminal and type ``python`` to start the interpreter::
 
 Python responds with version information and a prompt::
 
-    Python 2.7.3 (v2.7.3:70274d53c1dd, Apr  9 2012, 20:52:43) 
+    Python 2.7.3 (v2.7.3:70274d53c1dd, Apr 9 2012, 20:52:43)
     [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
     Type "help", "copyright", "credits" or "license" for more information.
-    >>> 
+    >>>
 
 The purpose of the interpreter is to let you try out code one line at a time.
 

--- a/abjad/docs/source/for_beginners/python_hello_world_at_the_interpreter.rst
+++ b/abjad/docs/source/for_beginners/python_hello_world_at_the_interpreter.rst
@@ -8,11 +8,15 @@ Let's start with Python's interactive interpreter.
 Starting the interpreter
 ------------------------
 
-Open the terminal and type ``python`` to start the interpreter::
+Open the terminal and type ``python`` to start the interpreter:
+
+::
 
     $ python
 
-Python responds with version information and a prompt::
+Python responds with version information and a prompt:
+
+::
 
     Python 2.7.3 (v2.7.3:70274d53c1dd, Apr 9 2012, 20:52:43)
     [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
@@ -25,7 +29,9 @@ The purpose of the interpreter is to let you try out code one line at a time.
 Entering commands
 -----------------
 
-Type the following at the interpreter's prompt::
+Type the following at the interpreter's prompt:
+
+::
 
     >>> print('hello, world!')
     hello, world!


### PR DESCRIPTION
- Corrected typos.
- Improved phrasing.
- Removed double spaces.
- Made use of `::` literal flag consistently on new line.
- Removed any `::` preceding enumerated (ordered) lists.
- Removed backticks around URLs.