### PR TITLE
Permit a C-accelerated Fraction class.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ python:
     - 3.5
     - pypy
 
+matrix:
+    include:
+        python: "3.5"
+        env: ACCELERATED=true
+
 addons:
     apt:
         packages:
@@ -48,6 +53,8 @@ install:
     - abjad/scr/devel/prime-parser-tables
     # then install development and ipython dependencies.
     - pip install -e .[development,ipython]
+    # install accelerated dependencies if requested
+    - if [[ $ACCELERATED == true ]]; then pip install -e .[accelerated]; fi
 
 script:
     - abjad/scr/ajv doctest --diff experimental

--- a/abjad/__init__.py
+++ b/abjad/__init__.py
@@ -26,6 +26,11 @@ try:
 except ImportError:
     pass
 
+try:
+    from quicktions import Fraction
+except ImportError:
+    from fractions import Fraction
+
 # ensure that the ~/.abjad directory and friends are setup,
 # and instantiate Abjad's configuration singleton
 from abjad.tools.systemtools.AbjadConfiguration import AbjadConfiguration
@@ -75,7 +80,6 @@ from abjad.tools.spannertools import Hairpin
 from abjad.tools.spannertools import Slur
 from abjad.tools.spannertools import Tie
 from abjad.tools.timespantools import Timespan
-from fractions import Fraction
 
 # import some frequently used functions for direct user access
 from abjad.tools.topleveltools import attach

--- a/abjad/tools/durationtools/Duration.py
+++ b/abjad/tools/durationtools/Duration.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import copy
-import fractions
 import math
 import re
+from abjad import Fraction
 from abjad.tools import mathtools
 from abjad.tools import systemtools
 from abjad.tools.abctools.AbjadObject import AbjadObject
@@ -10,7 +10,7 @@ from abjad.tools.topleveltools.override import override
 from abjad.tools.topleveltools.set_ import set_
 
 
-class Duration(AbjadObject, fractions.Fraction):
+class Duration(AbjadObject, Fraction):
     r'''Duration.
 
     ..  container:: example
@@ -141,33 +141,33 @@ class Duration(AbjadObject, fractions.Fraction):
             if type(arg) is class_:
                 return arg
             if isinstance(arg, mathtools.NonreducedFraction):
-                return fractions.Fraction.__new__(class_, *arg.pair)
+                return Fraction.__new__(class_, *arg.pair)
             try:
-                return fractions.Fraction.__new__(class_, *arg)
+                return Fraction.__new__(class_, *arg)
             except (AttributeError, TypeError):
                 pass
             try:
-                return fractions.Fraction.__new__(class_, arg)
+                return Fraction.__new__(class_, arg)
             except (AttributeError, TypeError):
                 pass
             if mathtools.is_fraction_equivalent_pair(arg):
-                return fractions.Fraction.__new__(
+                return Fraction.__new__(
                     class_, int(arg[0]), int(arg[1]))
             if hasattr(arg, 'duration'):
-                return fractions.Fraction.__new__(class_, arg.duration)
+                return Fraction.__new__(class_, arg.duration)
             if isinstance(arg, str) and '/' not in arg:
                 result = Duration._initialize_from_lilypond_duration_string(
                     arg)
-                return fractions.Fraction.__new__(class_, result)
+                return Fraction.__new__(class_, result)
             if mathtools.is_integer_equivalent_singleton(arg):
-                return fractions.Fraction.__new__(class_, int(arg[0]))
+                return Fraction.__new__(class_, int(arg[0]))
         else:
             try:
-                return fractions.Fraction.__new__(class_, *args)
+                return Fraction.__new__(class_, *args)
             except TypeError:
                 pass
             if mathtools.all_are_integer_equivalent_numbers(args):
-                return fractions.Fraction.__new__(
+                return Fraction.__new__(
                     class_,
                     *[int(x) for x in args]
                     )
@@ -182,7 +182,7 @@ class Duration(AbjadObject, fractions.Fraction):
 
         Returns nonnegative duration.
         '''
