### PR TITLE
Teach abjad-book about indentation, add raw LP blocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
 
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
 
 matrix:
@@ -21,6 +21,7 @@ matrix:
 addons:
     apt:
         packages:
+            - ghostscript
             - graphviz
             - imagemagick
             - lmodern

--- a/abjad/tools/abjadbooktools/CodeBlock.py
+++ b/abjad/tools/abjadbooktools/CodeBlock.py
@@ -156,12 +156,12 @@ class CodeBlock(abctools.AbjadValueObject):
         for key, value in block.attlist():
             key = key.replace('-', '_')
             cleaned_options[key] = value
-        code_block_specifier = abjadbooktools.CodeBlockSpecifier.from_options(
-            **cleaned_options)
-        image_layout_specifier = abjadbooktools.ImageLayoutSpecifier.from_options(
-            **cleaned_options)
-        image_render_specifier = abjadbooktools.ImageRenderSpecifier.from_options(
-            **cleaned_options)
+        code_block_specifier, cleaned_options = \
+            abjadbooktools.CodeBlockSpecifier.from_options(**cleaned_options)
+        image_layout_specifier, cleaned_options = \
+            abjadbooktools.ImageLayoutSpecifier.from_options(**cleaned_options)
+        image_render_specifier, cleaned_options = \
+            abjadbooktools.ImageRenderSpecifier.from_options(**cleaned_options)
         code_block = abjadbooktools.CodeBlock(
             code_block_specifier=code_block_specifier,
             executed_lines=executed_lines,
@@ -182,12 +182,12 @@ class CodeBlock(abctools.AbjadValueObject):
         for key, value in block.attlist():
             key = key.replace('-', '_')
             cleaned_options[key] = value
-        code_block_specifier = abjadbooktools.CodeBlockSpecifier.from_options(
-            **cleaned_options)
-        image_layout_specifier = abjadbooktools.ImageLayoutSpecifier.from_options(
-            **cleaned_options)
-        image_render_specifier = abjadbooktools.ImageRenderSpecifier.from_options(
-            **cleaned_options)
+        code_block_specifier, cleaned_options = \
+            abjadbooktools.CodeBlockSpecifier.from_options(**cleaned_options)
+        image_layout_specifier, cleaned_options = \
+            abjadbooktools.ImageLayoutSpecifier.from_options(**cleaned_options)
+        image_render_specifier, cleaned_options = \
+            abjadbooktools.ImageRenderSpecifier.from_options(**cleaned_options)
         code_block = abjadbooktools.CodeBlock(
             code_block_specifier=code_block_specifier,
             image_layout_specifier=image_layout_specifier,
@@ -231,12 +231,12 @@ class CodeBlock(abctools.AbjadValueObject):
         for key, value in options.items():
             key = key.replace('-', '_')
             cleaned_options[key] = value
-        code_block_specifier = abjadbooktools.CodeBlockSpecifier.from_options(
-            **cleaned_options)
-        image_layout_specifier = abjadbooktools.ImageLayoutSpecifier.from_options(
-            **cleaned_options)
-        image_render_specifier = abjadbooktools.ImageRenderSpecifier.from_options(
-            **cleaned_options)
+        code_block_specifier, cleaned_options = \
+            abjadbooktools.CodeBlockSpecifier.from_options(**cleaned_options)
+        image_layout_specifier, cleaned_options = \
+            abjadbooktools.ImageLayoutSpecifier.from_options(**cleaned_options)
+        image_render_specifier, cleaned_options = \
+            abjadbooktools.ImageRenderSpecifier.from_options(**cleaned_options)
         code_block = abjadbooktools.CodeBlock(
             code_block_specifier=code_block_specifier,
             image_layout_specifier=image_layout_specifier,
@@ -267,12 +267,12 @@ class CodeBlock(abctools.AbjadValueObject):
         for key, value in options.items():
             key = key.replace('-', '_')
             cleaned_options[key] = value
-        code_block_specifier = abjadbooktools.CodeBlockSpecifier.from_options(
-            **cleaned_options)
-        image_layout_specifier = abjadbooktools.ImageLayoutSpecifier.from_options(
-            **cleaned_options)
-        image_render_specifier = abjadbooktools.ImageRenderSpecifier.from_options(
-            **cleaned_options)
+        code_block_specifier, cleaned_options = \
+            abjadbooktools.CodeBlockSpecifier.from_options(**cleaned_options)
+        image_layout_specifier, cleaned_options = \
+            abjadbooktools.ImageLayoutSpecifier.from_options(**cleaned_options)
+        image_render_specifier, cleaned_options = \
+            abjadbooktools.ImageRenderSpecifier.from_options(**cleaned_options)
         code_block = abjadbooktools.CodeBlock(
             code_block_specifier=code_block_specifier,
             executed_lines=executed_lines,

--- a/abjad/tools/abjadbooktools/CodeBlockSpecifier.py
+++ b/abjad/tools/abjadbooktools/CodeBlockSpecifier.py
@@ -48,23 +48,31 @@ class CodeBlockSpecifier(abctools.AbjadValueObject):
 
         Returns code block specifier.
         '''
-        allow_exceptions = options.get('allow_exceptions', None) or None
-        hide = options.get('hide', None) or None
-        strip_prompt = options.get('strip_prompt', None) or None
-        text_width = options.get('text_width', None) or None
+        allow_exceptions = None
+        if 'allow_exceptions' in options:
+            allow_exceptions = options.pop('allow_exceptions')
+        hide = None
+        if 'hide' in options:
+            hide = options.pop('hide')
+        strip_prompt = None
+        if 'strip_prompt' in options:
+            strip_prompt = options.pop('strip_prompt')
+        text_width = None
+        if 'text_width' in options:
+            text_width = options.pop('text_width')
         if all(_ is None for _ in (
             allow_exceptions,
             hide,
             strip_prompt,
             text_width,
             )):
-            return None
+            return None, options
         return cls(
             allow_exceptions=allow_exceptions,
             hide=hide,
             strip_prompt=strip_prompt,
             text_width=text_width,
-            )
+            ), options
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjad/tools/abjadbooktools/ImageLayoutSpecifier.py
+++ b/abjad/tools/abjadbooktools/ImageLayoutSpecifier.py
@@ -40,20 +40,26 @@ class ImageLayoutSpecifier(abctools.AbjadValueObject):
 
         Returns image specifier.
         '''
-        pages = options.get('pages', None) or None
-        with_columns = options.get('with_columns', None) or None
-        with_thumbnail = options.get('with_thumbnail', None) or None
+        pages = None
+        if 'pages' in options:
+            pages = options.pop('pages')
+        with_columns = None
+        if 'with_columns' in options:
+            with_columns = options.pop('with_columns')
+        with_thumbnail = None
+        if 'with_thumbnail' in options:
+            with_thumbnail = options.pop('with_thumbnail')
         if all(_ is None for _ in (
             pages,
             with_columns,
             with_thumbnail,
             )):
-            return None
+            return None, options
         return cls(
             pages=pages,
             with_columns=with_columns,
             with_thumbnail=with_thumbnail,
-            )
+            ), options
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjad/tools/abjadbooktools/ImageOutputProxy.py
+++ b/abjad/tools/abjadbooktools/ImageOutputProxy.py
@@ -17,6 +17,7 @@ class ImageOutputProxy(abctools.AbjadValueObject):
     __slots__ = (
         '_image_layout_specifier',
         '_image_render_specifier',
+        '_options',
         '_payload',
         )
 
@@ -26,9 +27,11 @@ class ImageOutputProxy(abctools.AbjadValueObject):
         self,
         image_layout_specifier=None,
         image_render_specifier=None,
+        **options
         ):
         self._image_layout_specifier = image_layout_specifier
         self._image_render_specifier = image_render_specifier
+        self._options = options
 
     ### PRIVATE METHODS ###
 
@@ -58,8 +61,16 @@ class ImageOutputProxy(abctools.AbjadValueObject):
             string = '\\noindent\\includegraphics{{{}}}'.format(
                 relative_file_path,
                 )
-        before = latex_configuration.get('before-includegraphics', ())
-        after = latex_configuration.get('after-includegraphics', ())
+        before = self.options.get('before_includegraphics', ())
+        if isinstance(before, str):
+            before = (before,)
+        if not before:
+            before = latex_configuration.get('before-includegraphics', ())
+        after = self.options.get('after_includegraphics', ())
+        if isinstance(after, str):
+            after = (after,)
+        if not after:
+            after = latex_configuration.get('after-includegraphics', ())
         result.extend(before)
         result.append(string)
         result.extend(after)
@@ -85,7 +96,11 @@ class ImageOutputProxy(abctools.AbjadValueObject):
         configuration = configuration or {}
         latex_configuration = configuration.get('latex', {})
         options_key = '{}-options'.format(self.file_name_prefix)
-        options = latex_configuration.get(options_key, ())
+        options = self.options.get(options_key.replace('-', '_'), ())
+        if isinstance(options, str):
+            options = (options,)
+        if not options:
+            options = latex_configuration.get(options_key, ())
         options = ''.join(options)
         file_extension = '.pdf'
         file_name = self.file_name_without_extension + file_extension
@@ -176,6 +191,10 @@ class ImageOutputProxy(abctools.AbjadValueObject):
         r'''Gets image specifier.
         '''
         return self._image_render_specifier
+
+    @property
+    def options(self):
+        return self._options
 
     @property
     def payload(self):

--- a/abjad/tools/abjadbooktools/ImageRenderSpecifier.py
+++ b/abjad/tools/abjadbooktools/ImageRenderSpecifier.py
@@ -41,23 +41,31 @@ class ImageRenderSpecifier(abctools.AbjadValueObject):
 
         Returns image specifier.
         '''
-        no_resize = options.get('no_resize', None) or None
-        no_stylesheet = options.get('no_stylesheet', None) or None
-        no_trim = options.get('no_trim', None) or None
-        stylesheet = options.get('stylesheet', None) or None
+        no_resize = None
+        if 'no_resize' in options:
+            no_resize = options.pop('no_resize')
+        no_stylesheet = None
+        if 'no_stylesheet' in options:
+            no_stylesheet = options.pop('no_stylesheet')
+        no_trim = None
+        if 'no_trim' in options:
+            no_trim = options.pop('no_trim')
+        stylesheet = None
+        if 'stylesheet' in options:
+            stylesheet = options.pop('stylesheet')
         if all(_ is None for _ in (
             no_resize,
             no_stylesheet,
             no_trim,
             stylesheet,
             )):
-            return None
+            return None, options
         return cls(
             no_resize=no_resize,
             no_stylesheet=no_stylesheet,
             no_trim=no_trim,
             stylesheet=stylesheet,
-            )
+            ), options
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjad/tools/abjadbooktools/LilyPondBlock.py
+++ b/abjad/tools/abjadbooktools/LilyPondBlock.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+from abjad.tools import abctools
+
+
+class LilyPondBlock(abctools.AbjadValueObject):
+    r'''A LilyPond block.
+    '''
+
+    ### CLASS VARIABLES ###
+
+    __documentation_section__ = 'Internals'
+
+    ### CLASS VARIABLES ###
+
+    __slots__ = (
+        '_image_layout_specifier',
+        '_image_render_specifier',
+        '_output_proxies',
+        '_options',
+        '_source_lines',
+        '_starting_line_number',
+        )
+
+    ### INITIALIZER ###
+
+    def __init__(
+        self,
+        input_file_contents,
+        image_layout_specifier=None,
+        image_render_specifier=None,
+        starting_line_number=None,
+        **options
+        ):
+        from abjad.tools import abjadbooktools
+        self._image_layout_specifier = image_layout_specifier
+        self._image_render_specifier = image_render_specifier
+        self._source_lines = tuple(input_file_contents)
+        self._starting_line_number = starting_line_number
+        self._output_proxies = [
+            abjadbooktools.RawLilyPondOutputProxy(
+                payload='\n'.join(input_file_contents),
+                image_layout_specifier=image_layout_specifier,
+                image_render_specifier=image_render_specifier,
+                **options
+                ),
+            ]
+        self._options = options
+
+    ### PUBLIC METHODS ###
+
+    def as_latex(
+        self,
+        configuration=None,
+        output_directory=None,
+        relative_output_directory=None,
+        ):
+        from abjad.tools import abjadbooktools
+        result = []
+        configuration = configuration or {}
+        latex_configuration = configuration.get('latex', {})
+        output_start_delimiter = latex_configuration.get(
+            'output-start-delimiter',
+            ('%%% ABJADBOOK START %%%',),
+            )
+        output_stop_delimiter = latex_configuration.get(
+            'output-stop-delimiter',
+            ('%%% ABJADBOOK END %%%',),
+            )
+        if self.output_proxies:
+            result.extend(output_start_delimiter)
+            before = latex_configuration.get('before-code-block', ())
+            result.extend(before)
+            for i, output_proxy in enumerate(self.output_proxies):
+                lines = output_proxy.as_latex(
+                    configuration=configuration,
+                    output_directory=output_directory,
+                    relative_output_directory=relative_output_directory,
+                    )
+                string = '\n'.join(lines)
+                if isinstance(output_proxy, abjadbooktools.ImageOutputProxy):
+                    if i < len(self.output_proxies) - 1:
+                        next_proxy = self.output_proxies[i + 1]
+                        if isinstance(next_proxy, abjadbooktools.ImageOutputProxy):
+                            string += r'\\'
+                result.append(string)
+            after = latex_configuration.get('after-code-block', ())
+            result.extend(after)
+            result.extend(output_stop_delimiter)
+            result = '\n'.join(result)
+            result = [result]
+        return result
+
+    @classmethod
+    def from_latex_lilypond_block(
+        cls,
+        input_file_contents,
+        starting_line_number=None,
+        **options
+        ):
+        from abjad.tools import abjadbooktools
+        cleaned_options = {}
+        for key, value in options.items():
+            key = key.replace('-', '_')
+            cleaned_options[key] = value
+        image_layout_specifier, cleaned_options = abjadbooktools.ImageLayoutSpecifier.from_options(
+            **cleaned_options)
+        image_render_specifier, cleaned_options = abjadbooktools.ImageRenderSpecifier.from_options(
+            **cleaned_options)
+        code_block = cls(
+            image_layout_specifier=image_layout_specifier,
+            image_render_specifier=image_render_specifier,
+            input_file_contents=input_file_contents,
+            starting_line_number=starting_line_number,
+            **cleaned_options
+            )
+        return code_block
+
+    def interpret(self, console):
+        """
+        No-op.
+        """
+        pass
+
+    ### PUBLIC PROPERTIES ###
+
+    @property
+    def image_layout_specifier(self):
+        return self._image_layout_specifier
+
+    @property
+    def image_render_specifier(self):
+        return self._image_render_specifier
+
+    @property
+    def input_file_contents(self):
+        return self._source_lines
+
+    @property
+    def options(self):
+        return self._options
+
+    @property
+    def output_proxies(self):
+        return self._output_proxies
+
+    @property
+    def starting_line_number(self):
+        return self._starting_line_number

--- a/abjad/tools/abjadbooktools/LilyPondOutputProxy.py
+++ b/abjad/tools/abjadbooktools/LilyPondOutputProxy.py
@@ -53,11 +53,7 @@ class LilyPondOutputProxy(ImageOutputProxy):
 
     __documentation_section__ = 'Output Proxies'
 
-    __slots__ = (
-        '_pages',
-        '_payload',
-        '_stylesheet',
-        )
+    __slots__ = ()
 
     ### INITIALIZER ###
 
@@ -130,14 +126,6 @@ class LilyPondOutputProxy(ImageOutputProxy):
             raise AssertionError
         assert systemtools.IOManager.find_executable('pdfcrop')
         command = 'pdfcrop {path} {path}'.format(path=pdf_file_path)
-
-#        exit_code = subprocess.call(
-#            command,
-#            shell=True,
-#            stdout=subprocess.PIPE,
-#            stderr=subprocess.PIPE,
-#            )
-#        assert exit_code == 0
         process = subprocess.Popen(
             command,
             shell=True,
@@ -147,7 +135,6 @@ class LilyPondOutputProxy(ImageOutputProxy):
         stdout, stderr = process.communicate()
         if not process.returncode == 0:
             raise Exception(stdout)
-
         return pdf_file_path
 
     ### PUBLIC METHODS ###

--- a/abjad/tools/abjadbooktools/RawLilyPondOutputProxy.py
+++ b/abjad/tools/abjadbooktools/RawLilyPondOutputProxy.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+import os
+import subprocess
+from abjad.tools import systemtools
+from abjad.tools.abjadbooktools.ImageOutputProxy import ImageOutputProxy
+
+
+class RawLilyPondOutputProxy(ImageOutputProxy):
+    """
+    A raw LilyPond output proxy.
+
+    ::
+
+        >>> from abjad.tools import abjadbooktools
+        >>> raw_lilypond = '{ c d e f }'
+        >>> proxy = abjadbooktools.RawLilyPondOutputProxy(raw_lilypond)
+        >>> print(format(proxy))
+        abjadbooktools.RawLilyPondOutputProxy(
+            '\\version "2.19.0"\n\n{ c d e f }'
+            )
+
+    ::
+
+        >>> proxy.as_latex(relative_output_directory='assets')
+        ['\\noindent\\includegraphics{assets/lilypond-678fb46ce202b3d770361f814e6e1946.pdf}']
+
+    """
+
+    ### CLASS VARIABLES ###
+
+    __documentation_section__ = 'Output Proxies'
+
+    __slots__ = ()
+
+    ### INITIALIZER ###
+
+    def __init__(
+        self,
+        payload,
+        image_layout_specifier=None,
+        image_render_specifier=None,
+        **options
+        ):
+        from abjad.tools import abjadbooktools
+        ImageOutputProxy.__init__(
+            self,
+            image_layout_specifier=image_layout_specifier,
+            image_render_specifier=image_render_specifier,
+            **options
+            )
+        if image_render_specifier is None:
+            image_render_specifier = abjadbooktools.ImageRenderSpecifier()
+        preamble = []
+        if not payload.startswith(r'\version'):
+            preamble.extend([r'\version "2.19.0"', ''])
+        if (
+            image_render_specifier.stylesheet and
+            not image_render_specifier.no_stylesheet
+            ):
+            preamble.extend([
+                "#(ly:set-option 'relative-includes #t)",
+                '\include "{}"'.format(image_render_specifier.stylesheet),
+                '',
+                ])
+        if preamble:
+            payload = '\n'.join(preamble) + '\n' + payload
+        self._payload = payload
+
+    ### PRIVATE METHODS ###
+
+    def _render_pdf_source(
+        self,
+        temporary_directory_path,
+        ):
+        from abjad import abjad_configuration
+        log_file_path = abjad_configuration.lilypond_log_file_path
+        ly_file_path = os.path.join(
+            temporary_directory_path,
+            self.file_name_without_extension + '.ly',
+            )
+        source = format(self.payload)
+        with open(ly_file_path, 'w') as file_pointer:
+            file_pointer.write(source)
+        systemtools.IOManager.run_lilypond(ly_file_path)
+        pdf_file_path = os.path.join(
+            temporary_directory_path,
+            self.file_name_without_extension + '.pdf',
+            )
+        if not os.path.exists(pdf_file_path):
+            print(format(self.payload))
+            with open(log_file_path) as file_pointer:
+                print(file_pointer.read())
+            raise AssertionError
+        assert systemtools.IOManager.find_executable('pdfcrop')
+        command = 'pdfcrop {path} {path}'.format(path=pdf_file_path)
+        process = subprocess.Popen(
+            command,
+            shell=True,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            )
+        stdout, stderr = process.communicate()
+        if not process.returncode == 0:
+            raise Exception(stdout)
+        return pdf_file_path
+
+    ### PUBLIC PROPERTIES ###
+
+    @property
+    def file_name_prefix(self):
+        r'''Gets file name prefix of LilyPond output proxy.
+
+        Returns string.
+        '''
+        return 'lilypond'

--- a/abjad/tools/abjadbooktools/test/test_LaTeXDocumentHandler_lilypond.py
+++ b/abjad/tools/abjadbooktools/test/test_LaTeXDocumentHandler_lilypond.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+import platform
+import unittest
+from abjad.tools import abjadbooktools
+from abjad.tools import stringtools
+
+
+@unittest.skipIf(
+    platform.python_implementation() != 'CPython',
+    'Only for CPython',
+    )
+class TestCase(unittest.TestCase):
+
+    maxDiff = None
+
+    input_file_contents = stringtools.normalize(r'''
+    foo
+
+    \begin{comment}
+    <lilypond>
+    { c'4 d'4 e'4 f'4 }
+    </lilypond>
+    \end{comment}
+
+    bar
+
+    \begin{comment}
+    <lilypond>[stylesheet=quux.ily]
+    {
+        b'1
+        fs'1
+    }
+    </lilypond>
+    \end{comment}
+
+    baz
+    ''').split('\n')
+
+    def test_lilypond_1(self):
+        document_handler = abjadbooktools.LaTeXDocumentHandler()
+        input_blocks = document_handler.collect_input_blocks(
+            self.input_file_contents)
+        assert input_blocks == {
+            (3, 5): abjadbooktools.LilyPondBlock(
+                (
+                    "{ c'4 d'4 e'4 f'4 }",
+                    ),
+                starting_line_number=5,
+                ),
+            (11, 16): abjadbooktools.LilyPondBlock(
+                (
+                    '{',
+                    "    b'1",
+                    "    fs'1",
+                    '}',
+                    ),
+                image_render_specifier=abjadbooktools.ImageRenderSpecifier(
+                    stylesheet='quux.ily',
+                    ),
+                starting_line_number=16,
+                )
+            }
+
+    def test_lilypond_2(self):
+        document_handler = abjadbooktools.LaTeXDocumentHandler(
+            input_file_contents=self.input_file_contents,
+            )
+        rebuilt_source = document_handler(return_source=True)
+        assert rebuilt_source == stringtools.normalize(r"""
+            foo
+
+            \begin{comment}
+            <lilypond>
+            { c'4 d'4 e'4 f'4 }
+            </lilypond>
+            \end{comment}
+
+            %%% ABJADBOOK START %%%
+            \noindent\includegraphics{assets/lilypond-09540b526d368c57363f2e1774dd74e5.pdf}
+            %%% ABJADBOOK END %%%
+
+            bar
+
+            \begin{comment}
+            <lilypond>[stylesheet=quux.ily]
+            {
+                b'1
+                fs'1
+            }
+            </lilypond>
+            \end{comment}
+
+            %%% ABJADBOOK START %%%
+            \noindent\includegraphics{assets/lilypond-9908e347a02914cf77c6f44c3067ed7f.pdf}
+            %%% ABJADBOOK END %%%
+
+            baz
+        """)

--- a/abjad/tools/test/test_abjad___doc__.py
+++ b/abjad/tools/test/test_abjad___doc__.py
@@ -29,7 +29,9 @@ ignored_names = (
 
 ignored_classes = (
     abjadbooktools.CodeBlock,
+    abjadbooktools.ImageOutputProxy,
     abjadbooktools.LaTeXDocumentHandler,
+    abjadbooktools.LilyPondBlock,
     abjadbooktools.SphinxDocumentHandler,
     datastructuretools.Enumeration,
     lilypondparsertools.LilyPondLexicalDefinition,

--- a/abjad/tools/test/test_abjad___hash__.py
+++ b/abjad/tools/test/test_abjad___hash__.py
@@ -13,14 +13,17 @@ ignored_classes = (
     abjadbooktools.CodeOutputProxy,
     abjadbooktools.DoctestDirective,
     abjadbooktools.GraphvizOutputProxy,
+    abjadbooktools.ImageOutputProxy,
     abjadbooktools.ImportDirective,
+    abjadbooktools.LilyPondBlock,
     abjadbooktools.LilyPondOutputProxy,
+    abjadbooktools.RawLilyPondOutputProxy,
     abjadbooktools.RevealDirective,
     abjadbooktools.ShellDirective,
     abjadbooktools.ThumbnailDirective,
     datastructuretools.Enumeration,
-    systemtools.StorageFormatAgent,
     systemtools.FormatSpecification,
+    systemtools.StorageFormatAgent,
     systemtools.TestCase,
     )
 

--- a/abjad/tools/test/test_abjad___init__.py
+++ b/abjad/tools/test/test_abjad___init__.py
@@ -2,13 +2,14 @@
 import functools
 import inspect
 import pytest
-import sys
+#import sys
 from abjad.tools import abjadbooktools
 from abjad.tools import datastructuretools
 from abjad.tools import documentationtools
 from abjad.tools import durationtools
 from abjad.tools import mathtools
 from abjad.tools import systemtools
+#from distutils.version import StrictVersion
 
 
 ignored_classes = (
@@ -18,7 +19,9 @@ ignored_classes = (
     abjadbooktools.DoctestDirective,
     abjadbooktools.GraphvizOutputProxy,
     abjadbooktools.ImportDirective,
+    abjadbooktools.LilyPondBlock,
     abjadbooktools.LilyPondOutputProxy,
+    abjadbooktools.RawLilyPondOutputProxy,
     abjadbooktools.RevealDirective,
     abjadbooktools.ShellDirective,
     abjadbooktools.ThumbnailDirective,
@@ -45,15 +48,15 @@ def test_abjad___init___01(class_):
 
 valid_types = (
     bool,
+    datastructuretools.OrdinalConstant,
+    durationtools.Duration,
     float,
     int,
+    mathtools.Infinity,
+    mathtools.NegativeInfinity,
     str,
     tuple,
     type(None),
-    datastructuretools.OrdinalConstant,
-    durationtools.Duration,
-    mathtools.Infinity,
-    mathtools.NegativeInfinity,
     )
 
 
@@ -61,27 +64,29 @@ valid_types = (
 def test_abjad___init___02(obj):
     r'''Make sure class initializer keyword argument values are immutable.
     '''
-    version = sys.version
-    # NOTE: something changed in 3.5's "inspect" module
-    if not version.startswith('3.5'):
-        for attr in inspect.classify_class_attrs(obj):
-            if attr.defining_class is not obj:
+    #version = StrictVersion('.'.join(str(x) for x in sys.version_info[:3]))
+    #if StrictVersion('3.5.0') <= version:
+    #    return
+    for attr in inspect.classify_class_attrs(obj):
+        if attr.defining_class is not obj:
+            continue
+        elif attr.kind != 'method':
+            continue
+        obj = attr.object
+        if isinstance(obj, functools.partial):
+            obj = obj.function
+        argument_specification = inspect.getargspec(obj)
+        keyword_argument_names = argument_specification.args[1:]
+        keyword_argument_values = argument_specification.defaults
+        if keyword_argument_values is None:
+            continue
+        for name, value in zip(
+            keyword_argument_names, keyword_argument_values):
+            if value is NotImplemented:
                 continue
-            elif attr.kind != 'method':
-                continue
-            obj = attr.object
-            if isinstance(obj, functools.partial):
-                obj = obj.function
-            argument_specification = inspect.getargspec(obj)
-            keyword_argument_names = argument_specification.args[1:]
-            keyword_argument_values = argument_specification.defaults
-            if keyword_argument_values is None:
-                continue
-            for name, value in zip(
-                keyword_argument_names, keyword_argument_values):
-                assert isinstance(value, valid_types), (attr.name, name, value)
-                if isinstance(value, tuple):
-                    assert all(isinstance(x, valid_types) for x in value)
+            assert isinstance(value, valid_types), (attr.name, name, value)
+            if isinstance(value, tuple):
+                assert all(isinstance(x, valid_types) for x in value)
 
 
 functions = documentationtools.list_all_abjad_functions()

--- a/abjad/tools/test/test_abjad___repr__.py
+++ b/abjad/tools/test/test_abjad___repr__.py
@@ -14,13 +14,15 @@ ignored_classes = (
     abjadbooktools.DoctestDirective,
     abjadbooktools.GraphvizOutputProxy,
     abjadbooktools.ImportDirective,
+    abjadbooktools.LilyPondBlock,
     abjadbooktools.LilyPondOutputProxy,
+    abjadbooktools.RawLilyPondOutputProxy,
     abjadbooktools.RevealDirective,
     abjadbooktools.ShellDirective,
     abjadbooktools.ThumbnailDirective,
     datastructuretools.Enumeration,
-    systemtools.StorageFormatAgent,
     systemtools.FormatSpecification,
+    systemtools.StorageFormatAgent,
     systemtools.TestCase,
     )
 

--- a/abjad/tools/test/test_abjad___slots__.py
+++ b/abjad/tools/test/test_abjad___slots__.py
@@ -11,10 +11,12 @@ ignored_classes = (
     abjadbooktools.CodeBlock,
     abjadbooktools.CodeOutputProxy,
     abjadbooktools.GraphvizOutputProxy,
+    abjadbooktools.LilyPondBlock,
     abjadbooktools.LilyPondOutputProxy,
+    abjadbooktools.RawLilyPondOutputProxy,
     expressiontools.Expression,
-    systemtools.StorageFormatAgent,
     systemtools.FormatSpecification,
+    systemtools.StorageFormatAgent,
     )
 
 classes = documentationtools.list_all_abjad_classes(

--- a/abjad/tools/test/test_abjad___str__.py
+++ b/abjad/tools/test/test_abjad___str__.py
@@ -28,13 +28,15 @@ ignored_classes = (
     abjadbooktools.DoctestDirective,
     abjadbooktools.GraphvizOutputProxy,
     abjadbooktools.ImportDirective,
+    abjadbooktools.LilyPondBlock,
     abjadbooktools.LilyPondOutputProxy,
+    abjadbooktools.RawLilyPondOutputProxy,
     abjadbooktools.RevealDirective,
     abjadbooktools.ShellDirective,
     abjadbooktools.ThumbnailDirective,
     datastructuretools.Enumeration,
-    systemtools.StorageFormatAgent,
     systemtools.FormatSpecification,
+    systemtools.StorageFormatAgent,
     systemtools.TestCase,
     )
 


### PR DESCRIPTION
`ajv book` can now locate abjad-book blocks which are indented, e.g.

```
Some text.

    \begin{comment}
    <abjad>
    note = Note("c'4")
    show(note)
    </abjad>
    \end{comment}

More text.
```

The output blocks (if any) will be indented to the same level.

This makes LaTeX sources easier to read.

Additionally, taught abjad-book about `<lilypond>` blocks. These blocks behave the same as `<abjad>` blocks, except they take LilyPond code as an input, rather than Python.