### PR TITLE
Changed LilyPondFile.date_time_token default to false. CHANGE.

### DIFF
--- a/abjad/tools/lilypondfiletools/LilyPondFile.py
+++ b/abjad/tools/lilypondfiletools/LilyPondFile.py
@@ -110,7 +110,7 @@ class LilyPondFile(AbjadObject):
         comments = tuple(comments)
         self._comments = comments
         self._date_time_token = None
-        if date_time_token is not False:
+        if bool(date_time_token):
             self._date_time_token = lilypondfiletools.DateTimeToken()
         self._default_paper_size = default_paper_size
         self._global_staff_size = global_staff_size
@@ -343,7 +343,7 @@ class LilyPondFile(AbjadObject):
 
                 >>> lilypond_file
                 LilyPondFile(comments=[],
-                date_time_token=DateTimeToken(date_string='...'), includes=[],
+                includes=[],
                 items=[<Block(name='header')>, <Block(name='layout')>,
                 <Block(name='paper')>, <Block(name='score')>],
                 lilypond_language_token=LilyPondLanguageToken(),
@@ -514,7 +514,7 @@ class LilyPondFile(AbjadObject):
 
             ::
 
-                >>> lilypond_file = abjad.LilyPondFile.new()
+                >>> lilypond_file = abjad.LilyPondFile.new(date_time_token=True)
 
             ::
 

--- a/abjad/tools/metertools/MeterList.py
+++ b/abjad/tools/metertools/MeterList.py
@@ -57,8 +57,6 @@ class MeterList(TypedList):
 
                 >>> lilypond_file = meters.__illustrate__()
                 >>> f(lilypond_file)
-                % ...
-                <BLANKLINE>
                 \version "..."
                 \language "english"
                 <BLANKLINE>


### PR DESCRIPTION
OLD: `abjad.LilyPondFile.new()` included a date-time token by default.

NEW: `abjad.LilyPondFile.new()` no longer includes a date-time token by default. (Use `abjad.LilyPondFile.new(..., date_time_token=True)` for the old behavior.

The motivation is that the date-time comment included at the top of most realworld files just leads to versioning contention under Git. Easier to just exclude by default and then allow users to include in the cases where they actually need it.