-        return type(self)(fractions.Fraction.__abs__(self, *args))
+        return type(self)(Fraction.__abs__(self, *args))
 
     def __add__(self, *args):
         r'''Adds duration to `args`.
@@ -218,7 +218,7 @@ class Duration(AbjadObject, fractions.Fraction):
             ):
             result = args[0].__radd__(self)
         else:
-            result = type(self)(fractions.Fraction.__add__(self, *args))
+            result = type(self)(Fraction.__add__(self, *args))
         return result
 
     def __div__(self, *args):
@@ -228,13 +228,13 @@ class Duration(AbjadObject, fractions.Fraction):
         '''
         from abjad.tools import durationtools
         if len(args) == 1 and isinstance(args[0], type(self)):
-            fraction = fractions.Fraction.__truediv__(self, *args)
+            fraction = Fraction.__truediv__(self, *args)
             result = durationtools.Multiplier(fraction)
         elif len(args) == 1 and isinstance(
             args[0], mathtools.NonreducedFraction):
             result = args[0].__rdiv__(self)
         else:
-            result = type(self)(fractions.Fraction.__truediv__(self, *args))
+            result = type(self)(Fraction.__truediv__(self, *args))
         return result
 
     def __divmod__(self, *args):
@@ -242,7 +242,7 @@ class Duration(AbjadObject, fractions.Fraction):
 
         Returns pair.
         '''
-        truncated, residue = fractions.Fraction.__divmod__(self, *args)
+        truncated, residue = Fraction.__divmod__(self, *args)
         truncated = type(self)(truncated)
         residue = type(self)(residue)
         return truncated, residue
@@ -253,7 +253,7 @@ class Duration(AbjadObject, fractions.Fraction):
 
         Returns true or false.
         '''
-        return fractions.Fraction.__eq__(self, arg)
+        return Fraction.__eq__(self, arg)
 
     def __format__(self, format_specification=''):
         r'''Formats duration.
@@ -274,7 +274,7 @@ class Duration(AbjadObject, fractions.Fraction):
 
         Returns true or false.
         '''
-        return fractions.Fraction.__ge__(self, arg)
+        return Fraction.__ge__(self, arg)
 
     def __gt__(self, arg):
         r'''Is true when duration is greater than `arg`.
@@ -282,7 +282,7 @@ class Duration(AbjadObject, fractions.Fraction):
 
         Returns true or false.
         '''
-        return fractions.Fraction.__gt__(self, arg)
+        return Fraction.__gt__(self, arg)
 
     def __hash__(self):
         r'''Hashes duration.
@@ -299,7 +299,7 @@ class Duration(AbjadObject, fractions.Fraction):
 
         Returns true or false.
         '''
-        return fractions.Fraction.__le__(self, arg)
+        return Fraction.__le__(self, arg)
 
     def __lt__(self, arg):
         r'''Is true when duration is less than `arg`.
@@ -307,14 +307,14 @@ class Duration(AbjadObject, fractions.Fraction):
 
         Returns true or false.
         '''
-        return fractions.Fraction.__lt__(self, arg)
+        return Fraction.__lt__(self, arg)
 
     def __mod__(self, *args):
         r'''Modulus operator applied to duration.
 
         Returns duration.
         '''
-        return type(self)(fractions.Fraction.__mod__(self, *args))
+        return type(self)(Fraction.__mod__(self, *args))
 
     def __mul__(self, *args):
         r'''Duration multiplied by `args`.
@@ -350,7 +350,7 @@ class Duration(AbjadObject, fractions.Fraction):
             ):
             result = args[0].__rmul__(self)
         else:
-            result = type(self)(fractions.Fraction.__mul__(self, *args))
+            result = type(self)(Fraction.__mul__(self, *args))
         return result
 
     def __ne__(self, arg):
@@ -359,47 +359,47 @@ class Duration(AbjadObject, fractions.Fraction):
 
         Returns true or false.
         '''
