### PR TITLE
Taught detach() about different types of grace container.

### DIFF
--- a/abjad/tools/scoretools/GraceContainer.py
+++ b/abjad/tools/scoretools/GraceContainer.py
@@ -67,6 +67,178 @@ class GraceContainer(Container):
     Fill grace containers with notes, rests or chords.
 
     Attach grace containers to notes, rests or chords.
+
+    ..  container:: example
+
+        **Example 3.** Detaches all grace containers:
+
+        ::
+
+            >>> voice = Voice("c'4 d'4 e'4 f'4")
+            >>> note = Note("cs'16")
+            >>> grace_container = scoretools.GraceContainer(
+            ...     [note],
+            ...     kind='grace',
+            ...     )
+            >>> attach(grace_container, voice[1])
+            >>> note = Note("ds'16")
+            >>> after_grace_container = scoretools.GraceContainer(
+            ...     [note],
+            ...     kind='after',
+            ...     )
+            >>> attach(after_grace_container, voice[1])
+            >>> show(voice) # doctest: +SKIP
+
+        ..  doctest::
+
+            >>> f(voice)
+            \new Voice {
+                c'4
+                \grace {
+                    cs'16
+                }
+                \afterGrace
+                d'4
+                {
+                    ds'16
+                }
+                e'4
+                f'4
+            }
+
+        ::
+
+            >>> detach(scoretools.GraceContainer, voice[1])
+            (GraceContainer(), GraceContainer())
+            >>> show(voice) # doctest: +SKIP
+
+        ..  doctest::
+
+            >>> f(voice)
+            \new Voice {
+                c'4
+                d'4
+                e'4
+                f'4
+            }
+
+    ..  container:: example
+
+        **Example 4.** Detaches (proper) grace container but leaves after grace
+        container attached:
+
+        ::
+
+            >>> voice = Voice("c'4 d'4 e'4 f'4")
+            >>> note = Note("cs'16")
+            >>> grace_container = scoretools.GraceContainer(
+            ...     [note],
+            ...     kind='grace',
+            ...     )
+            >>> attach(grace_container, voice[1])
+            >>> note = Note("ds'16")
+            >>> after_grace_container = scoretools.GraceContainer(
+            ...     [note],
+            ...     kind='after',
+            ...     )
+            >>> attach(after_grace_container, voice[1])
+            >>> show(voice) # doctest: +SKIP
+
+        ..  doctest::
+
+            >>> f(voice)
+            \new Voice {
+                c'4
+                \grace {
+                    cs'16
+                }
+                \afterGrace
+                d'4
+                {
+                    ds'16
+                }
+                e'4
+                f'4
+            }
+
+        ::
+
+            >>> detach(grace_container, voice[1])
+            (GraceContainer(),)
+            >>> show(voice) # doctest: +SKIP
+
+        ..  doctest::
+
+            >>> f(voice)
+            \new Voice {
+                c'4
+                \afterGrace
+                d'4
+                {
+                    ds'16
+                }
+                e'4
+                f'4
+            }
+
+    ..  container:: example
+
+        **Example 5.** Detaches after grace container but leaves (proper) grace
+        container attached:
+
+        ::
+
+            >>> voice = Voice("c'4 d'4 e'4 f'4")
+            >>> note = Note("cs'16")
+            >>> grace_container = scoretools.GraceContainer(
+            ...     [note],
+            ...     kind='grace',
+            ...     )
+            >>> attach(grace_container, voice[1])
+            >>> note = Note("ds'16")
+            >>> after_grace_container = scoretools.GraceContainer(
+            ...     [note],
+            ...     kind='after',
+            ...     )
+            >>> attach(after_grace_container, voice[1])
+            >>> show(voice) # doctest: +SKIP
+
+        ..  doctest::
+
+            >>> f(voice)
+            \new Voice {
+                c'4
+                \grace {
+                    cs'16
+                }
+                \afterGrace
+                d'4
+                {
+                    ds'16
+                }
+                e'4
+                f'4
+            }
+
+        ::
+
+            >>> detach(after_grace_container, voice[1])
+            (GraceContainer(),)
+            >>> show(voice) # doctest: +SKIP
+
+        ..  doctest::
+
+            >>> f(voice)
+            \new Voice {
+                c'4
+                \grace {
+                    cs'16
+                }
+                d'4
+                e'4
+                f'4
+            }
+
     '''
 
     ### CLASS VARIABLES ###

--- a/abjad/tools/topleveltools/detach.py
+++ b/abjad/tools/topleveltools/detach.py
@@ -29,8 +29,8 @@ def detach(prototype, component_expression=None):
                     component_expression._indicator_expressions.remove(x)
                     result.append(x)
                 # indicator is a expression
-                elif hasattr(x, 'indicator') and \
-                    isinstance(x.indicator, prototype):
+                elif (hasattr(x, 'indicator') and
+                    isinstance(x.indicator, prototype)):
                     x._detach()
                     result.append(x.indicator)
             result = tuple(result)
@@ -39,7 +39,9 @@ def detach(prototype, component_expression=None):
         if isinstance(prototype, spannertools.Spanner):
             spanners = inspector.get_spanners(prototype)
         elif isinstance(prototype, scoretools.GraceContainer):
-            grace_containers = inspector.get_grace_containers(prototype)
+            grace_containers = inspector.get_grace_containers(
+                kind=prototype.kind,
+                )
         else:
             assert hasattr(component_expression, '_indicator_expressions')
             result = []
@@ -47,7 +49,7 @@ def detach(prototype, component_expression=None):
                 if x == prototype:
                     component_expression._indicator_expressions.remove(x)
                     result.append(x)
-                # indicator is a expression
+                # indicator is an expression
                 elif hasattr(x, 'indicator') and x.indicator == prototype:
                     x._detach()
                     result.append(x.indicator)


### PR DESCRIPTION
This ...

    >>> detach(grace_container, leaf)

... now differs from ...

    >>> detach(after_grace_container, leaf)

... and also from ...

    >>> detach(GraceContainer, leaf)

... with the following difference:

    1. detaches just (proper) grace containers
    2. detaches just after grace containers
    3. detaches all grace containers

This is new functionality. But doesn't need to be included in release notes.