### PR TITLE
BREAK: Context.context_name --> Context.lilypond_type. Closes #895.

### DIFF
--- a/abjad/demos/bartok/make_bartok_score.py
+++ b/abjad/demos/bartok/make_bartok_score.py
@@ -4,7 +4,7 @@ import copy
 
 def make_bartok_score():
     score = abjad.Score()
-    piano_staff = abjad.StaffGroup([], context_name='PianoStaff')
+    piano_staff = abjad.StaffGroup([], lilypond_type='PianoStaff')
     upper_staff = abjad.Staff([])
     lower_staff = abjad.Staff([])
     piano_staff.append(upper_staff)

--- a/abjad/demos/ferneyhough/FerneyhoughDemo.py
+++ b/abjad/demos/ferneyhough/FerneyhoughDemo.py
@@ -797,7 +797,7 @@ class FerneyhoughDemo(object):
             )
         for row_of_nested_tuplets in rows_of_nested_tuplets:
             staff = abjad.Staff(row_of_nested_tuplets)
-            staff.context_name = 'RhythmicStaff'
+            staff.lilypond_type = 'RhythmicStaff'
             time_signature = abjad.TimeSignature((1, 4))
             leaf = abjad.inspect(staff).get_leaf(0)
             abjad.attach(time_signature, leaf)

--- a/abjad/demos/ligeti/make_desordre_score.py
+++ b/abjad/demos/ligeti/make_desordre_score.py
@@ -7,7 +7,7 @@ def make_desordre_score(pitches):
 
     assert len(pitches) == 2
     staff_group = abjad.StaffGroup()
-    staff_group.context_name = 'PianoStaff'
+    staff_group.lilypond_type = 'PianoStaff'
 
     # build the music
     for hand in pitches:

--- a/abjad/demos/part/configure_lilypond_file.py
+++ b/abjad/demos/part/configure_lilypond_file.py
@@ -8,7 +8,7 @@ def configure_lilypond_file(lilypond_file):
     lilypond_file._global_staff_size = 8
 
     context_block = abjad.ContextBlock(
-        source_context_name=r'Staff \RemoveEmptyStaves',
+        source_lilypond_type=r'Staff \RemoveEmptyStaves',
         )
     abjad.override(context_block).vertical_axis_group.remove_first = True
     lilypond_file.layout_block.items.append(context_block)

--- a/abjad/docs/source/core_concepts/durations.rst
+++ b/abjad/docs/source/core_concepts/durations.rst
@@ -122,8 +122,8 @@ quarter notes:
     half_note = abjad.Note("c'2")
     abjad.attach(abjad.Multiplier(1, 2), half_note)
     half_notes = 4 * half_note
-    top_staff = abjad.Staff(quarter_notes, context_name='RhythmicStaff')
-    bottom_staff = abjad.Staff(half_notes, context_name='RhythmicStaff')
+    top_staff = abjad.Staff(quarter_notes, lilypond_type='RhythmicStaff')
+    bottom_staff = abjad.Staff(half_notes, lilypond_type='RhythmicStaff')
     staff_group = abjad.StaffGroup([top_staff, bottom_staff])
 
 ..  abjad::
@@ -152,7 +152,7 @@ Consider the measure below:
     leaves = abjad.select(measure).leaves()
     beam = abjad.Beam()
     attach(beam, leaves)
-    staff = abjad.Staff([measure], context_name='RhythmicStaff')
+    staff = abjad.Staff([measure], lilypond_type='RhythmicStaff')
 
 ..  abjad::
 
@@ -174,7 +174,7 @@ But now consider this measure:
     leaves = abjad.select(measure).leaves()
     beam = Beam()
     attach(beam, leaves)
-    staff = abjad.Staff([measure], context_name='RhythmicStaff')
+    staff = abjad.Staff([measure], lilypond_type='RhythmicStaff')
 
 ..  abjad::
 

--- a/abjad/docs/source/literature_examples/bartok.rst
+++ b/abjad/docs/source/literature_examples/bartok.rst
@@ -32,7 +32,7 @@ First let's create an empty score with a pair of staves connected by a brace:
 ..  abjad::
 
     score = abjad.Score()
-    piano_staff = abjad.StaffGroup([], context_name='PianoStaff')
+    piano_staff = abjad.StaffGroup([], lilypond_type='PianoStaff')
     upper_staff = abjad.Staff()
     lower_staff = abjad.Staff()
 

--- a/abjad/docs/source/literature_examples/ferneyhough.rst
+++ b/abjad/docs/source/literature_examples/ferneyhough.rst
@@ -44,19 +44,19 @@ divithe final `logical tie` of the resulting tuplet into yet another ratio:
 ..  abjad::
 
     tuplet = ferneyhough.make_nested_tuplet(abjad.Duration(1, 4), (1, 1), 5)
-    staff = abjad.Staff([tuplet], context_name='RhythmicStaff')
+    staff = abjad.Staff([tuplet], lilypond_type='RhythmicStaff')
     show(staff)
 
 ..  abjad::
 
     tuplet = ferneyhough.make_nested_tuplet(abjad.Duration(1, 4), (2, 1), 5)
-    staff = abjad.Staff([tuplet], context_name='RhythmicStaff')
+    staff = abjad.Staff([tuplet], lilypond_type='RhythmicStaff')
     show(staff)
 
 ..  abjad::
 
     tuplet = ferneyhough.make_nested_tuplet(abjad.Duration(1, 4), (3, 1), 5)
-    staff = abjad.Staff([tuplet], context_name='RhythmicStaff')
+    staff = abjad.Staff([tuplet], lilypond_type='RhythmicStaff')
     show(staff)
 
 A `logical tie` is a selection of notes or chords connected by ties. It lets us
@@ -69,13 +69,13 @@ the second `logical tie` requires two notes to express the ``5/16`` duration:
 ..  abjad::
 
     normal_tuplet = abjad.Tuplet.from_duration_and_ratio(abjad.Duration(1, 4), (3, 5))
-    staff = abjad.Staff([normal_tuplet], context_name='RhythmicStaff')
+    staff = abjad.Staff([normal_tuplet], lilypond_type='RhythmicStaff')
     show(staff)
 
 ..  abjad::
 
     subdivided_tuplet = ferneyhough.make_nested_tuplet(abjad.Duration(1, 4), (3, 5), 3)
-    staff = abjad.Staff([subdivided_tuplet], context_name='RhythmicStaff')
+    staff = abjad.Staff([subdivided_tuplet], lilypond_type='RhythmicStaff')
     show(staff)
 
 The rhythms
@@ -96,7 +96,7 @@ subdivided:
 ..  abjad::
 
     tuplets = ferneyhough.make_row_of_nested_tuplets(duration, (2, 1), 6)
-    staff = abjad.Staff(tuplets, context_name='RhythmicStaff')
+    staff = abjad.Staff(tuplets, lilypond_type='RhythmicStaff')
     show(staff)
 
 If we can make one single row of rhythms, we can make many rows of rhythms.
@@ -106,7 +106,7 @@ Let's try:
 
     score = abjad.Score()
     for tuplet_row in ferneyhough.make_rows_of_nested_tuplets(duration, 4, 6):
-        staff = abjad.Staff(tuplet_row, context_name='RhythmicStaff')
+        staff = abjad.Staff(tuplet_row, lilypond_type='RhythmicStaff')
         score.append(staff)
 
     show(score)

--- a/abjad/docs/source/reference_manual/staves.rst
+++ b/abjad/docs/source/reference_manual/staves.rst
@@ -200,7 +200,7 @@ The context of a staff is set to ``Staff`` by default:
 
 ..  abjad::
 
-    staff.context_name
+    staff.lilypond_type
 
 But you can change the context of a staff if you want.
 
@@ -209,11 +209,11 @@ based on a LilyPond staff:
 
 ..  abjad::
 
-    staff.context_name = 'CustomUserStaff'
+    staff.lilypond_type = 'CustomUserStaff'
 
 ..  abjad::
 
-    staff.context_name
+    staff.lilypond_type
 
 ..  abjad::
 

--- a/abjad/docs/source/reference_manual/voices.rst
+++ b/abjad/docs/source/reference_manual/voices.rst
@@ -197,7 +197,7 @@ The context of a voice is set to ``'Voice'`` by default:
 
 ..  abjad::
 
-    voice.context_name
+    voice.lilypond_type
 
 But you can change the context of a voice if you want.
 
@@ -206,11 +206,11 @@ based on a LilyPond voice:
 
 ..  abjad::
 
-    voice.context_name = 'SpeciallyDefinedVoice'
+    voice.lilypond_type = 'SpeciallyDefinedVoice'
 
 ..  abjad::
 
-    voice.context_name
+    voice.lilypond_type
 
 ..  abjad::
 

--- a/abjad/tools/datastructuretools/Duration.py
+++ b/abjad/tools/datastructuretools/Duration.py
@@ -538,7 +538,7 @@ class Duration(AbjadObject, Fraction):
         import abjad
         selection = copy.deepcopy(selection)
         staff = abjad.Staff(selection)