-        return fractions.Fraction.__ne__(self, arg)
+        return Fraction.__ne__(self, arg)
 
     def __neg__(self, *args):
         r'''Negates duration.
 
         Returns new duration.
         '''
-        return type(self)(fractions.Fraction.__neg__(self, *args))
+        return type(self)(Fraction.__neg__(self, *args))
 
     def __pos__(self, *args):
         r'''Get positive duration.
 
         Returns new duration.
         '''
-        return type(self)(fractions.Fraction.__pos__(self, *args))
+        return type(self)(Fraction.__pos__(self, *args))
 
     def __pow__(self, *args):
         r'''Raises duration to `args` power.
 
         Returns new duration.
         '''
-        return type(self)(fractions.Fraction.__pow__(self, *args))
+        return type(self)(Fraction.__pow__(self, *args))
 
     def __radd__(self, *args):
         r'''Adds `args` to duration.
 
         Returns new duration.
         '''
-        return type(self)(fractions.Fraction.__radd__(self, *args))
+        return type(self)(Fraction.__radd__(self, *args))
 
     def __rdiv__(self, *args):
         r'''Divides `args` by duration.
 
         Returns new duration.
         '''
-        return type(self)(fractions.Fraction.__rdiv__(self, *args))
+        return type(self)(Fraction.__rdiv__(self, *args))
 
     def __rdivmod__(self, *args):
         r'''Documentation required.
         '''
-        return type(self)(fractions.Fraction.__rdivmod__(self, *args))
+        return type(self)(Fraction.__rdivmod__(self, *args))
 
     def __reduce__(self):
         r'''Documentation required.
@@ -414,35 +414,35 @@ class Duration(AbjadObject, fractions.Fraction):
     def __rmod__(self, *args):
         r'''Documentation required.
         '''
-        return type(self)(fractions.Fraction.__rmod__(self, *args))
+        return type(self)(Fraction.__rmod__(self, *args))
 
     def __rmul__(self, *args):
         r'''Multiplies `args` by duration.
 
         Returns new duration.
         '''
-        return type(self)(fractions.Fraction.__rmul__(self, *args))
+        return type(self)(Fraction.__rmul__(self, *args))
 
     def __rpow__(self, *args):
         r'''Raises `args` to the power of duration.
 
         Returns new duration.
         '''
-        return type(self)(fractions.Fraction.__rpow__(self, *args))
+        return type(self)(Fraction.__rpow__(self, *args))
 
     def __rsub__(self, *args):
         r'''Subtracts duration from `args`.
 
         Returns new duration.
         '''
-        return type(self)(fractions.Fraction.__rsub__(self, *args))
+        return type(self)(Fraction.__rsub__(self, *args))
 
     def __rtruediv__(self, *args):
         r'''Documentation required.
 
         Returns new duration.
         '''
-        return type(self)(fractions.Fraction.__rtruediv__(self, *args))
+        return type(self)(Fraction.__rtruediv__(self, *args))
 
     def __sub__(self, *args):
         r'''Subtracts `args` from duration.
@@ -455,7 +455,7 @@ class Duration(AbjadObject, fractions.Fraction):
             ):
             return args[0].__rsub__(self)
         else:
