### PR TITLE
.ajv configuration

### DIFF
--- a/abjad/tools/commandlinetools/DoctestScript.py
+++ b/abjad/tools/commandlinetools/DoctestScript.py
@@ -73,6 +73,15 @@ class DoctestScript(CommandlineScript):
         except ImportError:
             pass
         globs['print_function'] = print_function
+        config_parser = self._config_parser
+        try:
+            imports = config_parser.get(self.alias, 'imports')
+        except:
+            imports = ''
+        imports = stringtools.normalize(imports).split('\n')
+        for line in imports:
+            exec(line, globs, globs)
+        globs
         return globs
 
     def _get_optionflags(self, args):


### PR DESCRIPTION
CommandlineScript looks for ~/.ajv or .ajv in the current hierarchy.

It then parses both ~/.ajv and any .ajv found in the current hierarchy into a
ConfigParser instance, making that available to the current script for use as
needed.

DoctestScript can look under the [doctest] section for an "imports" option,
executing any lines there to help create the globs dictionary used during each
doctest. That allows custom projects to define how their doctests behave!