-        staff.context_name = 'RhythmicStaff'
+        staff.lilypond_type = 'RhythmicStaff'
         staff.remove_commands.append('Time_signature_engraver')
         staff.remove_commands.append('Staff_symbol_engraver')
         abjad.override(staff).stem.direction = abjad.Up
@@ -1200,7 +1200,7 @@ class Duration(AbjadObject, Fraction):
 
             >>> tuplet = abjad.Tuplet((5, 7), "c'16 c' c' c' c' c' c'")
             >>> abjad.attach(abjad.Beam(), tuplet[:])
-            >>> staff = abjad.Staff([tuplet], context_name='RhythmicStaff')
+            >>> staff = abjad.Staff([tuplet], lilypond_type='RhythmicStaff')
             >>> duration = abjad.inspect(tuplet).get_duration()
             >>> markup = duration.to_score_markup()
             >>> markup = markup.scale((0.75, 0.75))

--- a/abjad/tools/documentationtools/make_ligeti_example_lilypond_file.py
+++ b/abjad/tools/documentationtools/make_ligeti_example_lilypond_file.py
@@ -22,7 +22,7 @@ def make_ligeti_example_lilypond_file(music=None):
     lilypond_file.layout_block.merge_differently_headed = True
 
     context_block = lilypondfiletools.ContextBlock(
-        source_context_name='Score',
+        source_lilypond_type='Score',
         )
     lilypond_file.layout_block.items.append(context_block)
     context_block.remove_commands.append('Bar_number_engraver')
@@ -47,7 +47,7 @@ def make_ligeti_example_lilypond_file(music=None):
     setting(context_block).tupletFullLength = True
 
     context_block = lilypondfiletools.ContextBlock(
-        source_context_name='Staff',
+        source_lilypond_type='Staff',
         )
     lilypond_file.layout_block.items.append(context_block)
     # LilyPond CAUTION: Timing_translator must appear
@@ -58,7 +58,7 @@ def make_ligeti_example_lilypond_file(music=None):
     override(context_block).time_signature.style = scheme
 
     context_block = lilypondfiletools.ContextBlock(
-        source_context_name='RhythmicStaff',
+        source_lilypond_type='RhythmicStaff',
         )
     lilypond_file.layout_block.items.append(context_block)
     # LilyPond CAUTION: Timing_translator must appear
@@ -70,7 +70,7 @@ def make_ligeti_example_lilypond_file(music=None):
     override(context_block).vertical_axis_group.minimum_Y_extent = (-2, 4)
 
     context_block = lilypondfiletools.ContextBlock(
-        source_context_name='Voice',
+        source_lilypond_type='Voice',
         )
     lilypond_file.layout_block.items.append(context_block)
     context_block.remove_commands.append('Forbid_line_break_engraver')

--- a/abjad/tools/documentationtools/make_reference_manual_lilypond_file.py
+++ b/abjad/tools/documentationtools/make_reference_manual_lilypond_file.py
@@ -97,7 +97,7 @@ def make_reference_manual_lilypond_file(music=None, **keywords):
 
     # score context
     context_block = lilypondfiletools.ContextBlock(
-        source_context_name='Score',
+        source_lilypond_type='Score',
         )
     context_block.remove_commands.append('Bar_number_engraver')
     override(context_block).spacing_spanner.strict_grace_spacing = True

--- a/abjad/tools/documentationtools/make_text_alignment_example_lilypond_file.py
+++ b/abjad/tools/documentationtools/make_text_alignment_example_lilypond_file.py
@@ -68,7 +68,7 @@ def make_text_alignment_example_lilypond_file(music=None):
     lilypond_file.layout_block.indent = 0
     lilypond_file.layout_block.ragged_right = True
     context_block = abjad.ContextBlock(
-        source_context_name='Score',
+        source_lilypond_type='Score',
         )
     lilypond_file.layout_block.items.append(context_block)
     context_block.remove_commands.append('Bar_number_engraver')

--- a/abjad/tools/indicatortools/StaffChange.py
+++ b/abjad/tools/indicatortools/StaffChange.py
@@ -10,7 +10,7 @@ class StaffChange(AbjadValueObject):
         Explicit staff change:
 
         >>> staff_group = abjad.StaffGroup()
-        >>> staff_group.context_name = 'PianoStaff'
+        >>> staff_group.lilypond_type = 'PianoStaff'
         >>> rh_staff = abjad.Staff("c'8 d'8 e'8 f'8", name='RHStaff')
         >>> lh_staff = abjad.Staff("s2", name='LHStaff')
         >>> staff_group.extend([rh_staff, lh_staff])

--- a/abjad/tools/instrumenttools/Accordion.py
+++ b/abjad/tools/instrumenttools/Accordion.py
@@ -6,7 +6,7 @@ class Accordion(Instrument):
 
     ..  container:: example
 
-        >>> staff_group = abjad.StaffGroup(context_name='PianoStaff')
+        >>> staff_group = abjad.StaffGroup(lilypond_type='PianoStaff')
         >>> staff_group.append(abjad.Staff("c'4 d'4 e'4 f'4"))
         >>> staff_group.append(abjad.Staff("c'2 b2"))
         >>> accordion = abjad.Accordion()

--- a/abjad/tools/instrumenttools/Harp.py
+++ b/abjad/tools/instrumenttools/Harp.py
@@ -6,7 +6,7 @@ class Harp(Instrument):
 
     ..  container:: example
 
-        >>> staff_group = abjad.StaffGroup(context_name='PianoStaff')
+        >>> staff_group = abjad.StaffGroup(lilypond_type='PianoStaff')
         >>> staff_group.append(abjad.Staff("c'4 d'4 e'4 f'4"))
         >>> staff_group.append(abjad.Staff("c'2 b2"))
         >>> harp = abjad.Harp()

--- a/abjad/tools/instrumenttools/Harpsichord.py
+++ b/abjad/tools/instrumenttools/Harpsichord.py
@@ -10,7 +10,7 @@ class Harpsichord(Instrument):
         >>> lower_staff = abjad.Staff("c'2 b2")
         >>> staff_group = abjad.StaffGroup(
         ...     [upper_staff, lower_staff],
-        ...     context_name='PianoStaff',
+        ...     lilypond_type='PianoStaff',
         ...     )
         >>> harpsichord = abjad.Harpsichord()
         >>> abjad.attach(harpsichord, staff_group[0][0])

--- a/abjad/tools/instrumenttools/Instrument.py
+++ b/abjad/tools/instrumenttools/Instrument.py
@@ -138,7 +138,7 @@ class Instrument(AbjadValueObject):
     ### PRIVATE PROPERTIES ###
 
     @property
-    def _context_name(self):
+    def _lilypond_type(self):
         if isinstance(self.context, type):
             return self.context.__name__
         elif isinstance(self.context, str):
@@ -177,9 +177,9 @@ class Instrument(AbjadValueObject):
         if isinstance(context, str):
             pass
         elif context is not None:
-            context = context.context_name
+            context = context.lilypond_type
         else:
-            context = self._context_name
+            context = self._lilypond_type
         pieces = markup._get_format_pieces()
         first_line = r'\set {!s}.instrumentName = {!s}'
         first_line = first_line.format(context, pieces[0])
@@ -235,7 +235,7 @@ class Instrument(AbjadValueObject):
 
         Defaults to ``'Staff'``.
 