-            return type(self)(fractions.Fraction.__sub__(self, *args))
+            return type(self)(Fraction.__sub__(self, *args))
 
     def __truediv__(self, *args):
         r'''Documentation required.
@@ -511,14 +511,14 @@ class Duration(AbjadObject, fractions.Fraction):
         body_string, dots_string = match.groups()
         try:
             body_denominator = int(body_string)
-            body_duration = fractions.Fraction(1, body_denominator)
+            body_duration = Fraction(1, body_denominator)
         except ValueError:
             if body_string == r'\breve':
-                body_duration = fractions.Fraction(2)
+                body_duration = Fraction(2)
             elif body_string == r'\longa':
-                body_duration = fractions.Fraction(4)
+                body_duration = Fraction(4)
             elif body_string == r'\maxima':
-                body_duration = fractions.Fraction(8)
+                body_duration = Fraction(8)
             else:
                 message = 'unknown body string: {!r}.'
                 message = message.format(body_string)
@@ -527,7 +527,7 @@ class Duration(AbjadObject, fractions.Fraction):
         for n in range(len(dots_string)):
             exponent = n + 1
             denominator = 2 ** exponent
-            multiplier = fractions.Fraction(1, denominator)
+            multiplier = Fraction(1, denominator)
             addend = multiplier * body_duration
             rational += addend
         return rational

--- a/abjad/tools/indicatortools/Tempo.py
+++ b/abjad/tools/indicatortools/Tempo.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import collections
-import fractions
 import functools
 import math
 import numbers
+from abjad import Fraction
 from abjad.tools import durationtools
 from abjad.tools import mathtools
 from abjad.tools import schemetools
@@ -202,7 +202,7 @@ class Tempo(AbjadValueObject):
         prototype = (
             int,
             float,
-            fractions.Fraction,
+            Fraction,
             collections.Sequence,
             type(None),
             )
@@ -495,14 +495,14 @@ class Tempo(AbjadValueObject):
         elif isinstance(self.units_per_minute, (int, float)):
             string = '{}={}'
             string = string.format(self._dotted, self.units_per_minute)
-        elif (isinstance(self.units_per_minute, fractions.Fraction) and
+        elif (isinstance(self.units_per_minute, Fraction) and
             not mathtools.is_integer_equivalent_number(self.units_per_minute)):
             integer_part = int(self.units_per_minute)
             remainder = self.units_per_minute - integer_part
-            remainder = fractions.Fraction(remainder)
+            remainder = Fraction(remainder)
             string = '{}={}+{}'
             string = string.format(self._dotted, integer_part, remainder)
-        elif (isinstance(self.units_per_minute, fractions.Fraction) and
+        elif (isinstance(self.units_per_minute, Fraction) and
             mathtools.is_integer_equivalent_number(self.units_per_minute)):
             string = '{}={}'
             integer = int(self.units_per_minute)
@@ -757,7 +757,7 @@ class Tempo(AbjadValueObject):
         multipliers = [durationtools.Multiplier(_) for _ in pairs]
         multipliers = [
             _ for _ in multipliers
-            if fractions.Fraction(1, 2) <= _ <= fractions.Fraction(2)
+            if Fraction(1, 2) <= _ <= Fraction(2)
             ]
         multipliers.sort()
         multipliers = sequencetools.remove_repeated_elements(multipliers)
@@ -1100,7 +1100,7 @@ class Tempo(AbjadValueObject):
         lhs_score_markup = durationtools.Duration._to_score_markup(selection)
         lhs_score_markup = lhs_score_markup.scale((0.75, 0.75))
         equal_markup = markuptools.Markup('=')
-        if (isinstance(units_per_minute, fractions.Fraction) and
+        if (isinstance(units_per_minute, Fraction) and
             not mathtools.is_integer_equivalent_number(units_per_minute)):
             rhs_markup = markuptools.Markup.make_improper_fraction_markup(
                 units_per_minute)
@@ -1180,7 +1180,7 @@ class Tempo(AbjadValueObject):
                 self.units_per_minute[1],
                 )
             return string
-        elif isinstance(self.units_per_minute, (float, fractions.Fraction)):
+        elif isinstance(self.units_per_minute, (float, Fraction)):
             markup = Tempo.make_tempo_equation_markup(
                 self.reference_duration,
                 self.units_per_minute,
@@ -1415,7 +1415,7 @@ class Tempo(AbjadValueObject):
             return (low, high)
         result = durationtools.Duration(1, 4) / self.reference_duration * \
             self.units_per_minute
-        return fractions.Fraction(result)
+        return Fraction(result)
 
     @property
     def reference_duration(self):

--- a/abjad/tools/lilypondparsertools/LilyPondSyntacticalDefinition.py
+++ b/abjad/tools/lilypondparsertools/LilyPondSyntacticalDefinition.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-import fractions
 from ply import lex
+from abjad import Fraction
 from abjad.tools import indicatortools
 from abjad.tools import durationtools
 from abjad.tools import lilypondfiletools
@@ -1224,7 +1224,7 @@ class LilyPondSyntacticalDefinition(AbjadObject):
 
     def p_fraction__UNSIGNED__Chr47__UNSIGNED(self, p):
         "fraction : UNSIGNED '/' UNSIGNED"
-        p[0] = fractions.Fraction(p[1], p[3])
+        p[0] = Fraction(p[1], p[3])
 
     ### full_markup ###
 
@@ -2218,7 +2218,7 @@ class LilyPondSyntacticalDefinition(AbjadObject):
                 p[1].duration, p[1].multiplier * p[3])
         else:
             p[0] = lilypondparsertools.LilyPondDuration(
-                p[1].duration, fractions.Fraction(p[3].numerator, p[3].denominator))
+                p[1].duration, Fraction(p[3].numerator, p[3].denominator))
 
     def p_multiplied_duration__multiplied_duration__Chr42__bare_unsigned(self, p):
         "multiplied_duration : multiplied_duration '*' bare_unsigned"

--- a/abjad/tools/markuptools/Markup.py
+++ b/abjad/tools/markuptools/Markup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import collections
-import fractions
 import numbers
+from abjad import Fraction
 from abjad.tools import mathtools
 from abjad.tools import schemetools
 from abjad.tools import stringtools
@@ -1577,7 +1577,7 @@ class Markup(AbjadValueObject):
             number = int(rational)
             markup = Markup(number)
             return markup
-        assert isinstance(rational, fractions.Fraction), repr(rational)
+        assert isinstance(rational, Fraction), repr(rational)
         integer_part = int(rational)
         fraction_part = rational - integer_part
         integer_markup = Markup(integer_part)

--- a/abjad/tools/mathtools/NonreducedFraction.py
+++ b/abjad/tools/mathtools/NonreducedFraction.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-import fractions
+from abjad import Fraction
 from abjad.tools import systemtools
 from abjad.tools.abctools.AbjadObject import AbjadObject
 
 
-class NonreducedFraction(AbjadObject, fractions.Fraction):
+class NonreducedFraction(AbjadObject, Fraction):
     r'''Initializes with an integer numerator and integer denominator:
 
     ::
