### PR TITLE
Bump Abjad to 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,16 @@ sudo: false
 
 env:
     global:
-        - LILYPOND_VERSION=2.19.28
+        - LILYPOND_VERSION=2.19.65
 
 python:
-    - 2.7
     - 3.4
     - 3.5
     - 3.6
-    - pypy
 
 matrix:
     include:
-        python: "3.5"
+        python: "3.6"
         env: ACCELERATED=true
 
 addons:
@@ -35,7 +33,6 @@ addons:
             - texlive-xetex
 
 before_install:
-    - echo TRAVIS_PYTHON_VERSION $TRAVIS_PYTHON_VERSION
     - wget -q http://download.linuxaudio.org/lilypond/binaries/linux-64/lilypond-$LILYPOND_VERSION-1.linux-64.sh
     - sh lilypond-$LILYPOND_VERSION-1.linux-64.sh --batch
     - export PATH=/home/travis/bin:$PATH
@@ -61,13 +58,10 @@ install:
 script:
     - abjad/scr/ajv doctest --diff experimental
     - py.test -rf experimental
-    - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then coverage run -a `which jupyter` nbconvert --to=html --ExecutePreprocessor.enabled=True abjad/ext/abjad-ipython-notebook-test-no-audio.ipynb; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != pypy ]]; then coverage run -a abjad/scr/ajv doctest --diff abjad; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != pypy ]]; then coverage run -a `which py.test` -rf abjad; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != pypy ]]; then coverage run -a abjad/scr/ajv api -R; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then abjad/scr/ajv doctest --diff abjad; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then `which py.test` -rf abjad; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then abjad/scr/ajv api -R; fi
+    - coverage run -a `which jupyter` nbconvert --to=html --ExecutePreprocessor.enabled=True abjad/ext/abjad-ipython-notebook-test-no-audio.ipynb
+    - coverage run -a abjad/scr/ajv doctest --diff abjad
+    - coverage run -a `which py.test` -rf abjad
+    - coverage run -a abjad/scr/ajv api -R
 
 after_success:
-    - if [[ $TRAVIS_PYTHON_VERSION != pypy ]]; then coveralls; fi
+    - coveralls

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+clean:
+	rm -Rif Abjad.egg-info/
+	rm -Rif build/
+	rm -Rif dist/
+
+release:
+	make -C abjad/docs upload
+	python setup.py sdist
+	twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -38,9 +38,7 @@ typographic details of the symbols on the page.
 Installation
 ============
 
-Abjad works on Unix/Linux, OSX, and Windows.
-
-Abjad also works with `CPython`_ versions 2.7 and 3.3+, as well as `PyPy`_.
+Abjad works on Unix/Linux, OSX, and Windows on Python versions 3.4+.
 
 Install Abjad
 -------------

--- a/abjad/_version.py
+++ b/abjad/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (2, 21)
+__version_info__ = (3, 0, 0)
 __version__ = '.'.join(str(x) for x in __version_info__)

--- a/abjad/docs/source/installation.rst
+++ b/abjad/docs/source/installation.rst
@@ -1,9 +1,7 @@
 Installation
 ============
 
-Abjad works on Unix/Linux, OSX, and Windows.
-
-Abjad also works with `CPython`_ versions 2.7 and 3.3+, as well as `PyPy`_.
+Abjad works on Unix/Linux, OSX, and Windows on Python versions 3.4+.
 
 Install Abjad
 -------------
@@ -426,7 +424,6 @@ you might want to set your ``pdf_viewer`` to ``evince`` and your
 ..  _MacTeX: https://tug.org/mactex/
 ..  _PyPDF2: http://pythonhosted.org/PyPDF2/
 ..  _PyPI: https://pypi.python.org/pypi/Abjad
-..  _PyPy: http://pypy.org/
 ..  _Python: https://www.python.org/
 ..  _Sphinx: http://sphinx-doc.org/
 ..  _TeXLive: https://www.tug.org/texlive/