-        Returns context headword.
+        Returns lilypond type of context.
 
         Override with ``abjad.attach(..., context='...')``.
         '''

--- a/abjad/tools/instrumenttools/Piano.py
+++ b/abjad/tools/instrumenttools/Piano.py
@@ -6,7 +6,7 @@ class Piano(Instrument):
 
     ..  container:: example
 
-        >>> staff_group = abjad.StaffGroup(context_name='PianoStaff')
+        >>> staff_group = abjad.StaffGroup(lilypond_type='PianoStaff')
         >>> staff_group.append(abjad.Staff("c'4 d'4 e'4 f'4"))
         >>> staff_group.append(abjad.Staff("c'2 b2"))
         >>> piano = abjad.Piano()

--- a/abjad/tools/lilypondfiletools/ContextBlock.py
+++ b/abjad/tools/lilypondfiletools/ContextBlock.py
@@ -7,7 +7,7 @@ class ContextBlock(Block):
     ..  container:: example
 
         >>> block = abjad.ContextBlock(
-        ...     source_context_name='Staff',
+        ...     source_lilypond_type='Staff',
         ...     name='FluteStaff',
         ...     type_='Engraver_group',
         ...     alias='Staff',
@@ -22,7 +22,7 @@ class ContextBlock(Block):
         >>> abjad.setting(block).auto_beaming = False
         >>> abjad.setting(block).tuplet_full_length = True
         >>> block
-        <ContextBlock(source_context_name='Staff', name='FluteStaff', type_='Engraver_group', alias='Staff')>
+        <ContextBlock(source_lilypond_type='Staff', name='FluteStaff', type_='Engraver_group', alias='Staff')>
 
         >>> print(format(block))
         \context {
@@ -47,13 +47,13 @@ class ContextBlock(Block):
 
     def __init__(
         self,
-        source_context_name=None,
+        source_lilypond_type=None,
         name=None,
         type_=None,
         alias=None,
         ):
         Block.__init__(self, name='context')
-        self._source_context_name = source_context_name
+        self._source_lilypond_type = source_lilypond_type
         self._name = name
         self._type_ = type_
         self._alias = alias
@@ -73,8 +73,8 @@ class ContextBlock(Block):
         manager = abjad.LilyPondFormatManager
         # CAUTION: source context name must come before type_ to allow
         # context redefinition.
-        if self.source_context_name is not None:
-            string = indent + r'\{}'.format(self.source_context_name)
+        if self.source_lilypond_type is not None:
+            string = indent + r'\{}'.format(self.source_lilypond_type)
             result.append(string)
         if self.name is not None:
             string = indent + r'\name {}'.format(self.name)
@@ -130,7 +130,7 @@ class ContextBlock(Block):
         ..  container:: example
 
             >>> block = abjad.ContextBlock(
-            ...     source_context_name='Staff',
+            ...     source_lilypond_type='Staff',
             ...     name='FluteStaff',
             ...     type_='Engraver_group',
             ...     alias='Staff',
@@ -159,7 +159,7 @@ class ContextBlock(Block):
         ..  container:: example
 
             >>> block = abjad.ContextBlock(
-            ...     source_context_name='Staff',
+            ...     source_lilypond_type='Staff',
             ...     name='FluteStaff',
             ...     type_='Engraver_group',
             ...     alias='Staff',
@@ -188,7 +188,7 @@ class ContextBlock(Block):
         ..  container:: example
 
             >>> block = abjad.ContextBlock(
-            ...     source_context_name='Staff',
+            ...     source_lilypond_type='Staff',
             ...     name='FluteStaff',
             ...     type_='Engraver_group',
             ...     alias='Staff',
@@ -217,7 +217,7 @@ class ContextBlock(Block):
         ..  container:: example
 
             >>> block = abjad.ContextBlock(
-            ...     source_context_name='Staff',
+            ...     source_lilypond_type='Staff',
             ...     name='FluteStaff',
             ...     type_='Engraver_group',
             ...     alias='Staff',
@@ -246,7 +246,7 @@ class ContextBlock(Block):
         ..  container:: example
 
             >>> block = abjad.ContextBlock(
-            ...     source_context_name='Staff',
+            ...     source_lilypond_type='Staff',
             ...     name='FluteStaff',
             ...     type_='Engraver_group',
             ...     alias='Staff',
@@ -275,7 +275,7 @@ class ContextBlock(Block):
         ..  container:: example
 
             >>> block = abjad.ContextBlock(
-            ...     source_context_name='Staff',
+            ...     source_lilypond_type='Staff',
             ...     name='FluteStaff',
             ...     type_='Engraver_group',
             ...     alias='Staff',
@@ -298,13 +298,13 @@ class ContextBlock(Block):
         return self._remove_commands
 
     @property
-    def source_context_name(self):
+    def source_lilypond_type(self):
         r'''Gets and sets source context name.
 
         ..  container:: example
 
             >>> block = abjad.ContextBlock(
-            ...     source_context_name='Staff',
+            ...     source_lilypond_type='Staff',
             ...     name='FluteStaff',
             ...     type_='Engraver_group',
             ...     alias='Staff',
@@ -319,12 +319,12 @@ class ContextBlock(Block):
             >>> abjad.setting(block).auto_beaming = False
             >>> abjad.setting(block).tuplet_full_length = True
 
-            >>> block.source_context_name
+            >>> block.source_lilypond_type
             'Staff'
 
         Returns string or none.
         '''
-        return self._source_context_name
+        return self._source_lilypond_type
 
     @property
     def type_(self):
@@ -333,7 +333,7 @@ class ContextBlock(Block):
         ..  container:: example
 
             >>> block = abjad.ContextBlock(
-            ...     source_context_name='Staff',
+            ...     source_lilypond_type='Staff',
             ...     name='FluteStaff',
             ...     type_='Engraver_group',
             ...     alias='Staff',

--- a/abjad/tools/lilypondfiletools/LilyPondFile.py
+++ b/abjad/tools/lilypondfiletools/LilyPondFile.py
@@ -855,7 +855,7 @@ class LilyPondFile(AbjadObject):
 
             >>> score = abjad.Score()
             >>> global_context = abjad.Context(
-            ...     context_name='GlobalContext',
+            ...     lilypond_type='GlobalContext',
             ...     )
             >>> durations = [(2, 8), (3, 8), (4, 8)]
             >>> maker = abjad.MeasureMaker()
@@ -1028,7 +1028,7 @@ class LilyPondFile(AbjadObject):
             padding=6,
             )
         lilypond_file.layout_block.items.append(block)
-        block = abjad.ContextBlock(source_context_name='Score')
+        block = abjad.ContextBlock(source_lilypond_type='Score')
         lilypond_file.layout_block.items.append(block)
         block.accepts_commands.append('GlobalContext')
         block.remove_commands.append('Bar_number_engraver')
@@ -1048,12 +1048,12 @@ class LilyPondFile(AbjadObject):
         abjad.setting(block).proportionalNotationDuration = moment
         abjad.setting(block).tupletFullLength = True
         # provided as a stub position for user customization
-        block = abjad.ContextBlock(source_context_name='StaffGroup')
+        block = abjad.ContextBlock(source_lilypond_type='StaffGroup')
         lilypond_file.layout_block.items.append(block)
-        block = abjad.ContextBlock(source_context_name='Staff')
+        block = abjad.ContextBlock(source_lilypond_type='Staff')
         lilypond_file.layout_block.items.append(block)
         block.remove_commands.append('Time_signature_engraver')
-        block = abjad.ContextBlock(source_context_name='RhythmicStaff')
+        block = abjad.ContextBlock(source_lilypond_type='RhythmicStaff')
         lilypond_file.layout_block.items.append(block)
         block.remove_commands.append('Time_signature_engraver')
         return lilypond_file
@@ -1521,7 +1521,7 @@ class LilyPondFile(AbjadObject):
             if pitched_staff:
                 staff = abjad.Staff(measures)
             else:
-                staff = abjad.Staff(measures, context_name='RhythmicStaff')
+                staff = abjad.Staff(measures, lilypond_type='RhythmicStaff')
             selections = abjad.sequence(selections).flatten(depth=-1)
             selections_ = copy.deepcopy(selections)
             try:
@@ -1533,7 +1533,7 @@ class LilyPondFile(AbjadObject):
                 else:
                     staff = abjad.Staff(
                         selections_,
-                        context_name='RhythmicStaff',
+                        lilypond_type='RhythmicStaff',
                         )
         elif isinstance(selections, dict):
             voices = []
@@ -1567,7 +1567,7 @@ class LilyPondFile(AbjadObject):
         score.append(staff)
         assert isinstance(divisions, collections.Sequence), repr(divisions)
         time_signatures = time_signatures or divisions
-        context = abjad.scoretools.Context(context_name='GlobalContext')
+        context = abjad.scoretools.Context(lilypond_type='GlobalContext')
         maker = abjad.MeasureMaker(implicit_scaling=implicit_scaling)
         measures = maker(time_signatures)
         context.extend(measures)

--- a/abjad/tools/lilypondnametools/LilyPondContext.py
+++ b/abjad/tools/lilypondnametools/LilyPondContext.py
@@ -329,7 +329,7 @@ class LilyPondContext(abctools.AbjadValueObject):
         assert self.is_custom
         del(contexts[self.name])
         del(self._identity_map[self.name])
-        for context_name, context_info in contexts.items():
+        for lilypond_type, context_info in contexts.items():
             if self.name in context_info['accepts']:
                 context_info['accepts'].remove(self.name)
 
@@ -473,9 +473,9 @@ class LilyPondContext(abctools.AbjadValueObject):
         '''
         from abjad.ly import contexts
         accepting_contexts = set()
-        for context_name, context_info in contexts.items():
+        for lilypond_type, context_info in contexts.items():
             if self.name in context_info['accepts']:
-                accepting_context = LilyPondContext(context_name)
+                accepting_context = LilyPondContext(lilypond_type)
                 accepting_contexts.add(accepting_context)
         return tuple(sorted(accepting_contexts, key=lambda x: x.name))
 

--- a/abjad/tools/lilypondnametools/LilyPondContextSetting.py
+++ b/abjad/tools/lilypondnametools/LilyPondContextSetting.py
@@ -5,7 +5,7 @@ class LilyPondContextSetting(AbjadValueObject):
     r'''LilyPond context setting.
 
     >>> context_setting = abjad.lilypondnametools.LilyPondContextSetting(
-    ...    context_name='Score',
+    ...    lilypond_type='Score',
     ...    context_property='autoBeaming',
     ...    value=False,
     ...    )
@@ -18,7 +18,7 @@ class LilyPondContextSetting(AbjadValueObject):
     ### CLASS VARIABLES ###
 
     __slots__ = (
-        '_context_name',
+        '_lilypond_type',
         '_context_property',
         '_is_unset',
         '_value',
@@ -30,14 +30,14 @@ class LilyPondContextSetting(AbjadValueObject):
 
     def __init__(
         self,
-        context_name=None,
+        lilypond_type=None,
         context_property='autoBeaming',
         is_unset=False,
         value=False,
         ):
-        if context_name is not None:
-            context_name = str(context_name)
-        self._context_name = context_name
+        if lilypond_type is not None:
+            lilypond_type = str(lilypond_type)
+        self._lilypond_type = lilypond_type
         assert isinstance(context_property, str) and context_property
         self._context_property = context_property
         if is_unset is not None:
@@ -72,12 +72,12 @@ class LilyPondContextSetting(AbjadValueObject):
     ### PUBLIC PROPERTIES ###
 
     @property
-    def context_name(self):
+    def lilypond_type(self):
         r'''Optional LilyPond context name.
 
         Returns string or none.
         '''
-        return self._context_name
+        return self._lilypond_type
 
     @property
     def context_property(self):
@@ -99,9 +99,9 @@ class LilyPondContextSetting(AbjadValueObject):
             result.append(r'\set')
         else:
             result.append(r'\unset')
-        if self.context_name is not None:
+        if self.lilypond_type is not None:
             string = '{}.{}'.format(
-                self.context_name,
+                self.lilypond_type,
                 self.context_property,
                 )
             result.append(string)

--- a/abjad/tools/lilypondnametools/LilyPondGrobOverride.py
+++ b/abjad/tools/lilypondnametools/LilyPondGrobOverride.py
@@ -5,7 +5,7 @@ class LilyPondGrobOverride(AbjadValueObject):
     r'''LilyPond grob override.
 
     >>> override = abjad.LilyPondGrobOverride(
-    ...    context_name='Staff',
+    ...    lilypond_type='Staff',
     ...    grob_name='TextSpanner',
     ...    once=True,
     ...    property_path=(
@@ -30,7 +30,7 @@ class LilyPondGrobOverride(AbjadValueObject):
     ### CLASS VARIABLES ###
 
     __slots__ = (
-        '_context_name',
+        '_lilypond_type',
         '_grob_name',
         '_once',
         '_is_revert',
@@ -44,16 +44,16 @@ class LilyPondGrobOverride(AbjadValueObject):
 
     def __init__(
         self,
-        context_name=None,
+        lilypond_type=None,
         grob_name='NoteHead',
         once=None,
         is_revert=None,
         property_path='color',
         value='red',
         ):
-        if context_name is not None:
-            context_name = str(context_name)
-        self._context_name = context_name
+        if lilypond_type is not None:
+            lilypond_type = str(lilypond_type)
+        self._lilypond_type = lilypond_type
         assert grob_name
         self._grob_name = str(grob_name)
         if once is not None:
@@ -102,8 +102,8 @@ class LilyPondGrobOverride(AbjadValueObject):
     @property
     def _override_property_path_string(self):
         parts = []
-        if self.context_name is not None:
-            parts.append(self.context_name)
+        if self.lilypond_type is not None:
+            parts.append(self.lilypond_type)
         parts.append(self.grob_name)
         parts.extend(self.property_path)
         path = '.'.join(parts)
@@ -112,8 +112,8 @@ class LilyPondGrobOverride(AbjadValueObject):
     @property
     def _revert_property_path_string(self):
         parts = []
-        if self.context_name is not None:
-            parts.append(self.context_name)
+        if self.lilypond_type is not None:
+            parts.append(self.lilypond_type)
         parts.append(self.grob_name)
         parts.append(self.property_path[0])
         path = '.'.join(parts)
@@ -122,11 +122,11 @@ class LilyPondGrobOverride(AbjadValueObject):
     ### PUBLIC PROPERTIES ###
 
     @property
-    def context_name(self):
+    def lilypond_type(self):
         r'''Optional LilyPond grob override context name.
 
         >>> override = abjad.LilyPondGrobOverride(
-        ...    context_name='Staff',
+        ...    lilypond_type='Staff',
         ...    grob_name='TextSpanner',
         ...    once=True,
         ...    property_path=(
@@ -136,7 +136,7 @@ class LilyPondGrobOverride(AbjadValueObject):
         ...        ),
         ...    value=abjad.Markup(r'\bold { over pressure }'),
         ...    )
-        >>> override.context_name
+        >>> override.lilypond_type
         'Staff'
 
         >>> override = abjad.LilyPondGrobOverride(
@@ -144,12 +144,12 @@ class LilyPondGrobOverride(AbjadValueObject):
         ...     property_path='style',
         ...     value=abjad.SchemeSymbol('zigzag'),
         ...     )
-        >>> override.context_name is None
+        >>> override.lilypond_type is None
         True
 
         Returns string or none.
         '''
-        return self._context_name
+        return self._lilypond_type
 
     @property
     def grob_name(self):
@@ -173,7 +173,7 @@ class LilyPondGrobOverride(AbjadValueObject):
         false.
 
         >>> override = abjad.LilyPondGrobOverride(
-        ...    context_name='Staff',
+        ...    lilypond_type='Staff',
         ...    grob_name='TextSpanner',
         ...    once=True,
         ...    property_path=(
@@ -227,7 +227,7 @@ class LilyPondGrobOverride(AbjadValueObject):
         r'''Gets LilyPond grob override \override format pieces.
 
         >>> override = abjad.LilyPondGrobOverride(
-        ...    context_name='Staff',
+        ...    lilypond_type='Staff',
         ...    grob_name='TextSpanner',
         ...    once=True,
         ...    property_path=(
@@ -286,7 +286,7 @@ class LilyPondGrobOverride(AbjadValueObject):
         r'''LilyPond grob override property path.
 
         >>> override = abjad.LilyPondGrobOverride(
-        ...    context_name='Staff',
+        ...    lilypond_type='Staff',
         ...    grob_name='TextSpanner',
         ...    once=True,
         ...    property_path=(
@@ -341,7 +341,7 @@ class LilyPondGrobOverride(AbjadValueObject):
         r'''Value of LilyPond grob override.
 
         >>> override = abjad.LilyPondGrobOverride(
-        ...    context_name='Staff',
+        ...    lilypond_type='Staff',
         ...    grob_name='TextSpanner',
         ...    once=True,
         ...    property_path=(

--- a/abjad/tools/lilypondnametools/LilyPondSettingNameManager.py
+++ b/abjad/tools/lilypondnametools/LilyPondSettingNameManager.py
@@ -80,11 +80,11 @@ class LilyPondSettingNameManager(LilyPondNameManager):
         for name, value in vars(self).items():
             if type(value) is lilypondnametools.LilyPondNameManager:
                 prefixed_context_name = name
-                context_name = prefixed_context_name.strip('_')
+                lilypond_type = prefixed_context_name.strip('_')
                 context_proxy = value
                 attribute_pairs = context_proxy._get_attribute_pairs()
                 for attribute_name, attribute_value in attribute_pairs:
-                    triple = (context_name, attribute_name, attribute_value)
+                    triple = (lilypond_type, attribute_name, attribute_value)
                     result.append(triple)
             else:
                 attribute_name, attribute_value = name, value

--- a/abjad/tools/lilypondparsertools/ContextSpeccedMusic.py
+++ b/abjad/tools/lilypondparsertools/ContextSpeccedMusic.py
@@ -10,7 +10,7 @@ class ContextSpeccedMusic(Music):
 
     __slots__ = (
         #'context',
-        'context_name',
+        'lilypond_type',
         'music',
         'optional_id',
         'optional_context_mod',
@@ -20,17 +20,17 @@ class ContextSpeccedMusic(Music):
 
     def __init__(
         self,
-        context_name=None,
+        lilypond_type=None,
         optional_id=None,
         optional_context_mod=None,
         music=None,
         ):
         from abjad.tools import lilypondparsertools
-        context_name = context_name or ''
+        lilypond_type = lilypond_type or ''
         music = music or lilypondparsertools.SequentialMusic()
-        assert datastructuretools.String.is_string(context_name)
+        assert datastructuretools.String.is_string(lilypond_type)
         assert isinstance(music, Music)
-        self.context_name = context_name
+        self.lilypond_type = lilypond_type
         self.optional_id = optional_id
         self.optional_context_mod = optional_context_mod
         self.music = music
@@ -42,11 +42,11 @@ class ContextSpeccedMusic(Music):
 
         Returns context.
         '''
-        if self.context_name in self.known_contexts:
-            context = known_contexts[self.context_name]([])
+        if self.lilypond_type in self.known_contexts:
+            context = known_contexts[self.lilypond_type]([])
         else:
             message = 'context type not supported: {}.'
-            message = message.format(self.context_name)
+            message = message.format(self.lilypond_type)
             raise Exception(message)
 
         if self.optional_id is not None:

--- a/abjad/tools/lilypondparsertools/LilyPondParser.py
+++ b/abjad/tools/lilypondparsertools/LilyPondParser.py
@@ -605,15 +605,15 @@ class LilyPondParser(abctools.Parser):
             'StaffGroup': scoretools.StaffGroup,
             'Voice': scoretools.Voice,
             }
-        context_name = context
+        lilypond_type = context
         if context in known_contexts:
             context = known_contexts[context]([])
         else:
             message = 'context type {!r} not supported.'
             message = message.format(context)
             raise Exception(message)
-        if context_name in ('GrandStaff', 'PianoStaff'):
-            context.context_name = context_name
+        if lilypond_type in ('GrandStaff', 'PianoStaff'):
+            context.lilypond_type = lilypond_type
         if optional_id is not None:
             context.name = optional_id
         if optional_context_mod is not None:

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__PianoStaff.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__PianoStaff.py
@@ -8,7 +8,7 @@ def test_lilypondparsertools_LilyPondParser__contexts__PianoStaff_01():
         abjad.Staff(maker([0, 2, 4, 5, 7], (1, 8))),
         abjad.Staff(maker([0, 2, 4, 5, 7], (1, 8)))
     ])
-    target.context_name = 'PianoStaff'
+    target.lilypond_type = 'PianoStaff'
 
     assert format(target) == abjad.String.normalize(
         r'''

--- a/abjad/tools/pitchtools/PitchSet.py
+++ b/abjad/tools/pitchtools/PitchSet.py
@@ -185,7 +185,7 @@ class PitchSet(Set):
         lower_staff = abjad.Staff([lower_voice])
         staff_group = abjad.StaffGroup(
             [upper_staff, lower_staff],
-            context_name='PianoStaff',
+            lilypond_type='PianoStaff',
             )
         score = abjad.Score([staff_group])
         lilypond_file = abjad.LilyPondFile.new(score)

--- a/abjad/tools/quantizationtools/test/test_quantizationtools_Quantizer___call__.py
+++ b/abjad/tools/quantizationtools/test/test_quantizationtools_Quantizer___call__.py
@@ -8,7 +8,7 @@ def test_quantizationtools_Quantizer___call___01():
         milliseconds)
     quantizer = quantizationtools.Quantizer()
     result = quantizer(q_events)
-    staff = abjad.Staff([result], context_name='RhythmicStaff')
+    staff = abjad.Staff([result], lilypond_type='RhythmicStaff')
     score = abjad.Score([staff])
     assert format(score) == abjad.String.normalize(
         r'''
@@ -39,7 +39,7 @@ def test_quantizationtools_Quantizer___call___02():
         q_events,
         attack_point_optimizer=optimizer,
         )
-    staff = abjad.Staff([result], context_name='RhythmicStaff')
+    staff = abjad.Staff([result], lilypond_type='RhythmicStaff')
     score = abjad.Score([staff])
     assert format(score) == abjad.String.normalize(
         r'''
@@ -117,7 +117,7 @@ def test_quantizationtools_Quantizer___call___04():
     attack_point_optimizer = quantizationtools.NullAttackPointOptimizer()
     quantizer = quantizationtools.Quantizer()
     result = quantizer(sequence, attack_point_optimizer=attack_point_optimizer)
-    staff = abjad.Staff([result], context_name='RhythmicStaff')
+    staff = abjad.Staff([result], lilypond_type='RhythmicStaff')
     score = abjad.Score([staff])
 
     assert format(score) == abjad.String.normalize(
@@ -167,7 +167,7 @@ def test_quantizationtools_Quantizer___call___05():
         q_schema=q_schema,
         attack_point_optimizer=attack_point_optimizer,
         )
-    staff = abjad.Staff([result], context_name='RhythmicStaff')
+    staff = abjad.Staff([result], lilypond_type='RhythmicStaff')
     score = abjad.Score([staff])
 
     assert format(score) == abjad.String.normalize(

--- a/abjad/tools/scoretools/Container.py
+++ b/abjad/tools/scoretools/Container.py
@@ -601,10 +601,10 @@ class Container(Component):
             name = '-"{}"'.format(name)
         else:
             name = ''
-        if hasattr(self, '_context_name'):
+        if hasattr(self, '_lilypond_type'):
             result = '<{}{}{}{}{}>'
             result = result.format(
-                self.context_name,
+                self.lilypond_type,
                 name,
                 open_bracket_string,
                 summary,

--- a/abjad/tools/scoretools/Context.py
+++ b/abjad/tools/scoretools/Context.py
@@ -9,11 +9,11 @@ class Context(Container):
 
         >>> context = abjad.Context(
         ...     name='MeterVoice',
-        ...     context_name='GlobalContext',
+        ...     lilypond_type='GlobalContext',
         ...     )
 
         >>> context
-        Context(context_name='GlobalContext', name='MeterVoice')
+        Context(lilypond_type='GlobalContext', name='MeterVoice')
 
         ..  docs::
 
@@ -28,15 +28,15 @@ class Context(Container):
     __documentation_section__ = 'Contexts'
 
     __slots__ = (
-        '_context_name',
+        '_lilypond_type',
         '_consists_commands',
         '_dependent_wrappers',
         '_remove_commands',
         )
 
-    _default_context_name = 'Voice'
+    _default_lilypond_type = 'Voice'
 
-    lilypond_context_names = (
+    lilypond_types = (
         'Score',
         'StaffGroup',
         'ChoirStaff',
@@ -64,14 +64,14 @@ class Context(Container):
     def __init__(
         self,
         components=None,
-        context_name='Context',
+        lilypond_type='Context',
         is_simultaneous=None,
         name=None,
         ):
         self._consists_commands = []
         self._dependent_wrappers = []
         self._remove_commands = []
-        self.context_name = context_name
+        self.lilypond_type = lilypond_type
         Container.__init__(
             self,
             is_simultaneous=is_simultaneous,
@@ -103,17 +103,17 @@ class Context(Container):
 
         Returns tuple.
         '''
-        return [], self.context_name, self.is_simultaneous, self.name
+        return [], self.lilypond_type, self.is_simultaneous, self.name
 
     def __repr__(self):
         r'''Gets interpreter representation of context.
 
         >>> context = abjad.Context(
         ...     name='MeterVoice',
-        ...     context_name='GlobalContext',
+        ...     lilypond_type='GlobalContext',
         ...     )
         >>> repr(context)
-        "Context(context_name='GlobalContext', name='MeterVoice')"
+        "Context(lilypond_type='GlobalContext', name='MeterVoice')"
 
         Returns string.
         '''
@@ -140,10 +140,10 @@ class Context(Container):
     def _format_invocation(self):
         if self.name is not None:
             string = r'\context {} = "{}"'
-            string = string.format(self.context_name, self.name)
+            string = string.format(self.lilypond_type, self.name)
         else:
             string = r'\new {}'
-            string = string.format(self.context_name)
+            string = string.format(self.lilypond_type)
         return string
 
     def _format_open_brackets_slot(context, bundle):
@@ -233,10 +233,10 @@ class Context(Container):
         return wrappers
 
     def _get_repr_kwargs_names(self):
-        if self.context_name == type(self).__name__:
+        if self.lilypond_type == type(self).__name__:
             return ['is_simultaneous', 'name']
         else:
-            return ['is_simultaneous', 'context_name', 'name']
+            return ['is_simultaneous', 'lilypond_type', 'name']
 
     ### PUBLIC PROPERTIES ###
 
@@ -259,41 +259,31 @@ class Context(Container):
         return self._consists_commands
 
     @property
-    def context_name(self):
-        r'''DEPRECATED: use headword instead.
-        
-        Gets and sets context name of context.
-
-        Returns string.
-        '''
-        return self._context_name
-
-    @context_name.setter
-    def context_name(self, argument):
-        if argument is None:
-            argument = type(self).__name__
-        else:
-            argument = str(argument)
-        self._context_name = argument
-
-    @property
-    def headword(self):
-        r'''Gets headword.
+    def lilypond_type(self):
+        r'''Gets lilypond type.
 
         ..  container:: example
 
             >>> context = abjad.Context(
-            ...     context_name='ViolinStaff',
+            ...     lilypond_type='ViolinStaff',
             ...     name='MyViolinStaff',
             ...     )
-            >>> context.headword
+            >>> context.lilypond_type
             'ViolinStaff'
-
-        Synonym for `context_name`.
+        
+        Gets and sets lilypond type of context.
 
         Returns string.
         '''
-        return self._context_name
+        return self._lilypond_type
+
+    @lilypond_type.setter
+    def lilypond_type(self, argument):
+        if argument is None:
+            argument = type(self).__name__
+        else:
+            argument = str(argument)
+        self._lilypond_type = argument
 
     @property
     def lilypond_context(self):
@@ -303,10 +293,10 @@ class Context(Container):
         '''
         import abjad
         try:
-            lilypond_context = abjad.LilyPondContext(name=self.context_name)
+            lilypond_context = abjad.LilyPondContext(name=self.lilypond_type)
         except AssertionError:
             lilypond_context = abjad.LilyPondContext(
-                name=self._default_context_name,
+                name=self._default_lilypond_type,
                 )
         return lilypond_context
 

--- a/abjad/tools/scoretools/Inspection.py
+++ b/abjad/tools/scoretools/Inspection.py
@@ -1429,7 +1429,7 @@ class Inspection(abctools.AbjadObject):
             >>> score = abjad.Score()
             >>> tuplet = abjad.Tuplet((4, 3), "d''8 c''8 b'8")
             >>> score.append(abjad.Staff([tuplet]))
-            >>> staff_group = abjad.StaffGroup(context_name='PianoStaff')
+            >>> staff_group = abjad.StaffGroup(lilypond_type='PianoStaff')
             >>> staff_group.append(abjad.Staff("a'4 g'4"))
             >>> staff_group.append(abjad.Staff("f'8 e'8 d'8 c'8"))
             >>> clef = abjad.Clef('bass')

--- a/abjad/tools/scoretools/Iteration.py
+++ b/abjad/tools/scoretools/Iteration.py
@@ -2149,7 +2149,7 @@ class Iteration(abctools.AbjadObject):
                 >>> staff = abjad.Staff(r"\times 4/3 { d''8 c''8 b'8 }")
                 >>> score.append(staff)
                 >>> staff_group = abjad.StaffGroup([])
-                >>> staff_group.context_name = 'PianoStaff'
+                >>> staff_group.lilypond_type = 'PianoStaff'
                 >>> staff_group.append(abjad.Staff("a'4 g'4"))
                 >>> staff_group.append(abjad.Staff(r"""\clef "bass" f'8 e'8 d'8 c'8"""))
                 >>> score.append(staff_group)
@@ -2212,7 +2212,7 @@ class Iteration(abctools.AbjadObject):
                 >>> staff = abjad.Staff(r"\times 4/3 { d''8 c''8 b'8 }")
                 >>> score.append(staff)
                 >>> staff_group = abjad.StaffGroup([])
-                >>> staff_group.context_name = 'PianoStaff'
+                >>> staff_group.lilypond_type = 'PianoStaff'
                 >>> staff_group.append(abjad.Staff("a'4 g'4"))
                 >>> staff_group.append(abjad.Staff(r"""\clef "bass" f'8 e'8 d'8 c'8"""))
                 >>> score.append(staff_group)

--- a/abjad/tools/scoretools/LeafMaker.py
+++ b/abjad/tools/scoretools/LeafMaker.py
@@ -55,7 +55,7 @@ class LeafMaker(AbjadValueObject):
         >>> durations = [abjad.Duration(1, 4)]
         >>> leaves = maker(pitches, durations)
         >>> staff = abjad.Staff(leaves)
-        >>> staff.context_name = 'RhythmicStaff'
+        >>> staff.lilypond_type = 'RhythmicStaff'
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -353,7 +353,7 @@ class LeafMaker(AbjadValueObject):
         ...     abjad.Measure((3, 8), [leaves[0]]),
         ...     abjad.Measure((5, 8), [leaves[1]]),
         ...     ])
-        >>> staff.context_name = 'RhythmicStaff'
+        >>> staff.lilypond_type = 'RhythmicStaff'
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::

--- a/abjad/tools/scoretools/Mutation.py
+++ b/abjad/tools/scoretools/Mutation.py
@@ -189,7 +189,7 @@ class Mutation(abctools.AbjadObject):
 
             Container contents can be safely added to a new container:
 
-            >>> staff = abjad.Staff(contents, context_name='RhythmicStaff')
+            >>> staff = abjad.Staff(contents, lilypond_type='RhythmicStaff')
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2492,7 +2492,7 @@ class Mutation(abctools.AbjadObject):
 
             >>> voice = abjad.Voice(
             ...     "c'4 d' e' f'",
-            ...     context_name='CustomVoice',
+            ...     lilypond_type='CustomVoice',
             ...     name='1',
             ...     )
             >>> staff = abjad.Staff([voice])
@@ -2559,14 +2559,14 @@ class Mutation(abctools.AbjadObject):
             >>> for voice in staff:
             ...     voice
             ...
-            Voice("c'8 ~", context_name='CustomVoice', name='1')
-            Voice("c'8", context_name='CustomVoice', name='1')
-            Voice("d'8 ~", context_name='CustomVoice', name='1')
-            Voice("d'8", context_name='CustomVoice', name='1')
-            Voice("e'8 ~", context_name='CustomVoice', name='1')
-            Voice("e'8", context_name='CustomVoice', name='1')
-            Voice("f'8 ~", context_name='CustomVoice', name='1')
-            Voice("f'8", context_name='CustomVoice', name='1')
+            Voice("c'8 ~", lilypond_type='CustomVoice', name='1')
+            Voice("c'8", lilypond_type='CustomVoice', name='1')
+            Voice("d'8 ~", lilypond_type='CustomVoice', name='1')
+            Voice("d'8", lilypond_type='CustomVoice', name='1')
+            Voice("e'8 ~", lilypond_type='CustomVoice', name='1')
+            Voice("e'8", lilypond_type='CustomVoice', name='1')
+            Voice("f'8 ~", lilypond_type='CustomVoice', name='1')
+            Voice("f'8", lilypond_type='CustomVoice', name='1')
 
         ..  container:: example
 

--- a/abjad/tools/scoretools/Score.py
+++ b/abjad/tools/scoretools/Score.py
@@ -38,21 +38,21 @@ class Score(Context):
 
     __slots__ = ()
 
-    _default_context_name = 'Score'
+    _default_lilypond_type = 'Score'
 
     ### INITIALIZER ###
 
     def __init__(
         self,
         components=None,
-        context_name='Score',
+        lilypond_type='Score',
         is_simultaneous=True,
         name=None,
         ):
         Context.__init__(
             self,
             components=components,
-            context_name=context_name,
+            lilypond_type=lilypond_type,
             is_simultaneous=is_simultaneous,
             name=name,
             )
@@ -334,7 +334,7 @@ class Score(Context):
         bass_staff = abjad.Staff([])
         bass_staff.name = 'Bass Staff'
         staff_group = abjad.StaffGroup([treble_staff, bass_staff])
-        staff_group.context_name = 'PianoStaff'
+        staff_group.lilypond_type = 'PianoStaff'
         score = abjad.Score([])
         score.append(staff_group)
         for leaf in leaves:

--- a/abjad/tools/scoretools/Selection.py
+++ b/abjad/tools/scoretools/Selection.py
@@ -439,7 +439,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 found_different_pitch = True
                 break
         if not found_different_pitch:
-            staff.context_name = 'RhythmicStaff'
+            staff.lilypond_type = 'RhythmicStaff'
         score = abjad.Score([staff])
         lilypond_file = abjad.LilyPondFile.new(score)
         lilypond_file.header_block.tagline = False

--- a/abjad/tools/scoretools/Staff.py
+++ b/abjad/tools/scoretools/Staff.py
@@ -73,21 +73,21 @@ class Staff(Context):
 
     __slots__ = ()
 
-    _default_context_name = 'Staff'
+    _default_lilypond_type = 'Staff'
 
     ### INITIALIZER ###
 
     def __init__(
         self,
         components=None,
-        context_name='Staff',
+        lilypond_type='Staff',
         is_simultaneous=None,
         name=None,
         ):
         Context.__init__(
             self,
             components=components,
-            context_name=context_name,
+            lilypond_type=lilypond_type,
             is_simultaneous=is_simultaneous,
             name=name,
             )

--- a/abjad/tools/scoretools/StaffGroup.py
+++ b/abjad/tools/scoretools/StaffGroup.py
@@ -37,21 +37,21 @@ class StaffGroup(Context):
 
     __slots__ = ()
 
-    _default_context_name = 'StaffGroup'
+    _default_lilypond_type = 'StaffGroup'
 
     ### INITIALIZER ###
 
     def __init__(
         self,
         components=None,
-        context_name='StaffGroup',
+        lilypond_type='StaffGroup',
         is_simultaneous=True,
         name=None,
         ):
         Context.__init__(
             self,
             components=components,
-            context_name=context_name,
+            lilypond_type=lilypond_type,
             is_simultaneous=is_simultaneous,
             name=name,
             )

--- a/abjad/tools/scoretools/Tuplet.py
+++ b/abjad/tools/scoretools/Tuplet.py
@@ -1201,7 +1201,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1231,7 +1231,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1261,7 +1261,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1293,7 +1293,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1323,7 +1323,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1356,7 +1356,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1386,7 +1386,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1416,7 +1416,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1448,7 +1448,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name = 'RhythmicStaff',
+            ...     lilypond_type = 'RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1477,7 +1477,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(measure) # doctest: +SKIP
 
@@ -1569,7 +1569,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1591,7 +1591,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1614,7 +1614,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1639,7 +1639,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1665,7 +1665,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1692,7 +1692,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1720,7 +1720,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1742,7 +1742,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1765,7 +1765,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1789,7 +1789,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1815,7 +1815,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1842,7 +1842,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((3, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1884,7 +1884,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((7, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1910,7 +1910,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((7, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1934,7 +1934,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((7, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1956,7 +1956,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((7, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1978,7 +1978,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((7, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2002,7 +2002,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((7, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2027,7 +2027,7 @@ class Tuplet(Container):
             ...     )
             >>> staff = abjad.Staff(
             ...     [abjad.Measure((7, 16), [tuplet])],
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 

--- a/abjad/tools/scoretools/VerticalMoment.py
+++ b/abjad/tools/scoretools/VerticalMoment.py
@@ -9,7 +9,7 @@ class VerticalMoment(abctools.AbjadObject):
 
         >>> score = abjad.Score()
         >>> staff_group = abjad.StaffGroup()
-        >>> staff_group.context_name = 'PianoStaff'
+        >>> staff_group.lilypond_type = 'PianoStaff'
         >>> staff_group.append(abjad.Staff("c'4 e'4 d'4 f'4"))
         >>> staff_group.append(abjad.Staff(r"""\clef "bass" g2 f2"""))
         >>> score.append(staff_group)

--- a/abjad/tools/scoretools/Voice.py
+++ b/abjad/tools/scoretools/Voice.py
@@ -27,21 +27,21 @@ class Voice(Context):
 
     __slots__ = ()
 
-    _default_context_name = 'Voice'
+    _default_lilypond_type = 'Voice'
 
     ### INITIALIZER ###
 
     def __init__(
         self,
         components=None,
-        context_name='Voice',
+        lilypond_type='Voice',
         is_simultaneous=None,
         name=None,
         ):
         Context.__init__(
             self,
             components=components,
-            context_name=context_name,
+            lilypond_type=lilypond_type,
             is_simultaneous=is_simultaneous,
             name=name,
             )

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_get_effective_staff.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_get_effective_staff.py
@@ -7,7 +7,7 @@ def test_scoretools_Inspection_get_effective_staff_01():
 
     staves = 2 * abjad.Staff("c'8 d'8 e'8 f'8")
     staff_group = abjad.StaffGroup(staves)
-    staff_group.context_name = 'PianoStaff'
+    staff_group.lilypond_type = 'PianoStaff'
     staff_group.is_simultaneous = True
     staff_group[0].name = 'RH'
     staff_group[1].name = 'LH'
@@ -51,7 +51,7 @@ def test_scoretools_Inspection_get_effective_staff_02():
 
     staves = 2 * abjad.Staff("c'8 d'8 e'8 f'8")
     staff_group = abjad.StaffGroup(staves)
-    staff_group.context_name = 'PianoStaff'
+    staff_group.lilypond_type = 'PianoStaff'
     staff_group.is_simultaneous = True
     staff_group[0].name = 'RH'
     staff_group[1].name = 'LH'
@@ -98,7 +98,7 @@ def test_scoretools_Inspection_get_effective_staff_03():
 
     staves = 2 * abjad.Staff("c'8 d'8 e'8 f'8")
     staff_group = abjad.StaffGroup(staves)
-    staff_group.context_name = 'PianoStaff'
+    staff_group.lilypond_type = 'PianoStaff'
     staff_group.is_simultaneous = True
     staff_group[0].name = 'RH'
     staff_group[1].name = 'LH'
@@ -134,7 +134,7 @@ def test_scoretools_Inspection_get_effective_staff_04():
 
     staves = 2 * abjad.Staff("c'8 d'8 e'8 f'8")
     staff_group = abjad.StaffGroup(staves)
-    staff_group.context_name = 'PianoStaff'
+    staff_group.lilypond_type = 'PianoStaff'
     staff_group.is_simultaneous = True
     staff_group[0].name = 'RH'
     staff_group[1].name = 'LH'

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_get_vertical_moment_at.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_get_vertical_moment_at.py
@@ -7,7 +7,7 @@ def test_scoretools_Inspection_get_vertical_moment_at_01():
     tuplet = abjad.Tuplet((4, 3), "d''8 c''8 b'8")
     score.append(abjad.Staff([tuplet]))
     staff_group = abjad.StaffGroup([])
-    staff_group.context_name = 'PianoStaff'
+    staff_group.lilypond_type = 'PianoStaff'
     staff_group.append(abjad.Staff("a'4 g'4"))
     staff_group.append(abjad.Staff("f'8 e'8 d'8 c'8"))
     clef = abjad.Clef('bass')
@@ -64,7 +64,7 @@ def test_scoretools_Inspection_get_vertical_moment_at_02():
     tuplet = abjad.Tuplet((4, 3), "d''8 c''8 b'8")
     score.append(abjad.Staff([tuplet]))
     staff_group = abjad.StaffGroup([])
-    staff_group.context_name = 'PianoStaff'
+    staff_group.lilypond_type = 'PianoStaff'
     staff_group.append(abjad.Staff("a'4 g'4"))
     staff_group.append(abjad.Staff("f'8 e'8 d'8 c'8"))
     clef = abjad.Clef('bass')

--- a/abjad/tools/scoretools/test/test_scoretools_Staff___init__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Staff___init__.py
@@ -5,8 +5,8 @@ def test_scoretools_Staff___init___01():
     r'''Initialize with context name.
     '''
 
-    staff = abjad.Staff(context_name='BlueStaff')
-    assert staff.context_name == 'BlueStaff'
+    staff = abjad.Staff(lilypond_type='BlueStaff')
+    assert staff.lilypond_type == 'BlueStaff'
 
 
 def test_scoretools_Staff___init___02():
@@ -21,6 +21,6 @@ def test_scoretools_Staff___init___03():
     r'''Initialize with both context name and name.
     '''
 
-    staff = abjad.Staff(context_name='BlueStaff', name='FirstBlueStaff')
-    assert staff.context_name == 'BlueStaff'
+    staff = abjad.Staff(lilypond_type='BlueStaff', name='FirstBlueStaff')
+    assert staff.lilypond_type == 'BlueStaff'
     assert staff.name == 'FirstBlueStaff'

--- a/abjad/tools/scoretools/test/test_scoretools_VerticalMoment___eq__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_VerticalMoment___eq__.py
@@ -58,7 +58,7 @@ def test_scoretools_VerticalMoment___eq___02():
         }
         '''
         )
-    staff_group.context_name = 'PianoStaff'
+    staff_group.lilypond_type = 'PianoStaff'
     score.append(staff_group)
 
     assert format(score) == abjad.String.normalize(

--- a/abjad/tools/segmenttools/GroupedRhythmicStavesScoreTemplate.py
+++ b/abjad/tools/segmenttools/GroupedRhythmicStavesScoreTemplate.py
@@ -165,7 +165,7 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
                 voice = abjad.Voice([], name=name)
                 name = 'Staff {}'.format(number)
                 staff = abjad.Staff([voice], name=name)
-                staff.context_name = 'RhythmicStaff'
+                staff.lilypond_type = 'RhythmicStaff'
                 abjad.annotate(staff, 'default_clef', abjad.Clef('percussion'))
                 staves.append(staff)
                 key = 'v{}'.format(number)
@@ -175,7 +175,7 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
                 staff_number = staff_index + 1
                 name = 'Staff {}'.format(staff_number)
                 staff = abjad.Staff(name=name)
-                staff.context_name = 'RhythmicStaff'
+                staff.lilypond_type = 'RhythmicStaff'
                 assert 1 <= voice_count
                 for voice_index in range(voice_count):
                     voice_number = voice_index + 1

--- a/abjad/tools/segmenttools/SegmentMaker.py
+++ b/abjad/tools/segmenttools/SegmentMaker.py
@@ -53,16 +53,16 @@ class SegmentMaker(AbjadObject):
     def _make_global_context(self):
         import abjad
         global_rests = abjad.Context(
-            context_name='GlobalRests',
+            lilypond_type='GlobalRests',
             name='GlobalRests',
             )
         global_skips = abjad.Context(
-            context_name='GlobalSkips',
+            lilypond_type='GlobalSkips',
             name='GlobalSkips',
             )
         global_context = abjad.Context(
             [global_rests, global_skips ],
-            context_name='GlobalContext',
+            lilypond_type='GlobalContext',
             is_simultaneous=True,
             name='GlobalContext',
             )

--- a/abjad/tools/segmenttools/StringOrchestraScoreTemplate.py
+++ b/abjad/tools/segmenttools/StringOrchestraScoreTemplate.py
@@ -490,7 +490,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
 
         global_context = abjad.Context(
             name='GlobalContext',
-            context_name='GlobalContext',
+            lilypond_type='GlobalContext',
             )
         instrument_tags = ' '.join(tag_names)
         tag_string = r"\tag #'({})".format(instrument_tags)
@@ -510,7 +510,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         import abjad
         name = instrument.name.title()
         instrument_staff_group = abjad.StaffGroup(
-            context_name='{}StaffGroup'.format(name),
+            lilypond_type='{}StaffGroup'.format(name),
             name='{} Staff Group'.format(name),
             )
         tag_names = []
@@ -551,7 +551,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
             name = instrument.name.title()
         pitch_range = instrument.pitch_range
         staff_group = abjad.StaffGroup(
-            context_name='StringPerformerStaffGroup',
+            lilypond_type='StringPerformerStaffGroup',
             name='{} Staff Group'.format(name),
             )
         tag_name = name.replace(' ', '')
@@ -561,7 +561,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         if self.split_hands:
             lh_voice = abjad.Voice(
                 [],
-                context_name='FingeringVoice',
+                lilypond_type='FingeringVoice',
                 name='{} Fingering Voice'.format(name),
                 )
             abbreviation = lh_voice.name.lower().replace(' ', '_')
@@ -570,7 +570,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
                 [
                     lh_voice
                     ],
-                context_name='FingeringStaff',
+                lilypond_type='FingeringStaff',
                 name='{} Fingering Staff'.format(name),
                 )
             lh_staff.is_simultaneous = True
@@ -580,7 +580,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
             abjad.annotate(lh_staff, 'default_clef', abjad.Clef(clef_name))
             rh_voice = abjad.Voice(
                 [],
-                context_name='BowingVoice',
+                lilypond_type='BowingVoice',
                 name='{} Bowing Voice'.format(name),
                 )
             abbreviation = rh_voice.name.lower().replace(' ', '_')
@@ -589,7 +589,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
                 [
                     rh_voice
                     ],
-                context_name='BowingStaff',
+                lilypond_type='BowingStaff',
                 name='{} Bowing Staff'.format(name),
                 )
             rh_staff.is_simultaneous = True
@@ -597,14 +597,14 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         else:
             lh_voice = abjad.Voice(
                 [],
-                context_name='FingeringVoice',
+                lilypond_type='FingeringVoice',
                 name='{} Voice'.format(name),
                 )
             lh_staff = abjad.Staff(
                 [
                     lh_voice
                     ],
-                context_name='FingeringStaff',
+                lilypond_type='FingeringStaff',
                 name='{} Staff'.format(name),
                 )
             lh_staff.is_simultaneous = True

--- a/abjad/tools/segmenttools/TwoStaffPianoScoreTemplate.py
+++ b/abjad/tools/segmenttools/TwoStaffPianoScoreTemplate.py
@@ -77,7 +77,7 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
         # PIANO STAFF
         staff_group = abjad.StaffGroup(
             [rh_staff, lh_staff],
-            context_name='PianoStaff',
+            lilypond_type='PianoStaff',
             name='Piano Staff',
             )
         abjad.annotate(

--- a/abjad/tools/segmenttools/test/test_custom_score_template_class.py
+++ b/abjad/tools/segmenttools/test/test_custom_score_template_class.py
@@ -54,8 +54,8 @@ def test_custom_score_template_class_02():
         ### SPECIAL METHODS ###
 
         def __call__(self):
-            custom_voice = abjad.Voice(context_name='CustomVoice')
-            custom_staff = abjad.Staff(context_name='CustomStaff')
+            custom_voice = abjad.Voice(lilypond_type='CustomVoice')
+            custom_staff = abjad.Staff(lilypond_type='CustomStaff')
             score = abjad.Score()
             custom_staff.append(custom_voice)
             score.append(custom_staff)
@@ -82,7 +82,7 @@ def test_custom_score_template_class_02():
     lilypond_file = abjad.LilyPondFile.new(score)
 
     context_block = abjad.ContextBlock(
-        source_context_name='Voice',
+        source_lilypond_type='Voice',
         type_='Engraver_group',
         name='CustomVoice',
         alias='Voice',
@@ -92,7 +92,7 @@ def test_custom_score_template_class_02():
     abjad.override(context_block).stem.color = 'green'
 
     context_block = abjad.ContextBlock(
-        source_context_name='Staff',
+        source_lilypond_type='Staff',
         type_='Engraver_group',
         name='CustomStaff',
         alias='Staff',
@@ -102,7 +102,7 @@ def test_custom_score_template_class_02():
     abjad.override(context_block).staff_symbol.color = 'red'
 
     context_block = abjad.ContextBlock(
-        source_context_name='Score',
+        source_lilypond_type='Score',
         )
     lilypond_file.layout_block.items.append(context_block)
     context_block.accepts_commands.append('CustomStaff')

--- a/abjad/tools/spannertools/Beam.py
+++ b/abjad/tools/spannertools/Beam.py
@@ -188,16 +188,16 @@ class Beam(Spanner):
         if self._is_my_first_leaf(leaf):
             parentage = abjad.inspect(leaf).get_parentage()
             staff = parentage.get_first(abjad.Staff)
-            headword = getattr(staff, 'headword', 'Staff')
+            lilypond_type = staff.lilypond_type
             string = r'\override {}.Stem.stemlet-length = {}'
-            string = string.format(headword, self.stemlet_length)
+            string = string.format(lilypond_type, self.stemlet_length)
             bundle.before.commands.append(string)
         if self._is_my_last_leaf(leaf):
             parentage = abjad.inspect(leaf).get_parentage()
             staff = parentage.get_first(abjad.Staff)
-            headword = getattr(staff, 'headword', 'Staff')
+            lilypond_type = staff.lilypond_type
             string = r'\revert {}.Stem.stemlet-length'
-            string = string.format(headword, self.stemlet_length)
+            string = string.format(lilypond_type, self.stemlet_length)
             bundle.before.commands.append(string)
 
     def _copy_keyword_args(self, new):
@@ -335,7 +335,7 @@ class Beam(Spanner):
 
             >>> staff = abjad.Staff(
             ...     "r8 c' r c' g'2",
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.setting(staff).auto_beaming = False
             >>> beam = abjad.Beam(stemlet_length=2)

--- a/abjad/tools/spannertools/ComplexBeam.py
+++ b/abjad/tools/spannertools/ComplexBeam.py
@@ -483,7 +483,7 @@ class ComplexBeam(Beam):
 
             >>> staff = abjad.Staff(
             ...     "r8 c' r c' g'2",
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> abjad.setting(staff).auto_beaming = False
             >>> beam = abjad.ComplexBeam(beam_rests=True, stemlet_length=2)

--- a/abjad/tools/spannertools/DuratedComplexBeam.py
+++ b/abjad/tools/spannertools/DuratedComplexBeam.py
@@ -664,7 +664,7 @@ class DuratedComplexBeam(ComplexBeam):
 
             >>> staff = abjad.Staff(
             ...     "c'16 r c' c' r c'",
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> durations = [(3, 16), (3, 16)]
             >>> beam = abjad.DuratedComplexBeam(

--- a/abjad/tools/spannertools/MultipartBeam.py
+++ b/abjad/tools/spannertools/MultipartBeam.py
@@ -277,7 +277,7 @@ class MultipartBeam(Beam):
 
             >>> staff = abjad.Staff(
             ...     "c'16 r c' c' r c'",
-            ...     context_name='RhythmicStaff',
+            ...     lilypond_type='RhythmicStaff',
             ...     )
             >>> durations = [(3, 16), (3, 16)]
             >>> beam = abjad.MultipartBeam(

--- a/abjad/tools/spannertools/PianoPedalSpanner.py
+++ b/abjad/tools/spannertools/PianoPedalSpanner.py
@@ -80,7 +80,7 @@ class PianoPedalSpanner(Spanner):
         if self._is_my_only_leaf(leaf):
             style = abjad.SchemeSymbol(self.style)
             context_setting = abjad.lilypondnametools.LilyPondContextSetting(
-                context_name='Staff',
+                lilypond_type='Staff',
                 context_property='pedalSustainStyle',
                 value=style,
                 )
@@ -92,7 +92,7 @@ class PianoPedalSpanner(Spanner):
         elif self._is_my_first_leaf(leaf):
             style = abjad.SchemeSymbol(self.style)
             context_setting = abjad.lilypondnametools.LilyPondContextSetting(
-                context_name='Staff',
+                lilypond_type='Staff',
                 context_property='pedalSustainStyle',
                 value=style,
                 )

--- a/abjad/tools/spannertools/StaffLinesSpanner.py
+++ b/abjad/tools/spannertools/StaffLinesSpanner.py
@@ -82,7 +82,7 @@ class StaffLinesSpanner(Spanner):
             bundle.before.commands.append(r'\stopStaff')
             if isinstance(self.lines, int):
                 override = abjad.LilyPondGrobOverride(
-                    context_name='Staff',
+                    lilypond_type='Staff',
                     grob_name='StaffSymbol',
                     once=True,
                     property_path='line-count',
@@ -92,7 +92,7 @@ class StaffLinesSpanner(Spanner):
                 bundle.before.commands.append(string)
             else:
                 override = abjad.LilyPondGrobOverride(
-                    context_name='Staff',
+                    lilypond_type='Staff',
                     grob_name='StaffSymbol',
                     once=True,
                     property_path='line-positions',

--- a/abjad/tools/systemtools/Wrapper.py
+++ b/abjad/tools/systemtools/Wrapper.py
@@ -578,7 +578,7 @@ class Wrapper(AbjadValueObject):
                 if not isinstance(component, abjad.Context):
                     continue
                 if (component.name == context or
-                    component.context_name == context):
+                    component.lilypond_type == context):
                     return component
         else:
             message = 'must be context or string: {!r}.'

--- a/abjad/tools/test/test_abjad___doc__.py
+++ b/abjad/tools/test/test_abjad___doc__.py
@@ -13,7 +13,7 @@ ignored_names = (
     '__init__',
     '__new__',
     '__weakref__',
-    'context_name',
+    'lilypond_type',
     'denominator',
     'duration',
     'multiplier',


### PR DESCRIPTION
Removed Context.headword. use Context.lilypond_type instead.