@@ -91,7 +91,7 @@ class NonreducedFraction(AbjadObject, fractions.Fraction):
             raise ValueError(message)
         numerator *= mathtools.sign(denominator)
         denominator = abs(denominator)
-        self = fractions.Fraction.__new__(class_, numerator, denominator)
+        self = Fraction.__new__(class_, numerator, denominator)
         self._numerator = numerator
         self._denominator = denominator
         return self
@@ -613,7 +613,7 @@ class NonreducedFraction(AbjadObject, fractions.Fraction):
 
         Returns fraction.
         '''
-        return fractions.Fraction(self.numerator, self.denominator)
+        return Fraction(self.numerator, self.denominator)
 
     def with_denominator(self, denominator):
         r'''Returns new nonreduced fraction with integer `denominator`.
@@ -688,7 +688,7 @@ class NonreducedFraction(AbjadObject, fractions.Fraction):
 
         Returns zero.
         '''
-        return fractions.Fraction.imag.fget(self)
+        return Fraction.imag.fget(self)
 
     @property
     def numerator(self):

--- a/abjad/tools/mathtools/NonreducedFraction.py
+++ b/abjad/tools/mathtools/NonreducedFraction.py
@@ -59,6 +59,8 @@ class NonreducedFraction(AbjadObject, Fraction):
     ### CLASS VARIABLES ###
 
     __slots__ = (
+        '_numerator',
+        '_denominator',
         )
 
     ### CONSTRUCTOR ###
@@ -688,7 +690,7 @@ class NonreducedFraction(AbjadObject, Fraction):
 
         Returns zero.
         '''