--- a/abjad/tools/datastructuretools/Expression.py
+++ b/abjad/tools/datastructuretools/Expression.py
@@ -368,8 +368,6 @@ class Expression(AbjadValueObject):
     def __dict__(self):
         r'''Gets attributes.
 
-        Trivial implementation defined equal to ``dir(self)`` to satisfy PyPy.
-
         Returns list or strings.
         '''
         return dir(self)

--- a/abjad/tools/systemtools/AbjadConfiguration.py
+++ b/abjad/tools/systemtools/AbjadConfiguration.py
@@ -135,7 +135,7 @@ class AbjadConfiguration(Configuration):
             ::
 
                 >>> abjad_configuration.get_abjad_startup_string()
-                'Abjad 2.21 (development)'
+                'Abjad 3.0.0 (development)'
 
         Returns string.
         '''
@@ -155,7 +155,7 @@ class AbjadConfiguration(Configuration):
             ::
 
                 >>> abjad_configuration.get_abjad_version_string()
-                '2.21'
+                '3.0.0'
 
         Returns string.
         '''

--- a/abjad/tools/systemtools/StorageFormatAgent.py
+++ b/abjad/tools/systemtools/StorageFormatAgent.py
@@ -733,34 +733,15 @@ class StorageFormatAgent(AbjadValueObject):
         accepts_kwargs = False
         if not isinstance(subject, type):
             subject = type(subject)
-        if platform.python_implementation() == 'PyPy':
-            # Under PyPy, funcsigs can't automatically find the correct 
-            # initializer or constructor, so must be told what's desired.
-            # PyPy also seems to create function objects that don't exist
-            # under CPython, so we have to check for the existence of a 
-            # filename to prove that those functions / methods are actually
-            # being pulled from code that exists on the filesystem.
-            if hasattr(subject.__init__.func_code, 'co_filename'):
-                signature = funcsigs.signature(subject.__init__)
-            elif hasattr(subject.__new__.func_code, 'co_filename'):
-                signature = funcsigs.signature(subject.__new__)
-            else:
-                return (
-                    positional_names,
-                    keyword_names,
-                    accepts_args,
-                    accepts_kwargs,
-                    )
-        else:
-            try:
-                signature = funcsigs.signature(subject)
-            except ValueError:
-                return (
-                    positional_names,
-                    keyword_names,
-                    accepts_args,
-                    accepts_kwargs,
-                    )
+        try:
+            signature = funcsigs.signature(subject)
+        except ValueError:
+            return (
+                positional_names,
+                keyword_names,
+                accepts_args,
+                accepts_kwargs,
+                )
         for name, parameter in signature.parameters.items():
             if parameter.kind == funcsigs._POSITIONAL_OR_KEYWORD:
                 if parameter.default == parameter.empty:
@@ -775,10 +756,6 @@ class StorageFormatAgent(AbjadValueObject):
                 accepts_args = True
             elif parameter.kind == funcsigs._VAR_KEYWORD:
                 accepts_kwargs = True
-        if platform.python_implementation() == 'PyPy':
-            # Funcsigs under PyPy doesn't discard class_ or self.
-            if positional_names:
-                positional_names.pop(0)
         return (
             positional_names,
             keyword_names,

--- a/abjad/tools/test/test_abjad___doc__.py
+++ b/abjad/tools/test/test_abjad___doc__.py
@@ -55,8 +55,6 @@ def test_abjad___doc___01(class_):
     missing_doc_names = []
     if class_.__doc__ is None:
         missing_doc_names.append(class_.__name__)
-    if class_ is abjad.String and platform.python_implementation() == 'PyPy':
-        return
     for attribute in inspect.classify_class_attrs(class_):
         if attribute.name in ignored_names:
             continue


### PR DESCRIPTION
This PR bumps Abjad to 3.0.0, and drops support for Python 2.x and PyPy.