### PR TITLE
BREAK: Changed abjad.TypedOrderedDict to abjad.OrderedDict.

### DIFF
--- a/abjad/__init__.py
+++ b/abjad/__init__.py
@@ -75,9 +75,6 @@ from abjad.tools.rhythmmakertools import SustainMask
 silence = SilenceMask.silence
 sustain = SustainMask.sustain
 
-# abjad.TypedOrderedDict will eventually be renamed abjad.OrderedDict
-OrderedDict = TypedOrderedDict
-
 # import version information
 from abjad._version import __version_info__, __version__
 del _version

--- a/abjad/boilerplate/__aliases__.py
+++ b/abjad/boilerplate/__aliases__.py
@@ -1,6 +1,6 @@
 import abjad
 
 
-aliases = abjad.TypedOrderedDict([
+aliases = abjad.OrderedDict([
     ('todo', 'etc/to-do.md'),
     ])

--- a/abjad/boilerplate/__make_segment_pdf__.py
+++ b/abjad/boilerplate/__make_segment_pdf__.py
@@ -29,14 +29,8 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
-        segment_directory = pathlib.Path(os.path.realpath(__file__)).parent
-        builds_directory = segment_directory.parent.parent / 'builds'
-        builds_directory = ide.Path(builds_directory)
-    except:
-        traceback.print_exc()
-        sys.exit(1)
-
-    try:
+        segment = ide.Path(os.path.realpath(__file__)).parent
+        ly = segment('illustration.ly')
         with abjad.Timer() as timer:
             lilypond_file = maker.run(
                 metadata=metadata,
@@ -48,12 +42,6 @@ if __name__ == '__main__':
         message = f'Segment-maker runtime {{count}} {{counter}} ...'
         print(message)
         segment_maker_runtime = (count, counter)
-    except:
-        traceback.print_exc()
-        sys.exit(1)
-
-    try:
-        segment = ide.Path(__file__).parent
         segment.write_metadata_py(maker.metadata)
     except:
         traceback.print_exc()
@@ -73,8 +61,6 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
-        segment = ide.Path(__file__).parent
-        ly = segment('illustration.ly')
         text = ly.read_text()
         text = abjad.LilyPondFormatManager.left_shift_tags(text, realign=89)
         ly.write_text(text)
@@ -123,8 +109,6 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
-        segment = ide.Path(__file__).parent
-        ly = segment('illustration.ly')
         with abjad.Timer() as timer:
             abjad.IOManager.run_lilypond(ly)
         lilypond_runtime = int(timer.elapsed_time)
@@ -138,7 +122,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
-        history = ide.Path(__file__).parent('.history')
+        history = segment('.history')
         with history.open(mode='a') as pointer:
             pointer.write('\n')
             line = time.strftime('%Y-%m-%d %H:%M:%S') + '\n'

--- a/abjad/boilerplate/__metadata__.py
+++ b/abjad/boilerplate/__metadata__.py
@@ -1,4 +1,4 @@
 import abjad
 
 
-metadata = abjad.TypedOrderedDict()
+metadata = abjad.OrderedDict()

--- a/abjad/boilerplate/score/score/__metadata__.py
+++ b/abjad/boilerplate/score/score/__metadata__.py
@@ -1,7 +1,7 @@
 import abjad
 
 
-metadata = abjad.TypedOrderedDict(
+metadata = abjad.OrderedDict(
     [
         ('composer', {composer_last_name!r}),
         ('title', {score_title!r}),

--- a/abjad/boilerplate/score/score/test/test_materials.py
+++ b/abjad/boilerplate/score/score/test/test_materials.py
@@ -12,13 +12,13 @@ directories = path.materials.list_paths()
 
 @pytest.mark.parametrize('directory', directories)
 def test_materials_01(directory):
-    exit_code = abjad_ide.check_definition(directory)
+    exit_code = abjad_ide.check_definition_py(directory)
     if exit_code != 0:
         sys.exit(exit_code)
 
 
 @pytest.mark.parametrize('directory', directories)
 def test_materials_02(directory):
-    exit_code = abjad_ide.make_pdf(directory, open_after=False)
+    exit_code = abjad_ide.make_illustration_pdf(directory, open_after=False)
     if exit_code != 0:
         sys.exit(exit_code)

--- a/abjad/boilerplate/score/score/test/test_segments.py
+++ b/abjad/boilerplate/score/score/test/test_segments.py
@@ -16,7 +16,7 @@ directories = path.segments.list_paths()
 
 @pytest.mark.parametrize('directory', directories)
 def test_packages_01(directory):
-    exit_code = abjad_ide.check_definition(directory)
+    exit_code = abjad_ide.check_definition_py(directory)
     if exit_code != 0:
         sys.exit(exit_code)
 
@@ -31,7 +31,10 @@ def test_packages_02(directory):
         ly_old = directory / 'illustration.old.ly'
         if ly.exists():
             shutil.copyfile(ly, ly_old)
-        exit_code = abjad_ide.make_pdf(directory, open_after=False)
+        exit_code = abjad_ide.make_illustration_pdf(
+            directory,
+            open_after=False,
+            )
         if exit_code != 0:
             sys.exit(exit_code)
         if not ly_old.exists():

--- a/abjad/tools/datastructuretools/OrderedDict.py
+++ b/abjad/tools/datastructuretools/OrderedDict.py
@@ -3,20 +3,20 @@ from abjad.tools import systemtools
 from abjad.tools.datastructuretools.TypedCollection import TypedCollection
 
 
-class TypedOrderedDict(TypedCollection, collections.MutableMapping):
+class OrderedDict(TypedCollection, collections.MutableMapping):
     r'''Typed ordered dictionary.
 
     ..  container:: example
 
         Initializes from list of pairs:
 
-        >>> dictionary = abjad.TypedOrderedDict([
+        >>> dictionary = abjad.OrderedDict([
         ...     ('color', 'red'),
         ...     ('directive', abjad.Markup(r'\italic Allegretto')),
         ...     ])
 
         >>> abjad.f(dictionary)
-        abjad.TypedOrderedDict(
+        abjad.OrderedDict(
             [
                 ('color', 'red'),
                 (
@@ -41,12 +41,12 @@ class TypedOrderedDict(TypedCollection, collections.MutableMapping):
         ...     'color': 'red',
         ...     'directive': abjad.Markup(r'\italic Allegretto'),
         ...     }
-        >>> dictionary = abjad.TypedOrderedDict(
+        >>> dictionary = abjad.OrderedDict(
         ...     dictionary
         ...     )
 
         >>> abjad.f(dictionary)
-        abjad.TypedOrderedDict(
+        abjad.OrderedDict(
             [
                 ('color', 'red'),
                 (
@@ -67,16 +67,16 @@ class TypedOrderedDict(TypedCollection, collections.MutableMapping):
 
         Initializes from other typed ordered dictionary:
 
-        >>> dictionary_1 = abjad.TypedOrderedDict([
+        >>> dictionary_1 = abjad.OrderedDict([
         ...     ('color', 'red'),
         ...     ('directive', abjad.Markup(r'\italic Allegretto')),
         ...     ])
-        >>> dictionary_2 = abjad.TypedOrderedDict(
+        >>> dictionary_2 = abjad.OrderedDict(
         ...     dictionary_1
         ...     )
 
         >>> abjad.f(dictionary_2)
-        abjad.TypedOrderedDict(
+        abjad.OrderedDict(
             [
                 ('color', 'red'),
                 (

--- a/abjad/tools/datastructuretools/__init__.py
+++ b/abjad/tools/datastructuretools/__init__.py
@@ -32,6 +32,7 @@ from .Offset import Offset
 from .Pattern import Pattern
 from .TypedCollection import TypedCollection
 from .TypedTuple import TypedTuple
+from .OrderedDict import OrderedDict
 from .PatternTuple import PatternTuple
 from .PitchInequality import PitchInequality
 from .Sequence import Sequence
@@ -42,7 +43,6 @@ from .TreeContainer import TreeContainer
 from .TypedCounter import TypedCounter
 from .TypedFrozenset import TypedFrozenset
 from .TypedList import TypedList
-from .TypedOrderedDict import TypedOrderedDict
 
 
 _documentation_section = 'core'

--- a/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict.py
+++ b/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict.py
@@ -1,11 +1,11 @@
 import abjad
 
 
-def test_datastructuretools_TypedOrderedDict_01():
+def test_datastructuretools_OrderedDict_01():
     r'''Implements __contains__().
     '''
 
-    dictionary = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary['soprano'] = 'treble'
     dictionary['alto'] = 'alto'
     dictionary['tenor'] = 'tenor'
@@ -16,29 +16,29 @@ def test_datastructuretools_TypedOrderedDict_01():
     assert [_ for _ in dictionary] == ['soprano', 'alto', 'tenor', 'bass']
 
 
-def test_datastructuretools_TypedOrderedDict_02():
+def test_datastructuretools_OrderedDict_02():
     r'''Implements __delitem__().
     '''
 
-    dictionary_1 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_1 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_1['soprano'] = 'treble'
     del(dictionary_1['soprano'])
 
-    dictionary_2 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_2 = abjad.OrderedDict(item_class=abjad.Clef)
     assert dictionary_1 == dictionary_2
 
 
-def test_datastructuretools_TypedOrderedDict_03():
+def test_datastructuretools_OrderedDict_03():
     r'''Implements __eq__().
     '''
 
-    dictionary_1 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_1 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_1['soprano'] = 'treble'
 
-    dictionary_2 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_2 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_2['soprano'] = 'treble'
 
-    dictionary_3 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_3 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_3['bass'] = 'bass'
 
     assert dictionary_1 == dictionary_1
@@ -52,11 +52,11 @@ def test_datastructuretools_TypedOrderedDict_03():
     assert dictionary_3 == dictionary_3
 
 
-def test_datastructuretools_TypedOrderedDict_04():
+def test_datastructuretools_OrderedDict_04():
     r'''Implements __format__().
     '''
 
-    dictionary_1 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_1 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_1['soprano'] = 'treble'
     dictionary_1['alto'] = 'alto'
     dictionary_1['tenor'] = 'tenor'
@@ -64,7 +64,7 @@ def test_datastructuretools_TypedOrderedDict_04():
 
     assert format(dictionary_1) == abjad.String.normalize(
         r'''
-        abjad.TypedOrderedDict(
+        abjad.OrderedDict(
             [
                 (
                     'soprano',
@@ -94,7 +94,7 @@ def test_datastructuretools_TypedOrderedDict_04():
     assert dictionary_1 == dictionary_2
 
 
-def test_datastructuretools_TypedOrderedDict_05():
+def test_datastructuretools_OrderedDict_05():
     r'''Initializes from dictionary items.
     '''
 
@@ -104,12 +104,12 @@ def test_datastructuretools_TypedOrderedDict_05():
         ('tenor', abjad.Clef('tenor')),
         ('bass', abjad.Clef('bass')),
         ]
-    dictionary_1 = abjad.TypedOrderedDict(
+    dictionary_1 = abjad.OrderedDict(
         item_class=abjad.Clef,
         items=items,
         )
 
-    dictionary_2 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_2 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_2['soprano'] = 'treble'
     dictionary_2['alto'] = 'alto'
     dictionary_2['tenor'] = 'tenor'
@@ -118,27 +118,27 @@ def test_datastructuretools_TypedOrderedDict_05():
     assert dictionary_1 == dictionary_2
 
 
-def test_datastructuretools_TypedOrderedDict_06():
+def test_datastructuretools_OrderedDict_06():
     r'''Implements __len__().
     '''
 
-    dictionary = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary = abjad.OrderedDict(item_class=abjad.Clef)
     assert len(dictionary) == 0
 
-    dictionary = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary['soprano'] = 'treble'
     assert len(dictionary) == 1
 
 
-def test_datastructuretools_TypedOrderedDict_07():
+def test_datastructuretools_OrderedDict_07():
 
-    dictionary_1 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_1 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_1['soprano'] = 'treble'
 
-    dictionary_2 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_2 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_2['soprano'] = 'treble'
 
-    dictionary_3 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_3 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_3['bass'] = 'bass'
 
     assert not dictionary_1 != dictionary_1
@@ -152,11 +152,11 @@ def test_datastructuretools_TypedOrderedDict_07():
     assert not dictionary_3 != dictionary_3
 
 
-def test_datastructuretools_TypedOrderedDict_08():
+def test_datastructuretools_OrderedDict_08():
     r'''Implements __reversed__().
     '''
 
-    dictionary = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary['soprano'] = 'treble'
     dictionary['alto'] = 'alto'
     dictionary['tenor'] = 'tenor'
@@ -166,26 +166,26 @@ def test_datastructuretools_TypedOrderedDict_08():
     assert [_ for _ in generator] == ['bass', 'tenor', 'alto', 'soprano']
 
 
-def test_datastructuretools_TypedOrderedDict_09():
+def test_datastructuretools_OrderedDict_09():
     r'''Implements clear().
     '''
 
-    dictionary_1 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_1 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_1['soprano'] = 'treble'
     dictionary_1['alto'] = 'alto'
     dictionary_1['tenor'] = 'tenor'
     dictionary_1['bass'] = 'bass'
     dictionary_1.clear()
 
-    dictionary_2 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_2 = abjad.OrderedDict(item_class=abjad.Clef)
     assert dictionary_1 == dictionary_2
 
 
-def test_datastructuretools_TypedOrderedDict_10():
+def test_datastructuretools_OrderedDict_10():
     r'''Implements copy().
     '''
 
-    dictionary_1 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_1 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_1['soprano'] = 'treble'
     dictionary_1['alto'] = 'alto'
     dictionary_1['tenor'] = 'tenor'
@@ -195,11 +195,11 @@ def test_datastructuretools_TypedOrderedDict_10():
     assert dictionary_1 == dictionary_2
 
 
-def test_datastructuretools_TypedOrderedDict_11():
+def test_datastructuretools_OrderedDict_11():
     r'''Implements get().
     '''
 
-    dictionary = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary['soprano'] = 'treble'
     dictionary['alto'] = 'alto'
     dictionary['tenor'] = 'tenor'
@@ -210,11 +210,11 @@ def test_datastructuretools_TypedOrderedDict_11():
     assert dictionary.get('foo', 'bar') == 'bar'
 
 
-def test_datastructuretools_TypedOrderedDict_12():
+def test_datastructuretools_OrderedDict_12():
     r'''Implements has_key().
     '''
 
-    dictionary = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary['soprano'] = 'treble'
     dictionary['alto'] = 'alto'
     dictionary['tenor'] = 'tenor'
@@ -225,11 +225,11 @@ def test_datastructuretools_TypedOrderedDict_12():
     assert not dictionary.has_key('foo')
 
 
-def test_datastructuretools_TypedOrderedDict_13():
+def test_datastructuretools_OrderedDict_13():
     r'''Implements items().
     '''
 
-    dictionary = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary['soprano'] = 'treble'
     dictionary['alto'] = 'alto'
     dictionary['tenor'] = 'tenor'
@@ -243,11 +243,11 @@ def test_datastructuretools_TypedOrderedDict_13():
         ]
 
 
-def test_datastructuretools_TypedOrderedDict_14():
+def test_datastructuretools_OrderedDict_14():
     r'''Implements keys().
     '''
 
-    dictionary = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary['soprano'] = 'treble'
     dictionary['alto'] = 'alto'
     dictionary['tenor'] = 'tenor'
@@ -256,17 +256,17 @@ def test_datastructuretools_TypedOrderedDict_14():
     assert list(dictionary.keys()) == ['soprano', 'alto', 'tenor', 'bass']
 
 
-def test_datastructuretools_TypedOrderedDict_15():
+def test_datastructuretools_OrderedDict_15():
     r'''Implements pop().
     '''
 
-    dictionary_1 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_1 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_1['soprano'] = 'treble'
     dictionary_1['alto'] = 'alto'
     dictionary_1['tenor'] = 'tenor'
     dictionary_1['bass'] = 'bass'
 
-    dictionary_2 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_2 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_2['alto'] = 'alto'
     dictionary_2['tenor'] = 'tenor'
     dictionary_2['bass'] = 'bass'
@@ -275,17 +275,17 @@ def test_datastructuretools_TypedOrderedDict_15():
     assert dictionary_1 == dictionary_2
 
 
-#def test_datastructuretools_TypedOrderedDict_16():
+#def test_datastructuretools_OrderedDict_16():
 #    r'''Implements popitem().
 #    '''
 #
-#    dictionary_1 = abjad.TypedOrderedDict(item_class=Clef)
+#    dictionary_1 = abjad.OrderedDict(item_class=Clef)
 #    dictionary_1['soprano'] = 'treble'
 #    dictionary_1['alto'] = 'alto'
 #    dictionary_1['tenor'] = 'tenor'
 #    dictionary_1['bass'] = 'bass'
 #
-#    dictionary_2 = abjad.TypedOrderedDict(item_class=Clef)
+#    dictionary_2 = abjad.OrderedDict(item_class=Clef)
 #    dictionary_2['alto'] = 'alto'
 #    dictionary_2['tenor'] = 'tenor'
 #    dictionary_2['bass'] = 'bass'
@@ -295,19 +295,19 @@ def test_datastructuretools_TypedOrderedDict_15():
 #    assert dictionary_1 == dictionary_2
 
 
-def test_datastructuretools_TypedOrderedDict_17():
+def test_datastructuretools_OrderedDict_17():
     r'''Implements update().
     '''
 
-    dictionary_1 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_1 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_1['soprano'] = 'treble'
     dictionary_1['alto'] = 'alto'
 
-    dictionary_2 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_2 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_2['tenor'] = 'tenor'
     dictionary_2['bass'] = 'bass'
 
-    dictionary_3 = abjad.TypedOrderedDict(item_class=abjad.Clef)
+    dictionary_3 = abjad.OrderedDict(item_class=abjad.Clef)
     dictionary_3['soprano'] = 'treble'
     dictionary_3['alto'] = 'alto'
     dictionary_3['tenor'] = 'tenor'

--- a/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict___copy__.py
+++ b/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict___copy__.py
@@ -2,9 +2,9 @@ import copy
 import abjad
 
 
-def test_datastructuretools_TypedOrderedDict___copy___01():
+def test_datastructuretools_OrderedDict___copy___01():
 
-    dictionary_1 = abjad.TypedOrderedDict([
+    dictionary_1 = abjad.OrderedDict([
         ('flavor', 'cherry'), ('count', 2),
         ])
     dictionary_2 = copy.copy(dictionary_1)

--- a/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict___deepcopy__.py
+++ b/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict___deepcopy__.py
@@ -2,9 +2,9 @@ import copy
 import abjad
 
 
-def test_datastructuretools_TypedOrderedDict___deepcopy___01():
+def test_datastructuretools_OrderedDict___deepcopy___01():
 
-    dictionary_1 = abjad.TypedOrderedDict([
+    dictionary_1 = abjad.OrderedDict([
         ('flavor', 'cherry'), ('count', 2),
         ])
     dictionary_2 = copy.deepcopy(dictionary_1)

--- a/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict___eq__.py
+++ b/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict___eq__.py
@@ -1,15 +1,15 @@
 import abjad
 
 
-def test_datastructuretools_TypedOrderedDict___eq___01():
+def test_datastructuretools_OrderedDict___eq___01():
 
-    dictionary_1 = abjad.TypedOrderedDict([
+    dictionary_1 = abjad.OrderedDict([
         ('flavor', 'cherry'), ('count', 2),
         ])
-    dictionary_2 = abjad.TypedOrderedDict([
+    dictionary_2 = abjad.OrderedDict([
         ('flavor', 'cherry'), ('count', 2),
         ])
-    dictionary_3 = abjad.TypedOrderedDict([
+    dictionary_3 = abjad.OrderedDict([
         ('flavor', 'chocolate'), ('count', 2),
         ])
 
@@ -24,12 +24,12 @@ def test_datastructuretools_TypedOrderedDict___eq___01():
     assert dictionary_3 == dictionary_3
 
 
-def test_datastructuretools_TypedOrderedDict___eq___02():
+def test_datastructuretools_OrderedDict___eq___02():
 
-    dictionary_1 = abjad.TypedOrderedDict([
+    dictionary_1 = abjad.OrderedDict([
         ('flavor', 'cherry'), ('count', 2),
         ])
-    dictionary_2 = abjad.TypedOrderedDict([
+    dictionary_2 = abjad.OrderedDict([
         ('flavor', 'cherry'), ('count', 2), ('color', 'red'),
         ])
 

--- a/abjad/tools/indicatortools/MetronomeMarkDictionary.py
+++ b/abjad/tools/indicatortools/MetronomeMarkDictionary.py
@@ -1,8 +1,8 @@
 import copy
-from abjad.tools.datastructuretools.TypedOrderedDict import TypedOrderedDict
+from abjad.tools.datastructuretools.OrderedDict import OrderedDict
 
 
-class MetronomeMarkDictionary(TypedOrderedDict):
+class MetronomeMarkDictionary(OrderedDict):
     r'''Metronome mark dictionary.
 
     ..  container:: example

--- a/abjad/tools/instrumenttools/InstrumentDictionary.py
+++ b/abjad/tools/instrumenttools/InstrumentDictionary.py
@@ -1,7 +1,7 @@
-from abjad.tools.datastructuretools.TypedOrderedDict import TypedOrderedDict
+from abjad.tools.datastructuretools.OrderedDict import OrderedDict
 
 
-class InstrumentDictionary(TypedOrderedDict):
+class InstrumentDictionary(OrderedDict):
     r'''Instrument dictionary.
 
     ..  container:: example

--- a/abjad/tools/rhythmmakertools/PartitionTable.py
+++ b/abjad/tools/rhythmmakertools/PartitionTable.py
@@ -1,8 +1,8 @@
 from abjad.tools import mathtools
-from abjad.tools.datastructuretools.TypedOrderedDict import TypedOrderedDict
+from abjad.tools.datastructuretools.OrderedDict import OrderedDict
 
 
-class PartitionTable(TypedOrderedDict):
+class PartitionTable(OrderedDict):
     r'''Partition table.
 
     ..  container:: example

--- a/abjad/tools/scoretools/Selection.py
+++ b/abjad/tools/scoretools/Selection.py
@@ -568,7 +568,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             new_components.append(new_component)
         new_components = type(self)(new_components)
         # find spanners and piecewise indicators
-        spanner_to_pairs = abjad.TypedOrderedDict()
+        spanner_to_pairs = abjad.OrderedDict()
         for i, component in enumerate(abjad.iterate(self).components()):
             for spanner in abjad.inspect(component).get_spanners():
                 pairs = spanner_to_pairs.setdefault(spanner, [])
@@ -582,12 +582,12 @@ class Selection(AbjadValueObject, collections.Sequence):
                 else:
                     pairs.append((i, None))
         # copy spanners
-        new_spanner_to_pairs = abjad.TypedOrderedDict()
+        new_spanner_to_pairs = abjad.OrderedDict()
         for spanner, pairs in spanner_to_pairs.items():
             new_spanner = copy.copy(spanner)
             new_spanner_to_pairs[new_spanner] = pairs
         # make reversed map
-        index_to_pairs = abjad.TypedOrderedDict()
+        index_to_pairs = abjad.OrderedDict()
         for new_spanner, pairs in new_spanner_to_pairs.items():
             for (i, wrapper) in pairs:
                 pairs = index_to_pairs.setdefault(i, [])

--- a/abjad/tools/segmenttools/SegmentMaker.py
+++ b/abjad/tools/segmenttools/SegmentMaker.py
@@ -92,9 +92,9 @@ class SegmentMaker(AbjadObject):
         Returns LilyPond file.
         '''
         import abjad
-        self._documents_metadata = abjad.TypedOrderedDict(documents_metadata)
-        self._metadata = abjad.TypedOrderedDict(metadata)
-        self._previous_metadata = abjad.TypedOrderedDict(previous_metadata)
+        self._documents_metadata = abjad.OrderedDict(documents_metadata)
+        self._metadata = abjad.OrderedDict(metadata)
+        self._previous_metadata = abjad.OrderedDict(previous_metadata)
         lilypond_file = self._make_lilypond_file(midi=midi)
         assert isinstance(lilypond_file, abjad.LilyPondFile)
         self._lilypond_file = lilypond_file

--- a/abjad/tools/systemtools/StorageFormatManager.py
+++ b/abjad/tools/systemtools/StorageFormatManager.py
@@ -80,7 +80,7 @@ class StorageFormatManager(AbjadValueObject):
             return self._format_sequence(as_storage_format, is_indented)
         elif isinstance(self._client, (
             collections.OrderedDict,
-            datastructuretools.TypedOrderedDict,
+            datastructuretools.OrderedDict,
             )):
             return self._format_ordered_mapping(as_storage_format, is_indented)
         elif isinstance(self._client, dict):
@@ -363,7 +363,7 @@ class StorageFormatManager(AbjadValueObject):
 
         ..  container:: example
 
-            >>> dictionary = abjad.TypedOrderedDict(
+            >>> dictionary = abjad.OrderedDict(
             ...     item_class=abjad.NamedPitch,
             ...     )
 
@@ -371,7 +371,7 @@ class StorageFormatManager(AbjadValueObject):
             >>> for _ in types:
             ...     _
             ...
-            <class 'abjad.tools.datastructuretools.TypedOrderedDict.TypedOrderedDict'>
+            <class 'abjad.tools.datastructuretools.OrderedDict.OrderedDict'>
             <class 'abjad.tools.pitchtools.NamedPitch.NamedPitch'>
 
         Returns tuple of types.


### PR DESCRIPTION
Renamed `abjad.TypedOrderedDict` to just `abjad.OrderedDict`.

Casual Abjad users are unlikely to notice.

Experienced Abjad users leveraging `abjad.OrderedDict` to store segment metadata (and similar) should run
```
ajv replace TypedOrderedDict OrderedDict
```
... everywhere.