-        return Fraction.imag.fget(self)
+        return 0
 
     @property
     def numerator(self):

--- a/abjad/tools/mathtools/arithmetic_mean.py
+++ b/abjad/tools/mathtools/arithmetic_mean.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import fractions
+from abjad import Fraction
 
 
 def arithmetic_mean(sequence):
@@ -33,7 +33,7 @@ def arithmetic_mean(sequence):
     if isinstance(sum_l, float):
         return sum_l / len_l
 
-    result = fractions.Fraction(sum(sequence), len(sequence))
+    result = Fraction(sum(sequence), len(sequence))
 
     int_result = int(result)
     if int_result == result:

--- a/abjad/tools/mathtools/divide_number_by_ratio.py
+++ b/abjad/tools/mathtools/divide_number_by_ratio.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import fractions
 import numbers
+from abjad import Fraction
 
 
 def divide_number_by_ratio(number, ratio):
@@ -39,7 +39,7 @@ def divide_number_by_ratio(number, ratio):
 
     # find factors and multiply by factors
     factors = [
-        fractions.Fraction(p, sum(ratio.numbers)) 
+        Fraction(p, sum(ratio.numbers))
         for p in ratio.numbers
         ]
     result = [factor * number for factor in factors]

--- a/abjad/tools/mathtools/fraction_to_proper_fraction.py
+++ b/abjad/tools/mathtools/fraction_to_proper_fraction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import fractions
+from abjad import Fraction
 
 
 def fraction_to_proper_fraction(rational):
@@ -13,7 +13,7 @@ def fraction_to_proper_fraction(rational):
     Returns pair.
     '''
 
-    if not isinstance(rational, fractions.Fraction):
+    if not isinstance(rational, Fraction):
         raise TypeError
 
     quotient = int(rational)

--- a/abjad/tools/mathtools/is_nonnegative_integer_power_of_two.py
+++ b/abjad/tools/mathtools/is_nonnegative_integer_power_of_two.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import fractions
+from abjad import Fraction
 
 
 def is_nonnegative_integer_power_of_two(expr):
@@ -9,7 +9,7 @@ def is_nonnegative_integer_power_of_two(expr):
 
         >>> for n in range(10):
         ...     print(n, mathtools.is_nonnegative_integer_power_of_two(n))
-        ... 
+        ...
         0 True
         1 True
         2 True
@@ -28,7 +28,7 @@ def is_nonnegative_integer_power_of_two(expr):
 
     if isinstance(expr, int):
         return not bool(expr & (expr - 1))
-    elif isinstance(expr, fractions.Fraction):
+    elif isinstance(expr, Fraction):
         return is_nonnegative_integer_power_of_two(expr.numerator * expr.denominator)
     else:
         return False

--- a/abjad/tools/mathtools/least_power_of_two_greater_equal.py
+++ b/abjad/tools/mathtools/least_power_of_two_greater_equal.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import fractions
 import math
+from abjad import Fraction
 
 
 def least_power_of_two_greater_equal(n, i=0):
@@ -11,17 +11,17 @@ def least_power_of_two_greater_equal(n, i=0):
 
         >>> for n in range(10, 20):
         ...     print('\t%s\t%s' % (n, mathtools.least_power_of_two_greater_equal(n)))
-        ... 
-            10 16
-            11 16
-            12 16
-            13 16
-            14 16
-            15 16
-            16 16
-            17 32
-            18 32
-            19 32
+        ...
+        10 16
+        11 16
+        12 16
+        13 16
+        14 16
+        15 16
+        16 16
+        17 32
+        18 32
+        19 32
 
     When ``i = 1``, returns the first integer power of ``2`` greater than
     the least integer power of ``2`` greater than or equal to *n*.
@@ -30,17 +30,17 @@ def least_power_of_two_greater_equal(n, i=0):
 
         >>> for n in range(10, 20):
         ...     print('\t%s\t%s' % (n, mathtools.least_power_of_two_greater_equal(n, i=1)))
-        ... 
-            10 32
-            11 32
-            12 32
-            13 32
-            14 32
-            15 32
-            16 32
-            17 64
-            18 64
-            19 64
+        ...
+        10 32
+        11 32
+        12 32
+        13 32
+        14 32
+        15 32
+        16 32
+        17 64
+        18 64
+        19 64
 
     When ``i = 2``, returns the second integer power of ``2`` greater than
     the least integer power of ``2`` greater than or equal to `n`, and,
@@ -53,13 +53,9 @@ def least_power_of_two_greater_equal(n, i=0):
 
     Returns integer.
     '''
-
-    if not isinstance(n, (int, float, fractions.Fraction)):
+    if not isinstance(n, (int, float, Fraction)):
         raise TypeError
-
     if n <= 0:
         raise ValueError
-
     result = 2 ** (int(math.ceil(math.log(n, 2))) + i)
-
     return result

--- a/abjad/tools/mathtools/test/test_mathtools_NonreducedFraction___init__.py
+++ b/abjad/tools/mathtools/test/test_mathtools_NonreducedFraction___init__.py
@@ -2,7 +2,6 @@
 import platform
 import pytest
 import sys
-import fractions
 from abjad import *
 from abjad.tools import systemtools
 
@@ -14,14 +13,14 @@ from abjad.tools import systemtools
 def test_mathtools_NonreducedFraction___init___01():
     if sys.version_info[0] == 2:
         result = systemtools.IOManager.count_function_calls(
-            'fractions.Fraction(3, 6)', globals())
+            'Fraction(3, 6)', globals())
         assert result == 13
         result = systemtools.IOManager.count_function_calls(
             'mathtools.NonreducedFraction(3, 6)', globals())
         assert result == 30
     else:
         result = systemtools.IOManager.count_function_calls(
-            'fractions.Fraction(3, 6)', globals())
+            'Fraction(3, 6)', globals())
         assert result < 20
         result = systemtools.IOManager.count_function_calls(
             'mathtools.NonreducedFraction(3, 6)', globals())

--- a/abjad/tools/rhythmtreetools/RhythmTreeMixin.py
+++ b/abjad/tools/rhythmtreetools/RhythmTreeMixin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import abc
-import fractions
+from abjad import Fraction
 from abjad.tools import abctools
 from abjad.tools import durationtools
 from abjad.tools import mathtools
@@ -181,7 +181,7 @@ class RhythmTreeMixin(abctools.AbjadObject):
 
     @preprolated_duration.setter
     def preprolated_duration(self, arg):
-        if not isinstance(arg, fractions.Fraction):
+        if not isinstance(arg, Fraction):
             arg = durationtools.Duration(arg)
         assert 0 < arg
         self._duration = arg

--- a/abjad/tools/scoretools/Leaf.py
+++ b/abjad/tools/scoretools/Leaf.py
@@ -582,7 +582,7 @@ class Leaf(Component):
         try:
             notes = [scoretools.Note(0, x) for x in written_durations]
         except AssignabilityError:
-            denominator = target_duration._denominator
+            denominator = target_duration.denominator
             note_durations = [
                 durationtools.Duration(_, denominator)
                 for _ in proportions.numbers

--- a/abjad/tools/scoretools/Tuplet.py
+++ b/abjad/tools/scoretools/Tuplet.py
@@ -663,7 +663,7 @@ class Tuplet(Container):
                 for x in written_durations
                 ]
         except AssignabilityError:
-            denominator = duration._denominator
+            denominator = duration.denominator
             note_durations = [
                 durationtools.Duration(x, denominator)
                 for x in ratio.numbers

--- a/abjad/tools/scoretools/Tuplet.py
+++ b/abjad/tools/scoretools/Tuplet.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import fractions
 import math
+from abjad import Fraction
 from abjad.tools import durationtools
 from abjad.tools import mathtools
 from abjad.tools import systemtools
@@ -2112,7 +2112,7 @@ class Tuplet(Container):
 
     @multiplier.setter
     def multiplier(self, expr):
-        if isinstance(expr, (int, fractions.Fraction)):
+        if isinstance(expr, (int, Fraction)):
             rational = durationtools.Multiplier(expr)
         elif isinstance(expr, tuple):
             rational = durationtools.Multiplier(expr)

--- a/abjad/tools/scoretools/make_notes.py
+++ b/abjad/tools/scoretools/make_notes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import fractions
 import numbers
+from abjad import Fraction
 from abjad.tools import durationtools
 from abjad.tools import mathtools
 from abjad.tools import sequencetools
@@ -246,7 +246,7 @@ def make_notes(
             denominator = duration[0].denominator
             numerator = mathtools.greatest_power_of_two_less_equal(denominator)
             multiplier = (numerator, denominator)
-            ratio = 1 / fractions.Fraction(*multiplier)
+            ratio = 1 / Fraction(*multiplier)
             duration = [ratio * durationtools.Duration(d) for d in duration]
             ns = _make_unprolated_notes(
                 ps,

--- a/abjad/tools/scoretools/make_repeated_notes_with_shorter_notes_at_end.py
+++ b/abjad/tools/scoretools/make_repeated_notes_with_shorter_notes_at_end.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import fractions
+from abjad import Fraction
 from abjad.tools import durationtools
 from abjad.tools import selectiontools
 
@@ -81,7 +81,7 @@ def make_repeated_notes_with_shorter_notes_at_end(
     written_duration = durationtools.Duration(written_duration)
     total_duration = durationtools.Duration(total_duration)
     prolation = durationtools.Duration(prolation)
-    prolation = fractions.Fraction(prolation)
+    prolation = Fraction(prolation)
 
     duration = prolation * written_duration
     current_duration = durationtools.Duration(0)

--- a/abjad/tools/sequencetools/partition_sequence_by_ratio_of_weights.py
+++ b/abjad/tools/sequencetools/partition_sequence_by_ratio_of_weights.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import collections
-import fractions
+from abjad import Fraction
 from abjad.tools import mathtools
 
 
@@ -65,7 +65,7 @@ def partition_sequence_by_ratio_of_weights(sequence, weights):
     result.append(sublist)
     current_cumulative_weight = cumulative_weights.pop(0)
     for n in sequence:
-        if not isinstance(n, (int, float, fractions.Fraction)):
+        if not isinstance(n, (int, float, Fraction)):
             message = 'must be number: {!r}.'
             message = message.format(n)
             raise TypeError(message)

--- a/abjad/tools/sequencetools/sum_elements.py
+++ b/abjad/tools/sequencetools/sum_elements.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import collections
-import fractions
+from abjad import Fraction
 
 
 def sum_elements(
@@ -49,7 +49,7 @@ def sum_elements(
     sequence_type = type(sequence)
 
     assert all(
-        isinstance(x, (int, float, fractions.Fraction)) for x in sequence)
+        isinstance(x, (int, float, Fraction)) for x in sequence)
     assert isinstance(period, (int, type(None)))
     assert isinstance(overhang, bool)
 

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,9 @@ if StrictVersion(version) < StrictVersion('3.3.0'):
     install_requires.append('mock')
 
 extras_require = {
+    'accelerated': [
+        'quicktions>=1.3',
+        ],
     'development': [
         'pytest>=3.0.0',
         'sphinx>=1.4',


### PR DESCRIPTION
This PR allows Abjad to use the C-accelerated `quicktions.Fraction` class in place of the standard library `fractions.Fraction` class.

Install via `pip install -e .[accelerated]`.