### PR TITLE
3.0 FORMAT ENGINE CHANGE 1: context-open-statement formatting.

### DIFF
--- a/abjad/boilerplate/__make_layout_ly__.py
+++ b/abjad/boilerplate/__make_layout_ly__.py
@@ -11,11 +11,11 @@ import traceback
 if __name__ == '__main__':
 
     layout_module_name = '{layout_module_name}'
+    maker = ide.Path(os.path.realpath(__file__))
 
     try:
         from {layout_module_name} import breaks
         assert isinstance(breaks, baca.BreakMeasureMap), repr(breaks)
-        maker = ide.Path(os.path.realpath(__file__))
     except ImportError:
         print(f'No breaks in {{maker.trim()}} ...')
         sys.exit(1)
@@ -77,15 +77,7 @@ if __name__ == '__main__':
             spacing=spacing,
             time_signatures=time_signatures,
             )
-        remove = (
-            abjad.tags.EMPTY_START_BAR,
-            abjad.tags.EXPLICIT_TIME_SIGNATURE_COLOR,
-            abjad.tags.MEASURE_NUMBER_MARKUP,
-            abjad.tags.REDUNDANT_TIME_SIGNATURE_COLOR,
-            abjad.tags.STAGE_NUMBER_MARKUP,
-            'SM29',
-            )
-        lilypond_file = maker.run(remove=remove)
+        lilypond_file = maker.run(remove=abjad.tags.layout_removal_tags())
         context = lilypond_file['GlobalSkips']
         skips = baca.select(context).skips()
         for skip in skips:

--- a/abjad/boilerplate/__make_segment_pdf__.py
+++ b/abjad/boilerplate/__make_segment_pdf__.py
@@ -12,17 +12,7 @@ if __name__ == '__main__':
 
     try:
         from definition import maker
-    except ImportError:
-        traceback.print_exc()
-        sys.exit(1)
-
-    try:
         from __metadata__ import metadata as metadata
-    except ImportError:
-        traceback.print_exc()
-        sys.exit(1)
-
-    try:
         {previous_segment_metadata_import_statement}
     except ImportError:
         traceback.print_exc()
@@ -44,11 +34,6 @@ if __name__ == '__main__':
         print(message)
         segment_maker_runtime = (count, counter)
         segment_directory.write_metadata_py(maker.metadata)
-    except:
-        traceback.print_exc()
-        sys.exit(1)
-
-    try:
         result = abjad.persist(lilypond_file).as_ly(illustration_ly, strict=89)
         abjad_format_time = int(result[1])
         count = abjad_format_time
@@ -64,20 +49,14 @@ if __name__ == '__main__':
         text = illustration_ly.read_text()
         text = abjad.LilyPondFormatManager.left_shift_tags(text, realign=89)
         illustration_ly.write_text(text)
-        for message in abjad.Job.document_specific_job(illustration_ly)():
-            print(message)
-        job = abjad.Job.music_annotation_job(illustration_ly, undo=True)
-        for message in job():
-            print(message)
-    except:
-        traceback.print_exc()
-        sys.exit(1)
-
-    try:
-        for message in abjad.Job.fermata_bar_line_job(segment_directory)():
-            print(message)
-        for message in abjad.Job.shifted_clef_job(segment_directory)():
-            print(message)
+        for job in [
+            abjad.Job.document_specific_job(illustration_ly),
+            abjad.Job.music_annotation_job(illustration_ly, undo=True),
+            abjad.Job.fermata_bar_line_job(segment_directory),
+            abjad.Job.shifted_clef_job(segment_directory),
+            ]:
+            for message in job():
+                print(message)
     except:
         traceback.print_exc()
         sys.exit(1)
@@ -87,11 +66,6 @@ if __name__ == '__main__':
         if not layout_py.exists():
             print('Writing stub layout.py ...')
             layout_py.write_text('')
-    except:
-        traceback.print_exc()
-        sys.exit(1)
-
-    try:
         layout_ly = segment_directory('layout.ly')
         if not layout_ly.exists():
             print('Writing stub layout.ly ...')
@@ -101,6 +75,10 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
+        if getattr(maker, 'do_not_externalize', False) is not True:
+            illustration_ly.extern()
+            illustration_ily = illustration_ly.with_suffix('.ily')
+            assert illustration_ily.is_file()
         with abjad.Timer() as timer:
             abjad.IOManager.run_lilypond(illustration_ly)
         lilypond_runtime = int(timer.elapsed_time)

--- a/abjad/boilerplate/part-music.ly
+++ b/abjad/boilerplate/part-music.ly
@@ -6,6 +6,19 @@
 
 #(ly:set-option 'relative-includes #t)
 \include "stylesheet.ily"
+{segment_ily_include_statements}
+
+\header {{
+    subtitle =
+        \markup \column \center-align
+        {{
+            \override #'(font-name . "Palatino Italic") \fontsize #3
+            {{
+                \line {{ {part_subtitle} }}
+                \line {{ part }}
+            }}
+        }}
+}}
 
 
 \score {{
@@ -13,9 +26,24 @@
         {{
         \include "{dashed_part_name}-layout.ly"
         }}
-        {keep_with_tag_command}
         {{
-        {segment_include_statements}
+            \context Score = "Score"
+            <<
+                \context GlobalContext = "GlobalContext"
+                <<
+                    \context GlobalSkips = "GlobalSkips"
+                    {{
+                    {global_skip_identifiers}
+                    }}
+                >> 
+                \context MusicContext = "MusicContext"
+                {{
+                    \context Staff = "Staff"
+                    {{
+                    {segment_ly_include_statements}
+                    }}
+                }}
+            >>
         }}
     >>
 }}

--- a/abjad/boilerplate/score-music.ly
+++ b/abjad/boilerplate/score-music.ly
@@ -5,6 +5,7 @@
 
 #(ly:set-option 'relative-includes #t)
 \include "stylesheet.ily"
+{segment_ily_include_statements}
 
 
 \score {{
@@ -13,7 +14,7 @@
         \include "layout.ly"
         }}
         {{
-        {segment_include_statements}
+        {segment_ly_include_statements}
         }}
     >>
 }}

--- a/abjad/demos/mozart/make_mozart_score.py
+++ b/abjad/demos/mozart/make_mozart_score.py
@@ -30,8 +30,8 @@ def make_mozart_score():
     abjad.attach(command, bass_volta)
 
     # append the volta containers to our staves
-    score['RH Voice'].append(treble_volta)
-    score['LH Voice'].append(bass_volta)
+    score['RHVoice'].append(treble_volta)
+    score['LHVoice'].append(bass_volta)
 
     # create and populate the alternative ending containers
     treble_alternative = abjad.Container()
@@ -52,33 +52,33 @@ def make_mozart_score():
     abjad.attach(command, bass_alternative)
 
     # append the alternative containers to our staves
-    score['RH Voice'].append(treble_alternative)
-    score['LH Voice'].append(bass_alternative)
+    score['RHVoice'].append(treble_alternative)
+    score['LHVoice'].append(bass_alternative)
 
     # create the remaining measures
     for choice in choices[9:]:
         treble, bass = abjad.demos.mozart.make_mozart_measure(choice)
-        score['RH Voice'].append(treble)
-        score['LH Voice'].append(bass)
+        score['RHVoice'].append(treble)
+        score['LHVoice'].append(bass)
 
     # abjad.attach indicators
     time_signature = abjad.TimeSignature((3, 8))
-    leaf = abjad.inspect(score['RH Staff']).get_leaf(0)
+    leaf = abjad.inspect(score['RHStaff']).get_leaf(0)
     abjad.attach(time_signature, leaf)
     bar_line = abjad.BarLine('|.')
-    leaf = abjad.inspect(score['RH Staff']).get_leaf(-1)
+    leaf = abjad.inspect(score['RHStaff']).get_leaf(-1)
     abjad.attach(bar_line, leaf)
     bar_line = abjad.BarLine('|.')
-    leaf = abjad.inspect(score['LH Staff']).get_leaf(-1)
+    leaf = abjad.inspect(score['LHStaff']).get_leaf(-1)
     abjad.attach(bar_line, leaf)
 
     # remove the default piano instrument and add a custom one:
-    abjad.detach(abjad.Instrument, score['Piano Staff'])
+    abjad.detach(abjad.Instrument, score['PianoStaff'])
     klavier = abjad.instrumenttools.Piano(
         name='Katzenklavier',
         short_name='kk.',
         )
-    leaf = abjad.inspect(score['Piano Staff']).get_leaf(0)
+    leaf = abjad.inspect(score['PianoStaff']).get_leaf(0)
     abjad.attach(klavier, leaf)
 
     return score

--- a/abjad/etc/editors/vimrc
+++ b/abjad/etc/editors/vimrc
@@ -140,7 +140,18 @@ noremap <leader>q :quit<cr>
 noremap <leader>wq :wq<cr>
 
 
-" 4. plugins (alphabetical)
+" 4. macros
+" =========
+"Macro @i sets the first left-edge-adjacent number to 1.
+"Macro @j increments the next left-edge-adjacent number.
+"Macro @r ("renumber") calls @j recursively and then returns to top-of-file.
+"Use @r to renumber all items in a to-do list.
+let @i='gg/^\dcw1"nyw/\.dwi.	'
+let @j='/^\dcwn0"nyw/\.dwi.	'
+let @r='@i:g/^\d/ normal @j@i'
+
+
+" 5. plugins (alphabetical)
 " =========================
 
 " ctrlp (https://github.com/kien/ctrlp.vim)
@@ -192,7 +203,7 @@ let g:syntastic_python_flake8_args = '--builtins="unicode, basestring,Infinity,N
 " no configuration required
 
 
-" 5. other
+" 6. other
 " ========
 
 " show tab number (adapted from http://stackoverflow.com/q/5927952)

--- a/abjad/tools/abjadbooktools/LilyPondOutputProxy.py
+++ b/abjad/tools/abjadbooktools/LilyPondOutputProxy.py
@@ -42,7 +42,7 @@ class LilyPondOutputProxy(ImageOutputProxy):
         )
 
     >>> proxy.as_latex(relative_output_directory='assets')
-    ['\\noindent\\includegraphics{assets/lilypond-9a3d90e80bc733e46a43d1ee30b68fa9.pdf}']
+    ['\\noindent\\includegraphics{assets/lilypond-d68b813dd2ff6ac422fcdfb7a6b5f3a2.pdf}']
 
     """
 

--- a/abjad/tools/abjadbooktools/test/expected_configured.tex
+++ b/abjad/tools/abjadbooktools/test/expected_configured.tex
@@ -69,7 +69,7 @@ abjad.show(staff)
 >>> staff = Staff("c'4 d'4 e'4 f'4")
 >>> abjad.show(staff)
 \end{lstlisting}
-\noindent\includegraphics{assets/lilypond-9a3d90e80bc733e46a43d1ee30b68fa9.pdf}
+\noindent\includegraphics{assets/lilypond-d68b813dd2ff6ac422fcdfb7a6b5f3a2.pdf}
 \end{singlespacing}
 %%% ABJADBOOK END %%%
 

--- a/abjad/tools/abjadbooktools/test/expected_styled.tex
+++ b/abjad/tools/abjadbooktools/test/expected_styled.tex
@@ -64,7 +64,7 @@ abjad.show(staff)
 >>> staff = Staff("c'4 d'4 e'4 f'4")
 >>> abjad.show(staff)
 \end{lstlisting}
-\noindent\includegraphics{assets/lilypond-ef7d9d5db77fdbbf21122f8479e9e338.pdf}
+\noindent\includegraphics{assets/lilypond-4f0001093f4a9de61a1f620353888218.pdf}
 %%% ABJADBOOK END %%%
 
 Here's notation in a loop:

--- a/abjad/tools/abjadbooktools/test/expected_valid.tex
+++ b/abjad/tools/abjadbooktools/test/expected_valid.tex
@@ -64,7 +64,7 @@ abjad.show(staff)
 >>> staff = Staff("c'4 d'4 e'4 f'4")
 >>> abjad.show(staff)
 \end{lstlisting}
-\noindent\includegraphics{assets/lilypond-9a3d90e80bc733e46a43d1ee30b68fa9.pdf}
+\noindent\includegraphics{assets/lilypond-d68b813dd2ff6ac422fcdfb7a6b5f3a2.pdf}
 %%% ABJADBOOK END %%%
 
 Here's notation in a loop:

--- a/abjad/tools/abjadbooktools/test/test_LaTeXDocumentHandler_valid.py
+++ b/abjad/tools/abjadbooktools/test/test_LaTeXDocumentHandler_valid.py
@@ -31,10 +31,10 @@ class TestLaTeXDocumentHandler(unittest.TestCase):
         'lilypond-159af81bc32aca4b263146c9052b99ec.pdf',
         'lilypond-71f63c1f11f143bb0f7a2f7ddbc77d75.ly',
         'lilypond-71f63c1f11f143bb0f7a2f7ddbc77d75.pdf',
-        'lilypond-9a3d90e80bc733e46a43d1ee30b68fa9.ly',
-        'lilypond-9a3d90e80bc733e46a43d1ee30b68fa9.pdf',
         'lilypond-9e8d4612a88db8a2f31e974c78fc915d.ly',
         'lilypond-9e8d4612a88db8a2f31e974c78fc915d.pdf',
+        'lilypond-d68b813dd2ff6ac422fcdfb7a6b5f3a2.ly',
+        'lilypond-d68b813dd2ff6ac422fcdfb7a6b5f3a2.pdf',
         'lilypond-fe5d1d78512d19b7f51b96c2ce9180f9.ly',
         'lilypond-fe5d1d78512d19b7f51b96c2ce9180f9.pdf',
         )
@@ -43,19 +43,19 @@ class TestLaTeXDocumentHandler(unittest.TestCase):
     expected_styled_path = os.path.join(test_directory, 'expected_styled.tex')
     with open(expected_styled_path, 'r') as file_pointer:
         expected_styled_contents = file_pointer.read().rstrip()
-    styled_asset_names = (
+    styled_asset_names =(
         'graphviz-31410f5aefd17473e91ebc219ddff36e.dot',
         'graphviz-31410f5aefd17473e91ebc219ddff36e.pdf',
         'lilypond-29a694fcaa88ad2e66126db254f6e44c.ly',
         'lilypond-29a694fcaa88ad2e66126db254f6e44c.pdf',
+        'lilypond-4f0001093f4a9de61a1f620353888218.ly',
+        'lilypond-4f0001093f4a9de61a1f620353888218.pdf',
         'lilypond-60a8aa65d1dc86d7b3b3396d1dd25fa6.ly',
         'lilypond-60a8aa65d1dc86d7b3b3396d1dd25fa6.pdf',
         'lilypond-65404525b3a554691b49772ace1d914c.ly',
         'lilypond-65404525b3a554691b49772ace1d914c.pdf',
         'lilypond-8d473a765e713b5eb5d0a95f35161666.ly',
         'lilypond-8d473a765e713b5eb5d0a95f35161666.pdf',
-        'lilypond-ef7d9d5db77fdbbf21122f8479e9e338.ly',
-        'lilypond-ef7d9d5db77fdbbf21122f8479e9e338.pdf',
         )
 
     configuration_path = os.path.join(test_directory, 'configuration.cfg')

--- a/abjad/tools/abjadbooktools/test/test_SphinxDocumentHandler_read.py
+++ b/abjad/tools/abjadbooktools/test/test_SphinxDocumentHandler_read.py
@@ -537,7 +537,8 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
                         }
 
                         \score {
-                            \new Staff {
+                            \new Staff
+                            {
                                 c'4
                                 d'4
                                 e'4

--- a/abjad/tools/abjadbooktools/test/test_SphinxDocumentHandler_write.py
+++ b/abjad/tools/abjadbooktools/test/test_SphinxDocumentHandler_write.py
@@ -77,15 +77,15 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
         handler.on_build_finished(self.app, None)
         actual = '\n'.join(self.app.body)
         expected = abjad.String.normalize(r'''
-            <a href="../_images/abjadbook/lilypond-7803f52afedde4eb2ade80aa92cfa82c1e7cc36b.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-7803f52afedde4eb2ade80aa92cfa82c1e7cc36b.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-9fc2c4855204dd276ff878a261ad36d4a358c63d.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-9fc2c4855204dd276ff878a261ad36d4a358c63d.png" alt=""/>
             </a>
             ''')
         self.assertEqual(actual, expected)
         assert len(os.listdir(self.abjadbook_images_directory)) == 2
         for name in (
-            'lilypond-7803f52afedde4eb2ade80aa92cfa82c1e7cc36b.ly',
-            'lilypond-7803f52afedde4eb2ade80aa92cfa82c1e7cc36b.png',
+            'lilypond-9fc2c4855204dd276ff878a261ad36d4a358c63d.ly',
+            'lilypond-9fc2c4855204dd276ff878a261ad36d4a358c63d.png',
             ):
             path = os.path.join(self.images_directory, 'abjadbook', name)
             assert os.path.exists(path)
@@ -112,15 +112,15 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
         handler.on_build_finished(self.app, None)
         actual = '\n'.join(self.app.body)
         expected = abjad.String.normalize(r'''
-            <a href="../_images/abjadbook/lilypond-4da9e9fdacc548126c08ef963af14d1b25cad4a9.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-4da9e9fdacc548126c08ef963af14d1b25cad4a9.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-1d6adce9cf45520580076ea56583302a683b8a68.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-1d6adce9cf45520580076ea56583302a683b8a68.png" alt=""/>
             </a>
             ''')
         self.assertEqual(actual, expected)
         assert len(os.listdir(self.abjadbook_images_directory)) == 2
         for name in (
-            'lilypond-4da9e9fdacc548126c08ef963af14d1b25cad4a9.ly',
-            'lilypond-4da9e9fdacc548126c08ef963af14d1b25cad4a9.png',
+            'lilypond-1d6adce9cf45520580076ea56583302a683b8a68.ly',
+            'lilypond-1d6adce9cf45520580076ea56583302a683b8a68.png',
             ):
             path = os.path.join(self.images_directory, 'abjadbook', name)
             assert os.path.exists(path)
@@ -148,15 +148,15 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
         handler.on_build_finished(self.app, None)
         actual = '\n'.join(self.app.body)
         expected = abjad.String.normalize(r'''
-            <a href="../_images/abjadbook/lilypond-6868d59d5934f664a4e11b137839de0f9bcfd373.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-6868d59d5934f664a4e11b137839de0f9bcfd373.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-b70ff76f6d891a8b5ffa889dfb989dd31d659911.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-b70ff76f6d891a8b5ffa889dfb989dd31d659911.png" alt=""/>
             </a>
             ''')
         self.assertEqual(actual, expected)
         assert len(os.listdir(self.abjadbook_images_directory)) == 2
         for name in (
-            'lilypond-6868d59d5934f664a4e11b137839de0f9bcfd373.ly',
-            'lilypond-6868d59d5934f664a4e11b137839de0f9bcfd373.png',
+            'lilypond-b70ff76f6d891a8b5ffa889dfb989dd31d659911.ly',
+            'lilypond-b70ff76f6d891a8b5ffa889dfb989dd31d659911.png',
             ):
             path = os.path.join(self.images_directory, 'abjadbook', name)
             assert os.path.exists(path)
@@ -184,19 +184,19 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
             pass
         handler.on_build_finished(self.app, None)
         assert len(self.app.builder.thumbnails) == 1
-        assert '../_images/abjadbook/lilypond-6868d59d5934f664a4e11b137839de0f9bcfd373.png' in self.app.builder.thumbnails
+        assert '../_images/abjadbook/lilypond-b70ff76f6d891a8b5ffa889dfb989dd31d659911.png' in self.app.builder.thumbnails
         actual = '\n'.join(self.app.body)
         expected = abjad.String.normalize(r'''
-            <a data-lightbox="group-lilypond-6868d59d5934f664a4e11b137839de0f9bcfd373.ly" href="../_images/abjadbook/lilypond-6868d59d5934f664a4e11b137839de0f9bcfd373.png" title="" data-title="" class="abjadbook thumbnail">
-                <img src="../_images/abjadbook/lilypond-6868d59d5934f664a4e11b137839de0f9bcfd373-thumbnail.png" alt=""/>
+            <a data-lightbox="group-lilypond-b70ff76f6d891a8b5ffa889dfb989dd31d659911.ly" href="../_images/abjadbook/lilypond-b70ff76f6d891a8b5ffa889dfb989dd31d659911.png" title="" data-title="" class="abjadbook thumbnail">
+                <img src="../_images/abjadbook/lilypond-b70ff76f6d891a8b5ffa889dfb989dd31d659911-thumbnail.png" alt=""/>
             </a>
             ''')
         self.assertEqual(actual, expected)
         assert len(os.listdir(self.abjadbook_images_directory)) == 3
         for name in (
-            'lilypond-6868d59d5934f664a4e11b137839de0f9bcfd373.ly',
-            'lilypond-6868d59d5934f664a4e11b137839de0f9bcfd373.png',
-            'lilypond-6868d59d5934f664a4e11b137839de0f9bcfd373-thumbnail.png',
+            'lilypond-b70ff76f6d891a8b5ffa889dfb989dd31d659911.ly',
+            'lilypond-b70ff76f6d891a8b5ffa889dfb989dd31d659911.png',
+            'lilypond-b70ff76f6d891a8b5ffa889dfb989dd31d659911-thumbnail.png',
             ):
             path = os.path.join(self.images_directory, 'abjadbook', name)
             assert os.path.exists(path)
@@ -224,8 +224,8 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
         handler.on_build_finished(self.app, None)
         actual = '\n'.join(self.app.body)
         expected = abjad.String.normalize(r'''
-            <a href="../_images/abjadbook/lilypond-c6c477783474a7d258cef8c73fe6f086e11e4280.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-c6c477783474a7d258cef8c73fe6f086e11e4280.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-0b7a2a64005bc82bc16303c2f194f4497ea94e15.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-0b7a2a64005bc82bc16303c2f194f4497ea94e15.png" alt=""/>
             </a>
             ''')
         self.assertEqual(actual, expected)
@@ -234,8 +234,8 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
             'default.ly',
             'external-settings-file-1.ly',
             'external-settings-file-2.ly',
-            'lilypond-c6c477783474a7d258cef8c73fe6f086e11e4280.ly',
-            'lilypond-c6c477783474a7d258cef8c73fe6f086e11e4280.png',
+            'lilypond-0b7a2a64005bc82bc16303c2f194f4497ea94e15.ly',
+            'lilypond-0b7a2a64005bc82bc16303c2f194f4497ea94e15.png',
             'non-proportional.ly',
             ):
             path = os.path.join(self.images_directory, 'abjadbook', name)
@@ -266,31 +266,31 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
         handler.on_build_finished(self.app, None)
         actual = '\n'.join(self.app.body)
         expected = abjad.String.normalize(r'''
-            <a href="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page1.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page1.png" alt=""/>
             </a>
-            <a href="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page2.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page2.png" alt=""/>
             </a>
-            <a href="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page3.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page3.png" alt=""/>
             </a>
-            <a href="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page4.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page4.png" alt=""/>
             </a>
-            <a href="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page5.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page5.png" alt=""/>
             </a>
             ''')
         self.assertEqual(actual, expected)
         assert len(os.listdir(self.abjadbook_images_directory)) == 6
         for name in (
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page1.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page2.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page3.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page4.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page5.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page1.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page2.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page3.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page4.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page5.png',
             ):
             path = os.path.join(self.images_directory, 'abjadbook', name)
             assert os.path.exists(path)
@@ -321,25 +321,25 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
         handler.on_build_finished(self.app, None)
         actual = '\n'.join(self.app.body)
         expected = abjad.String.normalize(r'''
-            <a href="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page2.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page2.png" alt=""/>
             </a>
-            <a href="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page3.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page3.png" alt=""/>
             </a>
-            <a href="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly" title="" class="abjadbook">
-                <img src="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page4.png" alt=""/>
+            <a href="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly" title="" class="abjadbook">
+                <img src="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page4.png" alt=""/>
             </a>
             ''')
         self.assertEqual(actual, expected)
         assert len(os.listdir(self.abjadbook_images_directory)) == 6
         for name in (
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page1.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page2.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page3.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page4.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page5.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page1.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page2.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page3.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page4.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page5.png',
             ):
             path = os.path.join(self.images_directory, 'abjadbook', name)
             assert os.path.exists(path)
@@ -372,28 +372,28 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
         actual = '\n'.join(self.app.body)
         expected = abjad.String.normalize(r'''
             <div class="table-row">
-                <a href="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly" title="" class="table-cell">
-                    <img src="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page2.png" alt=""/>
+                <a href="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly" title="" class="table-cell">
+                    <img src="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page2.png" alt=""/>
                 </a>
-                <a href="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly" title="" class="table-cell">
-                    <img src="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page3.png" alt=""/>
+                <a href="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly" title="" class="table-cell">
+                    <img src="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page3.png" alt=""/>
                 </a>
             </div>
             <div class="table-row">
-                <a href="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly" title="" class="table-cell">
-                    <img src="../_images/abjadbook/lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page4.png" alt=""/>
+                <a href="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly" title="" class="table-cell">
+                    <img src="../_images/abjadbook/lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page4.png" alt=""/>
                 </a>
             </div>
             ''')
         self.assertEqual(actual, expected)
         assert len(os.listdir(self.abjadbook_images_directory)) == 6
         for name in (
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1.ly',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page1.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page2.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page3.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page4.png',
-            'lilypond-961ede3dfbd0b5c408f4c705ff62e4939fd859a1-page5.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968.ly',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page1.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page2.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page3.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page4.png',
+            'lilypond-ebfcef165988df8b00f79d283de3019c96f17968-page5.png',
             ):
             path = os.path.join(self.images_directory, 'abjadbook', name)
             assert os.path.exists(path)
@@ -427,36 +427,32 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
         actual = '\n'.join(self.app.body)
         expected = abjad.String.normalize(r'''
             <div class="table-row">
-                <a href="../_images/abjadbook/lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b.ly" title="" class="table-cell">
-                    <img src="../_images/abjadbook/lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b-page2.png" alt=""/>
+                <a href="../_images/abjadbook/lilypond-3455132ce86f419c903206441de9049369a1c8fa.ly" title="" class="table-cell">
+                    <img src="../_images/abjadbook/lilypond-3455132ce86f419c903206441de9049369a1c8fa-page2.png" alt=""/>
                 </a>
-                <a href="../_images/abjadbook/lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b.ly" title="" class="table-cell">
-                    <img src="../_images/abjadbook/lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b-page3.png" alt=""/>
+                <a href="../_images/abjadbook/lilypond-3455132ce86f419c903206441de9049369a1c8fa.ly" title="" class="table-cell">
+                    <img src="../_images/abjadbook/lilypond-3455132ce86f419c903206441de9049369a1c8fa-page3.png" alt=""/>
                 </a>
             </div>
             <div class="table-row">
-                <a href="../_images/abjadbook/lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b.ly" title="" class="table-cell">
-                    <img src="../_images/abjadbook/lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b-page4.png" alt=""/>
+                <a href="../_images/abjadbook/lilypond-3455132ce86f419c903206441de9049369a1c8fa.ly" title="" class="table-cell">
+                    <img src="../_images/abjadbook/lilypond-3455132ce86f419c903206441de9049369a1c8fa-page4.png" alt=""/>
                 </a>
             </div>
             ''')
         self.assertEqual(actual, expected)
         assert len(os.listdir(self.abjadbook_images_directory)) == 6
         for name in (
-            'lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b.ly',
-            'lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b-page1.png',
-            'lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b-page2.png',
-            'lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b-page3.png',
-            'lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b-page4.png',
-            'lilypond-19c0fcbf7e06c54c75e38181eb11da94ce50d35b-page5.png',
+            'lilypond-3455132ce86f419c903206441de9049369a1c8fa.ly',
+            'lilypond-3455132ce86f419c903206441de9049369a1c8fa-page1.png',
+            'lilypond-3455132ce86f419c903206441de9049369a1c8fa-page2.png',
+            'lilypond-3455132ce86f419c903206441de9049369a1c8fa-page3.png',
+            'lilypond-3455132ce86f419c903206441de9049369a1c8fa-page4.png',
+            'lilypond-3455132ce86f419c903206441de9049369a1c8fa-page5.png',
             ):
             path = os.path.join(self.images_directory, 'abjadbook', name)
             assert os.path.exists(path)
 
-#    @unittest.skipIf(
-#        True,
-#        'macOS High Sierra introduces glob(*) alphabetization bug.',
-#        )
     def test_10(self):
         source = r'''
         ..  abjad::
@@ -484,36 +480,36 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
         handler.on_build_finished(self.app, None)
         actual = '\n'.join(self.app.body)
         expected = abjad.String.normalize(r'''
-            <a data-lightbox="group-lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly" href="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page1.png" title="" data-title="" class="abjadbook thumbnail">
-                <img src="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page1-thumbnail.png" alt=""/>
+            <a data-lightbox="group-lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly" href="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page1.png" title="" data-title="" class="abjadbook thumbnail">
+                <img src="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page1-thumbnail.png" alt=""/>
             </a>
-            <a data-lightbox="group-lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly" href="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page2.png" title="" data-title="" class="abjadbook thumbnail">
-                <img src="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page2-thumbnail.png" alt=""/>
+            <a data-lightbox="group-lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly" href="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page2.png" title="" data-title="" class="abjadbook thumbnail">
+                <img src="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page2-thumbnail.png" alt=""/>
             </a>
-            <a data-lightbox="group-lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly" href="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page3.png" title="" data-title="" class="abjadbook thumbnail">
-                <img src="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page3-thumbnail.png" alt=""/>
+            <a data-lightbox="group-lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly" href="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page3.png" title="" data-title="" class="abjadbook thumbnail">
+                <img src="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page3-thumbnail.png" alt=""/>
             </a>
-            <a data-lightbox="group-lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly" href="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page4.png" title="" data-title="" class="abjadbook thumbnail">
-                <img src="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page4-thumbnail.png" alt=""/>
+            <a data-lightbox="group-lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly" href="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page4.png" title="" data-title="" class="abjadbook thumbnail">
+                <img src="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page4-thumbnail.png" alt=""/>
             </a>
-            <a data-lightbox="group-lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly" href="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page5.png" title="" data-title="" class="abjadbook thumbnail">
-                <img src="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page5-thumbnail.png" alt=""/>
+            <a data-lightbox="group-lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly" href="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page5.png" title="" data-title="" class="abjadbook thumbnail">
+                <img src="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page5-thumbnail.png" alt=""/>
             </a>
             ''')
         self.assertEqual(actual, expected)
         assert len(os.listdir(self.abjadbook_images_directory)) == 11
         for name in (
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page1.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page1-thumbnail.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page2.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page2-thumbnail.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page3.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page3-thumbnail.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page4.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page4-thumbnail.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page5.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page5-thumbnail.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page1.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page1-thumbnail.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page2.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page2-thumbnail.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page3.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page3-thumbnail.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page4.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page4-thumbnail.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page5.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page5-thumbnail.png',
             ):
             path = os.path.join(self.images_directory, 'abjadbook', name)
             assert os.path.exists(path)
@@ -547,41 +543,41 @@ class SphinxDocumentHandlerTests(unittest.TestCase):
         actual = '\n'.join(self.app.body)
         expected = abjad.String.normalize(r'''
             <div class="table-row">
-                <a data-lightbox="group-lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly" href="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page1.png" title="" data-title="" class="table-cell thumbnail">
-                    <img src="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page1-thumbnail.png" alt=""/>
+                <a data-lightbox="group-lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly" href="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page1.png" title="" data-title="" class="table-cell thumbnail">
+                    <img src="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page1-thumbnail.png" alt=""/>
                 </a>
-                <a data-lightbox="group-lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly" href="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page2.png" title="" data-title="" class="table-cell thumbnail">
-                    <img src="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page2-thumbnail.png" alt=""/>
-                </a>
-            </div>
-            <div class="table-row">
-                <a data-lightbox="group-lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly" href="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page3.png" title="" data-title="" class="table-cell thumbnail">
-                    <img src="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page3-thumbnail.png" alt=""/>
-                </a>
-                <a data-lightbox="group-lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly" href="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page4.png" title="" data-title="" class="table-cell thumbnail">
-                    <img src="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page4-thumbnail.png" alt=""/>
+                <a data-lightbox="group-lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly" href="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page2.png" title="" data-title="" class="table-cell thumbnail">
+                    <img src="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page2-thumbnail.png" alt=""/>
                 </a>
             </div>
             <div class="table-row">
-                <a data-lightbox="group-lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly" href="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page5.png" title="" data-title="" class="table-cell thumbnail">
-                    <img src="../_images/abjadbook/lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page5-thumbnail.png" alt=""/>
+                <a data-lightbox="group-lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly" href="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page3.png" title="" data-title="" class="table-cell thumbnail">
+                    <img src="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page3-thumbnail.png" alt=""/>
+                </a>
+                <a data-lightbox="group-lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly" href="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page4.png" title="" data-title="" class="table-cell thumbnail">
+                    <img src="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page4-thumbnail.png" alt=""/>
+                </a>
+            </div>
+            <div class="table-row">
+                <a data-lightbox="group-lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly" href="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page5.png" title="" data-title="" class="table-cell thumbnail">
+                    <img src="../_images/abjadbook/lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page5-thumbnail.png" alt=""/>
                 </a>
             </div>
             ''')
         self.assertEqual(actual, expected)
         assert len(os.listdir(self.abjadbook_images_directory)) == 11
         for name in (
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208.ly',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page1.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page1-thumbnail.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page2.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page2-thumbnail.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page3.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page3-thumbnail.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page4.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page4-thumbnail.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page5.png',
-            'lilypond-73b5c6d2d76fa211ae38dd0081a86219dbfe6208-page5-thumbnail.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623.ly',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page1.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page1-thumbnail.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page2.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page2-thumbnail.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page3.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page3-thumbnail.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page4.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page4-thumbnail.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page5.png',
+            'lilypond-0aa2622a00db4f1eb5e873ef7e6a7f14fa465623-page5-thumbnail.png',
             ):
             path = os.path.join(self.images_directory, 'abjadbook', name)
             assert os.path.exists(path)

--- a/abjad/tools/commandlinetools/test/test_commandlinetools_ManageSegmentScript_metadata.py
+++ b/abjad/tools/commandlinetools/test/test_commandlinetools_ManageSegmentScript_metadata.py
@@ -67,53 +67,53 @@ class Test(ScorePackageScriptTestCase):
                         \tag #'first-violin
                         \context Staff = "First Violin Staff" {
                             \context Voice = "First Violin Voice" {
-                                { % measure
+                                {   % measure
                                     \time 4/4
                                     \set Staff.instrumentName = \markup { Violin }   %! ST1
                                     \set Staff.shortInstrumentName = \markup { Vn. } %! ST1
                                     \clef "treble" %! ST3
                                     c'1
                                     \bar "|." %! SCORE1
-                                } % measure
+                                }   % measure
                             }
                         }
                         \tag #'second-violin
                         \context Staff = "Second Violin Staff" {
                             \context Voice = "Second Violin Voice" {
-                                { % measure
+                                {   % measure
                                     \time 4/4
                                     \set Staff.instrumentName = \markup { Violin }   %! ST1
                                     \set Staff.shortInstrumentName = \markup { Vn. } %! ST1
                                     \clef "treble" %! ST3
                                     c'1
                                     \bar "|." %! SCORE1
-                                } % measure
+                                }   % measure
                             }
                         }
                         \tag #'viola
                         \context Staff = "Viola Staff" {
                             \context Voice = "Viola Voice" {
-                                { % measure
+                                {   % measure
                                     \time 4/4
                                     \set Staff.instrumentName = \markup { Viola }   %! ST1
                                     \set Staff.shortInstrumentName = \markup { Va. } %! ST1
                                     \clef "alto" %! ST3
                                     c'1
                                     \bar "|." %! SCORE1
-                                } % measure
+                                }   % measure
                             }
                         }
                         \tag #'cello
                         \context Staff = "Cello Staff" {
                             \context Voice = "Cello Voice" {
-                                { % measure
+                                {   % measure
                                     \time 4/4
                                     \set Staff.instrumentName = \markup { Cello }   %! ST1
                                     \set Staff.shortInstrumentName = \markup { Vc. } %! ST1
                                     \clef "bass" %! ST3
                                     c'1
                                     \bar "|." %! SCORE1
-                                } % measure
+                                }   % measure
                             }
                         }
                     >>

--- a/abjad/tools/datastructuretools/Duration.py
+++ b/abjad/tools/datastructuretools/Duration.py
@@ -1128,11 +1128,16 @@ class Duration(AbjadObject, Fraction):
                 \markup {
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -1143,7 +1148,8 @@ class Duration(AbjadObject, Fraction):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     c'8.
                                 }
                             >>
@@ -1167,11 +1173,16 @@ class Duration(AbjadObject, Fraction):
                 \markup {
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -1182,7 +1193,8 @@ class Duration(AbjadObject, Fraction):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     c'4 ~
                                     c'16
                                 }
@@ -1210,17 +1222,23 @@ class Duration(AbjadObject, Fraction):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new RhythmicStaff {
+                \new RhythmicStaff
+                {
                     \override TupletNumber.text = \markup {
                         \scale
                             #'(0.75 . 0.75)
                             \score
                                 {
-                                    \new Score \with {
+                                    \new Score
+                                    \with
+                                    {
                                         \override SpacingSpanner.spacing-increment = #0.5
                                         proportionalNotationDuration = ##f
-                                    } <<
-                                        \new RhythmicStaff \with {
+                                    }
+                                    <<
+                                        \new RhythmicStaff
+                                        \with
+                                        {
                                             \remove Time_signature_engraver
                                             \remove Staff_symbol_engraver
                                             \override Stem.direction = #up
@@ -1231,7 +1249,8 @@ class Duration(AbjadObject, Fraction):
                                             \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                             \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                             tupletFullLength = ##t
-                                        } {
+                                        }
+                                        {
                                             c'4 ~
                                             c'16
                                         }

--- a/abjad/tools/datastructuretools/Expression.py
+++ b/abjad/tools/datastructuretools/Expression.py
@@ -1872,7 +1872,8 @@ class Expression(AbjadValueObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'4.
                             ^ \markup {
                                 \small
@@ -1975,7 +1976,8 @@ class Expression(AbjadValueObject):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         b'8
                             ^ \markup {
                                 \concat
@@ -2053,20 +2055,21 @@ class Expression(AbjadValueObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
-                        { % measure
+                    \new Staff
+                    {
+                        {   % measure
                             \time 2/8
                             <c' bf'>8
                             <g' a'>8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             af'8
                             r8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             r8
                             gf'8
-                        } % measure
+                        }   % measure
                     }
 
             ..  container:: example expression

--- a/abjad/tools/indicatortools/Accelerando.py
+++ b/abjad/tools/indicatortools/Accelerando.py
@@ -15,8 +15,10 @@ class Accelerando(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     c'4
                         ^ \markup {
                             \large

--- a/abjad/tools/indicatortools/ArrowLineSegment.py
+++ b/abjad/tools/indicatortools/ArrowLineSegment.py
@@ -38,10 +38,13 @@ class ArrowLineSegment(LineSegment):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TextScript.staff-padding = #1.25
                 \override TextSpanner.staff-padding = #2
-            } {
+            }
+            {
                 \once \override TextSpanner.Y-extent = ##f
                 \once \override TextSpanner.arrow-width = 0.25
                 \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -158,10 +161,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -222,10 +228,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.5
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -284,10 +293,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 1
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -358,10 +370,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -421,10 +436,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -482,10 +500,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -555,10 +576,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -622,10 +646,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -688,10 +715,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -783,10 +813,13 @@ class ArrowLineSegment(LineSegment):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #1.25
                         \override TextSpanner.staff-padding = #2
-                    } {
+                    }
+                    {
                         \time 3/8
                         c'4.
                         d'4.
@@ -891,10 +924,13 @@ class ArrowLineSegment(LineSegment):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #1.25
                         \override TextSpanner.staff-padding = #2
-                    } {
+                    }
+                    {
                         \time 3/8
                         c'4.
                         d'4.
@@ -998,10 +1034,13 @@ class ArrowLineSegment(LineSegment):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #1.25
                         \override TextSpanner.staff-padding = #2
-                    } {
+                    }
+                    {
                         \time 3/8
                         c'4.
                         d'4.
@@ -1099,10 +1138,13 @@ class ArrowLineSegment(LineSegment):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #1.25
                         \override TextSpanner.staff-padding = #2
-                    } {
+                    }
+                    {
                         \time 3/8
                         c'4.
                         d'4.
@@ -1182,10 +1224,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -1246,10 +1291,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -1307,10 +1355,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -1368,10 +1419,13 @@ class ArrowLineSegment(LineSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f

--- a/abjad/tools/indicatortools/BarLine.py
+++ b/abjad/tools/indicatortools/BarLine.py
@@ -19,7 +19,8 @@ class BarLine(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4
                 d'4
                 e'4

--- a/abjad/tools/indicatortools/BreathMark.py
+++ b/abjad/tools/indicatortools/BreathMark.py
@@ -33,7 +33,8 @@ class BreathMark(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'8 [
                 d'8
                 e'8

--- a/abjad/tools/indicatortools/Clef.py
+++ b/abjad/tools/indicatortools/Clef.py
@@ -30,7 +30,8 @@ class Clef(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \clef "treble"
                 c'8
                 \clef "alto"
@@ -58,7 +59,8 @@ class Clef(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             \clef "treble" %! RED
             c'4
             d'4
@@ -75,7 +77,8 @@ class Clef(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             \clef "treble" %! M1
             c'4
             d'4
@@ -92,7 +95,8 @@ class Clef(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             \clef "treble" %! RED:M1
             c'4
             d'4
@@ -120,12 +124,18 @@ class Clef(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \remove Clef_engraver
-            } <<
-                \new Voice \with {
+            }
+            <<
+                \new Voice
+                \with
+                {
                     \consists Clef_engraver
-                } {
+                }
+                {
                     \voiceOne
                     \clef "treble"
                     e'8
@@ -135,9 +145,12 @@ class Clef(AbjadValueObject):
                     g'8
                     b'8
                 }
-                \new Voice \with {
+                \new Voice
+                \with
+                {
                     \consists Clef_engraver
-                } {
+                }
+                {
                     \voiceTwo
                     \clef "treble"
                     c'4.
@@ -401,7 +414,8 @@ class Clef(AbjadValueObject):
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \clef "treble"
                 c'4
                 d'4

--- a/abjad/tools/indicatortools/Dynamic.py
+++ b/abjad/tools/indicatortools/Dynamic.py
@@ -16,7 +16,8 @@ class Dynamic(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 c'8 \f
                 d'8
                 e'8
@@ -63,17 +64,22 @@ class Dynamic(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff <<
-                \new Voice \with {
+            \new Staff
+            <<
+                \new Voice
+                \with
+                {
                     \override DynamicLineSpanner.direction = #up
-                } {
+                }
+                {
                     \voiceOne
                     e'8 \f
                     g'8
                     f'8
                     a'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     \voiceTwo
                     c'2 \mf
                 }
@@ -441,9 +447,12 @@ class Dynamic(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice \with {
+                \new Voice
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #4
-                } {
+                }
+                {
                     c'4 _ #(make-dynamic-script
                         (markup
                             #:whiteout
@@ -511,9 +520,12 @@ class Dynamic(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice \with {
+                \new Voice
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #4
-                } {
+                }
+                {
                     c'4 _ #(make-dynamic-script
                         (markup
                             #:whiteout
@@ -585,7 +597,8 @@ class Dynamic(AbjadValueObject):
             >>> abjad.show(voice) # doctest: +SKIP
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 c'4 \f
                 d'4
                 e'4
@@ -643,9 +656,12 @@ class Dynamic(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice \with {
+                \new Voice
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #4
-                } {
+                }
+                {
                     c'4 \p
                     r4 _ #(make-dynamic-script (markup #:whiteout #:normal-text #:italic "niente"))
                     r4

--- a/abjad/tools/indicatortools/Fermata.py
+++ b/abjad/tools/indicatortools/Fermata.py
@@ -16,8 +16,10 @@ class Fermata(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     c'4 \shortfermata
                 }
             >>
@@ -34,8 +36,10 @@ class Fermata(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     c'4 \fermata
                 }
             >>
@@ -52,8 +56,10 @@ class Fermata(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     c'4 \longfermata
                 }
             >>
@@ -70,8 +76,10 @@ class Fermata(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     c'4 \verylongfermata
                 }
             >>

--- a/abjad/tools/indicatortools/KeySignature.py
+++ b/abjad/tools/indicatortools/KeySignature.py
@@ -14,7 +14,8 @@ class KeySignature(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \key e \major
                 e'8
                 fs'8
@@ -32,7 +33,8 @@ class KeySignature(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \key e \minor
                 e'8
                 fs'8

--- a/abjad/tools/indicatortools/LilyPondCommand.py
+++ b/abjad/tools/indicatortools/LilyPondCommand.py
@@ -18,7 +18,8 @@ class LilyPondCommand(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \slurDotted
                 c'8 (
                 d'8

--- a/abjad/tools/indicatortools/LilyPondLiteral.py
+++ b/abjad/tools/indicatortools/LilyPondLiteral.py
@@ -18,7 +18,8 @@ class LilyPondLiteral(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \slurDotted
                 c'8 (
                 d'8
@@ -48,7 +49,8 @@ class LilyPondLiteral(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
             <BLANKLINE>
                 % before all formatting
                 \slurDotted
@@ -70,7 +72,8 @@ class LilyPondLiteral(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             \slurDotted %! RED
             c'8 (
             d'8
@@ -89,7 +92,8 @@ class LilyPondLiteral(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             \slurDotted %! M1
             c'8 (
             d'8
@@ -108,7 +112,8 @@ class LilyPondLiteral(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             \slurDotted %! RED:M1
             c'8 (
             d'8
@@ -132,7 +137,8 @@ class LilyPondLiteral(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             c'8 (
             d'8
             \stopStaff                                     %! RED

--- a/abjad/tools/indicatortools/LineBreak.py
+++ b/abjad/tools/indicatortools/LineBreak.py
@@ -15,7 +15,8 @@ class LineBreak(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             c'4
             d'4
             e'4
@@ -82,7 +83,8 @@ class LineBreak(AbjadValueObject):
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4
                 d'4
                 e'4
@@ -100,7 +102,8 @@ class LineBreak(AbjadValueObject):
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \break
                 c'4
                 d'4

--- a/abjad/tools/indicatortools/MarginMarkup.py
+++ b/abjad/tools/indicatortools/MarginMarkup.py
@@ -18,7 +18,8 @@ class MarginMarkup(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Cello }
                 \set Staff.shortInstrumentName = \markup { Vc. }
                 c'4

--- a/abjad/tools/indicatortools/MetricModulation.py
+++ b/abjad/tools/indicatortools/MetricModulation.py
@@ -24,11 +24,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -39,7 +44,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     c'4
                                 }
                             >>
@@ -55,11 +61,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -70,7 +81,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     c'4.
                                 }
                             >>
@@ -100,11 +112,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -115,7 +132,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     \tweak edge-height #'(0.7 . 0)
                                     \times 4/5 {
                                         c'4
@@ -134,11 +152,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -149,7 +172,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     c'4
                                 }
                             >>
@@ -179,11 +203,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -194,7 +223,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     c16.
                                 }
                             >>
@@ -210,11 +240,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -225,7 +260,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     \tweak edge-height #'(0.7 . 0)
                                     \times 2/3 {
                                         c8
@@ -260,11 +296,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -275,7 +316,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     c'4
                                 }
                             >>
@@ -291,11 +333,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -306,7 +353,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     c'4 ~
                                     c'16
                                 }
@@ -340,11 +388,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -355,7 +408,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     c'4
                                 }
                             >>
@@ -371,11 +425,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -386,7 +445,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     \tweak edge-height #'(0.7 . 0)
                                     \times 2/3 {
                                         c'4 ~
@@ -422,10 +482,14 @@ class MetricModulation(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #2.5
-                } {
+                }
+                {
                     \time 3/4
                     c'4
                     d'4
@@ -436,11 +500,16 @@ class MetricModulation(AbjadValueObject):
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -451,7 +520,8 @@ class MetricModulation(AbjadValueObject):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c4
                                             }
                                         >>
@@ -467,11 +537,16 @@ class MetricModulation(AbjadValueObject):
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -482,7 +557,8 @@ class MetricModulation(AbjadValueObject):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c8.
                                             }
                                         >>
@@ -659,11 +735,16 @@ class MetricModulation(AbjadValueObject):
                         #'(0.75 . 0.75)
                         \score
                             {
-                                \new Score \with {
+                                \new Score
+                                \with
+                                {
                                     \override SpacingSpanner.spacing-increment = #0.5
                                     proportionalNotationDuration = ##f
-                                } <<
-                                    \new RhythmicStaff \with {
+                                }
+                                <<
+                                    \new RhythmicStaff
+                                    \with
+                                    {
                                         \remove Time_signature_engraver
                                         \remove Staff_symbol_engraver
                                         \override Stem.direction = #up
@@ -674,7 +755,8 @@ class MetricModulation(AbjadValueObject):
                                         \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                         \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                         tupletFullLength = ##t
-                                    } {
+                                    }
+                                    {
                                         \tweak edge-height #'(0.7 . 0)
                                         \times 2/3 {
                                             c'4
@@ -693,11 +775,16 @@ class MetricModulation(AbjadValueObject):
                         #'(0.75 . 0.75)
                         \score
                             {
-                                \new Score \with {
+                                \new Score
+                                \with
+                                {
                                     \override SpacingSpanner.spacing-increment = #0.5
                                     proportionalNotationDuration = ##f
-                                } <<
-                                    \new RhythmicStaff \with {
+                                }
+                                <<
+                                    \new RhythmicStaff
+                                    \with
+                                    {
                                         \remove Time_signature_engraver
                                         \remove Staff_symbol_engraver
                                         \override Stem.direction = #up
@@ -708,7 +795,8 @@ class MetricModulation(AbjadValueObject):
                                         \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                         \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                         tupletFullLength = ##t
-                                    } {
+                                    }
+                                    {
                                         c'4.
                                     }
                                 >>
@@ -743,11 +831,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -758,7 +851,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     \tweak edge-height #'(0.7 . 0)
                                     \times 2/3 {
                                         c'4
@@ -777,11 +871,16 @@ class MetricModulation(AbjadValueObject):
                     #'(0.75 . 0.75)
                     \score
                         {
-                            \new Score \with {
+                            \new Score
+                            \with
+                            {
                                 \override SpacingSpanner.spacing-increment = #0.5
                                 proportionalNotationDuration = ##f
-                            } <<
-                                \new RhythmicStaff \with {
+                            }
+                            <<
+                                \new RhythmicStaff
+                                \with
+                                {
                                     \remove Time_signature_engraver
                                     \remove Staff_symbol_engraver
                                     \override Stem.direction = #up
@@ -792,7 +891,8 @@ class MetricModulation(AbjadValueObject):
                                     \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                     \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                     tupletFullLength = ##t
-                                } {
+                                }
+                                {
                                     c'4
                                 }
                             >>

--- a/abjad/tools/indicatortools/MetronomeMark.py
+++ b/abjad/tools/indicatortools/MetronomeMark.py
@@ -25,8 +25,10 @@ class MetronomeMark(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     \tempo 4=90
                     c'8
                     d'8
@@ -49,18 +51,25 @@ class MetronomeMark(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     \tempo \markup {
                         \scale
                             #'(0.75 . 0.75)
                             \score
                                 {
-                                    \new Score \with {
+                                    \new Score
+                                    \with
+                                    {
                                         \override SpacingSpanner.spacing-increment = #0.5
                                         proportionalNotationDuration = ##f
-                                    } <<
-                                        \new RhythmicStaff \with {
+                                    }
+                                    <<
+                                        \new RhythmicStaff
+                                        \with
+                                        {
                                             \remove Time_signature_engraver
                                             \remove Staff_symbol_engraver
                                             \override Stem.direction = #up
@@ -71,7 +80,8 @@ class MetronomeMark(AbjadValueObject):
                                             \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                             \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                             tupletFullLength = ##t
-                                        } {
+                                        }
+                                        {
                                             c'4
                                         }
                                     >>
@@ -107,18 +117,25 @@ class MetronomeMark(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     \tempo \markup {
                         \scale
                             #'(0.75 . 0.75)
                             \score
                                 {
-                                    \new Score \with {
+                                    \new Score
+                                    \with
+                                    {
                                         \override SpacingSpanner.spacing-increment = #0.5
                                         proportionalNotationDuration = ##f
-                                    } <<
-                                        \new RhythmicStaff \with {
+                                    }
+                                    <<
+                                        \new RhythmicStaff
+                                        \with
+                                        {
                                             \remove Time_signature_engraver
                                             \remove Staff_symbol_engraver
                                             \override Stem.direction = #up
@@ -129,7 +146,8 @@ class MetronomeMark(AbjadValueObject):
                                             \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                             \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                             tupletFullLength = ##t
-                                        } {
+                                        }
+                                        {
                                             c'4
                                         }
                                     >>
@@ -170,8 +188,10 @@ class MetronomeMark(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     \tempo Quick 4=120-133
                     c'8
                     d'8
@@ -840,47 +860,55 @@ class MetronomeMark(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff {
+                \new Score
+                <<
+                    \new Staff
+                    {
                         \tempo \markup {
-                        \with-color
-                            #red
-                            {
-                                \scale
-                                    #'(0.75 . 0.75)
-                                    \score
-                                        {
-                                            \new Score \with {
-                                                \override SpacingSpanner.spacing-increment = #0.5
-                                                proportionalNotationDuration = ##f
-                                            } <<
-                                                \new RhythmicStaff \with {
-                                                    \remove Time_signature_engraver
-                                                    \remove Staff_symbol_engraver
-                                                    \override Stem.direction = #up
-                                                    \override Stem.length = #5
-                                                    \override TupletBracket.bracket-visibility = ##t
-                                                    \override TupletBracket.direction = #up
-                                                    \override TupletBracket.padding = #1.25
-                                                    \override TupletBracket.shorten-pair = #'(-1 . -1.5)
-                                                    \override TupletNumber.text = #tuplet-number::calc-fraction-text
-                                                    tupletFullLength = ##t
-                                                } {
-                                                    c'4
+                            \with-color
+                                #red
+                                {
+                                    \scale
+                                        #'(0.75 . 0.75)
+                                        \score
+                                            {
+                                                \new Score
+                                                \with
+                                                {
+                                                    \override SpacingSpanner.spacing-increment = #0.5
+                                                    proportionalNotationDuration = ##f
                                                 }
-                                            >>
-                                            \layout {
-                                                indent = #0
-                                                ragged-right = ##t
+                                                <<
+                                                    \new RhythmicStaff
+                                                    \with
+                                                    {
+                                                        \remove Time_signature_engraver
+                                                        \remove Staff_symbol_engraver
+                                                        \override Stem.direction = #up
+                                                        \override Stem.length = #5
+                                                        \override TupletBracket.bracket-visibility = ##t
+                                                        \override TupletBracket.direction = #up
+                                                        \override TupletBracket.padding = #1.25
+                                                        \override TupletBracket.shorten-pair = #'(-1 . -1.5)
+                                                        \override TupletNumber.text = #tuplet-number::calc-fraction-text
+                                                        tupletFullLength = ##t
+                                                    }
+                                                    {
+                                                        c'4
+                                                    }
+                                                >>
+                                                \layout {
+                                                    indent = #0
+                                                    ragged-right = ##t
+                                                }
                                             }
-                                        }
-                                =
-                                \general-align
-                                    #Y
-                                    #-0.5
-                                    67.5
+                                    =
+                                    \general-align
+                                        #Y
+                                        #-0.5
+                                        67.5
+                                }
                             }
-                        }
                         c'4
                         d'4
                         e'4
@@ -941,8 +969,10 @@ class MetronomeMark(AbjadValueObject):
             >>> abjad.show(score) # doctest: +SKIP
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     \tempo 4=72
                     c'4
                     d'4
@@ -1302,11 +1332,16 @@ class MetronomeMark(AbjadValueObject):
                         #'(0.75 . 0.75)
                         \score
                             {
-                                \new Score \with {
+                                \new Score
+                                \with
+                                {
                                     \override SpacingSpanner.spacing-increment = #0.5
                                     proportionalNotationDuration = ##f
-                                } <<
-                                    \new RhythmicStaff \with {
+                                }
+                                <<
+                                    \new RhythmicStaff
+                                    \with
+                                    {
                                         \remove Time_signature_engraver
                                         \remove Staff_symbol_engraver
                                         \override Stem.direction = #up
@@ -1317,7 +1352,8 @@ class MetronomeMark(AbjadValueObject):
                                         \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                         \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                         tupletFullLength = ##t
-                                    } {
+                                    }
+                                    {
                                         c'4
                                     }
                                 >>
@@ -1351,11 +1387,16 @@ class MetronomeMark(AbjadValueObject):
                         #'(0.75 . 0.75)
                         \score
                             {
-                                \new Score \with {
+                                \new Score
+                                \with
+                                {
                                     \override SpacingSpanner.spacing-increment = #0.5
                                     proportionalNotationDuration = ##f
-                                } <<
-                                    \new RhythmicStaff \with {
+                                }
+                                <<
+                                    \new RhythmicStaff
+                                    \with
+                                    {
                                         \remove Time_signature_engraver
                                         \remove Staff_symbol_engraver
                                         \override Stem.direction = #up
@@ -1366,7 +1407,8 @@ class MetronomeMark(AbjadValueObject):
                                         \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                         \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                         tupletFullLength = ##t
-                                    } {
+                                    }
+                                    {
                                         c'4
                                     }
                                 >>
@@ -1400,11 +1442,16 @@ class MetronomeMark(AbjadValueObject):
                         #'(0.75 . 0.75)
                         \score
                             {
-                                \new Score \with {
+                                \new Score
+                                \with
+                                {
                                     \override SpacingSpanner.spacing-increment = #0.5
                                     proportionalNotationDuration = ##f
-                                } <<
-                                    \new RhythmicStaff \with {
+                                }
+                                <<
+                                    \new RhythmicStaff
+                                    \with
+                                    {
                                         \remove Time_signature_engraver
                                         \remove Staff_symbol_engraver
                                         \override Stem.direction = #up
@@ -1415,7 +1462,8 @@ class MetronomeMark(AbjadValueObject):
                                         \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                         \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                         tupletFullLength = ##t
-                                    } {
+                                    }
+                                    {
                                         c'4
                                     }
                                 >>
@@ -1454,11 +1502,16 @@ class MetronomeMark(AbjadValueObject):
                         #'(0.75 . 0.75)
                         \score
                             {
-                                \new Score \with {
+                                \new Score
+                                \with
+                                {
                                     \override SpacingSpanner.spacing-increment = #0.5
                                     proportionalNotationDuration = ##f
-                                } <<
-                                    \new RhythmicStaff \with {
+                                }
+                                <<
+                                    \new RhythmicStaff
+                                    \with
+                                    {
                                         \remove Time_signature_engraver
                                         \remove Staff_symbol_engraver
                                         \override Stem.direction = #up
@@ -1469,7 +1522,8 @@ class MetronomeMark(AbjadValueObject):
                                         \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                         \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                         tupletFullLength = ##t
-                                    } {
+                                    }
+                                    {
                                         c'4 ~
                                         c'16
                                     }
@@ -1501,11 +1555,16 @@ class MetronomeMark(AbjadValueObject):
                         #'(0.75 . 0.75)
                         \score
                             {
-                                \new Score \with {
+                                \new Score
+                                \with
+                                {
                                     \override SpacingSpanner.spacing-increment = #0.5
                                     proportionalNotationDuration = ##f
-                                } <<
-                                    \new RhythmicStaff \with {
+                                }
+                                <<
+                                    \new RhythmicStaff
+                                    \with
+                                    {
                                         \remove Time_signature_engraver
                                         \remove Staff_symbol_engraver
                                         \override Stem.direction = #up
@@ -1516,7 +1575,8 @@ class MetronomeMark(AbjadValueObject):
                                         \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                         \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                         tupletFullLength = ##t
-                                    } {
+                                    }
+                                    {
                                         \tweak edge-height #'(0.7 . 0)
                                         \times 2/3 {
                                             c'4
@@ -1555,11 +1615,16 @@ class MetronomeMark(AbjadValueObject):
                         #'(0.75 . 0.75)
                         \score
                             {
-                                \new Score \with {
+                                \new Score
+                                \with
+                                {
                                     \override SpacingSpanner.spacing-increment = #0.5
                                     proportionalNotationDuration = ##f
-                                } <<
-                                    \new RhythmicStaff \with {
+                                }
+                                <<
+                                    \new RhythmicStaff
+                                    \with
+                                    {
                                         \remove Time_signature_engraver
                                         \remove Staff_symbol_engraver
                                         \override Stem.direction = #up
@@ -1570,7 +1635,8 @@ class MetronomeMark(AbjadValueObject):
                                         \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                         \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                         tupletFullLength = ##t
-                                    } {
+                                    }
+                                    {
                                         c'16 ~ [
                                         c'8. ~
                                         c'16 ]

--- a/abjad/tools/indicatortools/MetronomeMarkDictionary.py
+++ b/abjad/tools/indicatortools/MetronomeMarkDictionary.py
@@ -81,7 +81,9 @@ class MetronomeMarkDictionary(OrderedDict):
 
                 >>> lilypond_file = marks.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Score])
-                \new Score \with {
+                \new Score
+                \with
+                {
                     \override BarLine.transparent = ##t
                     \override BarNumber.stencil = ##f
                     \override Clef.stencil = ##f
@@ -90,8 +92,10 @@ class MetronomeMarkDictionary(OrderedDict):
                     \override StaffSymbol.transparent = ##t
                     \override Stem.transparent = ##t
                     \override TimeSignature.stencil = ##f
-                } <<
-                    \new Staff {
+                }
+                <<
+                    \new Staff
+                    {
                         \time 2/4
                         \break
                         c'2

--- a/abjad/tools/indicatortools/PageBreak.py
+++ b/abjad/tools/indicatortools/PageBreak.py
@@ -20,7 +20,8 @@ class PageBreak(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4
                 d'4
                 e'4
@@ -90,7 +91,8 @@ class PageBreak(AbjadValueObject):
             PageBreak(format_slot='closing')
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4
                 d'4
                 e'4
@@ -108,7 +110,8 @@ class PageBreak(AbjadValueObject):
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \pageBreak
                 c'4
                 d'4

--- a/abjad/tools/indicatortools/Part.py
+++ b/abjad/tools/indicatortools/Part.py
@@ -1,0 +1,187 @@
+import roman # type: ignore
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
+from abjad.tools.abctools.AbjadValueObject import AbjadValueObject
+from abjad.tools.systemtools.FormatSpecification import FormatSpecification
+
+
+class Part(AbjadValueObject):
+    r'''Part.
+
+    ..  container:: example
+
+        >>> abjad.Part('Horn')
+        Part('Horn')
+
+        >>> abjad.Part('Horn', 1)
+        Part('Horn', 1)
+
+        >>> abjad.Part('Horn', 2)
+        Part('Horn', 2)
+
+        >>> abjad.Part('Horn', (3, 4))
+        Part('Horn', (3, 4))
+
+        >>> abjad.Part('Horn', [1, 3])
+        Part('Horn', [1, 3])
+
+    ..  container:: example
+
+        >>> part = abjad.Part('Horn', [1, 3])
+
+        >>> abjad.f(part)
+        Part('Horn', [1, 3])
+
+        >>> print(format(part))
+        abjad.Part('Horn', [1, 3])
+        
+    '''
+
+    ### CLASS VARIABLES ###
+
+    __slots__ = (
+        '_members',
+        '_section',
+        )
+
+    ### INITIALIZER ###
+
+    def __init__(
+        self,
+        section: str = None,
+        members: Union[int, Tuple[int, int], List[int]] = None,
+        ) -> None:
+        self._members: Union[int, Tuple[int, int], List[int]] = members
+        self._section: str = section
+
+    ### SPECIAL METHODS ###
+
+    def __contains__(self, argument: str) -> bool:
+        r'''Is true when part contains ``argument``.
+
+        ..  container:: example
+
+            >>> part_names = ['HornI', 'HornII', 'HornIII', 'HornIV']
+
+            >>> part = abjad.Part('Horn')
+            >>> for part_name in part_names:
+            ...     part_name, part_name in part
+            ...
+            ('HornI', True)
+            ('HornII', True)
+            ('HornIII', True)
+            ('HornIV', True)
+
+            >>> part = abjad.Part('Horn', 1)
+            >>> for part_name in part_names:
+            ...     part_name, part_name in part
+            ...
+            ('HornI', True)
+            ('HornII', False)
+            ('HornIII', False)
+            ('HornIV', False)
+
+            >>> part = abjad.Part('Horn', 2)
+            >>> for part_name in part_names:
+            ...     part_name, part_name in part
+            ...
+            ('HornI', False)
+            ('HornII', True)
+            ('HornIII', False)
+            ('HornIV', False)
+
+            >>> part = abjad.Part('Horn', (3, 4))
+            >>> for part_name in part_names:
+            ...     part_name, part_name in part
+            ...
+            ('HornI', False)
+            ('HornII', False)
+            ('HornIII', True)
+            ('HornIV', True)
+
+            >>> part = abjad.Part('Horn', [1, 3])
+            >>> for part_name in part_names:
+            ...     part_name, part_name in part
+            ...
+            ('HornI', True)
+            ('HornII', False)
+            ('HornIII', True)
+            ('HornIV', False)
+
+
+        '''
+        if not isinstance(argument, str):
+            return False
+        if self.members is None:
+            if argument.startswith(self.section):
+                return True
+            else:
+                return False
+        part_names = self._expand()
+        if argument in part_names:
+            return True
+        return False
+
+    ### PRIVATE METHODS ###
+
+    def _expand(self) -> List[str]:
+        if self.members is None:
+            return []
+        if isinstance(self.members, int):
+            members = [self.members]
+        elif isinstance(self.members, tuple):
+            assert len(self.members) == 2
+            members = list(range(self.members[0], self.members[1] + 1))
+        else:
+            assert isinstance(self.members, list)
+            members = self.members
+        part_names_ = []
+        for member in members:
+            member_numeral = roman.toRoman(member)
+            part_name = self.section + member_numeral
+            part_names_.append(part_name)
+        return part_names_
+
+    def _get_format_specification(self):
+        repr_args_values = [self.section]
+        if self.members is not None:
+            repr_args_values.append(self.members)
+        repr_is_indented = False
+        repr_kwargs_names = []
+        return FormatSpecification(
+            self,
+            repr_args_values=repr_args_values,
+            repr_is_indented=repr_is_indented,
+            repr_kwargs_names=repr_kwargs_names,
+            storage_format_args_values=repr_args_values,
+            storage_format_is_indented=repr_is_indented,
+            storage_format_kwargs_names=repr_kwargs_names,
+            )
+
+    ### PUBLIC PROPERTIES ###
+
+    @property
+    def members(self) -> Optional[Union[int, Tuple[int, int], List[int]]]:
+        r'''Gets members.
+
+        ..  container:: example
+
+            >>> abjad.Part('Horn', [1, 3]).members
+            [1, 3]
+
+        '''
+        return self._members
+
+    @property
+    def section(self) -> str:
+        r'''Gets section.
+
+        ..  container:: example
+
+            >>> abjad.Part('Horn', [1, 3]).section
+            'Horn'
+
+        '''
+        return self._section

--- a/abjad/tools/indicatortools/RehearsalMark.py
+++ b/abjad/tools/indicatortools/RehearsalMark.py
@@ -19,10 +19,14 @@ class RehearsalMark(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score \with {
+            \new Score
+            \with
+            {
                 markFormatter = #format-mark-box-alphabet
-            } <<
-                \new Staff {
+            }
+            <<
+                \new Staff
+                {
                     \mark #1
                     c'4
                     d'4
@@ -67,7 +71,8 @@ class RehearsalMark(AbjadValueObject):
             ..  docs::
             
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \mark #1
                     c'4
                     d'4
@@ -130,7 +135,8 @@ class RehearsalMark(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \mark \markup {
                         \bold
                             {

--- a/abjad/tools/indicatortools/Repeat.py
+++ b/abjad/tools/indicatortools/Repeat.py
@@ -18,8 +18,10 @@ class Repeat(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     \repeat volta 2
                     {
                         c'4
@@ -44,8 +46,10 @@ class Repeat(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     \repeat unfold 2
                     {
                         c'4

--- a/abjad/tools/indicatortools/Ritardando.py
+++ b/abjad/tools/indicatortools/Ritardando.py
@@ -17,8 +17,10 @@ class Ritardando(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     c'4
                         ^ \markup {
                             \large
@@ -45,8 +47,10 @@ class Ritardando(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     c'4
                         ^ \markup {
                             \bold

--- a/abjad/tools/indicatortools/Staccatissimo.py
+++ b/abjad/tools/indicatortools/Staccatissimo.py
@@ -33,7 +33,8 @@ class Staccatissimo(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'8 [
                 d'8
                 e'8

--- a/abjad/tools/indicatortools/Staccato.py
+++ b/abjad/tools/indicatortools/Staccato.py
@@ -33,7 +33,8 @@ class Staccato(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'8 [
                 d'8
                 e'8

--- a/abjad/tools/indicatortools/StaffChange.py
+++ b/abjad/tools/indicatortools/StaffChange.py
@@ -21,15 +21,18 @@ class StaffChange(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff_group)
-            \new PianoStaff <<
-                \context Staff = "RHStaff" {
+            \new PianoStaff
+            <<
+                \context Staff = "RHStaff"
+                {
                     c'8
                     d'8
                     \change Staff = LHStaff
                     e'8
                     f'8
                 }
-                \context Staff = "LHStaff" {
+                \context Staff = "LHStaff"
+                {
                     s2
                 }
             >>

--- a/abjad/tools/indicatortools/TimeSignature.py
+++ b/abjad/tools/indicatortools/TimeSignature.py
@@ -15,7 +15,8 @@ class TimeSignature(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \time 3/8
                 c'8
                 d'8
@@ -34,7 +35,8 @@ class TimeSignature(AbjadValueObject):
         score container is found:
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             %%% \time 3/8 %%%
             c'8
             d'8
@@ -51,8 +53,10 @@ class TimeSignature(AbjadValueObject):
 
         >>> score = abjad.Score([staff])
         >>> abjad.f(score)
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \time 3/8
                 c'8
                 d'8
@@ -76,8 +80,10 @@ class TimeSignature(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(score)
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \time 3/8 %! RED
                 c'8
                 d'8
@@ -432,7 +438,8 @@ class TimeSignature(AbjadValueObject):
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \time 4/4
                 c'4
                 d'4

--- a/abjad/tools/indicatortools/__init__.py
+++ b/abjad/tools/indicatortools/__init__.py
@@ -25,6 +25,7 @@ from .MetricModulation import MetricModulation
 from .MetronomeMark import MetronomeMark
 from .MetronomeMarkDictionary import MetronomeMarkDictionary
 from .PageBreak import PageBreak
+from .Part import Part
 from .RehearsalMark import RehearsalMark
 from .Repeat import Repeat
 from .Ritardando import Ritardando

--- a/abjad/tools/instrumenttools/Accordion.py
+++ b/abjad/tools/instrumenttools/Accordion.py
@@ -17,8 +17,10 @@ class Accordion(Instrument):
         ..  docs::
 
             >>> abjad.f(staff_group)
-            \new PianoStaff <<
-                \new Staff {
+            \new PianoStaff
+            <<
+                \new Staff
+                {
                     \set PianoStaff.instrumentName = \markup { Accordion }
                     \set PianoStaff.shortInstrumentName = \markup { Acc. }
                     c'4
@@ -26,7 +28,8 @@ class Accordion(Instrument):
                     e'4
                     f'4
                 }
-                \new Staff {
+                \new Staff
+                {
                     \clef "bass"
                     c'2
                     b2

--- a/abjad/tools/instrumenttools/AltoFlute.py
+++ b/abjad/tools/instrumenttools/AltoFlute.py
@@ -14,7 +14,8 @@ class AltoFlute(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Alto flute" }
                 \set Staff.shortInstrumentName = \markup { "Alt. fl." }
                 c'4

--- a/abjad/tools/instrumenttools/AltoSaxophone.py
+++ b/abjad/tools/instrumenttools/AltoSaxophone.py
@@ -14,7 +14,8 @@ class AltoSaxophone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Alto saxophone" }
                 \set Staff.shortInstrumentName = \markup { "Alt. sax." }
                 c'4

--- a/abjad/tools/instrumenttools/AltoTrombone.py
+++ b/abjad/tools/instrumenttools/AltoTrombone.py
@@ -16,7 +16,8 @@ class AltoTrombone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Alto trombone" }
                 \set Staff.shortInstrumentName = \markup { "Alt. trb." }
                 \clef "bass"

--- a/abjad/tools/instrumenttools/AltoVoice.py
+++ b/abjad/tools/instrumenttools/AltoVoice.py
@@ -14,7 +14,8 @@ class AltoVoice(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Alto }
                 \set Staff.shortInstrumentName = \markup { Alto }
                 c'4

--- a/abjad/tools/instrumenttools/BaritoneSaxophone.py
+++ b/abjad/tools/instrumenttools/BaritoneSaxophone.py
@@ -14,7 +14,8 @@ class BaritoneSaxophone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Baritone saxophone" }
                 \set Staff.shortInstrumentName = \markup { "Bar. sax." }
                 c'4

--- a/abjad/tools/instrumenttools/BaritoneVoice.py
+++ b/abjad/tools/instrumenttools/BaritoneVoice.py
@@ -16,7 +16,8 @@ class BaritoneVoice(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Baritone }
                 \set Staff.shortInstrumentName = \markup { Bar. }
                 \clef "bass"

--- a/abjad/tools/instrumenttools/BassClarinet.py
+++ b/abjad/tools/instrumenttools/BassClarinet.py
@@ -14,7 +14,8 @@ class BassClarinet(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Bass clarinet" }
                 \set Staff.shortInstrumentName = \markup { "Bass cl." }
                 c'4

--- a/abjad/tools/instrumenttools/BassFlute.py
+++ b/abjad/tools/instrumenttools/BassFlute.py
@@ -14,7 +14,8 @@ class BassFlute(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Bass flute" }
                 \set Staff.shortInstrumentName = \markup { "Bass fl." }
                 c'4

--- a/abjad/tools/instrumenttools/BassSaxophone.py
+++ b/abjad/tools/instrumenttools/BassSaxophone.py
@@ -14,7 +14,8 @@ class BassSaxophone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Bass saxophone" }
                 \set Staff.shortInstrumentName = \markup { "Bass sax." }
                 c'4

--- a/abjad/tools/instrumenttools/BassTrombone.py
+++ b/abjad/tools/instrumenttools/BassTrombone.py
@@ -16,7 +16,8 @@ class BassTrombone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Bass trombone" }
                 \set Staff.shortInstrumentName = \markup { "Bass trb." }
                 \clef "bass"

--- a/abjad/tools/instrumenttools/BassVoice.py
+++ b/abjad/tools/instrumenttools/BassVoice.py
@@ -16,7 +16,8 @@ class BassVoice(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Bass }
                 \set Staff.shortInstrumentName = \markup { Bass }
                 \clef "bass"

--- a/abjad/tools/instrumenttools/Bassoon.py
+++ b/abjad/tools/instrumenttools/Bassoon.py
@@ -16,7 +16,8 @@ class Bassoon(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Bassoon }
                 \set Staff.shortInstrumentName = \markup { Bsn. }
                 \clef "bass"

--- a/abjad/tools/instrumenttools/Cello.py
+++ b/abjad/tools/instrumenttools/Cello.py
@@ -16,7 +16,8 @@ class Cello(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Cello }
                 \set Staff.shortInstrumentName = \markup { Vc. }
                 \clef "bass"

--- a/abjad/tools/instrumenttools/ClarinetInA.py
+++ b/abjad/tools/instrumenttools/ClarinetInA.py
@@ -14,13 +14,14 @@ class ClarinetInA(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Clarinet in A" }
                 \set Staff.shortInstrumentName = \markup {
                     Cl.
                     A
                     \natural
-                }
+                    }
                 c'4
                 d'4
                 e'4

--- a/abjad/tools/instrumenttools/ClarinetInBFlat.py
+++ b/abjad/tools/instrumenttools/ClarinetInBFlat.py
@@ -14,7 +14,8 @@ class ClarinetInBFlat(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Clarinet in B-flat" }
                 \set Staff.shortInstrumentName = \markup { "Cl. in B-flat" }
                 c'4

--- a/abjad/tools/instrumenttools/ClarinetInEFlat.py
+++ b/abjad/tools/instrumenttools/ClarinetInEFlat.py
@@ -14,7 +14,8 @@ class ClarinetInEFlat(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Clarinet in E-flat" }
                 \set Staff.shortInstrumentName = \markup { "Cl. E-flat" }
                 c'4

--- a/abjad/tools/instrumenttools/Contrabass.py
+++ b/abjad/tools/instrumenttools/Contrabass.py
@@ -15,7 +15,8 @@ class Contrabass(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Contrabass }
                 \set Staff.shortInstrumentName = \markup { Cb. }
                 \clef "bass"

--- a/abjad/tools/instrumenttools/ContrabassClarinet.py
+++ b/abjad/tools/instrumenttools/ContrabassClarinet.py
@@ -14,7 +14,8 @@ class ContrabassClarinet(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Contrabass clarinet" }
                 \set Staff.shortInstrumentName = \markup { "Cbass. cl." }
                 c'4

--- a/abjad/tools/instrumenttools/ContrabassFlute.py
+++ b/abjad/tools/instrumenttools/ContrabassFlute.py
@@ -14,7 +14,8 @@ class ContrabassFlute(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Contrabass flute" }
                 \set Staff.shortInstrumentName = \markup { "Cbass. fl." }
                 c'4

--- a/abjad/tools/instrumenttools/ContrabassSaxophone.py
+++ b/abjad/tools/instrumenttools/ContrabassSaxophone.py
@@ -14,7 +14,8 @@ class ContrabassSaxophone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Contrabass saxophone" }
                 \set Staff.shortInstrumentName = \markup { "Cbass. sax." }
                 c'4

--- a/abjad/tools/instrumenttools/Contrabassoon.py
+++ b/abjad/tools/instrumenttools/Contrabassoon.py
@@ -16,7 +16,8 @@ class Contrabassoon(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Contrabassoon }
                 \set Staff.shortInstrumentName = \markup { Contrabsn. }
                 \clef "bass"

--- a/abjad/tools/instrumenttools/EnglishHorn.py
+++ b/abjad/tools/instrumenttools/EnglishHorn.py
@@ -14,7 +14,8 @@ class EnglishHorn(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "English horn" }
                 \set Staff.shortInstrumentName = \markup { "Eng. hn." }
                 c'4

--- a/abjad/tools/instrumenttools/Flute.py
+++ b/abjad/tools/instrumenttools/Flute.py
@@ -14,7 +14,8 @@ class Flute(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Flute }
                 \set Staff.shortInstrumentName = \markup { Fl. }
                 c'4
@@ -36,7 +37,8 @@ class Flute(Instrument):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             \set Staff.instrumentName = \markup {      %! RED:M1
                 \italic                                %! RED:M1
                     Flauto                             %! RED:M1
@@ -61,7 +63,8 @@ class Flute(Instrument):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             c'4
             d'4
             e'4

--- a/abjad/tools/instrumenttools/FrenchHorn.py
+++ b/abjad/tools/instrumenttools/FrenchHorn.py
@@ -14,7 +14,8 @@ class FrenchHorn(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Horn }
                 \set Staff.shortInstrumentName = \markup { Hn. }
                 c'4

--- a/abjad/tools/instrumenttools/Glockenspiel.py
+++ b/abjad/tools/instrumenttools/Glockenspiel.py
@@ -14,7 +14,8 @@ class Glockenspiel(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Glockenspiel }
                 \set Staff.shortInstrumentName = \markup { Gkspl. }
                 c'4

--- a/abjad/tools/instrumenttools/Guitar.py
+++ b/abjad/tools/instrumenttools/Guitar.py
@@ -14,7 +14,8 @@ class Guitar(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Guitar }
                 \set Staff.shortInstrumentName = \markup { Gt. }
                 c'4

--- a/abjad/tools/instrumenttools/Harp.py
+++ b/abjad/tools/instrumenttools/Harp.py
@@ -17,8 +17,10 @@ class Harp(Instrument):
         ..  docs::
 
             >>> abjad.f(staff_group)
-            \new PianoStaff <<
-                \new Staff {
+            \new PianoStaff
+            <<
+                \new Staff
+                {
                     \set PianoStaff.instrumentName = \markup { Harp }
                     \set PianoStaff.shortInstrumentName = \markup { Hp. }
                     c'4
@@ -26,7 +28,8 @@ class Harp(Instrument):
                     e'4
                     f'4
                 }
-                \new Staff {
+                \new Staff
+                {
                     \clef "bass"
                     c'2
                     b2

--- a/abjad/tools/instrumenttools/Harpsichord.py
+++ b/abjad/tools/instrumenttools/Harpsichord.py
@@ -20,8 +20,10 @@ class Harpsichord(Instrument):
         ..  docs::
 
             >>> abjad.f(staff_group)
-            \new PianoStaff <<
-                \new Staff {
+            \new PianoStaff
+            <<
+                \new Staff
+                {
                     \set PianoStaff.instrumentName = \markup { Harpsichord }
                     \set PianoStaff.shortInstrumentName = \markup { Hpschd. }
                     c'4
@@ -29,7 +31,8 @@ class Harpsichord(Instrument):
                     e'4
                     f'4
                 }
-                \new Staff {
+                \new Staff
+                {
                     \clef "bass"
                     c'2
                     b2

--- a/abjad/tools/instrumenttools/Instrument.py
+++ b/abjad/tools/instrumenttools/Instrument.py
@@ -27,15 +27,18 @@ class Instrument(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff <<
-                \new Voice {
+            \new Staff
+            <<
+                \new Voice
+                {
                     \voiceOne
                     e'8 ^ \markup { (flute) }
                     g'8
                     f'8
                     a'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     \voiceTwo
                     c'2 _ \markup { (viola) }
                 }
@@ -367,7 +370,8 @@ class Instrument(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.instrumentName = \markup { "Clarinet in B-flat" }
                     \set Staff.shortInstrumentName = \markup { "Cl. in B-flat" }
                     <c' e' g'>4
@@ -382,7 +386,8 @@ class Instrument(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.instrumentName = \markup { "Clarinet in B-flat" }
                     \set Staff.shortInstrumentName = \markup { "Cl. in B-flat" }
                     <d' fs' a'>4
@@ -427,7 +432,8 @@ class Instrument(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.instrumentName = \markup { "Clarinet in B-flat" }
                     \set Staff.shortInstrumentName = \markup { "Cl. in B-flat" }
                     <c' e' g'>4
@@ -442,7 +448,8 @@ class Instrument(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.instrumentName = \markup { "Clarinet in B-flat" }
                     \set Staff.shortInstrumentName = \markup { "Cl. in B-flat" }
                     <bf d' f'>4

--- a/abjad/tools/instrumenttools/Marimba.py
+++ b/abjad/tools/instrumenttools/Marimba.py
@@ -14,7 +14,8 @@ class Marimba(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Marimba }
                 \set Staff.shortInstrumentName = \markup { Mb. }
                 c'4

--- a/abjad/tools/instrumenttools/MezzoSopranoVoice.py
+++ b/abjad/tools/instrumenttools/MezzoSopranoVoice.py
@@ -15,7 +15,8 @@ class MezzoSopranoVoice(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Mezzo-soprano }
                 \set Staff.shortInstrumentName = \markup { Mezz. }
                 c''4

--- a/abjad/tools/instrumenttools/Oboe.py
+++ b/abjad/tools/instrumenttools/Oboe.py
@@ -14,7 +14,8 @@ class Oboe(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Oboe }
                 \set Staff.shortInstrumentName = \markup { Ob. }
                 c'4

--- a/abjad/tools/instrumenttools/Percussion.py
+++ b/abjad/tools/instrumenttools/Percussion.py
@@ -14,7 +14,8 @@ class Percussion(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Percussion }
                 \set Staff.shortInstrumentName = \markup { Perc. }
                 c'4

--- a/abjad/tools/instrumenttools/Piano.py
+++ b/abjad/tools/instrumenttools/Piano.py
@@ -17,8 +17,10 @@ class Piano(Instrument):
         ..  docs::
 
             >>> abjad.f(staff_group)
-            \new PianoStaff <<
-                \new Staff {
+            \new PianoStaff
+            <<
+                \new Staff
+                {
                     \set PianoStaff.instrumentName = \markup { Piano }
                     \set PianoStaff.shortInstrumentName = \markup { Pf. }
                     c'4
@@ -26,7 +28,8 @@ class Piano(Instrument):
                     e'4
                     f'4
                 }
-                \new Staff {
+                \new Staff
+                {
                     \clef "bass"
                     c'2
                     b2

--- a/abjad/tools/instrumenttools/Piccolo.py
+++ b/abjad/tools/instrumenttools/Piccolo.py
@@ -14,7 +14,8 @@ class Piccolo(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Piccolo }
                 \set Staff.shortInstrumentName = \markup { Picc. }
                 c'4

--- a/abjad/tools/instrumenttools/SopraninoSaxophone.py
+++ b/abjad/tools/instrumenttools/SopraninoSaxophone.py
@@ -14,7 +14,8 @@ class SopraninoSaxophone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Sopranino saxophone" }
                 \set Staff.shortInstrumentName = \markup { "Sopranino sax." }
                 c'4

--- a/abjad/tools/instrumenttools/SopranoSaxophone.py
+++ b/abjad/tools/instrumenttools/SopranoSaxophone.py
@@ -14,7 +14,8 @@ class SopranoSaxophone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Soprano saxophone" }
                 \set Staff.shortInstrumentName = \markup { "Sop. sax." }
                 c'4

--- a/abjad/tools/instrumenttools/SopranoVoice.py
+++ b/abjad/tools/instrumenttools/SopranoVoice.py
@@ -14,7 +14,8 @@ class SopranoVoice(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Soprano }
                 \set Staff.shortInstrumentName = \markup { Sop. }
                 c''4

--- a/abjad/tools/instrumenttools/TenorSaxophone.py
+++ b/abjad/tools/instrumenttools/TenorSaxophone.py
@@ -14,7 +14,8 @@ class TenorSaxophone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Tenor saxophone" }
                 \set Staff.shortInstrumentName = \markup { "Ten. sax." }
                 c'4

--- a/abjad/tools/instrumenttools/TenorTrombone.py
+++ b/abjad/tools/instrumenttools/TenorTrombone.py
@@ -16,7 +16,8 @@ class TenorTrombone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { "Tenor trombone" }
                 \set Staff.shortInstrumentName = \markup { "Ten. trb." }
                 \clef "bass"

--- a/abjad/tools/instrumenttools/TenorVoice.py
+++ b/abjad/tools/instrumenttools/TenorVoice.py
@@ -14,7 +14,8 @@ class TenorVoice(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Tenor }
                 \set Staff.shortInstrumentName = \markup { Ten. }
                 c'4

--- a/abjad/tools/instrumenttools/Trumpet.py
+++ b/abjad/tools/instrumenttools/Trumpet.py
@@ -14,7 +14,8 @@ class Trumpet(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Trumpet }
                 \set Staff.shortInstrumentName = \markup { Tp. }
                 c'4

--- a/abjad/tools/instrumenttools/Tuba.py
+++ b/abjad/tools/instrumenttools/Tuba.py
@@ -16,7 +16,8 @@ class Tuba(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Tuba }
                 \set Staff.shortInstrumentName = \markup { Tb. }
                 \clef "bass"

--- a/abjad/tools/instrumenttools/Vibraphone.py
+++ b/abjad/tools/instrumenttools/Vibraphone.py
@@ -14,7 +14,8 @@ class Vibraphone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Vibraphone }
                 \set Staff.shortInstrumentName = \markup { Vibr. }
                 c'4

--- a/abjad/tools/instrumenttools/Viola.py
+++ b/abjad/tools/instrumenttools/Viola.py
@@ -16,7 +16,8 @@ class Viola(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Viola }
                 \set Staff.shortInstrumentName = \markup { Va. }
                 \clef "alto"

--- a/abjad/tools/instrumenttools/Violin.py
+++ b/abjad/tools/instrumenttools/Violin.py
@@ -14,7 +14,8 @@ class Violin(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Violin }
                 \set Staff.shortInstrumentName = \markup { Vn. }
                 c'4

--- a/abjad/tools/instrumenttools/Xylophone.py
+++ b/abjad/tools/instrumenttools/Xylophone.py
@@ -14,7 +14,8 @@ class Xylophone(Instrument):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.instrumentName = \markup { Xylophone }
                 \set Staff.shortInstrumentName = \markup { Xyl. }
                 c'4

--- a/abjad/tools/lilypondfiletools/Block.py
+++ b/abjad/tools/lilypondfiletools/Block.py
@@ -269,7 +269,8 @@ class Block(AbjadObject):
             \score {
                 <<
                 { \include "layout.ly" }
-                \new Staff {
+                \new Staff
+                {
                     c'4
                     d'4
                     e'4

--- a/abjad/tools/lilypondfiletools/LilyPondFile.py
+++ b/abjad/tools/lilypondfiletools/LilyPondFile.py
@@ -159,8 +159,10 @@ class LilyPondFile(AbjadObject):
 
             >>> abjad.f(score_block)
             \score {
-                \new Score <<
-                    \new Staff {
+                \new Score
+                <<
+                    \new Staff
+                    {
                         c'8
                         d'8
                         e'8
@@ -193,8 +195,10 @@ class LilyPondFile(AbjadObject):
             <BLANKLINE>
             \score {
                 {
-                    \new Score <<
-                        \new Staff {
+                    \new Score
+                    <<
+                        \new Staff
+                        {
                             c'8 -\staccato - \markup { Allegro }
                             d'8
                             e'8
@@ -217,8 +221,10 @@ class LilyPondFile(AbjadObject):
             <BLANKLINE>
             \score {
                 {
-                    \new Score <<
-                        \new Staff {
+                    \new Score
+                    <<
+                        \new Staff
+                        {
                             c'8
                             -\staccato
                             - \markup { Allegro }
@@ -273,16 +279,20 @@ class LilyPondFile(AbjadObject):
             ..  docs::
 
                 >>> abjad.f(score)
-                \context Score = "Custom Score" <<
-                    \context Staff = "Custom Staff" <<
-                        \context Voice = "Custom Voice 1" {
+                \context Score = "Custom Score"
+                <<
+                    \context Staff = "Custom Staff"
+                    <<
+                        \context Voice = "Custom Voice 1"
+                        {
                             \voiceOne
                             c''4
                             b'4
                             a'4
                             g'4
                         }
-                        \context Voice = "Custom Voice 2" {
+                        \context Voice = "Custom Voice 2"
+                        {
                             \voiceTwo
                             c'4
                             d'4
@@ -342,7 +352,8 @@ class LilyPondFile(AbjadObject):
                         {
                             \include "layout.ly"
                         }
-                        \context Staff = "CustomStaff" {
+                        \context Staff = "CustomStaff"
+                        {
                             c'4
                             d'4
                             e'4
@@ -710,7 +721,8 @@ class LilyPondFile(AbjadObject):
             \customCommand
             <BLANKLINE>
             \score {
-                \new Staff {
+                \new Staff
+                {
                     c'4
                     d'4
                     e'4
@@ -939,37 +951,37 @@ class LilyPondFile(AbjadObject):
                 \score {
                     \new Score <<
                         \new GlobalContext {
-                            { % measure
+                            {   % measure
                                 \time 2/8
                                 s1 * 1/4
-                            } % measure
-                            { % measure
+                            }   % measure
+                            {   % measure
                                 \time 3/8
                                 s1 * 3/8
-                            } % measure
-                            { % measure
+                            }   % measure
+                            {   % measure
                                 \time 4/8
                                 s1 * 1/2
-                            } % measure
+                            }   % measure
                         }
                         \new Staff {
-                            { % measure
+                            {   % measure
                                 \time 2/8
                                 c'8 (
                                 d'8 )
-                            } % measure
-                            { % measure
+                            }   % measure
+                            {   % measure
                                 \time 3/8
                                 e'8 (
                                 f'8
                                 g'8 )
-                            } % measure
-                            { % measure
+                            }   % measure
+                            {   % measure
                                 \time 4/8
                                 fs'4 (
                                 e'8
                                 d'8 )
-                            } % measure
+                            }   % measure
                         }
                     >>
                 }
@@ -1182,23 +1194,26 @@ class LilyPondFile(AbjadObject):
 
                 >>> score = lilypond_file[abjad.Score]
                 >>> abjad.f(score)
-                \new Score <<
-                    \new GlobalContext {
-                        { % measure
+                \new Score
+                <<
+                    \new GlobalContext
+                    {
+                        {   % measure
                             \time 3/4
                             s1 * 3/4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 4/8
                             s1 * 1/2
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 1/4
                             s1 * 1/4
-                        } % measure
+                        }   % measure
                     }
-                    \new RhythmicStaff {
-                        { % measure
+                    \new RhythmicStaff
+                    {
+                        {   % measure
                             \time 3/4
                             c'8 [
                             c'8
@@ -1206,8 +1221,8 @@ class LilyPondFile(AbjadObject):
                             c'8
                             c'8
                             c'8 ]
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 4/8
                             c'16 [
                             c'16
@@ -1217,12 +1232,12 @@ class LilyPondFile(AbjadObject):
                             c'16
                             c'16
                             c'16 ]
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 1/4
                             c'8 [
                             c'8 ]
-                        } % measure
+                        }   % measure
                     }
                 >>
 
@@ -1250,23 +1265,26 @@ class LilyPondFile(AbjadObject):
 
                 >>> score = lilypond_file[abjad.Score]
                 >>> abjad.f(score)
-                \new Score <<
-                    \new GlobalContext {
-                        { % measure
+                \new Score
+                <<
+                    \new GlobalContext
+                    {
+                        {   % measure
                             \time 6/8
                             s1 * 3/4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 4/8
                             s1 * 1/2
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 2/8
                             s1 * 1/4
-                        } % measure
+                        }   % measure
                     }
-                    \new RhythmicStaff {
-                        { % measure
+                    \new RhythmicStaff
+                    {
+                        {   % measure
                             \time 6/8
                             c'8 [
                             c'8
@@ -1274,8 +1292,8 @@ class LilyPondFile(AbjadObject):
                             c'8
                             c'8
                             c'8 ]
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 4/8
                             c'16 [
                             c'16
@@ -1285,12 +1303,12 @@ class LilyPondFile(AbjadObject):
                             c'16
                             c'16
                             c'16 ]
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 2/8
                             c'8 [
                             c'8 ]
-                        } % measure
+                        }   % measure
                     }
                 >>
 
@@ -1318,23 +1336,26 @@ class LilyPondFile(AbjadObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Score])
-                \new Score <<
-                    \new GlobalContext {
-                        { % measure
+                \new Score
+                <<
+                    \new GlobalContext
+                    {
+                        {   % measure
                             \time 3/4
                             s1 * 3/4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 4/8
                             s1 * 1/2
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 1/4
                             s1 * 1/4
-                        } % measure
+                        }   % measure
                     }
-                    \new Staff {
-                        { % measure
+                    \new Staff
+                    {
+                        {   % measure
                             \time 3/4
                             c'8 [
                             c'8
@@ -1342,8 +1363,8 @@ class LilyPondFile(AbjadObject):
                             c'8
                             c'8
                             c'8 ]
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 4/8
                             c'16 [
                             c'16
@@ -1353,12 +1374,12 @@ class LilyPondFile(AbjadObject):
                             c'16
                             c'16
                             c'16 ]
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 1/4
                             c'8 [
                             c'8 ]
-                        } % measure
+                        }   % measure
                     }
                 >>
 
@@ -1406,23 +1427,27 @@ class LilyPondFile(AbjadObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Score])
-                \new Score <<
-                    \new GlobalContext {
-                        { % measure
+                \new Score
+                <<
+                    \new GlobalContext
+                    {
+                        {   % measure
                             \time 3/4
                             s1 * 3/4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 4/8
                             s1 * 1/2
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 1/4
                             s1 * 1/4
-                        } % measure
+                        }   % measure
                     }
-                    \new Staff <<
-                        \context Voice = "Voice 1" {
+                    \new Staff
+                    <<
+                        \context Voice = "Voice 1"
+                        {
                             \voiceOne
                             e'8 [
                             e'8
@@ -1441,7 +1466,8 @@ class LilyPondFile(AbjadObject):
                             e'8 [
                             e'8 ]
                         }
-                        \context Voice = "Voice 2" {
+                        \context Voice = "Voice 2"
+                        {
                             \voiceTwo
                             c'16 [
                             c'16

--- a/abjad/tools/lilypondnametools/test/test_lilypondproxytools_LilyPondGrobNameManager___delattr__.py
+++ b/abjad/tools/lilypondnametools/test/test_lilypondproxytools_LilyPondGrobNameManager___delattr__.py
@@ -38,7 +38,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___delattr___02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             d'8
             e'8

--- a/abjad/tools/lilypondnametools/test/test_lilypondproxytools_LilyPondGrobNameManager___setattr__.py
+++ b/abjad/tools/lilypondnametools/test/test_lilypondproxytools_LilyPondGrobNameManager___setattr__.py
@@ -11,9 +11,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override Accidental.color = #red
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -32,7 +35,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             \once \override Accidental.color = #red
             d'8
@@ -53,10 +57,14 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___03():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score \with {
+        \new Score
+        \with
+        {
             \override BarNumber.break-visibility = #end-of-line-invisible
-        } <<
-            \new Staff {
+        }
+        <<
+            \new Staff
+            {
                 c'8
                 d'8
                 e'8
@@ -81,10 +89,14 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___04():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score \with {
+        \new Score
+        \with
+        {
             \override BarNumber.color = #red
-        } <<
-            \new Staff {
+        }
+        <<
+            \new Staff
+            {
                 c'8
                 d'8
                 e'8
@@ -108,7 +120,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \override Beam.positions = #'(4 . 4)
             c'8 [
             d'8
@@ -159,9 +172,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override Clef.color = #red
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -219,7 +235,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___10():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \override DynamicLineSpanner.staff-padding = #4
             c'8 \< \p
             d'8
@@ -241,10 +258,13 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___11():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override DynamicLineSpanner.Y-extent = #'(-1.5 . 1.5)
             \override DynamicLineSpanner.staff-padding = #2
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -269,7 +289,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___12():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \override DynamicText.thickness = #3
             c'8 \f [
             d'8
@@ -293,10 +314,13 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___13():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override DynamicText.Y-extent = #'(-1.5 . 1.5)
             \override DynamicText.staff-padding = #2
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -316,10 +340,13 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___14():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override DynamicTextSpanner.Y-extent = #'(-1.5 . 1.5)
             \override DynamicTextSpanner.staff-padding = #2
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -340,7 +367,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___15():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \override Glissando.thickness = #3
             c'8 \glissando
             d'8 \glissando
@@ -362,10 +390,13 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___16():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override Hairpin.Y-extent = #'(-1.5 . 1.5)
             \override Hairpin.staff-padding = #2
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -385,7 +416,9 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___17():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override InstrumentName.color = #red
             instrumentName = \markup {
                 \circle
@@ -393,7 +426,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___17():
                         V
                     }
                 }
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -417,10 +451,14 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___18():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score \with {
+        \new Score
+        \with
+        {
             \override MetronomeMark.color = #red
-        } <<
-            \new Staff {
+        }
+        <<
+            \new Staff
+            {
                 \tempo 4=58
                 c'8
                 d'8
@@ -443,9 +481,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___19():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override MultiMeasureRest.expand-limit = #12
-        } {
+        }
+        {
             c'4
         }
         '''
@@ -462,11 +503,15 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___20():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score \with {
+        \new Score
+        \with
+        {
             \override NonMusicalPaperColumn.line-break-permission = ##f
             \override NonMusicalPaperColumn.page-break-permission = ##f
-        } <<
-            \new Staff {
+        }
+        <<
+            \new Staff
+            {
                 c'8
                 d'8
                 e'8
@@ -505,9 +550,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___22():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override NoteColumn.ignore-collision = ##t
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -642,9 +690,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___29():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice \with {
+        \new Voice
+        \with
+        {
             \override NoteHead.color = #red
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -667,7 +718,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___30():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \ottava #1
             \override Staff.OttavaBracket.staff-position = #4
             c'8
@@ -691,10 +743,13 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___31():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override RehearsalMark.Y-extent = #'(-1.5 . 1.5)
             \override RehearsalMark.staff-padding = #2
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -713,9 +768,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___32():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override Rest.transparent = ##t
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -752,10 +810,13 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___34():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override Script.Y-extent = #'(-1.5 . 1.5)
             \override Script.staff-padding = #2
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -778,7 +839,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___35():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \override Score.SpacingSpanner.strict-grace-spacing = ##t
             \override Score.SpacingSpanner.strict-note-spacing = ##t
             \override Score.SpacingSpanner.uniform-stretching = ##t
@@ -813,22 +875,23 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___36():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 \override Score.SpacingSpanner.strict-grace-spacing = ##t
                 \override Score.SpacingSpanner.strict-note-spacing = ##t
                 \override Score.SpacingSpanner.uniform-stretching = ##t
                 c'8 [
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 \revert Score.SpacingSpanner.strict-grace-spacing
                 \revert Score.SpacingSpanner.strict-note-spacing
                 \revert Score.SpacingSpanner.uniform-stretching
                 f'8 ]
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -847,11 +910,14 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___37():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score \with {
+        \new Score
+        \with
+        {
             \override SpacingSpanner.strict-grace-spacing = ##t
             \override SpacingSpanner.strict-note-spacing = ##t
             \override SpacingSpanner.uniform-stretching = ##t
-        } <<
+        }
+        <<
         >>
         '''
         )
@@ -874,18 +940,24 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___38():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score \with {
+        \new Score
+        \with
+        {
             \override SpanBar.color = #red
-        } <<
-            \new PianoStaff <<
-                \context Staff = "Treble Staff" {
+        }
+        <<
+            \new PianoStaff
+            <<
+                \context Staff = "Treble Staff"
+                {
                     \clef "treble"
                     c'8
                     d'8
                     e'8
                     f'8
                 }
-                \context Staff = "Bass Staff" {
+                \context Staff = "Bass Staff"
+                {
                     \clef "bass"
                     c'8
                     d'8
@@ -909,9 +981,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___39():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override StaffSymbol.color = #red
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -930,7 +1005,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___40():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             d'8
             \once \override Staff.StaffSymbol.color = #red
@@ -951,9 +1027,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___41():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override StaffSymbol.line-positions = #'(-4 -2 2 4)
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -989,10 +1068,13 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___43():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override StemTremolo.slope = #0.5
             \override StemTremolo.staff-padding = #2
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -1012,12 +1094,17 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___44():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score \with {
+        \new Score
+        \with
+        {
             \override SystemStartBar.collapse-height = #0
             \override SystemStartBar.color = #red
-        } <<
-            \new StaffGroup <<
-                \new Staff {
+        }
+        <<
+            \new StaffGroup
+            <<
+                \new Staff
+                {
                     c'8
                     c'8
                     c'8
@@ -1044,7 +1131,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___45():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \override TextScript.color = #red
             c'8
             d'8
@@ -1069,7 +1157,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___46():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \override TextSpanner.font-shape = #'italic
             c'8 \startTextSpan
             c'8
@@ -1107,9 +1196,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___48():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override TimeSignature.transparent = ##t
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -1128,7 +1220,7 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___49():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \override TimeSignature.transparent = ##t
             \time 4/8
             c'8
@@ -1136,7 +1228,7 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___49():
             e'8
             f'8
             \revert TimeSignature.transparent
-        } % measure
+        }   % measure
         '''
         )
 
@@ -1150,7 +1242,7 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___50():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \override Staff.TimeSignature.transparent = ##t
             \time 4/8
             c'8
@@ -1158,7 +1250,7 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___50():
             e'8
             f'8
             \revert Staff.TimeSignature.transparent
-        } % measure
+        }   % measure
         '''
         )
 
@@ -1173,10 +1265,13 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___51():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override TrillPitchAccidental.Y-extent = #'(-1.5 . 1.5)
             \override TrillPitchAccidental.staff-padding = #2
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -1197,7 +1292,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___52():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \override TrillSpanner.color = #red
             c'8
             \startTrillSpan
@@ -1221,9 +1317,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___53():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice \with {
+        \new Voice
+        \with
+        {
             \override TupletBracket.direction = #down
-        } {
+        }
+        {
             c'8 [
             d'8
             e'8
@@ -1246,7 +1345,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___54():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             \once \override TupletBracket.direction = #down
             d'8
@@ -1292,9 +1392,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___56():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice \with {
+        \new Voice
+        \with
+        {
             \override TupletNumber.fraction = ##t
-        } {
+        }
+        {
             c'8 [
             d'8
             e'8
@@ -1317,7 +1420,8 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___57():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             \once \override TupletNumber.fraction = ##t
             d'8
@@ -1341,9 +1445,12 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___58():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice \with {
+        \new Voice
+        \with
+        {
             \override TupletNumber.text = \markup { 6:4 }
-        } {
+        }
+        {
             c'8 [
             d'8
             e'8
@@ -1365,10 +1472,13 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___59():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override VerticalAlignment.Y-extent = #'(-1.5 . 1.5)
             \override VerticalAlignment.staff-padding = #2
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -1388,10 +1498,13 @@ def test_lilypondproxytools_LilyPondGrobNameManager___setattr___60():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override VerticalAxisGroup.Y-extent = #'(-1.5 . 1.5)
             \override VerticalAxisGroup.staff-padding = #2
-        } {
+        }
+        {
             c'8
             d'8
             e'8

--- a/abjad/tools/lilypondnametools/test/test_lilypondproxytools_LilyPondSettingNameManager___setattr__.py
+++ b/abjad/tools/lilypondnametools/test/test_lilypondproxytools_LilyPondSettingNameManager___setattr__.py
@@ -10,9 +10,12 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             autoBeaming = ##t
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -34,7 +37,8 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             d'8
             e'8
@@ -55,7 +59,8 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set Score.currentBarNumber = #12
             c'8
             d'8
@@ -79,17 +84,18 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \set Score.currentBarNumber = #12
                 \time 2/8
                 c'8
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -106,9 +112,12 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             fontSize = #-3
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -129,9 +138,12 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             instrumentName = #"Violini I"
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -152,14 +164,17 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___07():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             instrumentName = \markup {
                 \circle
                     {
                         V
                     }
                 }
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -181,10 +196,14 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___08():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score \with {
+        \new Score
+        \with
+        {
             proportionalNotationDuration = #(ly:make-moment 1 56)
-        } <<
-            \new Staff {
+        }
+        <<
+            \new Staff
+            {
                 c'8
                 d'8
                 e'8
@@ -206,9 +225,12 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             shortInstrumentName = #"Vni. I"
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -229,14 +251,17 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___10():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             shortInstrumentName = \markup {
                 \circle
                     {
                         V
                     }
                 }
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -257,9 +282,12 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___11():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             suggestAccidentals = ##t
-        } {
+        }
+        {
             c'8
             d'8
             e'8
@@ -280,7 +308,8 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___12():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             \set suggestAccidentals = ##t
             d'8
@@ -302,9 +331,12 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___13():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             tupletFullLength = ##t
-        } {
+        }
+        {
         }
         '''
         )
@@ -315,9 +347,12 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___13():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             tupletFullLength = ##f
-        } {
+        }
+        {
         }
         '''
         )
@@ -328,7 +363,8 @@ def test_lilypondproxytools_LilyPondSettingNameManager___setattr___13():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
         }
         '''
         )

--- a/abjad/tools/lilypondparsertools/ReducedLyParser.py
+++ b/abjad/tools/lilypondparsertools/ReducedLyParser.py
@@ -120,19 +120,19 @@ class ReducedLyParser(abctools.Parser):
 
             >>> abjad.f(container)
             {
-                { % measure
+                {   % measure
                     \time 4/4
                     c'4
                     c'4
                     c'4
                     c'4
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     c'8
                     c'8
                     c'8
-                } % measure
+                }   % measure
             }
 
     ..  container:: example

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__PianoStaff.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__PianoStaff.py
@@ -12,15 +12,18 @@ def test_lilypondparsertools_LilyPondParser__contexts__PianoStaff_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new PianoStaff <<
-            \new Staff {
+        \new PianoStaff
+        <<
+            \new Staff
+            {
                 c'8
                 d'8
                 e'8
                 f'8
                 g'8
             }
-            \new Staff {
+            \new Staff
+            {
                 c'8
                 d'8
                 e'8

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__Score.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__Score.py
@@ -7,7 +7,8 @@ def test_lilypondparsertools_LilyPondParser__contexts__Score_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Score <<
+        \new Score
+        <<
         >>
         '''
         )

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__Staff.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__Staff.py
@@ -7,7 +7,8 @@ def test_lilypondparsertools_LilyPondParser__contexts__Staff_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
         }
         '''
         )
@@ -27,8 +28,10 @@ def test_lilypondparsertools_LilyPondParser__contexts__Staff_02():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff <<
-            \new Voice {
+        \new Staff
+        <<
+            \new Voice
+            {
                 c'8
                 d'8
                 e'8
@@ -38,7 +41,8 @@ def test_lilypondparsertools_LilyPondParser__contexts__Staff_02():
                 b'8
                 c''8
             }
-            \new Voice {
+            \new Voice
+            {
                 c'8
                 d'8
                 e'8

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__StaffGroup.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__StaffGroup.py
@@ -7,7 +7,8 @@ def test_lilypondparsertools_LilyPondParser__contexts__StaffGroup_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new StaffGroup <<
+        \new StaffGroup
+        <<
         >>
         '''
         )

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__Voice.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__Voice.py
@@ -7,7 +7,8 @@ def test_lilypondparsertools_LilyPondParser__contexts__Voice_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
         }
         '''
         )

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__context_ids.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__contexts__context_ids.py
@@ -10,7 +10,8 @@ def test_lilypondparsertools_LilyPondParser__contexts__context_ids_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \context Staff = "foo" {
+        \context Staff = "foo"
+        {
             c'8
             d'8
             e'8

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__functions__transpose.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__functions__transpose.py
@@ -11,7 +11,8 @@ def test_lilypondparsertools_LilyPondParser__functions__transpose_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \key e \major
             e'4
             gs'4
@@ -37,7 +38,8 @@ def test_lilypondparsertools_LilyPondParser__functions__transpose_02():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \key ef \major
             ef'4
             f'4
@@ -63,7 +65,8 @@ def test_lilypondparsertools_LilyPondParser__functions__transpose_03():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 cs'4
                 ds'4

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__Articulation.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__Articulation.py
@@ -23,7 +23,8 @@ def test_lilypondparsertools_LilyPondParser__indicators__Articulation_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c''4 ^\marcato
             c''4 _\stopped
             c''4 -\tenuto

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__BarLine.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__BarLine.py
@@ -11,7 +11,8 @@ def test_lilypondparsertools_LilyPondParser__indicators__BarLine_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             e'4
             d'4
             c'2

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__Clef.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__Clef.py
@@ -9,7 +9,8 @@ def test_lilypondparsertools_LilyPondParser__indicators__Clef_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \clef "bass"
             c'1
         }

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__KeySignature.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__KeySignature.py
@@ -9,7 +9,8 @@ def test_lilypondparsertools_LilyPondParser__indicators__KeySignature_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \key g \major
             fs'1
         }

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__Markup.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__Markup.py
@@ -9,7 +9,8 @@ def test_lilypondparsertools_LilyPondParser__indicators__Markup_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'1 ^ \markup { hello! }
         }
         '''
@@ -32,7 +33,8 @@ def test_lilypondparsertools_LilyPondParser__indicators__Markup_02():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'4
                 _ \markup {
                     X
@@ -66,7 +68,8 @@ def test_lilypondparsertools_LilyPondParser__indicators__Markup_03():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'4 -\staccato ^ \markup { hello }
             d'4
         }

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__MetronomeMark.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__MetronomeMark.py
@@ -10,8 +10,10 @@ def test_lilypondparsertools_LilyPondParser__indicators__MetronomeMark_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \tempo "As fast as possible"
                 c'1
             }
@@ -37,8 +39,10 @@ def test_lilypondparsertools_LilyPondParser__indicators__MetronomeMark_02():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \tempo 4=60
                 c'1
             }
@@ -64,8 +68,10 @@ def test_lilypondparsertools_LilyPondParser__indicators__MetronomeMark_03():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \tempo 4=59-63
                 c'1
             }
@@ -95,8 +101,10 @@ def test_lilypondparsertools_LilyPondParser__indicators__MetronomeMark_04():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \tempo "Like a majestic swan, alive with youth and vigour!" 4=60
                 c'1
             }
@@ -126,8 +134,10 @@ def test_lilypondparsertools_LilyPondParser__indicators__MetronomeMark_05():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \tempo "Faster than a thousand suns" 16=34-55
                 c'1
             }

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__StemTremolo.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__StemTremolo.py
@@ -9,7 +9,8 @@ def test_lilypondparsertools_LilyPondParser__indicators__StemTremolo_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'1 :4
         }
         '''

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__TimeSignature.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__indicators__TimeSignature.py
@@ -9,8 +9,10 @@ def test_lilypondparsertools_LilyPondParser__indicators__TimeSignature_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \time 8/8
                 c'1
             }

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__misc__chord_repetition.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__misc__chord_repetition.py
@@ -50,7 +50,8 @@ def test_lilypondparsertools_LilyPondParser__misc__chord_repetition_02():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             <c' e' g'>8 \p
             <c' e' g'>8
             <c' e' g'>4 -\staccatissimo

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__misc__variables.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__misc__variables.py
@@ -22,7 +22,8 @@ def test_lilypondparsertools_LilyPondParser__misc__variables_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 {
                     {

--- a/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__spanners__Hairpin.py
+++ b/abjad/tools/lilypondparsertools/test/test_lilypondparsertools_LilyPondParser__spanners__Hairpin.py
@@ -15,7 +15,8 @@ def test_lilypondparsertools_LilyPondParser__spanners__Hairpin_01():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'4 \<
             c'4
             c'4 \! \>
@@ -75,7 +76,8 @@ def test_lilypondparsertools_LilyPondParser__spanners__Hairpin_03():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'4 \<
             c'4 \p \>
             c'4 \f
@@ -128,7 +130,8 @@ def test_lilypondparsertools_LilyPondParser__spanners__Hairpin_07():
 
     assert format(target) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'4 ^ \<
             c'4
             c'4 \! _ \>
@@ -150,7 +153,8 @@ def test_lilypondparsertools_LilyPondParser__spanners__Hairpin_08():
     result = parser(string)
     assert format(result) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'4 \p \< (
             d'4
             e'4

--- a/abjad/tools/markuptools/Markup.py
+++ b/abjad/tools/markuptools/Markup.py
@@ -62,7 +62,8 @@ class Markup(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'8
                     ^ \markup {
                         \italic
@@ -91,7 +92,8 @@ class Markup(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             c'4
                 ^ \markup {     %! RED:M1
                     \italic     %! RED:M1
@@ -112,7 +114,8 @@ class Markup(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             c'4
                 - \markup {
                     \column
@@ -148,7 +151,8 @@ class Markup(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             c'4
                 %@% ^ \markup {     %! RED:M1
                 %@%     \italic     %! RED:M1
@@ -173,7 +177,8 @@ class Markup(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             c'4
                 - \markup {
                     \column
@@ -206,7 +211,8 @@ class Markup(AbjadValueObject):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             c'4
                 ^ \markup {
                     \column
@@ -752,7 +758,8 @@ class Markup(AbjadValueObject):
             ..  doctest:
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     d'8
                         - \markup {
@@ -784,7 +791,8 @@ class Markup(AbjadValueObject):
             ..  doctest:
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     d'8
                         - \markup {
@@ -2682,7 +2690,8 @@ class Markup(AbjadValueObject):
             ..  docs::
             
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                         ^ \markup {
                             \with-dimensions-from

--- a/abjad/tools/markuptools/MarkupCommand.py
+++ b/abjad/tools/markuptools/MarkupCommand.py
@@ -73,11 +73,14 @@ class MarkupCommand(AbjadValueObject):
         >>> abjad.f(command)
         \score
             {
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \remove Clef_engraver
                     \remove Time_signature_engraver
                     fontSize = #-3
-                } {
+                }
+                {
                     fs'16
                     gs'16
                     as'16
@@ -97,16 +100,20 @@ class MarkupCommand(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4
                     ^ \markup {
                         \score
                             {
-                                \new Staff \with {
+                                \new Staff
+                                \with
+                                {
                                     \remove Clef_engraver
                                     \remove Time_signature_engraver
                                     fontSize = #-3
-                                } {
+                                }
+                                {
                                     fs'16
                                     gs'16
                                     as'16

--- a/abjad/tools/mathtools/integer_to_base_k_tuple.py
+++ b/abjad/tools/mathtools/integer_to_base_k_tuple.py
@@ -18,6 +18,13 @@ def integer_to_base_k_tuple(n, k):
         >>> abjad.mathtools.integer_to_base_k_tuple(1066, 2)
         (1, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0)
 
+    ..  container:: example
+
+        Gets base-26 digits of 1066:
+
+        >>> abjad.mathtools.integer_to_base_k_tuple(1066, 26)
+        (1, 15, 0)
+
     Returns tuple of positive integers.
     '''
     assert isinstance(n, int), repr(n)

--- a/abjad/tools/metertools/MeterManager.py
+++ b/abjad/tools/metertools/MeterManager.py
@@ -94,13 +94,14 @@ class MeterManager(abctools.AbjadObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
-                { % measure
+            \new Staff
+            {
+                {   % measure
                     \time 2/4
                     c'4
                     d'4 ~
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 4/4
                     d'8.
                     r16
@@ -112,20 +113,20 @@ class MeterManager(abctools.AbjadObject):
                         f'8 ~
                     }
                     f'4 ~
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     f'8
                     g'8 ~
                     g'4
                     a'4 ~
                     a'8
                     b'8 ~
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 2/4
                     b'4
                     c''4
-                } % measure
+                }   % measure
             }
 
         >>> for x in abjad.MeterManager.iterate_rewrite_inputs(

--- a/abjad/tools/metertools/MetricAccentKernel.py
+++ b/abjad/tools/metertools/MetricAccentKernel.py
@@ -121,14 +121,17 @@ class MetricAccentKernel(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff {
+                \new Score
+                <<
+                    \new Staff
+                    {
                         c'8
                         d'4.
                         e'8
                         f'4.
                     }
-                    \new Staff {
+                    \new Staff
+                    {
                         \clef "bass"
                         c4
                         b,4

--- a/abjad/tools/pitchtools/Accidental.py
+++ b/abjad/tools/pitchtools/Accidental.py
@@ -653,7 +653,8 @@ class Accidental(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     cs'8
                     d'8
@@ -668,7 +669,8 @@ class Accidental(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     df'8
                     d'8
@@ -702,7 +704,8 @@ class Accidental(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     cs'8
                     d'8
@@ -717,7 +720,8 @@ class Accidental(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     cs'8
                     d'8

--- a/abjad/tools/pitchtools/IntervalClassSet.py
+++ b/abjad/tools/pitchtools/IntervalClassSet.py
@@ -63,13 +63,16 @@ class IntervalClassSet(Set):
         ..  docs::
 
             >>> abjad.f(staff_group)
-            \new StaffGroup <<
-                \new Staff {
+            \new StaffGroup
+            <<
+                \new Staff
+                {
                     c'4
                     <d' fs' a'>4
                     b2
                 }
-                \new Staff {
+                \new Staff
+                {
                     c4.
                     r8
                     g2

--- a/abjad/tools/pitchtools/Inversion.py
+++ b/abjad/tools/pitchtools/Inversion.py
@@ -64,7 +64,8 @@ class Inversion(AbjadValueObject):
 
                 >>> lilypond_file = segment_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     a'8
                     g'8
                     f'8
@@ -88,7 +89,8 @@ class Inversion(AbjadValueObject):
 
                 >>> lilypond_file = segment_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     ef'8
                     cs'8
                     b'8

--- a/abjad/tools/pitchtools/Multiplication.py
+++ b/abjad/tools/pitchtools/Multiplication.py
@@ -62,7 +62,8 @@ class Multiplication(AbjadValueObject):
 
                 >>> lilypond_file = segment_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     ef'8
                     cs'8
                     b'8
@@ -86,7 +87,8 @@ class Multiplication(AbjadValueObject):
 
                 >>> lilypond_file = segment_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     ef'8
                     cs'8
                     b'8

--- a/abjad/tools/pitchtools/NamedPitch.py
+++ b/abjad/tools/pitchtools/NamedPitch.py
@@ -17,9 +17,12 @@ class NamedPitch(Pitch):
 
             >>> staff = pitch.__illustrate__()[abjad.Staff]
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TimeSignature.stencil = ##f
-            } {
+            }
+            {
                 \clef "treble"
                 cs''1 * 1/4
             }
@@ -33,9 +36,12 @@ class NamedPitch(Pitch):
 
             >>> staff = pitch.__illustrate__()[abjad.Staff]
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TimeSignature.stencil = ##f
-            } {
+            }
+            {
                 \clef "bass"
                 aqs1 * 1/4
             }
@@ -51,9 +57,12 @@ class NamedPitch(Pitch):
 
             >>> staff = pitch.__illustrate__()[abjad.Staff]
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TimeSignature.stencil = ##f
-            } {
+            }
+            {
                 \clef "treble"
                 cs''1 * 1/4
             }
@@ -67,9 +76,12 @@ class NamedPitch(Pitch):
 
             >>> staff = pitch.__illustrate__()[abjad.Staff]
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TimeSignature.stencil = ##f
-            } {
+            }
+            {
                 \clef "bass"
                 aqs1 * 1/4
             }
@@ -81,9 +93,12 @@ class NamedPitch(Pitch):
 
             >>> staff = pitch.__illustrate__()[abjad.Staff]
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TimeSignature.stencil = ##f
-            } {
+            }
+            {
                 \clef "bass"
                 aqs1 * 1/4
             }
@@ -99,9 +114,12 @@ class NamedPitch(Pitch):
 
             >>> staff = pitch.__illustrate__()[abjad.Staff]
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TimeSignature.stencil = ##f
-            } {
+            }
+            {
                 \once \override Accidental.stencil = #ly:text-interface::print
                 \once \override Accidental.text = \markup { \musicglyph #"accidentals.sharp.arrowup" }
                 \clef "treble"
@@ -866,9 +884,12 @@ class NamedPitch(Pitch):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #5
-                } {
+                }
+                {
                     g16 - \markup { -3 }
                     a16 - \markup { -2 }
                     b16 - \markup { -1 }
@@ -906,9 +927,12 @@ class NamedPitch(Pitch):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #5
-                } {
+                }
+                {
                     g16 - \markup { -9 }
                     a16 - \markup { -8 }
                     b16 - \markup { -7 }
@@ -947,9 +971,12 @@ class NamedPitch(Pitch):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #5
-                } {
+                }
+                {
                     \clef "bass"
                     g,16 - \markup { -4 }
                     a,16 - \markup { -3 }

--- a/abjad/tools/pitchtools/NumberedPitch.py
+++ b/abjad/tools/pitchtools/NumberedPitch.py
@@ -16,9 +16,12 @@ class NumberedPitch(Pitch):
         ..  docs::
 
             >>> abjad.f(numbered_pitch.__illustrate__()[abjad.Staff])
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TimeSignature.stencil = ##f
-            } {
+            }
+            {
                 \clef "treble"
                 cs''1 * 1/4
             }
@@ -33,9 +36,12 @@ class NumberedPitch(Pitch):
         ..  docs::
 
             >>> abjad.f(numbered_pitch.__illustrate__()[abjad.Staff])
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TimeSignature.stencil = ##f
-            } {
+            }
+            {
                 \clef "treble"
                 cs''1 * 1/4
             }
@@ -50,9 +56,12 @@ class NumberedPitch(Pitch):
         ..  docs::
 
             >>> abjad.f(numbered_pitch.__illustrate__()[abjad.Staff])
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TimeSignature.stencil = ##f
-            } {
+            }
+            {
                 \clef "treble"
                 cs''1 * 1/4
             }

--- a/abjad/tools/pitchtools/PitchClassSegment.py
+++ b/abjad/tools/pitchtools/PitchClassSegment.py
@@ -22,7 +22,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     bqf'8
                     fs'8
@@ -45,7 +46,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     bqf'8
                     fs'8
@@ -73,7 +75,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     ef'8
                     bqs'8
@@ -96,7 +99,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     ef'8
                     bqs'8
@@ -165,7 +169,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                         bqf'8
                         fs'8
@@ -204,7 +209,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                             ^ \markup {
                                 \line
@@ -245,7 +251,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8
                         ef'8
                         bqs'8
@@ -284,7 +291,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8
                             ^ \markup {
                                 \line
@@ -326,7 +334,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                         bqf'8
                         fs'8
@@ -372,7 +381,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                             ^ \markup {
                                 \line
@@ -427,7 +437,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                         bf'8
                         bqf'8
@@ -468,7 +479,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                             ^ \markup {
                                 \line
@@ -522,7 +534,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         ef'8
                         c'8
                         d'8
@@ -564,7 +577,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         ef'8
                             ^ \markup {
                                 \concat
@@ -639,7 +653,8 @@ class PitchClassSegment(Segment):
                 ...     figure_name=markup,
                 ...     )
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     g'8
                         ^ \markup {
                             \line
@@ -704,7 +719,8 @@ class PitchClassSegment(Segment):
                 ...     figure_name=markup,
                 ...     )
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     af'8
                         ^ \markup {
                             \concat
@@ -800,7 +816,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = J.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     bqf'8
                     fs'8
@@ -838,7 +855,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = K.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     ef'8
                     bqs'8
@@ -960,7 +978,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                         bqf'8
                         fs'8
@@ -991,7 +1010,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                             ^ \markup {
                                 \concat
@@ -1025,7 +1045,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                         fs'8
                         bqf'8
@@ -1057,7 +1078,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                             ^ \markup {
                                 \concat
@@ -1095,7 +1117,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                         bqf'8
                         g'8
@@ -1127,7 +1150,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                             ^ \markup {
                                 \concat
@@ -1185,7 +1209,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     bqf'8
                     fs'8
@@ -1211,7 +1236,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     ef'8
                     bqs'8
@@ -1667,7 +1693,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         d'8
                         dqf'8
                         fs'8
@@ -1700,7 +1727,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         d'8
                             ^ \markup {
                                 \concat
@@ -1735,7 +1763,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                         bqf'8
                         fs'8
@@ -1772,7 +1801,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                             ^ \markup {
                                 \concat
@@ -1830,7 +1860,8 @@ class PitchClassSegment(Segment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     d'8
                     eqs'8
                     fs'8
@@ -1852,7 +1883,8 @@ class PitchClassSegment(Segment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \time 5/4
                     d'4 ~
                     d'16
@@ -1924,7 +1956,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                         bqf'8
                         fs'8
@@ -1957,7 +1990,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                             ^ \markup {
                                 \concat
@@ -1994,7 +2028,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         d'8
                         eqs'8
                         fs'8
@@ -2027,7 +2062,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         d'8
                             ^ \markup {
                                 \concat
@@ -2064,7 +2100,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                         dqf'8
                         fs'8
@@ -2097,7 +2134,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                             ^ \markup {
                                 \concat
@@ -2134,7 +2172,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         d'8
                         gqs'8
                         fs'8
@@ -2167,7 +2206,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         d'8
                             ^ \markup {
                                 \concat
@@ -2219,7 +2259,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     b'8
                     fs'8
@@ -2240,7 +2281,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     e'8
                     b'8
                     f'8
@@ -2274,7 +2316,8 @@ class PitchClassSegment(Segment):
                 ...     figure_name=markup,
                 ...     )
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     e'8
                         ^ \markup {
                             \concat
@@ -2334,7 +2377,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                         bqf'8
                         g'8
@@ -2367,7 +2411,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                             ^ \markup {
                                 \concat
@@ -2402,7 +2447,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                         bqf'8
                         fs'8
@@ -2439,7 +2485,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                             ^ \markup {
                                 \concat
@@ -2512,7 +2559,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                         bf'8
                         bqf'8
@@ -2545,7 +2593,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                             ^ \markup {
                                 \concat
@@ -2582,7 +2631,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bqf'8
                         fs'8
                         g'8
@@ -2615,7 +2665,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bqf'8
                             ^ \markup {
                                 \concat
@@ -2652,7 +2703,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                         bqf'8
                         fs'8
@@ -2688,7 +2740,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                             ^ \markup {
                                 \concat
@@ -2729,7 +2782,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8
                         ef'8
                         eqf'8
@@ -2762,7 +2816,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8
                             ^ \markup {
                                 \concat
@@ -2820,7 +2875,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     bqf'8
                     fs'8
@@ -2841,7 +2897,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     bqf'8
                     fs'8
@@ -2870,7 +2927,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     bqf'8
                     fs'8
@@ -2891,7 +2949,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     bqf'8
                     fs'8
@@ -2925,7 +2984,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     bqf'8
                     fs'8
@@ -2946,8 +3006,10 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         bf'1 * 1/8
                         bqf'1 * 1/8
@@ -2956,7 +3018,8 @@ class PitchClassSegment(Segment):
                         bqf'1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         r1 * 1/8
                         r1 * 1/8
@@ -2985,7 +3048,8 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     bqf'8
                     fs'8
@@ -3006,8 +3070,10 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         bf'1 * 1/8
                         bqf'1 * 1/8
@@ -3016,7 +3082,8 @@ class PitchClassSegment(Segment):
                         bqf'1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         r1 * 1/8
                         r1 * 1/8
@@ -3069,7 +3136,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         b'8
                         bqs'8
                         g'8
@@ -3102,7 +3170,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         b'8
                             ^ \markup {
                                 \concat
@@ -3139,7 +3208,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         a'8
                         aqs'8
                         f'8
@@ -3172,7 +3242,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         a'8
                             ^ \markup {
                                 \concat
@@ -3209,7 +3280,8 @@ class PitchClassSegment(Segment):
 
                     >>> lilypond_file = segment.__illustrate__()
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                         bqf'8
                         fs'8
@@ -3245,7 +3317,8 @@ class PitchClassSegment(Segment):
                     ...     figure_name=markup,
                     ...     )
                     >>> abjad.f(lilypond_file[abjad.Voice])
-                    \new Voice {
+                    \new Voice
+                    {
                         bf'8
                             ^ \markup {
                                 \concat
@@ -3303,15 +3376,20 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = voiced_segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Score])
-                \new Score \with {
+                \new Score
+                \with
+                {
                     \override BarLine.stencil = ##f
                     \override BarNumber.transparent = ##t
                     \override Rest.transparent = ##t
                     \override SpanBar.stencil = ##f
                     \override TimeSignature.stencil = ##f
-                } <<
-                    \new PianoStaff <<
-                        \context Staff = "Treble Staff" {
+                }
+                <<
+                    \new PianoStaff
+                    <<
+                        \context Staff = "Treble Staff"
+                        {
                             \clef "treble"
                             c'1 * 1/8
                             b1 * 1/8
@@ -3324,7 +3402,8 @@ class PitchClassSegment(Segment):
                             r1 * 1/8
                             c'1 * 1/8
                         }
-                        \context Staff = "Bass Staff" {
+                        \context Staff = "Bass Staff"
+                        {
                             \clef "bass"
                             r1 * 1/8
                             r1 * 1/8
@@ -3398,15 +3477,20 @@ class PitchClassSegment(Segment):
 
                 >>> lilypond_file = voiced_segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Score])
-                \new Score \with {
+                \new Score
+                \with
+                {
                     \override BarLine.stencil = ##f
                     \override BarNumber.transparent = ##t
                     \override Rest.transparent = ##t
                     \override SpanBar.stencil = ##f
                     \override TimeSignature.stencil = ##f
-                } <<
-                    \new PianoStaff <<
-                        \context Staff = "Treble Staff" {
+                }
+                <<
+                    \new PianoStaff
+                    <<
+                        \context Staff = "Treble Staff"
+                        {
                             \clef "treble"
                             c'1 * 1/8
                             ef'1 * 1/8
@@ -3416,7 +3500,8 @@ class PitchClassSegment(Segment):
                             f''1 * 1/8
                             af''1 * 1/8
                         }
-                        \context Staff = "Bass Staff" {
+                        \context Staff = "Bass Staff"
+                        {
                             \clef "bass"
                             r1 * 1/8
                             r1 * 1/8

--- a/abjad/tools/pitchtools/PitchClassSet.py
+++ b/abjad/tools/pitchtools/PitchClassSet.py
@@ -86,7 +86,8 @@ class PitchClassSet(Set):
 
                 >>> lilypond_file = setting.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     <fs' g' bf' bqf'>1
                 }
 
@@ -105,7 +106,8 @@ class PitchClassSet(Set):
 
                 >>> lilypond_file = setting.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     <c' d' ef' bqs'>1
                 }
 

--- a/abjad/tools/pitchtools/PitchRange.py
+++ b/abjad/tools/pitchtools/PitchRange.py
@@ -360,19 +360,25 @@ class PitchRange(AbjadValueObject):
 
                 >>> lilypond_file = pitch_range.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Score])
-                \new Score \with {
+                \new Score
+                \with
+                {
                     \override BarLine.stencil = ##f
                     \override Glissando.thickness = #2
                     \override SpanBar.stencil = ##f
                     \override TimeSignature.stencil = ##f
-                } <<
-                    \new PianoStaff <<
-                        \context Staff = "Treble Staff" {
+                }
+                <<
+                    \new PianoStaff
+                    <<
+                        \context Staff = "Treble Staff"
+                        {
                             \clef "treble"
                             s1 * 1/4
                             s1 * 1/4
                         }
-                        \context Staff = "Bass Staff" {
+                        \context Staff = "Bass Staff"
+                        {
                             \clef "bass"
                             c1 * 1/4 \glissando
                             \change Staff = "Treble Staff"

--- a/abjad/tools/pitchtools/PitchSegment.py
+++ b/abjad/tools/pitchtools/PitchSegment.py
@@ -19,8 +19,10 @@ class PitchSegment(Segment):
 
             >>> lilypond_file = segment.__illustrate__()
             >>> abjad.f(lilypond_file[abjad.StaffGroup])
-            \new PianoStaff <<
-                \context Staff = "Treble Staff" {
+            \new PianoStaff
+            <<
+                \context Staff = "Treble Staff"
+                {
                     \clef "treble"
                     r1 * 1/8
                     r1 * 1/8
@@ -29,7 +31,8 @@ class PitchSegment(Segment):
                     r1 * 1/8
                     g'1 * 1/8
                 }
-                \context Staff = "Bass Staff" {
+                \context Staff = "Bass Staff"
+                {
                     \clef "bass"
                     bf1 * 1/8
                     bqf1 * 1/8
@@ -55,8 +58,10 @@ class PitchSegment(Segment):
 
             >>> lilypond_file = segment.__illustrate__()
             >>> abjad.f(lilypond_file[abjad.StaffGroup])
-            \new PianoStaff <<
-                \context Staff = "Treble Staff" {
+            \new PianoStaff
+            <<
+                \context Staff = "Treble Staff"
+                {
                     \clef "treble"
                     r1 * 1/8
                     r1 * 1/8
@@ -65,7 +70,8 @@ class PitchSegment(Segment):
                     r1 * 1/8
                     g'1 * 1/8
                 }
-                \context Staff = "Bass Staff" {
+                \context Staff = "Bass Staff"
+                {
                     \clef "bass"
                     bf,1 * 1/8
                     aqs1 * 1/8
@@ -148,8 +154,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -158,7 +166,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf,1 * 1/8
                         aqs1 * 1/8
@@ -287,8 +296,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -297,7 +308,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf1 * 1/8
                         bqf1 * 1/8
@@ -329,8 +341,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -339,7 +353,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf1 * 1/8
                         bqf1 * 1/8
@@ -377,8 +392,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -387,7 +404,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf1 * 1/8
                         bqf1 * 1/8
@@ -437,8 +455,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         c'1 * 1/8
                         d'1 * 1/8
@@ -448,7 +468,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         r1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         r1 * 1/8
                         r1 * 1/8
@@ -514,8 +535,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -524,7 +547,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf1 * 1/8
                         bqf1 * 1/8
@@ -546,8 +570,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         d'1 * 1/8
                         dqf'1 * 1/8
@@ -556,7 +582,8 @@ class PitchSegment(Segment):
                         dqf'1 * 1/8
                         r1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         r1 * 1/8
                         r1 * 1/8
@@ -593,7 +620,8 @@ class PitchSegment(Segment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     bf8
                     bqf8
                     fs'8
@@ -615,7 +643,8 @@ class PitchSegment(Segment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \time 5/4
                     bf4 ~
                     bf16
@@ -654,8 +683,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -664,7 +695,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf1 * 1/8
                         bqf1 * 1/8
@@ -686,8 +718,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -696,7 +730,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         a''1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         fs1 * 1/8
                         gqs1 * 1/8
@@ -726,8 +761,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -736,7 +773,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf1 * 1/8
                         bqf1 * 1/8
@@ -758,8 +796,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         g'1 * 1/8
                         r1 * 1/8
@@ -768,7 +808,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         r1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         r1 * 1/8
                         bqf1 * 1/8
@@ -797,8 +838,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -807,7 +850,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf1 * 1/8
                         bqf1 * 1/8
@@ -829,8 +873,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         g'1 * 1/8
                         r1 * 1/8
@@ -839,7 +885,8 @@ class PitchSegment(Segment):
                         g'1 * 1/8
                         r1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         r1 * 1/8
                         bf1 * 1/8
@@ -876,8 +923,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -886,7 +935,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf1 * 1/8
                         bqf1 * 1/8
@@ -908,7 +958,8 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     bqf'8
                     fs'8
@@ -931,8 +982,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -941,7 +994,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf,1 * 1/8
                         aqs1 * 1/8
@@ -963,7 +1017,8 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     aqs'8
                     fs'8
@@ -996,8 +1051,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -1006,7 +1063,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf1 * 1/8
                         bqf1 * 1/8
@@ -1028,8 +1086,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -1038,7 +1098,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf1 * 1/8
                         bqf1 * 1/8
@@ -1061,8 +1122,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -1071,7 +1134,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf,1 * 1/8
                         aqs1 * 1/8
@@ -1093,8 +1157,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -1103,7 +1169,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf,1 * 1/8
                         aqs1 * 1/8
@@ -1132,8 +1199,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         r1 * 1/8
                         r1 * 1/8
@@ -1142,7 +1211,8 @@ class PitchSegment(Segment):
                         r1 * 1/8
                         g'1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         bf1 * 1/8
                         bqf1 * 1/8
@@ -1164,8 +1234,10 @@ class PitchSegment(Segment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.StaffGroup])
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                         \clef "treble"
                         a'1 * 1/8
                         aqs'1 * 1/8
@@ -1174,7 +1246,8 @@ class PitchSegment(Segment):
                         aqs'1 * 1/8
                         fs''1 * 1/8
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                         \clef "bass"
                         r1 * 1/8
                         r1 * 1/8

--- a/abjad/tools/pitchtools/PitchSet.py
+++ b/abjad/tools/pitchtools/PitchSet.py
@@ -117,15 +117,21 @@ class PitchSet(Set):
 
                 >>> lilypond_file = set_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Score])
-                \new Score <<
-                    \new PianoStaff <<
-                        \new Staff {
-                            \new Voice {
+                \new Score
+                <<
+                    \new PianoStaff
+                    <<
+                        \new Staff
+                        {
+                            \new Voice
+                            {
                                 <fs' g'>1
                             }
                         }
-                        \new Staff {
-                            \new Voice {
+                        \new Staff
+                        {
+                            \new Voice
+                            {
                                 <bf bqf>1
                             }
                         }
@@ -147,15 +153,21 @@ class PitchSet(Set):
 
                 >>> lilypond_file = set_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Score])
-                \new Score <<
-                    \new PianoStaff <<
-                        \new Staff {
-                            \new Voice {
+                \new Score
+                <<
+                    \new PianoStaff
+                    <<
+                        \new Staff
+                        {
+                            \new Voice
+                            {
                                 <fs' g'>1
                             }
                         }
-                        \new Staff {
-                            \new Voice {
+                        \new Staff
+                        {
+                            \new Voice
+                            {
                                 s1
                             }
                         }

--- a/abjad/tools/pitchtools/Retrograde.py
+++ b/abjad/tools/pitchtools/Retrograde.py
@@ -59,7 +59,8 @@ class Retrograde(AbjadValueObject):
 
                 >>> lilypond_file = segment_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     af'8
                     g'8
                     f'8
@@ -83,7 +84,8 @@ class Retrograde(AbjadValueObject):
 
                 >>> lilypond_file = segment_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     af'8
                     g'8
                     f'8

--- a/abjad/tools/pitchtools/Rotation.py
+++ b/abjad/tools/pitchtools/Rotation.py
@@ -69,7 +69,8 @@ class Rotation(AbjadValueObject):
 
                 >>> lilypond_file = segment_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     f'8
                     g'8
                     af'8
@@ -93,7 +94,8 @@ class Rotation(AbjadValueObject):
 
                 >>> lilypond_file = segment_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     f'8
                     g'8
                     af'8

--- a/abjad/tools/pitchtools/Transposition.py
+++ b/abjad/tools/pitchtools/Transposition.py
@@ -62,7 +62,8 @@ class Transposition(AbjadValueObject):
 
                 >>> lilypond_file = segment_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     e'8
                     fs'8
                     af'8
@@ -86,7 +87,8 @@ class Transposition(AbjadValueObject):
 
                 >>> lilypond_file = segment_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     e'8
                     fs'8
                     af'8

--- a/abjad/tools/pitchtools/TwelveToneRow.py
+++ b/abjad/tools/pitchtools/TwelveToneRow.py
@@ -86,7 +86,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = segment_.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     af'8
                     c'8
                     f'8
@@ -109,7 +110,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = row_2.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     cs'8
                     d'8
@@ -133,7 +135,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = row_3.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     cs'8
                     b'8
                     a'8
@@ -162,7 +165,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = row_2.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     b'8
                     bf'8
                     a'8
@@ -186,7 +190,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = row_3.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     af'8
                     d'8
@@ -215,7 +220,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = row_2.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     bf'8
                     c'8
                     d'8
@@ -239,7 +245,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = row_3.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     af'8
                     cs'8
                     a'8
@@ -290,7 +297,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = row[:6].__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     cs'8
                     b'8
                     a'8
@@ -311,7 +319,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = row[-6:].__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     f'8
                     e'8
                     bf'8
@@ -354,7 +363,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = row.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     cs'8
                     d'8
@@ -384,7 +394,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = row.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     cs'8
                     b'8
                     a'8
@@ -429,7 +440,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     cs'8
                     d'8
@@ -474,7 +486,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     cs'8
                     b'8
                     a'8
@@ -531,7 +544,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     cs'8
                     d'8
@@ -575,7 +589,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = segment.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     cs'8
                     b'8
                     a'8
@@ -880,7 +895,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = inversion.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     cs'8
                     ef'8
                     f'8
@@ -914,7 +930,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = inversion.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     cs'8
                     ef'8
                     f'8
@@ -944,7 +961,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = inversion.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     b'8
                     cs'8
                     ef'8
@@ -972,7 +990,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = inversion.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     a'8
                     b'8
                     cs'8
@@ -1024,7 +1043,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = multiplication.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     f'8
                     g'8
                     a'8
@@ -1052,7 +1072,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = multiplication.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     g'8
                     f'8
                     ef'8
@@ -1080,7 +1101,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = multiplication.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     cs'8
                     b'8
                     a'8
@@ -1130,7 +1152,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = retrograde.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     af'8
                     d'8
@@ -1158,7 +1181,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = retrograde.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     cs'8
                     b'8
                     a'8
@@ -1211,7 +1235,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = rotation.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     cs'8
                     b'8
@@ -1239,7 +1264,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = rotation.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     b'8
                     a'8
                     ef'8
@@ -1267,7 +1293,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = rotation.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     cs'8
                     b'8
                     a'8
@@ -1298,7 +1325,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = rotation.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     bf'8
                     e'8
@@ -1348,7 +1376,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = transposition.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     d'8
                     c'8
                     bf'8
@@ -1376,7 +1405,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = transposition.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     bf'8
                     af'8
@@ -1404,7 +1434,8 @@ class TwelveToneRow(PitchClassSegment):
 
                 >>> lilypond_file = transposition.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Voice])
-                \new Voice {
+                \new Voice
+                {
                     cs'8
                     b'8
                     a'8

--- a/abjad/tools/quantizationtools/Quantizer.py
+++ b/abjad/tools/quantizationtools/Quantizer.py
@@ -29,23 +29,26 @@ class Quantizer(AbjadObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
-                    \new Voice {
-                        { % measure
+            \new Score
+            <<
+                \new Staff
+                {
+                    \new Voice
+                    {
+                        {   % measure
                             \time 4/4
                             \tempo 4=60
                             c'4
                             cs'4
                             d'4
                             ef'4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             e'4
                             f'4
                             fs'4
                             g'4
-                        } % measure
+                        }   % measure
                     }
                 }
             >>
@@ -76,10 +79,13 @@ class Quantizer(AbjadObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
-                    \new Voice {
-                        { % measure
+            \new Score
+            <<
+                \new Staff
+                {
+                    \new Voice
+                    {
+                        {   % measure
                             \time 2/4
                             \tempo 4=78
                             c'4 ~
@@ -87,8 +93,8 @@ class Quantizer(AbjadObject):
                                 c'16.
                                 cs'8.. ~
                             }
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 5/4
                             \times 4/7 {
                                 \tempo 8=57
@@ -125,7 +131,7 @@ class Quantizer(AbjadObject):
                                 r16
                             }
                             r4
-                        } % measure
+                        }   % measure
                     }
                 }
             >>
@@ -155,9 +161,12 @@ class Quantizer(AbjadObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
-                    \new Voice {
+            \new Score
+            <<
+                \new Staff
+                {
+                    \new Voice
+                    {
                         \tempo 4=60
                         c'4
                         cs'4

--- a/abjad/tools/quantizationtools/test/test_quantizationtools_Quantizer___call__.py
+++ b/abjad/tools/quantizationtools/test/test_quantizationtools_Quantizer___call__.py
@@ -12,16 +12,19 @@ def test_quantizationtools_Quantizer___call___01():
     score = abjad.Score([staff])
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new RhythmicStaff {
-                \new Voice {
-                    { % measure
+        \new Score
+        <<
+            \new RhythmicStaff
+            {
+                \new Voice
+                {
+                    {   % measure
                         \time 4/4
                         \tempo 4=60
                         c'4.
                         c'4.
                         r4
-                    } % measure
+                    }   % measure
                 }
             }
         >>
@@ -43,10 +46,13 @@ def test_quantizationtools_Quantizer___call___02():
     score = abjad.Score([staff])
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new RhythmicStaff {
-                \new Voice {
-                    { % measure
+        \new Score
+        <<
+            \new RhythmicStaff
+            {
+                \new Voice
+                {
+                    {   % measure
                         \time 4/4
                         \tempo 4=60
                         c'8.
@@ -54,7 +60,7 @@ def test_quantizationtools_Quantizer___call___02():
                         c'8
                         r8
                         r2
-                    } % measure
+                    }   % measure
                 }
             }
         >>
@@ -78,10 +84,13 @@ def test_quantizationtools_Quantizer___call___03():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
-                \new Voice {
-                    { % measure
+        \new Score
+        <<
+            \new Staff
+            {
+                \new Voice
+                {
+                    {   % measure
                         \time 4/4
                         \tempo 4=60
                         c'4 ~
@@ -91,8 +100,8 @@ def test_quantizationtools_Quantizer___call___03():
                         c'8 ~
                         c'8
                         c'8 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8
                         r8
                         r8
@@ -101,7 +110,7 @@ def test_quantizationtools_Quantizer___call___03():
                         r8
                         r8
                         c'8
-                    } % measure
+                    }   % measure
                 }
             }
         >>
@@ -122,10 +131,13 @@ def test_quantizationtools_Quantizer___call___04():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new RhythmicStaff {
-                \new Voice {
-                    { % measure
+        \new Score
+        <<
+            \new RhythmicStaff
+            {
+                \new Voice
+                {
+                    {   % measure
                         \time 4/4
                         \tempo 4=60
                         c'16
@@ -140,7 +152,7 @@ def test_quantizationtools_Quantizer___call___04():
                         c'16
                         c'16 ~
                         c'8
-                    } % measure
+                    }   % measure
                 }
             }
         >>
@@ -172,9 +184,12 @@ def test_quantizationtools_Quantizer___call___05():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new RhythmicStaff {
-                \new Voice {
+        \new Score
+        <<
+            \new RhythmicStaff
+            {
+                \new Voice
+                {
                     \grace {
                         c'16
                     }

--- a/abjad/tools/rhythmmakertools/AccelerandoRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/AccelerandoRhythmMaker.py
@@ -36,19 +36,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 5/8
                     \override TupletNumber.text = \markup {
                         \scale
                             #'(0.75 . 0.75)
                             \score
                                 {
-                                    \new Score \with {
+                                    \new Score
+                                    \with
+                                    {
                                         \override SpacingSpanner.spacing-increment = #0.5
                                         proportionalNotationDuration = ##f
-                                    } <<
-                                        \new RhythmicStaff \with {
+                                    }
+                                    <<
+                                        \new RhythmicStaff
+                                        \with
+                                        {
                                             \remove Time_signature_engraver
                                             \remove Staff_symbol_engraver
                                             \override Stem.direction = #up
@@ -59,7 +65,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                             \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                             \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                             tupletFullLength = ##t
-                                        } {
+                                        }
+                                        {
                                             c'2 ~
                                             c'8
                                         }
@@ -82,19 +89,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                         c'16 * 25/32 ]
                     }
                     \revert TupletNumber.text
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     \override TupletNumber.text = \markup {
                         \scale
                             #'(0.75 . 0.75)
                             \score
                                 {
-                                    \new Score \with {
+                                    \new Score
+                                    \with
+                                    {
                                         \override SpacingSpanner.spacing-increment = #0.5
                                         proportionalNotationDuration = ##f
-                                    } <<
-                                        \new RhythmicStaff \with {
+                                    }
+                                    <<
+                                        \new RhythmicStaff
+                                        \with
+                                        {
                                             \remove Time_signature_engraver
                                             \remove Staff_symbol_engraver
                                             \override Stem.direction = #up
@@ -105,7 +117,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                             \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                             \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                             tupletFullLength = ##t
-                                        } {
+                                        }
+                                        {
                                             c'4.
                                         }
                                     >>
@@ -124,19 +137,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                         c'16 * 47/64 ]
                     }
                     \revert TupletNumber.text
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 5/8
                     \override TupletNumber.text = \markup {
                         \scale
                             #'(0.75 . 0.75)
                             \score
                                 {
-                                    \new Score \with {
+                                    \new Score
+                                    \with
+                                    {
                                         \override SpacingSpanner.spacing-increment = #0.5
                                         proportionalNotationDuration = ##f
-                                    } <<
-                                        \new RhythmicStaff \with {
+                                    }
+                                    <<
+                                        \new RhythmicStaff
+                                        \with
+                                        {
                                             \remove Time_signature_engraver
                                             \remove Staff_symbol_engraver
                                             \override Stem.direction = #up
@@ -147,7 +165,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                             \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                             \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                             tupletFullLength = ##t
-                                        } {
+                                        }
+                                        {
                                             c'2 ~
                                             c'8
                                         }
@@ -170,19 +189,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                         c'16 * 25/32 ]
                     }
                     \revert TupletNumber.text
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     \override TupletNumber.text = \markup {
                         \scale
                             #'(0.75 . 0.75)
                             \score
                                 {
-                                    \new Score \with {
+                                    \new Score
+                                    \with
+                                    {
                                         \override SpacingSpanner.spacing-increment = #0.5
                                         proportionalNotationDuration = ##f
-                                    } <<
-                                        \new RhythmicStaff \with {
+                                    }
+                                    <<
+                                        \new RhythmicStaff
+                                        \with
+                                        {
                                             \remove Time_signature_engraver
                                             \remove Staff_symbol_engraver
                                             \override Stem.direction = #up
@@ -193,7 +217,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                             \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                             \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                             tupletFullLength = ##t
-                                        } {
+                                        }
+                                        {
                                             c'4.
                                         }
                                     >>
@@ -212,7 +237,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                         c'16 * 47/64 ]
                     }
                     \revert TupletNumber.text
-                } % measure
+                }   % measure
             }
 
     ..  container:: example
@@ -244,19 +269,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 5/8
                     \override TupletNumber.text = \markup {
                         \scale
                             #'(0.75 . 0.75)
                             \score
                                 {
-                                    \new Score \with {
+                                    \new Score
+                                    \with
+                                    {
                                         \override SpacingSpanner.spacing-increment = #0.5
                                         proportionalNotationDuration = ##f
-                                    } <<
-                                        \new RhythmicStaff \with {
+                                    }
+                                    <<
+                                        \new RhythmicStaff
+                                        \with
+                                        {
                                             \remove Time_signature_engraver
                                             \remove Staff_symbol_engraver
                                             \override Stem.direction = #up
@@ -267,7 +298,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                             \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                             \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                             tupletFullLength = ##t
-                                        } {
+                                        }
+                                        {
                                             c'2 ~
                                             c'8
                                         }
@@ -291,19 +323,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                         c'16 * 113/64 ]
                     }
                     \revert TupletNumber.text
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     \override TupletNumber.text = \markup {
                         \scale
                             #'(0.75 . 0.75)
                             \score
                                 {
-                                    \new Score \with {
+                                    \new Score
+                                    \with
+                                    {
                                         \override SpacingSpanner.spacing-increment = #0.5
                                         proportionalNotationDuration = ##f
-                                    } <<
-                                        \new RhythmicStaff \with {
+                                    }
+                                    <<
+                                        \new RhythmicStaff
+                                        \with
+                                        {
                                             \remove Time_signature_engraver
                                             \remove Staff_symbol_engraver
                                             \override Stem.direction = #up
@@ -314,7 +351,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                             \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                             \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                             tupletFullLength = ##t
-                                        } {
+                                        }
+                                        {
                                             c'4.
                                         }
                                     >>
@@ -334,19 +372,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                         c'16 * 25/16 ]
                     }
                     \revert TupletNumber.text
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 5/8
                     \override TupletNumber.text = \markup {
                         \scale
                             #'(0.75 . 0.75)
                             \score
                                 {
-                                    \new Score \with {
+                                    \new Score
+                                    \with
+                                    {
                                         \override SpacingSpanner.spacing-increment = #0.5
                                         proportionalNotationDuration = ##f
-                                    } <<
-                                        \new RhythmicStaff \with {
+                                    }
+                                    <<
+                                        \new RhythmicStaff
+                                        \with
+                                        {
                                             \remove Time_signature_engraver
                                             \remove Staff_symbol_engraver
                                             \override Stem.direction = #up
@@ -357,7 +400,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                             \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                             \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                             tupletFullLength = ##t
-                                        } {
+                                        }
+                                        {
                                             c'2 ~
                                             c'8
                                         }
@@ -381,19 +425,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                         c'16 * 113/64 ]
                     }
                     \revert TupletNumber.text
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     \override TupletNumber.text = \markup {
                         \scale
                             #'(0.75 . 0.75)
                             \score
                                 {
-                                    \new Score \with {
+                                    \new Score
+                                    \with
+                                    {
                                         \override SpacingSpanner.spacing-increment = #0.5
                                         proportionalNotationDuration = ##f
-                                    } <<
-                                        \new RhythmicStaff \with {
+                                    }
+                                    <<
+                                        \new RhythmicStaff
+                                        \with
+                                        {
                                             \remove Time_signature_engraver
                                             \remove Staff_symbol_engraver
                                             \override Stem.direction = #up
@@ -404,7 +453,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                             \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                             \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                             tupletFullLength = ##t
-                                        } {
+                                        }
+                                        {
                                             c'4.
                                         }
                                     >>
@@ -424,7 +474,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                         c'16 * 25/16 ]
                     }
                     \revert TupletNumber.text
-                } % measure
+                }   % measure
             }
 
     Set `written_duration` to `1/16` or less for multiple beams.
@@ -847,19 +897,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -870,7 +926,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -893,19 +950,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -916,7 +978,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -935,19 +998,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -958,7 +1026,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -981,19 +1050,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1004,7 +1078,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -1023,7 +1098,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1056,19 +1131,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1079,7 +1160,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -1117,19 +1199,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1140,7 +1227,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -1168,19 +1256,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1191,7 +1284,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -1229,19 +1323,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1252,7 +1351,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -1280,7 +1380,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
             It is important to leave feathering turned off here
@@ -1316,19 +1416,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1339,7 +1445,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -1361,19 +1468,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1384,7 +1496,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -1402,19 +1515,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1425,7 +1543,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -1447,19 +1566,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1470,7 +1594,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -1488,7 +1613,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
         Returns beam specifier.
@@ -1530,19 +1655,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1553,7 +1684,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -1576,19 +1708,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1599,7 +1736,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -1618,19 +1756,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1641,7 +1784,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -1664,19 +1808,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1687,7 +1836,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -1706,7 +1856,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1743,19 +1893,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1766,7 +1922,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -1789,23 +1946,28 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1816,7 +1978,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -1839,11 +2002,11 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -1883,19 +2046,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1906,7 +2075,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -1929,19 +2099,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1952,7 +2127,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -1971,19 +2147,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -1994,7 +2175,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -2017,19 +2199,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2040,7 +2227,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -2059,7 +2247,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2098,19 +2286,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2121,7 +2315,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -2144,19 +2339,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2167,7 +2367,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -2187,19 +2388,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/16 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2210,7 +2416,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -2233,19 +2440,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2256,7 +2468,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -2276,7 +2489,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/16 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2309,19 +2522,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2332,7 +2551,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -2355,19 +2575,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2378,7 +2603,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -2397,14 +2623,14 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 1/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Defaults to none.
@@ -2462,19 +2688,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2485,7 +2717,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -2509,19 +2742,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2532,7 +2770,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -2554,19 +2793,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/16 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2577,7 +2821,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -2602,19 +2847,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2625,7 +2875,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -2647,7 +2898,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             r16 * 25/16 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2692,19 +2943,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2715,7 +2972,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -2740,19 +2998,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2763,7 +3026,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -2784,19 +3048,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/16 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2807,7 +3076,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -2831,19 +3101,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2854,7 +3129,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -2876,7 +3152,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/16 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
         Defaults to none.
@@ -2924,19 +3200,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2947,7 +3229,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -2970,19 +3253,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -2993,7 +3281,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -3012,19 +3301,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3035,7 +3329,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -3058,19 +3353,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3081,7 +3381,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -3100,7 +3401,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -3135,19 +3436,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3158,7 +3465,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -3181,19 +3489,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ~ ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3204,7 +3517,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -3223,19 +3537,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ~ ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3246,7 +3565,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -3269,19 +3589,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ~ ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3292,7 +3617,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -3311,7 +3637,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -3350,19 +3676,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3373,7 +3705,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -3396,19 +3729,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ~ ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3419,7 +3757,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -3438,19 +3777,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3461,7 +3805,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -3484,19 +3829,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ~ ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3507,7 +3857,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -3526,7 +3877,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
         Returns tie specifier.
@@ -3570,19 +3921,25 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3593,7 +3950,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -3616,19 +3974,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3639,7 +4002,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -3658,19 +4022,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3681,7 +4050,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'2 ~
                                                 c'8
                                             }
@@ -3704,19 +4074,24 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 25/32 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override TupletNumber.text = \markup {
                             \scale
                                 #'(0.75 . 0.75)
                                 \score
                                     {
-                                        \new Score \with {
+                                        \new Score
+                                        \with
+                                        {
                                             \override SpacingSpanner.spacing-increment = #0.5
                                             proportionalNotationDuration = ##f
-                                        } <<
-                                            \new RhythmicStaff \with {
+                                        }
+                                        <<
+                                            \new RhythmicStaff
+                                            \with
+                                            {
                                                 \remove Time_signature_engraver
                                                 \remove Staff_symbol_engraver
                                                 \override Stem.direction = #up
@@ -3727,7 +4102,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                 tupletFullLength = ##t
-                                            } {
+                                            }
+                                            {
                                                 c'4.
                                             }
                                         >>
@@ -3746,7 +4122,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 47/64 ]
                         }
                         \revert TupletNumber.text
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -3781,8 +4157,9 @@ class AccelerandoRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -3796,8 +4173,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 13/16
                             c'16 * 25/32 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -3808,8 +4185,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 13/16
                             c'16 * 47/64 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -3823,8 +4200,8 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 13/16
                             c'16 * 25/32 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -3835,7 +4212,7 @@ class AccelerandoRhythmMaker(RhythmMaker):
                             c'16 * 13/16
                             c'16 * 47/64 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Returns tuplet specifier or none.

--- a/abjad/tools/rhythmmakertools/BeamSpecifier.py
+++ b/abjad/tools/rhythmmakertools/BeamSpecifier.py
@@ -21,9 +21,12 @@ class BeamSpecifier(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \context Staff = "RhythmicStaff" \with {
+            \context Staff = "RhythmicStaff"
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8 [
                 c'8
                 c'16
@@ -183,9 +186,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8 [
                     c'8
                     c'16
@@ -216,9 +222,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [
@@ -267,9 +276,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [
@@ -335,9 +347,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8
                     c'8
                     c'16
@@ -368,9 +383,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8 [
                     c'8
                     c'16
@@ -401,9 +419,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8 [
                     c'8
                     c'16
@@ -449,9 +470,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8 [
                     c'8
                     c'16
@@ -481,9 +505,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8 [
                     c'8
                     c'16
@@ -513,9 +540,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8 [
                     c'8
                     c'16
@@ -564,9 +594,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [ ]
@@ -614,9 +647,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8
                     r8
                     c'16 [
@@ -658,9 +694,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8 [
                     c'8
                     c'16
@@ -691,9 +730,12 @@ class BeamSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \context Staff = "RhythmicStaff" \with {
+                \context Staff = "RhythmicStaff"
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \override Staff.Stem.stemlet-length = 2
                     c'8 [
                     c'8

--- a/abjad/tools/rhythmmakertools/EvenDivisionRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/EvenDivisionRhythmMaker.py
@@ -91,8 +91,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -100,8 +101,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/6 {
                             c'16 [
@@ -111,16 +112,16 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
                             c'8 [
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/6 {
                             c'16 [
@@ -130,15 +131,15 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
                             c'8 [
                             c'8
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -162,8 +163,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/6 {
@@ -174,8 +176,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/7 {
                             c'16 [
@@ -186,8 +188,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/8 {
                             c'16 [
@@ -199,8 +201,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/6 {
                             c'16 [
@@ -210,8 +212,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/7 {
                             c'16 [
@@ -222,7 +224,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Returns list of of selections.
@@ -506,8 +508,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -515,8 +518,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -525,8 +528,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -534,8 +537,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -544,7 +547,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             r8
                             r8
                         }
-                    } % measure
+                    }   % measure
                 }
 
             Burnishing outer divisions also works when given a single division:
@@ -560,8 +563,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 7/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 7/7 {
@@ -573,7 +577,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             r8
                             r8
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -598,8 +602,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -607,8 +612,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -617,8 +622,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -626,8 +631,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -636,7 +641,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Returns burnish specifier or none.
@@ -668,8 +673,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         \times 2/3 {
                             c'16 [
@@ -685,8 +691,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -701,8 +707,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 2/3 {
                             c'16 [
@@ -718,8 +724,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -734,7 +740,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
             Expresses tuplet ratios in the usual way with numerator and
@@ -761,8 +767,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         \times 4/6 {
                             c'16 [
@@ -778,8 +785,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -794,8 +801,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 4/6 {
                             c'16 [
@@ -811,8 +818,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -827,7 +834,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
             Preferred denominator equal to 8:
@@ -849,8 +856,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         \times 8/12 {
                             c'16 [
@@ -866,8 +874,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -882,8 +890,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 8/12 {
                             c'16 [
@@ -899,8 +907,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -915,7 +923,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
             Preferred denominator equal to 16:
@@ -937,8 +945,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         \times 16/24 {
                             c'16 [
@@ -954,8 +963,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -970,8 +979,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 16/24 {
                             c'16 [
@@ -987,8 +996,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -1003,7 +1012,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1027,8 +1036,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         \times 8/12 {
                             c'16 [
@@ -1044,8 +1054,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/10 {
@@ -1060,8 +1070,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 8/12 {
                             c'16 [
@@ -1077,8 +1087,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/10 {
@@ -1093,7 +1103,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Defaults to none.
@@ -1127,8 +1137,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1136,8 +1147,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/6 {
@@ -1148,8 +1159,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 12/12 {
@@ -1166,7 +1177,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1188,15 +1199,16 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1204,8 +1216,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/6 {
@@ -1216,7 +1228,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
             Fills divisions less than twice the duration of an eighth note with
@@ -1241,22 +1253,23 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'4.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1264,7 +1277,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'4
                             c'4
                         }
-                    } % measure
+                    }   % measure
                 }
 
             Divisions less than twice the duration of a quarter note are filled
@@ -1289,28 +1302,29 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'4.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'2.
                         }
-                    } % measure
+                    }   % measure
                 }
 
             Fills divisions less than twice the duration of a half note with a
@@ -1342,8 +1356,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -1352,8 +1367,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1361,8 +1376,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -1371,8 +1386,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1380,7 +1395,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1404,12 +1419,13 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1417,12 +1433,12 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1430,7 +1446,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1454,12 +1470,13 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1467,12 +1484,12 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1480,7 +1497,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1502,23 +1519,24 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
+                    }   % measure
                 }
 
         Set to division masks or none.
@@ -1577,23 +1595,24 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 2/2 {
                             c'16 [
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1601,8 +1620,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -1611,8 +1630,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/4 {
@@ -1621,7 +1640,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1644,31 +1663,32 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 2/2 {
                             c'16 [
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/2 {
                             c'16 [
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/3 {
@@ -1676,8 +1696,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/5 {
@@ -1687,7 +1707,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1710,23 +1730,24 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 2/2 {
                             c'16 [
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1734,8 +1755,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -1744,8 +1765,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/3 {
@@ -1753,7 +1774,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1776,31 +1797,32 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 2/2 {
                             c'16 [
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/2 {
                             c'16 [
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/3 {
@@ -1808,8 +1830,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/4 {
@@ -1818,7 +1840,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1841,23 +1863,24 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 2/2 {
                             c'16 [
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -1865,8 +1888,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -1875,8 +1898,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/5 {
@@ -1886,7 +1909,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1909,23 +1932,24 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/16
                         \times 2/3 {
                             c'16 [
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/4 {
@@ -1934,8 +1958,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 4/5 {
                             c'16 [
@@ -1944,8 +1968,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/6 {
@@ -1956,7 +1980,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1979,23 +2003,24 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 2/2 {
                             c'16 [
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -2005,8 +2030,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 4/6 {
                             c'16 [
@@ -2016,8 +2041,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/7 {
@@ -2029,7 +2054,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2052,23 +2077,24 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/16
                         \times 2/3 {
                             c'16 [
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -2076,8 +2102,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 4/7 {
                             c'16 [
@@ -2088,8 +2114,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/8 {
@@ -2102,7 +2128,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
 
@@ -2126,23 +2152,24 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 2/2 {
                             c'16 [
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/4 {
@@ -2151,8 +2178,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -2161,8 +2188,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/9 {
@@ -2176,7 +2203,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Returns (possibly empty) tuple of integers or none.
@@ -2205,8 +2232,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -2215,8 +2243,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -2224,8 +2252,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -2234,8 +2262,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -2243,7 +2271,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2267,8 +2295,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -2277,8 +2306,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8 ]
                             r8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -2286,8 +2315,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8 ]
                             r8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -2296,8 +2325,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             r8
                             c'8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -2305,7 +2334,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             r8
                             c'8
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2332,8 +2361,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -2342,8 +2372,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             r8
                             r8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -2351,8 +2381,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             r8
                             r8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -2361,8 +2391,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             r8
                             r8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -2370,7 +2400,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2394,8 +2424,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -2404,8 +2435,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -2413,8 +2444,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -2423,8 +2454,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -2432,7 +2463,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
             Silences every fourth logical tie:
@@ -2455,8 +2486,9 @@ class EvenDivisionRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -2465,8 +2497,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8 ]
                             r8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -2474,8 +2506,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8 [
                             c'8 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/4 {
@@ -2484,8 +2516,8 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             r8
                             c'8 ~
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/3 {
@@ -2493,7 +2525,7 @@ class EvenDivisionRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
             Silencing the fourth logical tie produces two rests. Silencing the

--- a/abjad/tools/rhythmmakertools/EvenRunRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/EvenRunRhythmMaker.py
@@ -25,8 +25,9 @@ class EvenRunRhythmMaker(RhythmMaker):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 4/8
                     {
                         c'8 [
@@ -34,22 +35,22 @@ class EvenRunRhythmMaker(RhythmMaker):
                         c'8
                         c'8 ]
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/4
                     {
                         c'4
                         c'4
                         c'4
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 2/4
                     {
                         c'4
                         c'4
                     }
-                } % measure
+                }   % measure
             }
 
     '''
@@ -214,8 +215,9 @@ class EvenRunRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         {
                             c'8 [
@@ -223,8 +225,8 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/4
                         {
                             c'8 [
@@ -234,8 +236,8 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/4
                         {
                             c'8 [
@@ -243,7 +245,7 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Returns duration specifier or none.
@@ -274,8 +276,9 @@ class EvenRunRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         {
                             c'8 [
@@ -283,22 +286,22 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/4
                         {
                             c'4
                             c'4
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/4
                         {
                             c'4
                             c'4
                         }
-                    } % measure
+                    }   % measure
                 }
 
             (``d`` equals the denominator of each input division.)
@@ -326,8 +329,9 @@ class EvenRunRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         {
                             c'16 [
@@ -339,8 +343,8 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/4
                         {
                             c'8 [
@@ -350,8 +354,8 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/4
                         {
                             c'8 [
@@ -359,7 +363,7 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
             (``d`` equals the denominator of each input division.)
@@ -387,8 +391,9 @@ class EvenRunRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         {
                             c'32 [
@@ -408,8 +413,8 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'32
                             c'32 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/4
                         {
                             c'16 [
@@ -425,8 +430,8 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/4
                         {
                             c'16 [
@@ -438,7 +443,7 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
             (``d`` equals the denominator of each input division.)
@@ -480,8 +485,9 @@ class EvenRunRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         {
                             c'8 [
@@ -490,16 +496,16 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         {
                             c'8 [
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         {
                             c'8 [
@@ -507,14 +513,14 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/8
                         {
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -539,8 +545,9 @@ class EvenRunRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         {
                             c'8 [
@@ -549,16 +556,16 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         {
                             c'8 [
                             c'8
                             c'8 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         {
                             c'8 [
@@ -566,14 +573,14 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/8
                         {
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -599,8 +606,9 @@ class EvenRunRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         {
                             c'8 [
@@ -609,16 +617,16 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         {
                             c'8 [
                             c'8
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         {
                             c'8 [
@@ -626,14 +634,14 @@ class EvenRunRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/8
                         {
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Returns true or false.

--- a/abjad/tools/rhythmmakertools/InciseSpecifier.py
+++ b/abjad/tools/rhythmmakertools/InciseSpecifier.py
@@ -229,30 +229,31 @@ class InciseSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/16
                         c'8 [
                         c'8 ]
                         r16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         r16
                         c'16. [
                         c'16. ]
                         r16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8 [
                         c'8 ]
                         r16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         r16
                         c'16. [
                         c'16. ]
                         r16
-                    } % measure
+                    }   % measure
                 }
 
         Defaults to none.

--- a/abjad/tools/rhythmmakertools/IncisedRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/IncisedRhythmMaker.py
@@ -29,26 +29,27 @@ class IncisedRhythmMaker(RhythmMaker):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 5/16
                     c'4
                     r16
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     r16
                     c'8.
                     r16
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     c'4
                     r16
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     r16
                     c'8.
                     r16
-                } % measure
+                }   % measure
             }
 
     '''
@@ -458,29 +459,30 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         r16
                         c'4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r16
                         c'4 ~
                         c'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r16
                         c'4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r16
                         c'4 ~
                         c'16
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -512,27 +514,28 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r16
                         c'4 ~
                         c'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r16
                         c'4 ~
                         c'16
-                    } % measure
+                    }   % measure
                 }
 
         Set to division masks or none.
@@ -570,22 +573,23 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 8/8
                         r8
                         c'2..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         c'2 ~
                         c'8
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -618,26 +622,27 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 8/8
                         r8
                         c'4 ~
                         c'4 ~
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'4 ~
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         c'4 ~
                         c'4 ~
                         c'8
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -669,24 +674,25 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 8/8
                         r8
                         c'4. ~
                         c'4 ~
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         c'4. ~
                         c'4
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -719,22 +725,23 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 8/8
                         r8
                         c'2..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         c'4. ~
                         c'4
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -766,22 +773,23 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 8/8
                         r8
                         c'2..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         c'4. ~
                         c'4
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         Returns duration specifier or none.
@@ -819,20 +827,21 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         c'2 ~
                         c'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'2 ~
                         c'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'2 ~
                         c'8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -862,25 +871,26 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         r4
                         r8..
                         c'8 ~ [
                         c'32 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'2 ~
                         c'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4
                         r16.
                         r16.
                         r16.
                         r16.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -911,25 +921,26 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         c'8..
                         c'4
                         r8
                         r32
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         r2
                         r8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         r4
                         c'16. [
                         c'16.
                         c'16.
                         c'16. ]
-                    } % measure
+                    }   % measure
                 }
 
         Returns incise specifier or none.
@@ -966,26 +977,27 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         r16
                         c'4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4 ~
                         c'16
                         r16
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1017,26 +1029,27 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         r16
                         r4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4 ~
                         c'16
                         r16
-                    } % measure
+                    }   % measure
                 }
 
         Set to masks or none.
@@ -1078,29 +1091,30 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'16
                         r4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'16
                         r4
                         r16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16
                         r4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'16
                         r4
                         r16
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1128,29 +1142,30 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'16
                         s4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'16
                         s4
                         s16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16
                         s4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'16
                         s4
                         s16
-                    } % measure
+                    }   % measure
                 }
 
             Use in keyboard and other polyphonic selections where other voices
@@ -1200,22 +1215,23 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 8/8
                         r8
                         c'2..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         c'2 ~
                         c'8
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1247,22 +1263,23 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 8/8
                         r8
                         c'2.. ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         c'2 ~
                         c'8
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1298,22 +1315,23 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 8/8
                         r8
                         c'2.. ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         c'2 ~
                         c'8
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1346,22 +1364,23 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 8/8
                         r8
                         c'2..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2 \repeatTie
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         c'2 \repeatTie
                         c'8 \repeatTie
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1393,22 +1412,23 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 8/8
                         r8
                         c'2..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         c'2
                         c'8
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1443,24 +1463,25 @@ class IncisedRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 8/8
                         r8
                         c'4.
                         c'4
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         c'4.
                         c'4
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         Set to tie specifier or none.

--- a/abjad/tools/rhythmmakertools/NoteRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/NoteRhythmMaker.py
@@ -24,16 +24,17 @@ class NoteRhythmMaker(RhythmMaker):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 5/8
                     c'2 ~
                     c'8
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     c'4.
-                } % measure
+                }   % measure
             }
 
     Usage follows the two-step configure-once / call-repeatedly pattern shown
@@ -266,16 +267,17 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/32
                         c'8 ~ [
                         c'32 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8 ~ [
                         c'32 ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -299,8 +301,9 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/32
                         \set stemLeftBeamCount = 0
                         \set stemRightBeamCount = 1
@@ -308,15 +311,15 @@ class NoteRhythmMaker(RhythmMaker):
                         \set stemLeftBeamCount = 3
                         \set stemRightBeamCount = 1
                         c'32
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \set stemLeftBeamCount = 1
                         \set stemRightBeamCount = 1
                         c'8 ~
                         \set stemLeftBeamCount = 3
                         \set stemRightBeamCount = 0
                         c'32 ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -341,16 +344,17 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/32
                         c'8 ~
                         c'32
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8 ~
                         c'32
-                    } % measure
+                    }   % measure
                 }
 
         Returns beam specifier.
@@ -379,24 +383,25 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         c'2 ~
                         c'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/8
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         c'2 ~
                         c'8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -422,24 +427,25 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         r2
                         r8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/8
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         c'2 ~
                         c'8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -465,24 +471,25 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         r2
                         r8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/8
                         r4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         c'2 ~
                         c'8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -510,24 +517,25 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         r2
                         r8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/8
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/8
                         r2
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         ..  note:: Currently only works when `outer_divisions_only` is true.
@@ -557,23 +565,24 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -599,23 +608,24 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -637,23 +647,24 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -679,23 +690,24 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         R1 * 1/2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         R1 * 3/8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         R1 * 1/2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         R1 * 3/8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -723,27 +735,28 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/8
                         c'4
-                    } % measure
+                    }   % measure
                 }
 
         Set to masks or none.
@@ -772,16 +785,17 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         c'2 ~
                         c'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -806,17 +820,18 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         c'4 ~
                         c'4 ~
                         c'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -840,24 +855,25 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/4
                         c'4 ~
                         c'4 ~
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         c'8. ~ [
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 9/16
                         c'8. ~ [
                         c'8. ~
                         c'8. ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -882,21 +898,22 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/4
                         c'2.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 9/16
                         c'8. ~ [
                         c'8. ~
                         c'8. ]
-                    } % measure
+                    }   % measure
                 }
 
             ``9/16`` is spelled metrically because it is unassignable.
@@ -928,23 +945,24 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/16
                         c'8. ~ [
                         c'8 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 9/16
                         c'8. ~ [
                         c'8. ~
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 10/16
                         c'4. ~
                         c'4
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -968,20 +986,21 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/4
                         c'2.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 9/16
                         c'4. ~
                         c'8.
-                    } % measure
+                    }   % measure
                 }
 
         Returns duration specifier or none.
@@ -1009,23 +1028,24 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1047,23 +1067,24 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1085,23 +1106,24 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
+                    }   % measure
                 }
 
         Set to masks or none.
@@ -1134,23 +1156,24 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1174,23 +1197,24 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'2 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4. ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1218,23 +1242,24 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'2 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1259,25 +1284,26 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4. \repeatTie
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 9/16
                         c'2 \repeatTie
                         c'16 \repeatTie
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         c'4 \repeatTie
                         c'16 \repeatTie
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1301,20 +1327,21 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 7/16
                         c'4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 1/4
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         c'4
                         c'16
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1341,22 +1368,23 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 7/16
                         c'8. [
                         c'8
                         c'8 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 1/4
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         c'8. [
                         c'8 ]
-                    } % measure
+                    }   % measure
                 }
 
         Returns tie specifier.
@@ -1385,22 +1413,23 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/14
                         \tweak edge-height #'(0.7 . 0)
                         \times 4/7 {
                             c'2 ~
                             c'8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/7
                         \tweak edge-height #'(0.7 . 0)
                         \times 4/7 {
                             c'2.
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1424,8 +1453,9 @@ class NoteRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/14
                         \tweak text #tuplet-number::calc-fraction-text
                         \tweak edge-height #'(0.7 . 0)
@@ -1433,15 +1463,15 @@ class NoteRhythmMaker(RhythmMaker):
                             c'4 ~
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/7
                         \tweak text #tuplet-number::calc-fraction-text
                         \tweak edge-height #'(0.7 . 0)
                         \times 8/7 {
                             c'4.
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Returns tuplet specifier or none.

--- a/abjad/tools/rhythmmakertools/SilenceMask.py
+++ b/abjad/tools/rhythmmakertools/SilenceMask.py
@@ -55,23 +55,24 @@ class SilenceMask(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 7/16
                     c'4..
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     r4.
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 7/16
                     r4..
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     c'4.
-                } % measure
+                }   % measure
             }
 
     ..  container:: example
@@ -114,23 +115,24 @@ class SilenceMask(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 7/16
                     r4..
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     c'4.
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 7/16
                     c'4..
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     r4.
-                } % measure
+                }   % measure
             }
 
     '''
@@ -291,23 +293,24 @@ class SilenceMask(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 7/16
                         c'4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 7/16
                         r4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -335,23 +338,24 @@ class SilenceMask(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 7/16
                         c'4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 7/16
                         r4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
+                    }   % measure
                 }
 
 

--- a/abjad/tools/rhythmmakertools/SkipRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/SkipRhythmMaker.py
@@ -23,19 +23,20 @@ class SkipRhythmMaker(RhythmMaker):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 1/4
                     s1 * 1/4
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/16
                     s1 * 3/16
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 5/8
                     s1 * 5/8
-                } % measure
+                }   % measure
             }
 
     Usage follows the two-step configure-once / call-repeatedly pattern shown

--- a/abjad/tools/rhythmmakertools/SustainMask.py
+++ b/abjad/tools/rhythmmakertools/SustainMask.py
@@ -57,23 +57,24 @@ class SustainMask(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 7/16
                     r4..
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     c'4.
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 7/16
                     c'4..
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     r4.
-                } % measure
+                }   % measure
             }
 
     ..  container:: example
@@ -117,23 +118,24 @@ class SustainMask(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 7/16
                     c'4..
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     r4.
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 7/16
                     r4..
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     c'4.
-                } % measure
+                }   % measure
             }
 
     '''
@@ -255,23 +257,24 @@ class SustainMask(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 7/16
                         r4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 7/16
                         c'4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -300,23 +303,24 @@ class SustainMask(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 7/16
                         r4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 7/16
                         c'4..
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
 

--- a/abjad/tools/rhythmmakertools/TaleaRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/TaleaRhythmMaker.py
@@ -28,32 +28,33 @@ class TaleaRhythmMaker(RhythmMaker):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 3/8
                     c'16 [
                     c'8
                     c'8. ]
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 4/8
                     c'4
                     c'16 [
                     c'8
                     c'16 ~ ]
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     c'8
                     c'4
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 4/8
                     c'16 [
                     c'8
                     c'8.
                     c'8 ]
-                } % measure
+                }   % measure
             }
 
     ..  container:: example
@@ -79,8 +80,9 @@ class TaleaRhythmMaker(RhythmMaker):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 3/8
                     c'16 [
                     c'16
@@ -88,26 +90,26 @@ class TaleaRhythmMaker(RhythmMaker):
                     c'16
                     c'16
                     c'16 ~ ]
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 4/8
                     c'16 [
                     c'8. ]
                     c'4
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     c'16 [
                     c'8
                     c'8. ]
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 4/8
                     c'4
                     c'16 [
                     c'8
                     c'16 ]
-                } % measure
+                }   % measure
             }
 
     ..  container:: example
@@ -298,30 +300,31 @@ class TaleaRhythmMaker(RhythmMaker):
 
                 >>> lilypond_file = rhythm_maker.__illustrate__()
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'8
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'4
                         c'16 [
                         c'8
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         c'8 [
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         c'8. [
                         c'16 ]
-                    } % measure
+                    }   % measure
                 }
 
         Defaults `divisions` to ``3/8``, ``4/8``, ``3/16``, ``4/16``.
@@ -708,8 +711,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'16
@@ -717,8 +721,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16 [
                         c'16
@@ -728,8 +732,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'16
@@ -737,8 +741,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16 [
                         c'16
@@ -748,7 +752,7 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -776,8 +780,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \set stemLeftBeamCount = 0
                         \set stemRightBeamCount = 2
@@ -797,8 +802,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         \set stemLeftBeamCount = 2
                         \set stemRightBeamCount = 1
                         c'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \set stemLeftBeamCount = 1
                         \set stemRightBeamCount = 2
@@ -824,8 +829,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         \set stemLeftBeamCount = 2
                         \set stemRightBeamCount = 1
                         c'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \set stemLeftBeamCount = 1
                         \set stemRightBeamCount = 2
@@ -845,8 +850,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         \set stemLeftBeamCount = 2
                         \set stemRightBeamCount = 1
                         c'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \set stemLeftBeamCount = 1
                         \set stemRightBeamCount = 2
@@ -872,7 +877,7 @@ class TaleaRhythmMaker(RhythmMaker):
                         \set stemLeftBeamCount = 2
                         \set stemRightBeamCount = 0
                         c'16 ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -901,8 +906,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16
                         c'16
@@ -910,8 +916,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16
                         c'16
@@ -921,8 +927,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'16
                         c'16
@@ -930,8 +936,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16
                         c'16
@@ -941,7 +947,7 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -969,8 +975,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'16
@@ -978,8 +985,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         r16
                         c'16 [
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16
                         r16
@@ -989,8 +996,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         r16
                         c'16 [
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'16
                         r16
@@ -998,8 +1005,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16 ]
                         r16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16 [
                         c'16
@@ -1009,7 +1016,7 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16 ]
                         r16
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1038,8 +1045,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'16
@@ -1047,8 +1055,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         r16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16 [
                         r16
@@ -1058,8 +1066,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         r16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'16 [
                         r16
@@ -1067,8 +1075,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         r16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16 [
                         c'16
@@ -1078,7 +1086,7 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         r16 ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1108,8 +1116,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \override RhythmicStaff.Stem.stemlet-length = 0.75
                         c'16 [
@@ -1119,8 +1128,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         \revert RhythmicStaff.Stem.stemlet-length
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \override RhythmicStaff.Stem.stemlet-length = 0.75
                         c'16 [
@@ -1132,8 +1141,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         \revert RhythmicStaff.Stem.stemlet-length
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \override RhythmicStaff.Stem.stemlet-length = 0.75
                         c'16 [
@@ -1143,8 +1152,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         \revert RhythmicStaff.Stem.stemlet-length
                         r16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \override RhythmicStaff.Stem.stemlet-length = 0.75
                         c'16 [
@@ -1156,7 +1165,7 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         \revert RhythmicStaff.Stem.stemlet-length
                         r16 ]
-                    } % measure
+                    }   % measure
                 }
 
         Set to beam specifier or none.
@@ -1198,32 +1207,33 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         r16
                         c'8 [
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'4
                         c'16 [
                         c'8
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16 [
                         c'8 ]
                         r8.
                         r8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1252,32 +1262,33 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         r16
                         c'8 [
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r4
                         c'16 [
                         c'8
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r8
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r16
                         c'8 [
                         c'8.
                         c'8 ]
-                    } % measure
+                    }   % measure
                 }
 
         Set to burnish specifier or none.
@@ -1312,32 +1323,33 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'8
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'4
                         c'16 [
                         c'8
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16 [
                         c'8
                         c'8.
                         c'8 ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1367,26 +1379,27 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'8
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1414,26 +1427,27 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'8
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'2
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1464,8 +1478,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'16
@@ -1473,8 +1488,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r8.
                         c'16 [
@@ -1482,18 +1497,18 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         r4
                         c'16 [
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r4..
                         c'16
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1522,8 +1537,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'16
@@ -1531,8 +1547,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'8.
                         c'16 [
@@ -1540,18 +1556,18 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'4
                         c'16 [
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'4..
                         c'16
-                    } % measure
+                    }   % measure
                 }
 
         Set to tuple of division masks or none.
@@ -1593,26 +1609,27 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         c'4 ~
                         c'16
                         c'4 ~
                         c'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4 ~
                         c'16
                         c'4 ~
                         c'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4 ~
                         c'16
                         c'4 ~
                         c'16
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1641,26 +1658,27 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         c'16 ~
                         c'4
                         c'16 ~
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 ~
                         c'4
                         c'16 ~
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 ~
                         c'4
                         c'16 ~
                         c'4
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1688,8 +1706,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/4
                         c'16 [
                         c'16
@@ -1697,15 +1716,15 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16 ]
                         c'4
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'16
                         c'16
                         c'16 ]
                         c'4
                         c'4
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1733,8 +1752,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/4
                         c'16 [
                         c'16
@@ -1744,8 +1764,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'8
                         c'8 ~
                         c'8 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'16
                         c'16
@@ -1754,7 +1774,7 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'8
                         c'8 ~
                         c'8 ]
-                    } % measure
+                    }   % measure
                 }
 
             Rewrites forbidden durations with smaller durations tied together.
@@ -1784,8 +1804,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/4
                         c'8. ~ [
                         c'8 ]
@@ -1793,22 +1814,22 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16 ~ [
                         c'16 ~
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8
                         c'4
                         c'8. ~ [
                         c'8
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 ~ [
                         c'16 ~
                         c'16
                         c'8. ~
                         c'8 ]
                         c'4
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1836,27 +1857,28 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/4
                         c'8. ~ [
                         c'8 ]
                         c'4
                         c'8. ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8
                         c'4
                         c'8. ~ [
                         c'8
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8. [
                         c'8. ~
                         c'8 ]
                         c'4
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1884,29 +1906,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/4
                         c'4 ~
                         c'16 [
                         c'8. ~
                         c'16
                         c'8. ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8 [
                         c'8 ~
                         c'8
                         c'8 ~
                         c'8.
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8. [
                         c'16 ~ ]
                         c'4
                         c'4
-                    } % measure
+                    }   % measure
                 }
 
         Set to duration specifier or none.
@@ -1941,32 +1964,33 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'8
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'4
                         c'16 [
                         c'8
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8
                         c'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'16 [
                         c'8
                         c'8.
                         c'8 ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1992,8 +2016,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -2001,8 +2026,8 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'8
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 8/9 {
                             c'4
@@ -2010,8 +2035,8 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'8
                             c'8 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -2019,15 +2044,15 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'4
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 8/9 {
                             c'8 [
                             c'8. ]
                             c'4
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2053,8 +2078,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -2062,8 +2088,8 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'8
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 4/5 {
                             c'4
@@ -2071,8 +2097,8 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'8
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -2080,8 +2106,8 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'16 [
                             c'16 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 4/5 {
                             c'16 [
@@ -2090,7 +2116,7 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'16 [
                             c'16 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
             The duration of each added count equals the duration
@@ -2119,8 +2145,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -2128,8 +2155,8 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'8
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 8/7 {
@@ -2137,16 +2164,16 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'16 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8. ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 8/7 {
@@ -2155,7 +2182,7 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'8
                             c'8. ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Set to integer tuple or none.
@@ -2194,29 +2221,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'8 ]
                         r8.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4
                         c'16
                         r16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         r16
                         c'8. [
                         c'8 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8
                         r16
                         c'8 [
                         c'16 ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2245,29 +2273,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         r16
                         c'8 [
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4
                         c'16 [
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'8.
                         c'8 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8 [
                         c'16
                         c'8 ]
                         r16
-                    } % measure
+                    }   % measure
                 }
 
         Returns patterns or none.
@@ -2301,29 +2330,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'8
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4
                         c'16 [
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'8.
                         c'8 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8 [
                         c'16
                         c'8
                         c'16 ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2388,29 +2418,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'8
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4
                         c'16 [
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'8.
                         c'8 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8 [
                         c'16
                         c'8
                         c'16 ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2436,29 +2467,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'8
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4
                         c'16 [
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         r16
                         c'8. [
                         c'8 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         r8
                         c'16 [
                         c'8
                         c'16 ]
-                    } % measure
+                    }   % measure
                 }
 
         Defaults to none.
@@ -2499,8 +2531,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'16
@@ -2508,31 +2541,31 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'16
                         c'16
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'16
                         c'16
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'16
                         c'16
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2563,8 +2596,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'16
@@ -2572,8 +2606,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'16
                         c'32 ~ ]
@@ -2581,23 +2615,23 @@ class TaleaRhythmMaker(RhythmMaker):
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'16
                         c'16
                         c'16
                         c'16 ]
                         c'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'16
                         c'16
                         c'16
                         c'16
                         c'16 ]
-                    } % measure
+                    }   % measure
                 }
 
             Additional divisions created when using `split_divisions_by_counts`
@@ -2630,8 +2664,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -2642,8 +2677,8 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'16
                             c'16 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/6 {
                             c'16 [
@@ -2657,8 +2692,8 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'16
                             c'32 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/11 {
                             c'32 [
@@ -2672,8 +2707,8 @@ class TaleaRhythmMaker(RhythmMaker):
                         \times 1/1 {
                             c'16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 12/13 {
                             c'16 [
@@ -2684,7 +2719,7 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'16
                             c'32 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Set to tuple of positive integers or none.
@@ -2714,20 +2749,21 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4.
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2753,29 +2789,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         c'16 [
                         c'8
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'4
                         c'16 [
                         c'16 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'16 [
                         c'8.
                         c'8 ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         c'8 [
                         c'16
                         c'8
                         c'16 ]
-                    } % measure
+                    }   % measure
                 }
 
         Set to talea or none.
@@ -2810,29 +2847,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'4 ~
                         c'16 [
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8. [
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'4 ~
                         c'16 [
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8. [
                         c'8. ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2860,29 +2898,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'4 ~
                         c'16 [
                         c'8. ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8. [
                         c'8. ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'4 ~
                         c'16 [
                         c'8. ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8. [
                         c'8. ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2914,29 +2953,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'4 ~
                         c'16 [
                         c'8. ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8. [
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'4 ~
                         c'16 [
                         c'8. ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8. [
                         c'8. ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2965,29 +3005,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'4
                         c'16 \repeatTie [
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8. \repeatTie [
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'4 \repeatTie
                         c'16 \repeatTie [
                         c'8. ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8. \repeatTie [
                         c'8. ]
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -3015,29 +3056,30 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 4/8
                         c'4 ~
                         c'16
                         r8.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8. ~ [
                         c'8. ~ ]
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         c'4 ~
                         c'16
                         r8.
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         c'8. ~ [
                         c'8. ]
-                    } % measure
+                    }   % measure
                 }
 
         Set to tie specifier or none.
@@ -3089,37 +3131,38 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 2/3 {
                             c'4.
                             c'4.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 2/3 {
                             c'4.
                             c'4.
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -3150,39 +3193,40 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'4
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'4
                             c'4
                         }
-                    } % measure
+                    }   % measure
                 }
 
             REGRESSION #907a. Rewrites trivializable tuplets even when
@@ -3213,39 +3257,40 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8. ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'4
                             c'4 ~
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8. ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'4
                             c'4
                         }
-                    } % measure
+                    }   % measure
                 }
 
             REGRESSION #907b. Rewrites trivializable tuplets even when
@@ -3277,39 +3322,40 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. ~ [
                             c'8. ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'4 ~
                             c'4 ~
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. ~ [
                             c'8. ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'4 ~
                             c'4
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -3335,8 +3381,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/7 {
@@ -3344,8 +3391,8 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'8. ]
                             r16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -3353,8 +3400,8 @@ class TaleaRhythmMaker(RhythmMaker):
                             r16
                             r8.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/7 {
@@ -3362,15 +3409,15 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'8. [
                             c'16 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8
                             r4.
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -3399,8 +3446,9 @@ class TaleaRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/7 {
@@ -3408,15 +3456,15 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'8. ]
                             r16
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             r2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/7 {
@@ -3424,15 +3472,15 @@ class TaleaRhythmMaker(RhythmMaker):
                             c'8. [
                             c'16 ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8
                             r4.
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Set to tuplet specifier or none.

--- a/abjad/tools/rhythmmakertools/TupletRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/TupletRhythmMaker.py
@@ -25,37 +25,38 @@ class TupletRhythmMaker(RhythmMaker):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 1/2
                     \times 4/5 {
                         c'4.
                         c'4
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/5 {
                         c'4.
                         c'4
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 5/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 1/1 {
                         c'8. [
                         c'8 ]
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 1/1 {
                         c'8. [
                         c'8 ]
                     }
-                } % measure
+                }   % measure
             }
 
     ..  container:: example
@@ -77,38 +78,39 @@ class TupletRhythmMaker(RhythmMaker):
         ..  docs::
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 1/2
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 1/1 {
                         c'4
                         r4
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/4 {
                         c'4.
                         c'8
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 5/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 5/6 {
                         c'8.
                         r8.
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 5/8 {
                         c'4.
                         c'8
                     }
-                } % measure
+                }   % measure
             }
 
     Object model of a partially evaluated function that accepts a (possibly
@@ -186,37 +188,38 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/2
                         \times 4/5 {
                             c'4.
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             c'4.
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -238,38 +241,39 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/2
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'4
                             r4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/4 {
                             c'4.
                             c'8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/6 {
                             c'8.
                             r8.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/8 {
                             c'4.
                             c'8
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Returns list of selections structured one selection per division.
@@ -406,8 +410,9 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/9 {
@@ -417,8 +422,8 @@ class TupletRhythmMaker(RhythmMaker):
                             c'8. [
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -426,8 +431,8 @@ class TupletRhythmMaker(RhythmMaker):
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -437,15 +442,15 @@ class TupletRhythmMaker(RhythmMaker):
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 4/5 {
                             c'4.
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -470,8 +475,9 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/9 {
@@ -489,8 +495,8 @@ class TupletRhythmMaker(RhythmMaker):
                             \set stemRightBeamCount = 1
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -502,8 +508,8 @@ class TupletRhythmMaker(RhythmMaker):
                             \set stemRightBeamCount = 1
                             c'8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -521,8 +527,8 @@ class TupletRhythmMaker(RhythmMaker):
                             \set stemRightBeamCount = 1
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 4/5 {
                             c'4.
@@ -533,7 +539,7 @@ class TupletRhythmMaker(RhythmMaker):
                             \set stemRightBeamCount = 0
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -559,8 +565,9 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 5/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/9 {
@@ -570,8 +577,8 @@ class TupletRhythmMaker(RhythmMaker):
                             c'8.
                             c'8.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
@@ -579,8 +586,8 @@ class TupletRhythmMaker(RhythmMaker):
                             c'8
                             c'8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -590,15 +597,15 @@ class TupletRhythmMaker(RhythmMaker):
                             c'8
                             c'8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 4/5 {
                             c'4.
                             c'8
                             c'8
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Ignores `beam_each_division` when `beam_division_together` is true.
@@ -639,36 +646,37 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 4/5 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 4/5 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 4/5 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -698,36 +706,37 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 4/5 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 4/5 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/10 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 8/10 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -755,36 +764,37 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 4/5 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 4/5 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/10 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 8/10 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -811,36 +821,37 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 4/5 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 8/10 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 12/20 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 16/20 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -867,36 +878,37 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 8/10 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 16/20 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 24/40 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 32/40 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -925,36 +937,37 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 8/10 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 8/10 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 8/10 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -981,36 +994,37 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 12/15 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 12/15 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 12/20 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 12/15 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1037,36 +1051,37 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 4/5 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 4/5 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 4/5 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Set to ``'divisions'``, duration, positive integer or none.
@@ -1102,35 +1117,36 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \times 4/5 {
                             c'4.
                             c'16.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 4/5 {
                             c'2
                             c'8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \times 4/5 {
                             c'4.
                             c'16.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         \times 4/5 {
                             c'2
                             c'8
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1159,29 +1175,30 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \times 4/5 {
                             c'4.
                             c'16.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \times 4/5 {
                             c'4.
                             c'16.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/8
                         r2
-                    } % measure
+                    }   % measure
                 }
 
         Set to division masks or none.
@@ -1217,15 +1234,16 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/2
                         \times 4/5 {
                             c'4
                             c'4.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -1233,15 +1251,15 @@ class TupletRhythmMaker(RhythmMaker):
                             r8.
                             c'16.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8 [
                             c'8. ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1266,15 +1284,16 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/2
                         \times 4/5 {
                             c'4
                             c'4. ~
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -1282,15 +1301,15 @@ class TupletRhythmMaker(RhythmMaker):
                             r8.
                             c'16. ~
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8 [
                             c'8. ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1319,15 +1338,16 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/2
                         \times 4/5 {
                             c'4
                             c'4. ~
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
@@ -1335,23 +1355,23 @@ class TupletRhythmMaker(RhythmMaker):
                             r8.
                             c'16.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8 [
                             c'8. ~ ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/6 {
                             c'16.
                             r8.
                             c'16.
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Set to tie specifier or none.
@@ -1383,37 +1403,38 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/2
                         \times 4/5 {
                             c'4.
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             c'4.
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1435,38 +1456,39 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 1/2
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'4
                             r4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/4 {
                             c'4.
                             c'8
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 5/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/6 {
                             c'8.
                             r8.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 5/8 {
                             c'4.
                             c'8
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Set to tuple of ratios.
@@ -1503,31 +1525,32 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 7/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8.. [
                             c'8.. ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1553,31 +1576,32 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/4 {
                             c'4
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 7/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 7/8 {
                             c'4
                             c'4
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1603,31 +1627,32 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8. ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 7/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8.. [
                             c'8.. ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1653,31 +1678,32 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/2 {
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 7/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 7/4 {
                             c'8 [
                             c'8 ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1703,35 +1729,36 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             c'4.
                             r4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/4 {
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             r4
                             c'4.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/4 {
                             c'4
                             c'4
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1761,35 +1788,36 @@ class TupletRhythmMaker(RhythmMaker):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 3/8
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             c'4.
                             r4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'4.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             r4
                             c'4.
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 1/1 {
                             c'8. [
                             c'8. ]
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -1818,39 +1846,40 @@ class TupletRhythmMaker(RhythmMaker):
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 3/8
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/5 {
                         c'4
                         c'4. ~
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 2/8
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 1/1 {
                         c'8 [
                         c'8 ~ ]
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/5 {
                         c'4
                         c'4. ~
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 2/8
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 1/1 {
                         c'8 [
                         c'8 ]
                     }
-                } % measure
+                }   % measure
             }
 
         ..  container:: example
@@ -1878,33 +1907,34 @@ class TupletRhythmMaker(RhythmMaker):
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 3/8
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/5 {
                         c'4
                         c'4. ~
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 2/8
                     c'8 [
                     c'8 ~ ]
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/5 {
                         c'4
                         c'4. ~
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 2/8
                     c'8 [
                     c'8 ]
-                } % measure
+                }   % measure
             }
 
             .. note:: Flattening trivial tuplets makes it possible
@@ -1935,33 +1965,34 @@ class TupletRhythmMaker(RhythmMaker):
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             >>> abjad.f(lilypond_file[abjad.Staff])
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 3/8
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/5 {
                         c'4 ~
                         c'4. ~
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 2/8
                     c'8 ~ [
                     c'8 ~ ]
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 3/8
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/5 {
                         c'4 ~
                         c'4. ~
                     }
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 2/8
                     c'8 ~ [
                     c'8 ]
-                } % measure
+                }   % measure
             }
 
         Defaults to none.

--- a/abjad/tools/rhythmmakertools/TupletSpecifier.py
+++ b/abjad/tools/rhythmmakertools/TupletSpecifier.py
@@ -189,36 +189,37 @@ class TupletSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 4/5 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 4/5 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 4/5 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -248,36 +249,37 @@ class TupletSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 4/5 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 4/5 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/10 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 8/10 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -305,36 +307,37 @@ class TupletSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 4/5 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 4/5 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 6/10 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 8/10 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -361,36 +364,37 @@ class TupletSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 4/5 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 8/10 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 12/20 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 16/20 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -417,36 +421,37 @@ class TupletSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 8/10 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 16/20 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 24/40 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 32/40 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -475,36 +480,37 @@ class TupletSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 8/10 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 8/10 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 8/10 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -531,36 +537,37 @@ class TupletSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 12/15 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 12/15 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 12/20 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 12/15 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -587,36 +594,37 @@ class TupletSpecifier(AbjadValueObject):
             ..  docs::
 
                 >>> abjad.f(lilypond_file[abjad.Staff])
-                \new RhythmicStaff {
-                    { % measure
+                \new RhythmicStaff
+                {
+                    {   % measure
                         \time 2/16
                         \times 4/5 {
                             c'32 [
                             c'8 ]
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/16
                         \times 4/5 {
                             c'16
                             c'4
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 6/16
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 3/5 {
                             c'8
                             c'2
                         }
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 8/16
                         \times 4/5 {
                             c'8
                             c'2
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Defaults to none.

--- a/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_BeamSpecifier_beam_each_division.py
+++ b/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_BeamSpecifier_beam_each_division.py
@@ -28,8 +28,9 @@ def test_rhythmmakertools_BeamSpecifier_beam_each_division_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/16
                 \times 4/7 {
                     c'32 [
@@ -39,8 +40,8 @@ def test_rhythmmakertools_BeamSpecifier_beam_each_division_01():
                     c'16 [
                     c'32 ~ ]
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 5/16
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 5/7 {
@@ -57,7 +58,7 @@ def test_rhythmmakertools_BeamSpecifier_beam_each_division_01():
                     r32
                     c'32
                 }
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_BurnishSpecifier.py
+++ b/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_BurnishSpecifier.py
@@ -32,8 +32,9 @@ def test_rhythmmakertools_BurnishSpecifier_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/16
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
@@ -44,8 +45,8 @@ def test_rhythmmakertools_BurnishSpecifier_01():
                     c'32 ]
                     r32
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 6/16
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
@@ -56,7 +57,7 @@ def test_rhythmmakertools_BurnishSpecifier_01():
                     c'16 ]
                     r16
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -93,8 +94,9 @@ def test_rhythmmakertools_BurnishSpecifier_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/16
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
@@ -105,8 +107,8 @@ def test_rhythmmakertools_BurnishSpecifier_02():
                     r32
                     c'32
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 6/16
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
@@ -117,7 +119,7 @@ def test_rhythmmakertools_BurnishSpecifier_02():
                     r16
                     c'16
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -154,8 +156,9 @@ def test_rhythmmakertools_BurnishSpecifier_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/16
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 10/13 {
@@ -168,8 +171,8 @@ def test_rhythmmakertools_BurnishSpecifier_03():
                     r16
                     c'32 ~
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 6/16
                 \times 4/5 {
                     c'16. [
@@ -181,7 +184,7 @@ def test_rhythmmakertools_BurnishSpecifier_03():
                     r32
                     c'16
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -217,8 +220,9 @@ def test_rhythmmakertools_BurnishSpecifier_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/16
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
@@ -229,8 +233,8 @@ def test_rhythmmakertools_BurnishSpecifier_04():
                     c'32 ]
                     r32
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 6/16
                 \times 4/5 {
                     r16
@@ -241,7 +245,7 @@ def test_rhythmmakertools_BurnishSpecifier_04():
                     c'8 ]
                     r32
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -278,8 +282,9 @@ def test_rhythmmakertools_BurnishSpecifier_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/16
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
@@ -290,8 +295,8 @@ def test_rhythmmakertools_BurnishSpecifier_05():
                     c'32 ]
                     r32
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 6/16
                 \times 4/7 {
                     r16
@@ -305,7 +310,7 @@ def test_rhythmmakertools_BurnishSpecifier_05():
                     c'8 ]
                     r32
                 }
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_BurnishSpecifier_outer_divisions_only.py
+++ b/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_BurnishSpecifier_outer_divisions_only.py
@@ -36,8 +36,9 @@ def test_rhythmmakertools_BurnishSpecifier_outer_divisions_only_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/16
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/5 {
@@ -47,8 +48,8 @@ def test_rhythmmakertools_BurnishSpecifier_outer_divisions_only_01():
                     r16
                     r16
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/8
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/4 {
@@ -61,7 +62,7 @@ def test_rhythmmakertools_BurnishSpecifier_outer_divisions_only_01():
                     r16
                     c'16
                 }
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -98,16 +99,17 @@ def test_rhythmmakertools_BurnishSpecifier_outer_divisions_only_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/16
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/5 {
                     r4
                     c'16 ~
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/8
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/4 {
@@ -115,7 +117,7 @@ def test_rhythmmakertools_BurnishSpecifier_outer_divisions_only_02():
                     c'4
                     r16
                 }
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -154,16 +156,17 @@ def test_rhythmmakertools_BurnishSpecifier_outer_divisions_only_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/8
                 {
                     r16
                     c'8 [
                     c'8. ]
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 4/8
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/5 {
@@ -177,7 +180,7 @@ def test_rhythmmakertools_BurnishSpecifier_outer_divisions_only_03():
                     c'8 ]
                     r16
                 }
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -214,8 +217,9 @@ def test_rhythmmakertools_BurnishSpecifier_outer_divisions_only_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 8/8
                 r8
                 c'8 [
@@ -225,7 +229,7 @@ def test_rhythmmakertools_BurnishSpecifier_outer_divisions_only_04():
                 c'8 ]
                 r8
                 r8
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)

--- a/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_DurationSpecifier.py
+++ b/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_DurationSpecifier.py
@@ -38,7 +38,8 @@ def test_rhythmmakertools_DurationSpecifier_01():
 
     assert format(staff) == abjad.String.normalize(
         r"""
-        \new Staff {
+        \new Staff
+        {
             r16
             c'16 ~ [
             c'16 ]

--- a/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_IncisedRhythmMaker___call__.py
+++ b/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_IncisedRhythmMaker___call__.py
@@ -26,30 +26,31 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 c'2 ~
                 c'16.
                 r32
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r4
                 c'4 ~
                 c'16.
                 r32
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'2 ~
                 c'16.
                 r32
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r4
                 c'4 ~
                 c'16.
                 r32
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -79,30 +80,31 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 r4
                 c'4 ~
                 c'16.
                 r32
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r4
                 r4
                 c'16.
                 r32
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r4
                 r4
                 r8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r4
                 r4
                 r8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -132,26 +134,27 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 r32
                 c'4 ~
                 c'16.
                 r4
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r32
                 c'16.
                 r4
                 r4
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r32
                 r4
                 r4
                 r16.
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -175,20 +178,21 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 c'2 ~
                 c'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'2 ~
                 c'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'2 ~
                 c'8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -219,31 +223,32 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/8
                 \times 4/5 {
                     r8
                     c'4.
                     r8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     r8
                     c'4
                     r8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \times 4/7 {
                     r8
                     c'2 ~
                     c'8
                     r8
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -273,16 +278,17 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/8
                 \times 8/9 {
                     r32
                     c'2 ~
                     c'32
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     r32
@@ -294,8 +300,8 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___06():
                     c'4. ~
                     c'32
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     r32
@@ -306,7 +312,7 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___06():
                     c'4 ~
                     c'32
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -337,30 +343,31 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___07():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 r2
                 r16.
                 c'32
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'4
                 r4
                 r16.
                 c'32
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r2
                 r16.
                 c'32
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'4
                 r4
                 r16.
                 c'32
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -391,30 +398,31 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 c'4
                 r4
                 r16.
                 c'32
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'4
                 c'4
                 r16.
                 c'32
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'4
                 c'4
                 c'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'4
                 c'4
                 c'8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -445,26 +453,27 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 c'32
                 r4
                 r16.
                 c'4
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'32
                 r16.
                 c'4
                 c'4
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'32
                 c'4
                 c'4
                 c'16.
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -490,20 +499,21 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___10():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 r2
                 r8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r2
                 r8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r2
                 r8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -535,31 +545,32 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___11():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/8
                 \times 4/5 {
                     c'8
                     r4.
                     c'8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'8
                     r4
                     c'8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \times 4/7 {
                     c'8
                     r2
                     r8
                     c'8
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -592,16 +603,17 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___12():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/8
                 \times 8/9 {
                     c'32
                     r2
                     r32
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'32
@@ -613,8 +625,8 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___12():
                     r4.
                     r32
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'32
@@ -625,7 +637,7 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___12():
                     r4
                     r32
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -658,24 +670,25 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___13():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 r4
                 r4
                 c'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'2 ~
                 c'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'4
                 r16.
                 r16.
                 r16.
                 r16.
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -708,22 +721,23 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___14():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 r4
                 r4
                 r8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'2 ~
                 c'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'8
                 r4
                 r4
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -751,20 +765,21 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___15():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 c'2 ~
                 c'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'2 ~
                 c'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'2 ~
                 c'8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -798,26 +813,27 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___16():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/8
                 \times 4/5 {
                     r8
                     c'2
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'2
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \times 4/7 {
                     c'2.
                     r8
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -852,8 +868,9 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___17():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/8
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/4 {
@@ -864,14 +881,14 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___17():
                 \times 1/1 {
                     c'8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'2
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'8
@@ -881,7 +898,7 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___17():
                     c'2
                     r8
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -915,24 +932,25 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___18():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 c'4
                 c'4
                 r8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r2
                 r8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r4
                 c'16. [
                 c'16.
                 c'16.
                 c'16. ]
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -966,22 +984,23 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___19():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 c'4
                 c'4
                 c'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r2
                 r8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r8
                 c'4
                 c'4
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -1010,20 +1029,21 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___20():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/8
                 r2
                 r8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r2
                 r8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 r2
                 r8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -1058,26 +1078,27 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___21():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/8
                 \times 4/5 {
                     c'8
                     r2
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     r2
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \times 4/7 {
                     r2.
                     c'8
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -1113,8 +1134,9 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___22():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/8
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/4 {
@@ -1125,14 +1147,14 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___22():
                 \times 1/1 {
                     r8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     r2
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     r8
@@ -1142,7 +1164,7 @@ def test_rhythmmakertools_IncisedRhythmMaker___call___22():
                     r2
                     c'8
                 }
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_NoteRhythmMaker___call__.py
+++ b/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_NoteRhythmMaker___call__.py
@@ -16,16 +16,17 @@ def test_rhythmmakertools_NoteRhythmMaker___call___01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/16
                 c'4 ~
                 c'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/8
                 c'4.
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -50,16 +51,17 @@ def test_rhythmmakertools_NoteRhythmMaker___call___02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/16
                 c'16 ~
                 c'4
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/8
                 c'4.
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_TaleaRhythmMaker___call__.py
+++ b/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_TaleaRhythmMaker___call__.py
@@ -23,16 +23,17 @@ def test_rhythmmakertools_TaleaRhythmMaker___call___01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 \times 4/7 {
                     r16
                     c'4
                     r8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 5/8
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 5/7 {
@@ -43,7 +44,7 @@ def test_rhythmmakertools_TaleaRhythmMaker___call___01():
                     c'8.
                     r16
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -71,16 +72,17 @@ def test_rhythmmakertools_TaleaRhythmMaker___call___02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 \times 4/7 {
                     r16
                     c'4
                     r8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 5/8
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
@@ -97,7 +99,7 @@ def test_rhythmmakertools_TaleaRhythmMaker___call___02():
                 \times 1/1 {
                     c'8
                 }
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_TaleaRhythmMaker_tie_split_notes.py
+++ b/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_TaleaRhythmMaker_tie_split_notes.py
@@ -22,23 +22,24 @@ def test_rhythmmakertools_TaleaRhythmMaker_tie_split_notes_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'4 ~
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'16 [
                 c'8. ~ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'8 [
                 c'8 ~ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'8. [
                 c'16 ]
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -66,30 +67,31 @@ def test_rhythmmakertools_TaleaRhythmMaker_tie_split_notes_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/16
                 c'8. ~
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 5/8
                 c'8
                 c'4 ~
                 c'16 [
                 c'8. ~ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 4/8
                 c'8
                 c'4 ~
                 c'16 [
                 c'16 ~ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 7/16
                 c'4
                 c'8.
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_TieSpecifier.py
+++ b/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_TieSpecifier.py
@@ -24,7 +24,8 @@ def test_rhythmmakertools_TieSpecifier_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \tweak text #tuplet-number::calc-fraction-text
             \times 1/1 {
                 r16

--- a/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_TupletRhythmMaker___call__.py
+++ b/abjad/tools/rhythmmakertools/test/test_rhythmmakertools_TupletRhythmMaker___call__.py
@@ -16,7 +16,8 @@ def test_rhythmmakertools_TupletRhythmMaker___call___01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \tweak edge-height #'(0.7 . 0)
             \times 4/5 {
                 c'4

--- a/abjad/tools/rhythmtreetools/RhythmTreeContainer.py
+++ b/abjad/tools/rhythmtreetools/RhythmTreeContainer.py
@@ -190,7 +190,8 @@ class RhythmTreeContainer(RhythmTreeMixin, TreeContainer):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 4/5 {
                         c'16
                         \times 2/3 {

--- a/abjad/tools/scoretools/AcciaccaturaContainer.py
+++ b/abjad/tools/scoretools/AcciaccaturaContainer.py
@@ -27,7 +27,8 @@ class AcciaccaturaContainer(GraceContainer):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 c'4
                 \acciaccatura {
                     c'16

--- a/abjad/tools/scoretools/AfterGraceContainer.py
+++ b/abjad/tools/scoretools/AfterGraceContainer.py
@@ -20,7 +20,8 @@ class AfterGraceContainer(Container):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 #(define afterGraceFraction (cons 15 16))
                 c'4
                 \afterGrace

--- a/abjad/tools/scoretools/AppoggiaturaContainer.py
+++ b/abjad/tools/scoretools/AppoggiaturaContainer.py
@@ -24,7 +24,8 @@ class AppoggiaturaContainer(GraceContainer):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 c'4
                 \appoggiatura {
                     c'16

--- a/abjad/tools/scoretools/Context.py
+++ b/abjad/tools/scoretools/Context.py
@@ -18,7 +18,8 @@ class Context(Container):
         ..  docs::
 
             >>> abjad.f(context)
-            \context GlobalContext = "MeterVoice" {
+            \context GlobalContext = "MeterVoice"
+            {
             }
 
     '''
@@ -151,35 +152,43 @@ class Context(Container):
         indent = abjad.LilyPondFormatManager.indent
         result = []
         if context.is_simultaneous:
-            brackets_open = ['<<']
+            if context.identifier:
+                open_bracket = f'<<  {context.identifier}'
+            else:
+                open_bracket = '<<'
         else:
-            brackets_open = ['{']
+            if context.identifier:
+                open_bracket = f'{{   {context.identifier}'
+            else:
+                open_bracket = '{'
+        brackets_open = [open_bracket]
         remove_commands = context._format_remove_commands()
         consists_commands = context._format_consists_commands()
         overrides = bundle.grob_overrides
         settings = bundle.context_settings
         if remove_commands or consists_commands or overrides or settings:
-            contributions = [context._format_invocation() + r' \with {']
+            contributions = [context._format_invocation(), r'\with', '{']
             contributions = tuple(contributions)
             identifier_pair = ('context_brackets', 'open')
             result.append((identifier_pair, contributions))
-            contributions = [indent + x for x in remove_commands]
+            contributions = [indent + _ for _ in remove_commands]
             contributions = tuple(contributions)
             identifier_pair = ('engraver removals', 'remove_commands')
             result.append((identifier_pair, contributions))
-            contributions = [indent + x for x in consists_commands]
+            contributions = [indent + _ for _ in consists_commands]
             contributions = tuple(contributions)
             identifier_pair = ('engraver consists', 'consists_commands')
             result.append((identifier_pair, contributions))
-            contributions = [indent + x for x in overrides]
+            contributions = [indent + _ for _ in overrides]
             contributions = tuple(contributions)
             identifier_pair = ('overrides', 'overrides')
             result.append((identifier_pair, contributions))
-            contributions = [indent + x for x in settings]
+            contributions = [indent + _ for _ in settings]
             contributions = tuple(contributions)
             identifier_pair = ('settings', 'settings')
             result.append((identifier_pair, contributions))
             contributions = ['}} {}'.format(brackets_open[0])]
+            contributions = ['}', open_bracket]
             contributions = tuple(contributions)
             identifier_pair = ('context_brackets', 'open')
             result.append((identifier_pair, contributions))
@@ -187,6 +196,7 @@ class Context(Container):
             contribution = context._format_invocation()
             contribution += ' {}'.format(brackets_open[0])
             contributions = [contribution]
+            contributions = [context._format_invocation(), open_bracket]
             contributions = tuple(contributions)
             identifier_pair = ('context_brackets', 'open')
             result.append((identifier_pair, contributions))
@@ -250,9 +260,12 @@ class Context(Container):
         >>> staff = abjad.Staff([])
         >>> staff.consists_commands.append('Horizontal_bracket_engraver')
         >>> abjad.f(staff)
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \consists Horizontal_bracket_engraver
-        } {
+        }
+        {
         }
 
         '''
@@ -309,9 +322,12 @@ class Context(Container):
         >>> staff = abjad.Staff([])
         >>> staff.remove_commands.append('Time_signature_engraver')
         >>> abjad.f(staff)
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \remove Time_signature_engraver
-        } {
+        }
+        {
         }
 
         '''

--- a/abjad/tools/scoretools/Descendants.py
+++ b/abjad/tools/scoretools/Descendants.py
@@ -22,14 +22,19 @@ class Descendants(abctools.AbjadObject, collections.Sequence):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \context Staff = "Treble Staff" {
-                    \context Voice = "Treble Voice" {
+            \new Score
+            <<
+                \context Staff = "Treble Staff"
+                {
+                    \context Voice = "Treble Voice"
+                    {
                         c'4
                     }
                 }
-                \context Staff = "Bass Staff" {
-                    \context Voice = "Bass Voice" {
+                \context Staff = "Bass Staff"
+                {
+                    \context Voice = "Bass Voice"
+                    {
                         b,4
                     }
                 }

--- a/abjad/tools/scoretools/GraceContainer.py
+++ b/abjad/tools/scoretools/GraceContainer.py
@@ -21,7 +21,8 @@ class GraceContainer(Container):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 c'4
                 \grace {
                     c'16
@@ -52,7 +53,8 @@ class GraceContainer(Container):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 c'4
                 \grace {
                     cs'16
@@ -73,7 +75,8 @@ class GraceContainer(Container):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 c'4
                 \afterGrace
                 d'4
@@ -96,7 +99,8 @@ class GraceContainer(Container):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \grace {
                     fs'32
                 }
@@ -110,7 +114,8 @@ class GraceContainer(Container):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4
                 d'4
             }
@@ -121,7 +126,8 @@ class GraceContainer(Container):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4
                 \grace {
                     fs'32

--- a/abjad/tools/scoretools/Inspection.py
+++ b/abjad/tools/scoretools/Inspection.py
@@ -51,14 +51,17 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    \new Voice {
+                \new Staff
+                {
+                    \new Voice
+                    {
                         c'8
                         d'8
                         e'8
                         f'8
                     }
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                         a'8
                         b'8
@@ -88,7 +91,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4
                     e'4
                     e'4
@@ -154,7 +158,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \clef "alto"
                     c'4
                     d'4
@@ -197,7 +202,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     \afterGrace
                     d'8
@@ -227,7 +233,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4
                     e'4
                     e'4
@@ -293,7 +300,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 [
                     d'4
                     e'8
@@ -324,7 +332,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 2/3 {
                         c'8
                         d'8
@@ -364,7 +373,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 2/3 {
                         c'8
                         d'8
@@ -432,7 +442,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4
                     d'4
                     e'4
@@ -471,7 +482,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \clef "alto"
                     c'4
                     d'4
@@ -504,7 +516,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     d'8
                     e'8
@@ -534,7 +547,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     d'8
                     e'8
@@ -599,7 +613,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     d'8
                     e'8
@@ -628,7 +643,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \time 3/8
                     c'4
                     d'4
@@ -681,7 +697,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     \acciaccatura {
                         cs'16
@@ -742,7 +759,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4 -\marcato
                     d'4 -\marcato
                     e'4 -\marcato
@@ -776,14 +794,17 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    \new Voice {
+                \new Staff
+                {
+                    \new Voice
+                    {
                         c'8
                         d'8
                         e'8
                         f'8
                     }
-                    \new Voice {
+                    \new Voice
+                    {
                         g'8
                         a'8
                         b'8
@@ -931,7 +952,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
+                \new Voice
+                {
                     c'4
                     \grace {
                         c'16
@@ -957,7 +979,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
+                \new Voice
+                {
                     c'4
                     \grace {
                         c'16
@@ -1003,10 +1026,13 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TextScript.staff-padding = #1.25
                     \override TextSpanner.staff-padding = #2
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -1087,7 +1113,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.instrumentName = \markup { Piccolo }
                     \set Staff.shortInstrumentName = \markup { Picc. }
                     d'8
@@ -1095,8 +1122,6 @@ class Inspection(abctools.AbjadObject):
                     f'8
                     g'8
                 }
-                >>> abjad.inspect(staff[0]).get_sounding_pitch()
-                NamedPitch("d''")
 
         Returns named pitch.
         '''
@@ -1116,7 +1141,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.instrumentName = \markup { Glockenspiel }
                     \set Staff.shortInstrumentName = \markup { Gkspl. }
                     <c' e'>4
@@ -1162,7 +1188,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 [
                     d'8 ]
                     e'8 [
@@ -1218,7 +1245,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
+                \new Voice
+                {
                     c'8 [
                     \grace {
                         c'16
@@ -1308,7 +1336,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 [
                     d'8 ]
                     e'8 [
@@ -1360,7 +1389,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 2/3 {
                         c'8
                         d'8
@@ -1438,8 +1468,10 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff {
+                \new Score
+                <<
+                    \new Staff
+                    {
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 4/3 {
                             d''8
@@ -1447,12 +1479,15 @@ class Inspection(abctools.AbjadObject):
                             b'8
                         }
                     }
-                    \new PianoStaff <<
-                        \new Staff {
+                    \new PianoStaff
+                    <<
+                        \new Staff
+                        {
                             a'4
                             g'4
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             f'8
                             e'8
@@ -1531,7 +1566,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \time 3/8
                     c'4
                     d'4
@@ -1794,7 +1830,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 [
                     d'4
                     e'8
@@ -1894,7 +1931,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4 -\marcato
                     d'4 -\marcato
                     e'4 -\marcato
@@ -1929,7 +1967,8 @@ class Inspection(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4 -\marcato
                     d'4 -\marcato
                     e'4 -\marcato

--- a/abjad/tools/scoretools/Iteration.py
+++ b/abjad/tools/scoretools/Iteration.py
@@ -17,7 +17,8 @@ class Iteration(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4
                     e'4
                     d'4
@@ -74,15 +75,18 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff {
+                    \new Score
+                    <<
+                        \new Staff
+                        {
                             c''4 ~
                             c''8
                             d''8
                             r4
                             ef''4
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             r8
                             g'4. ~
                             g'8
@@ -126,15 +130,18 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff {
+                    \new Score
+                    <<
+                        \new Staff
+                        {
                             c''4 ~
                             c''8
                             d''8
                             r4
                             ef''4
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             r8
                             g'4. ~
                             g'8
@@ -181,7 +188,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8 [
                         \grace {
                             cf''16
@@ -353,27 +361,36 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         <<
-                            \context Voice = "Voice 1" \with {
+                            \context Voice = "Voice 1"
+                            \with
+                            {
                                 \override Stem.direction = #down
-                            } {
+                            }
+                            {
                                 c'8
                                 d'8
                             }
-                            \context Voice = "Voice 2" {
+                            \context Voice = "Voice 2"
+                            {
                                 e'8
                                 f'8
                             }
                         >>
                         <<
-                            \context Voice = "Voice 1" \with {
+                            \context Voice = "Voice 1"
+                            \with
+                            {
                                 \override Stem.direction = #down
-                            } {
+                            }
+                            {
                                 g'8
                                 a'8
                             }
-                            \context Voice = "Voice 2" {
+                            \context Voice = "Voice 2"
+                            {
                                 b'8
                                 c''8
                             }
@@ -421,27 +438,36 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         <<
-                            \context Voice = "Voice 1" \with {
+                            \context Voice = "Voice 1"
+                            \with
+                            {
                                 \override Stem.direction = #down
-                            } {
+                            }
+                            {
                                 c'8
                                 d'8
                             }
-                            \context Voice = "Voice 2" {
+                            \context Voice = "Voice 2"
+                            {
                                 e'8
                                 f'8
                             }
                         >>
                         <<
-                            \context Voice = "Voice 1" \with {
+                            \context Voice = "Voice 1"
+                            \with
+                            {
                                 \override Stem.direction = #down
-                            } {
+                            }
+                            {
                                 g'8
                                 a'8
                             }
-                            \context Voice = "Voice 2" {
+                            \context Voice = "Voice 2"
+                            {
                                 b'8
                                 c''8
                             }
@@ -489,27 +515,36 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         <<
-                            \context Voice = "Voice 1" \with {
+                            \context Voice = "Voice 1"
+                            \with
+                            {
                                 \override Stem.direction = #down
-                            } {
+                            }
+                            {
                                 c'8
                                 d'8
                             }
-                            \context Voice = "Voice 2" {
+                            \context Voice = "Voice 2"
+                            {
                                 e'8
                                 f'8
                             }
                         >>
                         <<
-                            \context Voice = "Voice 1" \with {
+                            \context Voice = "Voice 1"
+                            \with
+                            {
                                 \override Stem.direction = #down
-                            } {
+                            }
+                            {
                                 g'8
                                 a'8
                             }
-                            \context Voice = "Voice 2" {
+                            \context Voice = "Voice 2"
+                            {
                                 b'8
                                 c''8
                             }
@@ -557,27 +592,36 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         <<
-                            \context Voice = "Voice 1" \with {
+                            \context Voice = "Voice 1"
+                            \with
+                            {
                                 \override Stem.direction = #down
-                            } {
+                            }
+                            {
                                 c'8
                                 d'8
                             }
-                            \context Voice = "Voice 2" {
+                            \context Voice = "Voice 2"
+                            {
                                 e'8
                                 f'8
                             }
                         >>
                         <<
-                            \context Voice = "Voice 1" \with {
+                            \context Voice = "Voice 1"
+                            \with
+                            {
                                 \override Stem.direction = #down
-                            } {
+                            }
+                            {
                                 g'8
                                 a'8
                             }
-                            \context Voice = "Voice 2" {
+                            \context Voice = "Voice 2"
+                            {
                                 b'8
                                 c''8
                             }
@@ -667,20 +711,21 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
-                        { % measure
+                    \new Staff
+                    {
+                        {   % measure
                             \time 2/8
                             c'8
                             d'8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             e'8
                             f'8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             g'8
                             a'8
-                        } % measure
+                        }   % measure
                     }
 
             ..  container:: example
@@ -712,7 +757,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8 [
                         \grace {
                             cf''16
@@ -759,7 +805,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8 [
                         \grace {
                             cf''16
@@ -885,15 +932,18 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff {
+                    \new Score
+                    <<
+                        \new Staff
+                        {
                             c'8
                             d'8
                             e'8
                             f'8
                             g'4
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c4
                             a,4
@@ -965,20 +1015,21 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
-                        { % measure
+                    \new Staff
+                    {
+                        {   % measure
                             \time 2/8
                             <c' bf'>8
                             <g' a'>8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             af'8
                             r8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             r8
                             gf'8
-                        } % measure
+                        }   % measure
                     }
 
             ..  container:: example
@@ -1009,7 +1060,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8 [
                         \grace {
                             cf''16
@@ -1055,7 +1107,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8 [
                         \grace {
                             cf''16
@@ -1097,7 +1150,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8 [
                         \grace {
                             cf''16
@@ -1138,20 +1192,21 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
-                        { % measure
+                    \new Staff
+                    {
+                        {   % measure
                             \time 2/8
                             <c' bf'>8
                             <g' a'>8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             af'8
                             r8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             r8
                             gf'8
-                        } % measure
+                        }   % measure
                     }
 
             ..  container:: example
@@ -1179,20 +1234,21 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
-                        { % measure
+                    \new Staff
+                    {
+                        {   % measure
                             \time 2/8
                             <c' bf'>8
                             <g' a'>8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             af'8
                             r8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             r8
                             gf'8
-                        } % measure
+                        }   % measure
                     }
 
             ..  container:: example
@@ -1218,20 +1274,21 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
-                        { % measure
+                    \new Staff
+                    {
+                        {   % measure
                             \time 2/8
                             <c' bf'>8
                             <g' a'>8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             af'8
                             r8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             r8
                             gf'8
-                        } % measure
+                        }   % measure
                     }
 
             ..  container:: example
@@ -1282,7 +1339,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'4 ~
                         \times 2/3 {
                             c'16
@@ -1316,7 +1374,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'4 ~
                         \times 2/3 {
                             c'16
@@ -1352,7 +1411,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'4 ~
                         \times 2/3 {
                             c'16
@@ -1386,7 +1446,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'4 ~
                         \times 2/3 {
                             c'16
@@ -1424,7 +1485,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8 [
                         \grace {
                             cf''16
@@ -1467,7 +1529,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'4 ~
                         \times 2/3 {
                             c'16
@@ -1503,7 +1566,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8 ~ [
                         c'8 ~
                         c'8
@@ -1550,7 +1614,8 @@ class Iteration(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.instrumentName = \markup { Violin }
                     \set Staff.shortInstrumentName = \markup { Vn. }
                     c'8
@@ -1593,15 +1658,18 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff {
+                    \new Score
+                    <<
+                        \new Staff
+                        {
                             c'8
                             d'8
                             e'8
                             f'8
                             g'4
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c4
                             a,4
@@ -1641,7 +1709,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         <c' d' e'>4
                         <f'' g''>4
                     }
@@ -1704,7 +1773,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'8 [
                         d'8
                         e'8
@@ -1735,7 +1805,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'8 [
                         d'8
                         e'8
@@ -1853,7 +1924,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'8 [ (
                         d'8
                         e'8
@@ -1889,7 +1961,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'8 [ (
                         d'8
                         e'8
@@ -1947,14 +2020,17 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff {
+                    \new Score
+                    <<
+                        \new Staff
+                        {
                             c'4
                             d'4
                             e'4
                             f'4
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             g'8
                             a'8
                             b'8
@@ -1990,14 +2066,17 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff {
+                    \new Score
+                    <<
+                        \new Staff
+                        {
                             c'4
                             d'4
                             e'4
                             f'4
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             g'8
                             a'8
                             b'8
@@ -2033,7 +2112,8 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice {
+                    \new Voice
+                    {
                         c'8 [
                         \grace {
                             cf''16
@@ -2158,8 +2238,10 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff {
+                    \new Score
+                    <<
+                        \new Staff
+                        {
                             \tweak text #tuplet-number::calc-fraction-text
                             \times 4/3 {
                                 d''8
@@ -2167,12 +2249,15 @@ class Iteration(abctools.AbjadObject):
                                 b'8
                             }
                         }
-                        \new PianoStaff <<
-                            \new Staff {
+                        \new PianoStaff
+                        <<
+                            \new Staff
+                            {
                                 a'4
                                 g'4
                             }
-                            \new Staff {
+                            \new Staff
+                            {
                                 \clef "bass"
                                 f'8
                                 e'8
@@ -2221,8 +2306,10 @@ class Iteration(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff {
+                    \new Score
+                    <<
+                        \new Staff
+                        {
                             \tweak text #tuplet-number::calc-fraction-text
                             \times 4/3 {
                                 d''8
@@ -2230,12 +2317,15 @@ class Iteration(abctools.AbjadObject):
                                 b'8
                             }
                         }
-                        \new PianoStaff <<
-                            \new Staff {
+                        \new PianoStaff
+                        <<
+                            \new Staff
+                            {
                                 a'4
                                 g'4
                             }
-                            \new Staff {
+                            \new Staff
+                            {
                                 \clef "bass"
                                 f'8
                                 e'8

--- a/abjad/tools/scoretools/Label.py
+++ b/abjad/tools/scoretools/Label.py
@@ -22,7 +22,8 @@ class Label(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4
                         ^ \markup {
                             \small
@@ -74,7 +75,8 @@ class Label(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4
                         ^ \markup {
                             \small
@@ -111,7 +113,8 @@ class Label(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4
                         ^ \markup {
                             \small
@@ -163,7 +166,8 @@ class Label(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4
                         ^ \markup {
                             \small
@@ -324,7 +328,7 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(measure)
-                    { % measure
+                    {   % measure
                         \override Accidental.color = #red
                         \override Beam.color = #red
                         \override Dots.color = #red
@@ -344,7 +348,7 @@ class Label(abctools.AbjadObject):
                         \revert Stem.color
                         \revert TupletBracket.color
                         \revert TupletNumber.color
-                    } % measure
+                    }   % measure
 
             ..  container:: example expression
 
@@ -356,7 +360,7 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(measure)
-                    { % measure
+                    {   % measure
                         \override Accidental.color = #red
                         \override Beam.color = #red
                         \override Dots.color = #red
@@ -376,7 +380,7 @@ class Label(abctools.AbjadObject):
                         \revert Stem.color
                         \revert TupletBracket.color
                         \revert TupletNumber.color
-                    } % measure
+                    }   % measure
 
         Returns none.
         '''
@@ -408,7 +412,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -438,7 +443,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -581,7 +587,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         \once \override NoteHead.color = #(x11-color 'red)
                         c'8
                         \once \override NoteHead.color = #(x11-color 'MediumBlue)
@@ -620,7 +627,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         \once \override NoteHead.color = #(x11-color 'red)
                         c'8
                         \once \override NoteHead.color = #(x11-color 'MediumBlue)
@@ -687,7 +695,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'8
                             ^ \markup {
                                 \small
@@ -716,7 +725,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'8
                         d'8
                         e'8
@@ -733,7 +743,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'8
                             ^ \markup {
                                 \small
@@ -763,7 +774,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'8
                         d'8
                         e'8
@@ -800,8 +812,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -823,7 +837,8 @@ class Label(abctools.AbjadObject):
                                         4
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -832,7 +847,8 @@ class Label(abctools.AbjadObject):
                                         2
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -854,8 +870,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -877,7 +895,8 @@ class Label(abctools.AbjadObject):
                                         4
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -886,7 +905,8 @@ class Label(abctools.AbjadObject):
                                         2
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -913,8 +933,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -956,7 +978,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -970,7 +993,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -993,8 +1017,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -1036,7 +1062,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -1050,7 +1077,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -1076,8 +1104,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -1117,7 +1147,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -1131,7 +1162,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -1154,8 +1186,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -1195,7 +1229,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -1209,7 +1244,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -1235,8 +1271,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -1274,7 +1312,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -1287,7 +1326,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -1310,8 +1350,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -1349,7 +1391,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -1362,7 +1405,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -1388,8 +1432,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -1427,7 +1473,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -1440,7 +1487,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -1463,8 +1511,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -1502,7 +1552,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -1515,7 +1566,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -1541,8 +1593,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -1568,7 +1622,8 @@ class Label(abctools.AbjadObject):
                                             1000020
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -1578,7 +1633,8 @@ class Label(abctools.AbjadObject):
                                             0011010
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -1601,8 +1657,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -1628,7 +1686,8 @@ class Label(abctools.AbjadObject):
                                             1000020
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -1638,7 +1697,8 @@ class Label(abctools.AbjadObject):
                                             0011010
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -1664,8 +1724,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -1699,7 +1761,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -1711,7 +1774,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -1734,8 +1798,10 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff_group)
-                    \new StaffGroup <<
-                        \new Staff {
+                    \new StaffGroup
+                    <<
+                        \new Staff
+                        {
                             c'8
                                 ^ \markup {
                                     \tiny
@@ -1769,7 +1835,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "alto"
                             g4
                             f4
@@ -1781,7 +1848,8 @@ class Label(abctools.AbjadObject):
                                             }
                                     }
                         }
-                        \new Staff {
+                        \new Staff
+                        {
                             \clef "bass"
                             c,2
                         }
@@ -1915,7 +1983,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'4.
                             ^ \markup {
                                 \small
@@ -1949,7 +2018,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'4.
                             ^ \markup {
                                 \small
@@ -1986,7 +2056,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'4.
                             ^ \markup {
                                 \small
@@ -2020,7 +2091,8 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
+                    \new Staff
+                    {
                         c'4.
                             ^ \markup {
                                 \small
@@ -2075,9 +2147,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         <c' bf'>8
                             ^ \markup {
                                 \small
@@ -2113,9 +2188,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         <c' bf'>8
                             ^ \markup {
                                 \small
@@ -2154,9 +2232,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         <c' bf'>8
                         <g' a'>4
                         af'8 ~
@@ -2194,9 +2275,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         <c' bf'>8
                         <g' a'>4
                         af'8 ~
@@ -2235,9 +2319,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         <c' bf'>8
                             ^ \markup {
                                 \small
@@ -2267,9 +2354,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         <c' bf'>8
                             ^ \markup {
                                 \small
@@ -2300,9 +2390,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         <c' bf'>8
                             ^ \markup {
                                 \small
@@ -2348,9 +2441,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         <c' bf'>8
                             ^ \markup {
                                 \small
@@ -2398,9 +2494,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         \times 2/3 {
                             c'8
                                 ^ \markup {
@@ -2453,9 +2552,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         \times 2/3 {
                             c'8
                                 ^ \markup {
@@ -2532,9 +2634,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         c'4 ^ \markup { +aug15 }
                         cs'''4 ^ \markup { -M9 }
                         b'4 ^ \markup { -aug9 }
@@ -2559,9 +2664,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         c'4 ^ \markup { +aug15 }
                         cs'''4 ^ \markup { -M9 }
                         b'4 ^ \markup { -aug9 }
@@ -2590,9 +2698,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         c'4 ^ \markup { +aug8 }
                         cs'''4 ^ \markup { -M2 }
                         b'4 ^ \markup { -aug2 }
@@ -2618,9 +2729,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         c'4 ^ \markup { +aug8 }
                         cs'''4 ^ \markup { -M2 }
                         b'4 ^ \markup { -aug2 }
@@ -2649,9 +2763,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         c'4 ^ \markup { +25 }
                         cs'''4 ^ \markup { -14 }
                         b'4 ^ \markup { -15 }
@@ -2677,9 +2794,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         c'4 ^ \markup { +25 }
                         cs'''4 ^ \markup { -14 }
                         b'4 ^ \markup { -15 }
@@ -2709,9 +2829,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         c'4 ^ \markup { +1 }
                         cs'''4 ^ \markup { -2 }
                         b'4 ^ \markup { -3 }
@@ -2737,9 +2860,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         c'4 ^ \markup { +1 }
                         cs'''4 ^ \markup { -2 }
                         b'4 ^ \markup { -3 }
@@ -2769,9 +2895,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         c'4 ^ \markup { 1 }
                         cs'''4 ^ \markup { 2 }
                         b'4 ^ \markup { 3 }
@@ -2797,9 +2926,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         c'4 ^ \markup { 1 }
                         cs'''4 ^ \markup { 2 }
                         b'4 ^ \markup { 3 }
@@ -2859,9 +2991,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         <a d' fs'>4
                             ^ \markup {
                                 \small
@@ -2897,9 +3032,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         <a d' fs'>4
                             ^ \markup {
                                 \small
@@ -2938,9 +3076,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         <a d' fs'>4
                             ^ \markup {
                                 \small
@@ -2976,9 +3117,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         <a d' fs'>4
                             ^ \markup {
                                 \small
@@ -3018,9 +3162,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         <a d' fs'>4
                             ^ \markup {
                                 \small
@@ -3057,9 +3204,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         <a d' fs'>4
                             ^ \markup {
                                 \small
@@ -3099,9 +3249,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         <a d' fs'>4
                             ^ \markup {
                                 \small
@@ -3138,9 +3291,12 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
-                    } {
+                    }
+                    {
                         <a d' fs'>4
                             ^ \markup {
                                 \small
@@ -3187,11 +3343,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''4 \startGroup
                             ^ \markup {
                                 \small
@@ -3234,11 +3393,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''4 \startGroup
                             ^ \markup {
                                 \small
@@ -3285,11 +3447,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''4 \startGroup
                             ^ \markup {
                                 \small
@@ -3333,11 +3498,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''4 \startGroup
                             ^ \markup {
                                 \small
@@ -3385,11 +3553,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''4 \startGroup
                             ^ \markup {
                                 \small
@@ -3433,11 +3604,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''4 \startGroup
                             ^ \markup {
                                 \small
@@ -3545,11 +3719,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''8 \startGroup
                             ^ \markup {
                                 \tiny
@@ -3594,11 +3771,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''8 \startGroup
                             ^ \markup {
                                 \tiny
@@ -3648,11 +3828,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''8 \startGroup
                             ^ \markup {
                                 \tiny
@@ -3698,11 +3881,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''8 \startGroup
                             ^ \markup {
                                 \tiny
@@ -3751,11 +3937,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''8 \startGroup
                             ^ \markup {
                                 \tiny
@@ -3801,11 +3990,14 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(voice)
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \consists Horizontal_bracket_engraver
                         \override HorizontalBracket.staff-padding = #3
                         \override TextScript.staff-padding = #2
-                    } {
+                    }
+                    {
                         df''8 \startGroup
                             ^ \markup {
                                 \tiny
@@ -3886,10 +4078,13 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
                         \override TupletBracket.staff-padding = #0
-                    } {
+                    }
+                    {
                         \times 2/3 {
                             c'4 ^ \markup { 0 }
                             d'4 ^ \markup { 1/6 }
@@ -3914,10 +4109,13 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \override TextScript.staff-padding = #4
                         \override TupletBracket.staff-padding = #0
-                    } {
+                    }
+                    {
                         \times 2/3 {
                             c'4 ^ \markup { 0 }
                             d'4 ^ \markup { 1/6 }
@@ -3947,11 +4145,15 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff \with {
+                    \new Score
+                    <<
+                        \new Staff
+                        \with
+                        {
                             \override TextScript.staff-padding = #4
                             \override TupletBracket.staff-padding = #0
-                        } {
+                        }
+                        {
                             \tempo 4=60
                             c'2 ^ \markup { 0'00'' }
                             d'2 ^ \markup { 0'02'' }
@@ -3977,11 +4179,15 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff \with {
+                    \new Score
+                    <<
+                        \new Staff
+                        \with
+                        {
                             \override TextScript.staff-padding = #4
                             \override TupletBracket.staff-padding = #0
-                        } {
+                        }
+                        {
                             \tempo 4=60
                             c'2 ^ \markup { 0'00'' }
                             d'2 ^ \markup { 0'02'' }
@@ -4014,11 +4220,15 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff \with {
+                    \new Score
+                    <<
+                        \new Staff
+                        \with
+                        {
                             \override TextScript.staff-padding = #4
                             \override TupletBracket.staff-padding = #0
-                        } {
+                        }
+                        {
                             \tempo 4=60
                             c'2
                                 ^ \markup {
@@ -4067,11 +4277,15 @@ class Label(abctools.AbjadObject):
                 ..  docs::
 
                     >>> abjad.f(score)
-                    \new Score <<
-                        \new Staff \with {
+                    \new Score
+                    <<
+                        \new Staff
+                        \with
+                        {
                             \override TextScript.staff-padding = #4
                             \override TupletBracket.staff-padding = #0
-                        } {
+                        }
+                        {
                             \tempo 4=60
                             c'2
                                 ^ \markup {

--- a/abjad/tools/scoretools/LeafMaker.py
+++ b/abjad/tools/scoretools/LeafMaker.py
@@ -20,7 +20,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 d'4
                 e'4
                 fs''4
@@ -41,7 +42,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 <c' d' e'>2
                 <fs'' gs'' as''>2
             }
@@ -61,7 +63,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new RhythmicStaff {
+            \new RhythmicStaff
+            {
                 r4
                 r4
                 r4
@@ -82,7 +85,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 <c' d' e'>4
                 r4
                 cs''4
@@ -103,7 +107,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 e''4
                 ef''4
                 d''4
@@ -126,7 +131,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c''4.
                 c''8
                 c''4.
@@ -148,7 +154,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c''4
                 d''4
                 e''4
@@ -170,7 +177,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \times 2/3 {
                     d''2
                     d''2
@@ -195,7 +203,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \time 13/16
                 ds''2. ~
                 ds''16
@@ -218,7 +227,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \time 13/16
                 e''16 ~
                 e''2.
@@ -243,7 +253,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \time 5/4
                 f'4 ~
                 f'4 ~
@@ -272,7 +283,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \time 5/4
                 f'8 ~
                 f'4 ~
@@ -299,7 +311,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \tweak edge-height #'(0.7 . 0)
                 \times 4/7 {
                     \time 5/14
@@ -327,7 +340,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \tweak text #tuplet-number::calc-fraction-text
                 \tweak edge-height #'(0.7 . 0)
                 \times 8/7 {
@@ -359,15 +373,16 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new RhythmicStaff {
-                { % measure
+            \new RhythmicStaff
+            {
+                {   % measure
                     \time 3/8
                     R1 * 3/8
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 5/8
                     R1 * 5/8
-                } % measure
+                }   % measure
             }
 
     ..  container:: example
@@ -384,7 +399,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'2.
                 c'16 \repeatTie
             }
@@ -403,7 +419,8 @@ class LeafMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 fs'2. ~
                 fs'16
             }

--- a/abjad/tools/scoretools/Lineage.py
+++ b/abjad/tools/scoretools/Lineage.py
@@ -22,14 +22,19 @@ class Lineage(abctools.AbjadObject, collections.Sequence):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \context Staff = "Treble Staff" {
-                    \context Voice = "Treble Voice" {
+            \new Score
+            <<
+                \context Staff = "Treble Staff"
+                {
+                    \context Voice = "Treble Voice"
+                    {
                         c'4
                     }
                 }
-                \context Staff = "Bass Staff" {
-                    \context Voice = "Bass Voice" {
+                \context Staff = "Bass Staff"
+                {
+                    \context Voice = "Bass Voice"
+                    {
                         b,4
                     }
                 }

--- a/abjad/tools/scoretools/LogicalTie.py
+++ b/abjad/tools/scoretools/LogicalTie.py
@@ -208,9 +208,12 @@ class LogicalTie(Selection):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \time 7/16
                     c'8 ~ \< \p
                     c'16
@@ -228,9 +231,12 @@ class LogicalTie(Selection):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/5 {
                         \time 7/16
@@ -259,9 +265,12 @@ class LogicalTie(Selection):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \time 7/16
                     c'8 ~ \< \p
                     c'16
@@ -281,9 +290,12 @@ class LogicalTie(Selection):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 6/5 {
                         \time 7/16

--- a/abjad/tools/scoretools/Measure.py
+++ b/abjad/tools/scoretools/Measure.py
@@ -14,13 +14,13 @@ class Measure(Container):
     ..  docs::
 
         >>> abjad.f(measure)
-        { % measure
+        {   % measure
             \time 4/8
             c'8
             d'8
             e'8
             f'8
-        } % measure
+        }   % measure
 
     '''
 
@@ -33,14 +33,13 @@ class Measure(Container):
         '_implicit_scaling',
         )
 
-    _bracket_comment = ' % measure'
-
     ### INITIALIZER ###
 
     def __init__(
         self,
         time_signature=None,
         components=None,
+        identifier='% measure',
         implicit_scaling=False,
         ):
         import abjad
@@ -49,7 +48,7 @@ class Measure(Container):
         time_signature = time_signature or abjad.TimeSignature((4, 4))
         time_signature = abjad.TimeSignature(time_signature)
         self.implicit_scaling = bool(implicit_scaling)
-        Container.__init__(self, components)
+        Container.__init__(self, components, identifier=identifier)
         self._always_format_time_signature = False
         self._measure_number = None
         time_signature = abjad.TimeSignature(time_signature)
@@ -110,9 +109,14 @@ class Measure(Container):
     def __getnewargs__(self):
         r'''Gets arguments for shallow copy.
 
-        Returns triple.
+        Returns tuple.
         '''
-        return self.time_signature, [], self.implicit_scaling
+        return (
+            self.time_signature,
+            [],
+            self.identifier,
+            self.implicit_scaling,
+            )
 
     def __repr__(self):
         r'''Gets interpreter representation of measure.
@@ -668,18 +672,19 @@ class Measure(Container):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 3/4
                         c'4
                         d'4
                         e'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/4
                         f'4
                         g'4
-                    } % measure
+                    }   % measure
                 }
 
             >>> staff[0].measure_number
@@ -763,12 +768,12 @@ class Measure(Container):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 3/8
                     c'8
                     d'8
                     e'8
-                } % measure
+                }   % measure
 
             >>> measure.scale_and_adjust_time_signature(abjad.Multiplier(2, 3))
             >>> abjad.show(measure) # doctest: +SKIP
@@ -776,14 +781,14 @@ class Measure(Container):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 3/12
                     \scaleDurations #'(2 . 3) {
                         c'8
                         d'8
                         e'8
                     }
-                } % measure
+                }   % measure
 
         Returns none.
         '''

--- a/abjad/tools/scoretools/MeasureMaker.py
+++ b/abjad/tools/scoretools/MeasureMaker.py
@@ -14,18 +14,19 @@ class MeasureMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
-                { % measure
+            \new Staff
+            {
+                {   % measure
                     \time 1/8
                     s1 * 1/8
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \time 5/16
                     s1 * 5/16
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     s1 * 5/16
-                } % measure
+                }   % measure
             }
 
     '''

--- a/abjad/tools/scoretools/Mutation.py
+++ b/abjad/tools/scoretools/Mutation.py
@@ -61,7 +61,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \clef "treble"
                     c'8
                     cs'8
@@ -92,7 +93,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \clef "treble"
                     c'8
                     cs'8
@@ -120,7 +122,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \time 2/4
                     c'8 (
                     d'8
@@ -140,7 +143,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(new_staff)
-                \new Staff {
+                \new Staff
+                {
                     e'8 (
                     f'8 )
                 }
@@ -195,7 +199,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new RhythmicStaff {
+                \new RhythmicStaff
+                {
                     c'4 ~
                     c'4
                     d'4 ~
@@ -238,7 +243,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/2 {
                         \time 3/4
@@ -259,7 +265,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \time 3/4
                     c'4 \< \p
                     e'4
@@ -284,7 +291,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/2 {
                         \time 3/4
@@ -307,7 +315,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \time 3/4
                     c'4. \< \p
                     e'4.
@@ -336,7 +345,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     d'4.
                 }
@@ -357,7 +367,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 2/3 {
                         c'8 [
                         d'8
@@ -378,7 +389,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 2/3 {
                         c'8 [
                         d'8
@@ -416,17 +428,18 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 1/4
                         c'8 (
                         d'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/8
                         e'8
                         f'8 )
-                    } % measure
+                    }   % measure
                 }
 
             >>> measures = staff[:]
@@ -437,14 +450,15 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 2/4
                         c'8 (
                         d'8
                         e'8
                         f'8 )
-                    } % measure
+                    }   % measure
                 }
 
         Returns selection.
@@ -482,7 +496,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 2/3 {
                         c'4 \< \p (
                         d'4
@@ -503,7 +518,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'16 \< \p (
                     d'16
                     e'16
@@ -532,7 +548,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \clef "alto"
                     c'2
                     f'4
@@ -553,7 +570,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     <d' e'>2
                     f'4
                     g'4
@@ -582,7 +600,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \clef "alto"
                     c'2
                     f'4
@@ -603,7 +622,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \clef "alto"
                     <d' e'>2
                     f'4
@@ -680,15 +700,16 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 1/8
                         s1 * 1/8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         s1 * 3/16
-                    } % measure
+                    }   % measure
                 }
 
             >>> notes = [
@@ -704,18 +725,19 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 1/8
                         c'16
                         d'16
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/16
                         e'16
                         f'16
                         s1 * 1/16
-                    } % measure
+                    }   % measure
                 }
 
         Preserves duration of all measures.
@@ -804,22 +826,23 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 2/4
                         c'2 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/4
                         c'32
                         d'2.. ~
                         d'16
                         e'32 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/4
                         e'2
-                    } % measure
+                    }   % measure
                 }
 
             >>> meter = abjad.Meter((4, 4))
@@ -836,23 +859,24 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 2/4
                         c'2 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/4
                         c'32
                         d'8.. ~
                         d'2 ~
                         d'8..
                         e'32 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/4
                         e'2
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -865,22 +889,23 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 2/4
                         c'2 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/4
                         c'32
                         d'2.. ~
                         d'16
                         e'32 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/4
                         e'2
-                    } % measure
+                    }   % measure
                 }
 
             >>> rtm = '(4/4 ((2/4 (1/4 1/4)) (2/4 (1/4 1/4))))'
@@ -900,22 +925,23 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 2/4
                         c'2 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 4/4
                         c'32
                         d'4... ~
                         d'4...
                         e'32 ~
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 2/4
                         e'2
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -930,13 +956,13 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 3/4
                     c'32
                     d'8
                     e'8
                     fs'4...
-                } % measure
+                }   % measure
 
             Without constraining the `maximum_dot_count`:
 
@@ -946,7 +972,7 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 3/4
                     c'32
                     d'16. ~
@@ -954,7 +980,7 @@ class Mutation(abctools.AbjadObject):
                     e'16. ~
                     e'32
                     fs'4...
-                } % measure
+                }   % measure
 
             Constraining the `maximum_dot_count` to `2`:
 
@@ -968,7 +994,7 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 3/4
                     c'32
                     d'16. ~
@@ -977,7 +1003,7 @@ class Mutation(abctools.AbjadObject):
                     e'32
                     fs'8.. ~
                     fs'4
-                } % measure
+                }   % measure
 
             Constraining the `maximum_dot_count` to `1`:
 
@@ -991,7 +1017,7 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 3/4
                     c'32
                     d'16. ~
@@ -1001,7 +1027,7 @@ class Mutation(abctools.AbjadObject):
                     fs'16. ~
                     fs'8 ~
                     fs'4
-                } % measure
+                }   % measure
 
             Constraining the `maximum_dot_count` to `0`:
 
@@ -1015,7 +1041,7 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 3/4
                     c'32
                     d'16 ~
@@ -1028,7 +1054,7 @@ class Mutation(abctools.AbjadObject):
                     fs'32 ~
                     fs'8 ~
                     fs'4
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -1064,12 +1090,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 9/8
                     c'2
                     d'2
                     e'8
-                } % measure
+                }   % measure
 
             >>> abjad.mutate(measure[:]).rewrite_meter(measure)
             >>> abjad.show(measure) # doctest: +SKIP
@@ -1077,13 +1103,13 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 9/8
                     c'2
                     d'4 ~
                     d'4
                     e'8
-                } % measure
+                }   % measure
 
             With a `boundary_depth` of `1`, logical ties which cross any offsets
             created by nodes with a depth of `1` in this Meter's rhythm
@@ -1100,14 +1126,14 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 9/8
                     c'4. ~
                     c'8
                     d'4 ~
                     d'4
                     e'8
-                } % measure
+                }   % measure
 
             For this `9/8` meter, and this input notation, A `boundary_depth`
             of `2` causes no change, as all logical ties already align to
@@ -1123,13 +1149,13 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 9/8
                     c'2
                     d'4 ~
                     d'4
                     e'8
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -1161,68 +1187,77 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score \with {
+                \new Score
+                \with
+                {
                     \remove Timing_translator
                     \remove Time_signature_engraver
                     \remove Default_bar_line_engraver
-                } <<
-                    \new Staff \with {
+                }
+                <<
+                    \new Staff
+                    \with
+                    {
                         \consists Timing_translator
                         \consists Time_signature_engraver
                         \consists Default_bar_line_engraver
-                    } {
-                        { % measure
+                    }
+                    {
+                        {   % measure
                             \time 3/4
                             c'2
                             c'4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4
                             c'2
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4.
                             c'4.
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'2 ~
                             c'8
                             c'8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'8
                             c'8 ~
                             c'2
-                        } % measure
+                        }   % measure
                     }
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \consists Timing_translator
                         \consists Time_signature_engraver
                         \consists Default_bar_line_engraver
-                    } {
-                        { % measure
+                    }
+                    {
+                        {   % measure
                             \time 6/8
                             c'2
                             c'4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4
                             c'2
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4.
                             c'4.
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'2 ~
                             c'8
                             c'8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'8
                             c'8 ~
                             c'2
-                        } % measure
+                        }   % measure
                     }
                 >>
 
@@ -1236,68 +1271,77 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score \with {
+                \new Score
+                \with
+                {
                     \remove Timing_translator
                     \remove Time_signature_engraver
                     \remove Default_bar_line_engraver
-                } <<
-                    \new Staff \with {
+                }
+                <<
+                    \new Staff
+                    \with
+                    {
                         \consists Timing_translator
                         \consists Time_signature_engraver
                         \consists Default_bar_line_engraver
-                    } {
-                        { % measure
+                    }
+                    {
+                        {   % measure
                             \time 3/4
                             c'2
                             c'4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4
                             c'2
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4.
                             c'4.
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'2 ~
                             c'8
                             c'8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'8
                             c'8 ~
                             c'2
-                        } % measure
+                        }   % measure
                     }
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \consists Timing_translator
                         \consists Time_signature_engraver
                         \consists Default_bar_line_engraver
-                    } {
-                        { % measure
+                    }
+                    {
+                        {   % measure
                             \time 6/8
                             c'2
                             c'4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4
                             c'2
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4.
                             c'4.
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4. ~
                             c'4
                             c'8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'8
                             c'4 ~
                             c'4.
-                        } % measure
+                        }   % measure
                     }
                 >>
 
@@ -1314,72 +1358,81 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score \with {
+                \new Score
+                \with
+                {
                     \remove Timing_translator
                     \remove Time_signature_engraver
                     \remove Default_bar_line_engraver
-                } <<
-                    \new Staff \with {
+                }
+                <<
+                    \new Staff
+                    \with
+                    {
                         \consists Timing_translator
                         \consists Time_signature_engraver
                         \consists Default_bar_line_engraver
-                    } {
-                        { % measure
+                    }
+                    {
+                        {   % measure
                             \time 3/4
                             c'2
                             c'4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4
                             c'2
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4 ~
                             c'8
                             c'8 ~
                             c'4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'2 ~
                             c'8
                             c'8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'8
                             c'8 ~
                             c'2
-                        } % measure
+                        }   % measure
                     }
-                    \new Staff \with {
+                    \new Staff
+                    \with
+                    {
                         \consists Timing_translator
                         \consists Time_signature_engraver
                         \consists Default_bar_line_engraver
-                    } {
-                        { % measure
+                    }
+                    {
+                        {   % measure
                             \time 6/8
                             c'4. ~
                             c'8
                             c'4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4
                             c'8 ~
                             c'4.
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4.
                             c'4.
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'4. ~
                             c'4
                             c'8
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             c'8
                             c'4 ~
                             c'4.
-                        } % measure
+                        }   % measure
                     }
                 >>
 
@@ -1399,7 +1452,7 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 4/4
                     c'16 ~
                     c'4
@@ -1414,7 +1467,7 @@ class Mutation(abctools.AbjadObject):
                         }
                     }
                     f'4
-                } % measure
+                }   % measure
 
             When establishing a meter on a selection of components
             which contain containers, like `Tuplets` or `Containers`,
@@ -1432,7 +1485,7 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 4/4
                     c'4 ~
                     c'16
@@ -1449,7 +1502,7 @@ class Mutation(abctools.AbjadObject):
                         }
                     }
                     f'4
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -1465,12 +1518,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 6/8
                     c'4..
                     c'16 ~
                     c'4
-                } % measure
+                }   % measure
 
             Setting boundary depth to 1 subdivides the first note in this
             measure:
@@ -1483,13 +1536,13 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 6/8
                     c'4. ~
                     c'16
                     c'16 ~
                     c'4
-                } % measure
+                }   % measure
 
             Another way of doing this is by setting preferred boundary depth on
             the meter itself:
@@ -1505,13 +1558,13 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 6/8
                     c'4. ~
                     c'16
                     c'16 ~
                     c'4
-                } % measure
+                }   % measure
 
             This makes it possible to divide different meters in different
             ways.
@@ -1526,12 +1579,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 4/4
                     c'4.
                     c'4.
                     c'4
-                } % measure
+                }   % measure
 
             >>> meter = abjad.Meter((4, 4))
             >>> abjad.mutate(measure[:]).rewrite_meter(
@@ -1544,14 +1597,14 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 4/4
                     c'4
                     c'8 \repeatTie
                     c'8
                     c'4 \repeatTie
                     c'4
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -1571,7 +1624,7 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 6/4
                     c'8 ~
                     c'8 ~
@@ -1589,7 +1642,7 @@ class Mutation(abctools.AbjadObject):
                     c'8 ~
                     c'8 ~
                     c'8
-                } % measure
+                }   % measure
 
             >>> meter = abjad.Meter((6, 4))
             >>> abjad.mutate(measure[:]).rewrite_meter(
@@ -1601,7 +1654,7 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 6/4
                     c'4.
                     \tweak text #tuplet-number::calc-fraction-text
@@ -1618,7 +1671,7 @@ class Mutation(abctools.AbjadObject):
                         c'4
                     }
                     c'4.
-                } % measure
+                }   % measure
 
             The tied note rewriting is good while the tuplet rewriting
             could use some adjustment.
@@ -1639,7 +1692,7 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 6/4
                     c'8 ~
                     c'8 ~
@@ -1657,7 +1710,7 @@ class Mutation(abctools.AbjadObject):
                     c'8 ~
                     c'8 ~
                     c'8
-                } % measure
+                }   % measure
 
             >>> meter = abjad.Meter((6, 4))
             >>> abjad.mutate(measure[:]).rewrite_meter(
@@ -1670,7 +1723,7 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 6/4
                     c'4.
                     \tweak text #tuplet-number::calc-fraction-text
@@ -1684,7 +1737,7 @@ class Mutation(abctools.AbjadObject):
                         c'4.
                     }
                     c'4.
-                } % measure
+                }   % measure
 
         Operates in place and returns none.
         '''
@@ -1720,7 +1773,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 (
                     d'8.
                     e'8
@@ -1739,7 +1793,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \time 3/8
                     c'8 -\accent ~
                     c'8
@@ -1754,7 +1809,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \time 3/8
                     c'4. -\accent
                     d'8
@@ -1803,7 +1859,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 (
                     d'8 ~
                     d'32
@@ -1823,7 +1880,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \time 5/16
                     c'8 -\accent ~
                     c'8
@@ -1838,7 +1896,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \time 5/16
                     c'4 -\accent ~
                     c'16
@@ -1892,7 +1951,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 (
                     \tweak edge-height #'(0.7 . 0)
                     \times 2/3 {
@@ -1912,7 +1972,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 -\accent
                 }
 
@@ -1924,7 +1985,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \tweak edge-height #'(0.7 . 0)
                     \times 2/3 {
                         c'4 -\accent
@@ -1986,7 +2048,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 (
                     \tweak edge-height #'(0.7 . 0)
                     \times 2/3 {
@@ -2034,7 +2097,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 4/5 {
                         \time 4/8
                         c'8
@@ -2051,7 +2115,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 4/5 {
                         \time 4/8
                         c'4
@@ -2077,7 +2142,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 4/5 {
                         \time 4/8
                         c'8
@@ -2094,7 +2160,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 4/5 {
                         \time 4/8
                         c'4
@@ -2161,9 +2228,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     c'8 \< \p
                     e'8
                     d'8
@@ -2184,9 +2254,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     c'8 \< \p
                     e'16
                     e'16
@@ -2212,9 +2285,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     c'8 \< \p
                     e'8
                     d'8
@@ -2237,9 +2313,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     c'8 \< \p
                     e'16 \f
                     e'16 \< \p
@@ -2266,9 +2345,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     c'8 \< \p
                     e'8
                     d'8
@@ -2290,9 +2372,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     c'8 \< \p
                     e'16
                     e'16
@@ -2321,9 +2406,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     c'8 \< \p
                     e'8
                     d'8
@@ -2346,9 +2434,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     c'8 \< \p
                     e'16 \f
                     e'16 \< \p
@@ -2378,7 +2469,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 2/3 {
                         c'4 (
                         d'4
@@ -2402,7 +2494,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 2/3 {
                         c'4 (
                         d'8 )
@@ -2429,9 +2522,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     c'1 \< \p
                     d'1 \f
                 }
@@ -2448,9 +2544,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     c'2. ~ \< \p
                     c'4
                     d'2 ~
@@ -2477,9 +2576,12 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
+                }
+                {
                     c'2. \< \p
                     c'4 \repeatTie
                     d'2
@@ -2504,10 +2606,14 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
-                    \context CustomVoice = "1" {
+                }
+                {
+                    \context CustomVoice = "1"
+                    {
                         c'4 \< \p
                         d'4
                         e'4
@@ -2527,31 +2633,42 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #3
-                } {
-                    \context CustomVoice = "1" {
+                }
+                {
+                    \context CustomVoice = "1"
+                    {
                         c'8 ~ \< \p
                     }
-                    \context CustomVoice = "1" {
+                    \context CustomVoice = "1"
+                    {
                         c'8
                     }
-                    \context CustomVoice = "1" {
+                    \context CustomVoice = "1"
+                    {
                         d'8 ~
                     }
-                    \context CustomVoice = "1" {
+                    \context CustomVoice = "1"
+                    {
                         d'8
                     }
-                    \context CustomVoice = "1" {
+                    \context CustomVoice = "1"
+                    {
                         e'8 ~
                     }
-                    \context CustomVoice = "1" {
+                    \context CustomVoice = "1"
+                    {
                         e'8
                     }
-                    \context CustomVoice = "1" {
+                    \context CustomVoice = "1"
+                    {
                         f'8 ~
                     }
-                    \context CustomVoice = "1" {
+                    \context CustomVoice = "1"
+                    {
                         f'8 \f
                     }
                 }
@@ -2593,20 +2710,27 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     <<
-                        \context Voice = "Voice 1" \with {
+                        \context Voice = "Voice 1"
+                        \with
+                        {
                             \override Slur.direction = #up
                             \override Stem.direction = #up
-                        } {
+                        }
+                        {
                             e''4 (
                             es''4
                             f''4
                             fs''4 )
                         }
-                        \context Voice = "Voice 2" \with {
+                        \context Voice = "Voice 2"
+                        \with
+                        {
                             \override Stem.direction = #down
-                        } {
+                        }
+                        {
                             c'4 \p \<
                             cs'4
                             d'4
@@ -2625,34 +2749,47 @@ class Mutation(abctools.AbjadObject):
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 <<
-                    \context Voice = "Voice 1" \with {
+                    \context Voice = "Voice 1"
+                    \with
+                    {
                         \override Slur.direction = #up
                         \override Stem.direction = #up
-                    } {
+                    }
+                    {
                         e''4 (
                         es''8 ~
                     }
-                    \context Voice = "Voice 2" \with {
+                    \context Voice = "Voice 2"
+                    \with
+                    {
                         \override Stem.direction = #down
-                    } {
+                    }
+                    {
                         c'4 \p \<
                         cs'8 ~
                     }
                 >>
                 <<
-                    \context Voice = "Voice 1" \with {
+                    \context Voice = "Voice 1"
+                    \with
+                    {
                         \override Slur.direction = #up
                         \override Stem.direction = #up
-                    } {
+                    }
+                    {
                         es''8
                         f''4
                         fs''4 )
                     }
-                    \context Voice = "Voice 2" \with {
+                    \context Voice = "Voice 2"
+                    \with
+                    {
                         \override Stem.direction = #down
-                    } {
+                    }
+                    {
                         cs'8
                         d'4
                         ds'4 \f
@@ -2674,7 +2811,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4 -\marcato
                     d'4 \laissezVibrer
                     e'4 -\marcato
@@ -2693,7 +2831,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 -\marcato ~
                     c'8
                     d'8 ~
@@ -2866,18 +3005,19 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 3/4
                         c'4 \< \p (
                         d'4
                         e'4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         d'4
                         e'4
                         f'4 \f )
-                    } % measure
+                    }   % measure
                 }
 
             >>> measures = staff[:]
@@ -2889,7 +3029,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 4/6 {
                         c'4 \< \p (
                         d'4
@@ -2931,20 +3072,21 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                     >>> abjad.f(staff)
-                    \new Staff {
-                        { % measure
+                    \new Staff
+                    {
+                        {   % measure
                             \time 4/4
                             c'4
                             d'4
                             e'4
                             r4
-                        } % measure
-                        { % measure
+                        }   % measure
+                        {   % measure
                             \time 3/4
                             d'4
                             e'4
                             <f' a' c''>4
-                        } % measure
+                        }   % measure
                     }
 
             >>> abjad.mutate(staff).transpose("+m3")
@@ -2953,20 +3095,21 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 4/4
                         ef'4
                         f'4
                         g'4
                         r4
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \time 3/4
                         f'4
                         g'4
                         <af' c'' ef''>4
-                    } % measure
+                    }   % measure
                 }
 
         Returns none.
@@ -2999,7 +3142,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 [ (
                     d'8
                     e'8 ] )
@@ -3015,7 +3159,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 [ (
                     d'8
                     e'8 ] )
@@ -3060,14 +3205,15 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
-                    { % measure
+                \new Voice
+                {
+                    {   % measure
                         \time 4/8
                         c'8
                         cs'8
                         d'8
                         ef'8
-                    } % measure
+                    }   % measure
                     e'8
                     f'8
                     fs'8
@@ -3088,20 +3234,21 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    { % measure
+                \new Staff
+                {
+                    {   % measure
                         \time 1/1
                         c'1
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         cs'1
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         d'1
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         ef'1
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -3130,7 +3277,8 @@ class Mutation(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     {
                         \time 3/8
                         c'4

--- a/abjad/tools/scoretools/Note.py
+++ b/abjad/tools/scoretools/Note.py
@@ -14,10 +14,10 @@ class Note(Leaf):
         ..  docs::
 
             >>> abjad.f(measure)
-            { % measure
+            {   % measure
                 \time 3/16
                 cs''8.
-            } % measure
+            }   % measure
 
     '''
 

--- a/abjad/tools/scoretools/NoteMaker.py
+++ b/abjad/tools/scoretools/NoteMaker.py
@@ -22,7 +22,8 @@ class NoteMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'16
                 c'8
                 c'8
@@ -44,7 +45,8 @@ class NoteMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'16
                 d'8
                 e'8
@@ -64,7 +66,8 @@ class NoteMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'16
                 \tweak edge-height #'(0.7 . 0)
                 \times 2/3 {
@@ -86,7 +89,8 @@ class NoteMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'2. ~
                 c'16
             }
@@ -104,7 +108,8 @@ class NoteMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'16 ~
                 c'2.
             }
@@ -121,7 +126,8 @@ class NoteMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'2.
                 c'16 \repeatTie
             }
@@ -139,7 +145,8 @@ class NoteMaker(AbjadValueObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 bf8
                 bqf8
                 fs'8

--- a/abjad/tools/scoretools/Parentage.py
+++ b/abjad/tools/scoretools/Parentage.py
@@ -22,14 +22,19 @@ class Parentage(abctools.AbjadObject, collections.Sequence):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \context Staff = "Treble Staff" {
-                    \context Voice = "Treble Voice" {
+            \new Score
+            <<
+                \context Staff = "Treble Staff"
+                {
+                    \context Voice = "Treble Voice"
+                    {
                         e'4
                     }
                 }
-                \context Staff = "Bass Staff" {
-                    \context Voice = "Bass Voice" {
+                \context Staff = "Bass Staff"
+                {
+                    \context Voice = "Bass Voice"
+                    {
                         \clef "bass"
                         c4
                     }
@@ -177,7 +182,8 @@ class Parentage(abctools.AbjadObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
+                \new Voice
+                {
                     c'4
                     \grace {
                         c'16
@@ -232,9 +238,12 @@ class Parentage(abctools.AbjadObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(score)
-                \context Score = "CustomScore" <<
-                    \context Staff = "CustomStaff" {
-                        \context Voice = "CustomVoice" {
+                \context Score = "CustomScore"
+                <<
+                    \context Staff = "CustomStaff"
+                    {
+                        \context Voice = "CustomVoice"
+                        {
                             c'4
                             d'4
                             e'4
@@ -330,17 +339,20 @@ class Parentage(abctools.AbjadObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff {
+                \new Score
+                <<
+                    \new Staff
+                    {
                         \times 2/3 {
                             c''2
                             b'2
                             a'2
                         }
                     }
-                    \new Staff {
-                            c'2
-                            d'2
+                    \new Staff
+                    {
+                        c'2
+                        d'2
                     }
                 >>
 
@@ -366,7 +378,8 @@ class Parentage(abctools.AbjadObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
+                \new Voice
+                {
                     c'8 [
                     \grace {
                         cf''16
@@ -419,7 +432,8 @@ class Parentage(abctools.AbjadObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 2/3 {
                         c'2
                         d'2

--- a/abjad/tools/scoretools/Rest.py
+++ b/abjad/tools/scoretools/Rest.py
@@ -14,10 +14,10 @@ class Rest(Leaf):
         ..  docs::
 
             >>> abjad.f(measure)
-            { % measure
+            {   % measure
                 \time 3/16
                 r8.
-            } % measure
+            }   % measure
 
     '''
 

--- a/abjad/tools/scoretools/Score.py
+++ b/abjad/tools/scoretools/Score.py
@@ -15,14 +15,17 @@ class Score(Context):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     c'8
                     d'8
                     e'8
                     f'8
                 }
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     d'8
                     e'8
@@ -74,8 +77,10 @@ class Score(Context):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     c'4
                     d'4
                     e'4
@@ -90,8 +95,10 @@ class Score(Context):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     c'4
                     d'4
                     e'4
@@ -137,8 +144,10 @@ class Score(Context):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff {
+                \new Score
+                <<
+                    \new Staff
+                    {
                         c'4
                         d'4
                         e'4
@@ -181,8 +190,10 @@ class Score(Context):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff {
+                \new Score
+                <<
+                    \new Staff
+                    {
                         c'4
                         d'4
                         e'4
@@ -226,11 +237,15 @@ class Score(Context):
             >>> result = abjad.Score.make_piano_score()
 
             >>> abjad.f(result[0])
-            \new Score <<
-                \new PianoStaff <<
-                    \context Staff = "Treble Staff" {
+            \new Score
+            <<
+                \new PianoStaff
+                <<
+                    \context Staff = "Treble Staff"
+                    {
                     }
-                    \context Staff = "Bass Staff" {
+                    \context Staff = "Bass Staff"
+                    {
                     }
                 >>
             >>
@@ -246,9 +261,12 @@ class Score(Context):
             ..  docs::
 
                 >>> abjad.f(result[0])
-                \new Score <<
-                    \new PianoStaff <<
-                        \context Staff = "Treble Staff" {
+                \new Score
+                <<
+                    \new PianoStaff
+                    <<
+                        \context Staff = "Treble Staff"
+                        {
                             \clef "treble"
                             r4
                             cs''''4
@@ -257,7 +275,8 @@ class Score(Context):
                             e'4
                             f''4
                         }
-                        \context Staff = "Bass Staff" {
+                        \context Staff = "Bass Staff"
+                        {
                             \clef "bass"
                             c4
                             r4
@@ -287,14 +306,19 @@ class Score(Context):
             ..  docs::
 
                 >>> abjad.f(result[0])
-                \new Score \with {
+                \new Score
+                \with
+                {
                     \override BarLine.stencil = ##f
                     \override BarNumber.transparent = ##t
                     \override SpanBar.stencil = ##f
                     \override TimeSignature.stencil = ##f
-                } <<
-                    \new PianoStaff <<
-                        \context Staff = "Treble Staff" {
+                }
+                <<
+                    \new PianoStaff
+                    <<
+                        \context Staff = "Treble Staff"
+                        {
                             \clef "treble"
                             r16
                             r16
@@ -307,7 +331,8 @@ class Score(Context):
                             f'16
                             g'16
                         }
-                        \context Staff = "Bass Staff" {
+                        \context Staff = "Bass Staff"
+                        {
                             \clef "bass"
                             c16
                             d16
@@ -322,6 +347,7 @@ class Score(Context):
                         }
                     >>
                 >>
+
 
         Returns score, treble staff, bass staff triple.
         """

--- a/abjad/tools/scoretools/Selection.py
+++ b/abjad/tools/scoretools/Selection.py
@@ -46,9 +46,12 @@ class Selection(AbjadValueObject, collections.Sequence):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 \once \override Accidental.color = #red
                 \once \override Beam.color = #red
                 \once \override Dots.color = #red
@@ -199,9 +202,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -264,9 +270,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -337,9 +346,12 @@ class Selection(AbjadValueObject, collections.Sequence):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8
                 d'8 ~
                 \once \override Accidental.color = #blue
@@ -1309,11 +1321,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -1346,7 +1361,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             \once \override Stem.color = #green
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -1414,11 +1429,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -1491,7 +1509,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             \once \override Stem.color = #red
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -1544,9 +1562,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -1633,9 +1654,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8
                     r8
                     \once \override Accidental.color = #red
@@ -1700,9 +1724,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8
                     r8
                     \once \override Accidental.color = #red
@@ -1758,9 +1785,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -1829,9 +1859,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8
                     r8
                     \once \override Accidental.color = #red
@@ -1900,9 +1933,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -1975,9 +2011,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -2042,9 +2081,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -2110,9 +2152,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -2180,9 +2225,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8
                     r8
                     \once \override Accidental.color = #red
@@ -2238,9 +2286,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -2326,11 +2377,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -2379,7 +2433,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             <fs' gs'>4 ~
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -2434,11 +2488,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -2487,7 +2544,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             <fs' gs'>4 ~
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         Returns new selection (or expression).
@@ -2535,9 +2592,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #green
                     \once \override Beam.color = #green
                     \once \override Dots.color = #green
@@ -2664,9 +2724,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -2759,7 +2822,8 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
@@ -2851,9 +2915,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'4
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
@@ -2921,9 +2988,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -3035,9 +3105,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -3167,9 +3240,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -3282,9 +3358,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -3403,9 +3482,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -3502,9 +3584,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -3582,9 +3667,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \time 2/8
                     c'8
                     \once \override Accidental.color = #red
@@ -3656,9 +3744,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -3775,9 +3866,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -3891,11 +3985,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -3928,7 +4025,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             \once \override Stem.color = #green
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -4000,9 +4097,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         \once \override Dots.color = #red
                         \once \override Rest.color = #red
@@ -4101,9 +4201,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         r8
                         \once \override Accidental.color = #red
@@ -4202,9 +4305,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         r8
                         \ottava #1
@@ -4310,9 +4416,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
@@ -4419,9 +4528,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         \once \override Dots.color = #red
                         \once \override Rest.color = #red
@@ -4504,9 +4616,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         r8
                         \once \override Accidental.color = #red
@@ -4587,9 +4702,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
@@ -4671,9 +4789,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
@@ -4750,9 +4871,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
@@ -4847,9 +4971,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -4933,9 +5060,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -5016,9 +5146,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
@@ -5093,9 +5226,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
@@ -5203,9 +5339,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         c'8
                         d'8
@@ -5306,9 +5445,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         \once \override Dots.color = #red
                         \once \override Rest.color = #red
@@ -5393,9 +5535,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \times 2/3 {
                         \once \override Dots.color = #red
                         \once \override Rest.color = #red
@@ -5488,9 +5633,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -5572,11 +5720,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -5609,7 +5760,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             <fs' gs'>4 ~
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -5671,11 +5822,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -5733,7 +5887,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             <fs' gs'>4 ~
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -5778,9 +5932,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     c'8
                     r8
                     \once \override Accidental.color = #red
@@ -5875,9 +6032,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -5942,9 +6102,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -6023,9 +6186,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -6114,9 +6280,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -6212,9 +6381,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -6375,10 +6547,13 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 2/8
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
@@ -6392,8 +6567,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #red
                         \once \override Stem.color = #red
                         d'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -6406,8 +6581,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         f'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #blue
                         \once \override Beam.color = #blue
                         \once \override Dots.color = #blue
@@ -6420,8 +6595,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         a'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -6434,7 +6609,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #red
                         \once \override Stem.color = #red
                         c''8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -6486,10 +6661,13 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 2/8
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
@@ -6503,8 +6681,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #red
                         \once \override Stem.color = #red
                         d'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -6512,15 +6690,15 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override Stem.color = #red
                         e'8
                         f'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         g'8
                         a'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         b'8
                         c''8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -6580,10 +6758,13 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 2/8
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
@@ -6597,8 +6778,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #red
                         \once \override Stem.color = #red
                         d'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #blue
                         \once \override Beam.color = #blue
                         \once \override Dots.color = #blue
@@ -6611,8 +6792,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #red
                         \once \override Stem.color = #red
                         f'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -6625,8 +6806,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         a'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -6639,7 +6820,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #red
                         \once \override Stem.color = #red
                         c''8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -6703,10 +6884,13 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 2/8
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
@@ -6720,8 +6904,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         d'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -6734,8 +6918,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         f'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -6748,8 +6932,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         a'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -6757,7 +6941,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override Stem.color = #red
                         b'8
                         c''8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -6809,10 +6993,13 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 2/8
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
@@ -6821,19 +7008,19 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override Stem.color = #red
                         c'8
                         d'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         e'8
                         f'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         g'8
                         a'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         b'8
                         c''8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -6890,10 +7077,13 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 2/8
                         \tempo 4=60
                         \once \override Accidental.color = #red
@@ -6908,8 +7098,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #red
                         \once \override Stem.color = #red
                         d'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -6922,8 +7112,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         f'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #blue
                         \once \override Beam.color = #blue
                         \once \override Dots.color = #blue
@@ -6936,11 +7126,11 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         a'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         b'8
                         c''8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -6998,10 +7188,13 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 2/8
                         \tempo 4=60
                         \once \override Accidental.color = #red
@@ -7016,8 +7209,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #red
                         \once \override Stem.color = #red
                         d'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -7030,8 +7223,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         f'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #blue
                         \once \override Beam.color = #blue
                         \once \override Dots.color = #blue
@@ -7044,8 +7237,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         a'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -7058,7 +7251,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #red
                         \once \override Stem.color = #red
                         c''8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -7113,10 +7306,13 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 2/8
                         \tempo 4=60
                         \once \override Accidental.color = #red
@@ -7131,8 +7327,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #red
                         \once \override Stem.color = #red
                         d'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -7140,15 +7336,15 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override Stem.color = #red
                         e'8
                         f'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         g'8
                         a'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         b'8
                         c''8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -7215,10 +7411,13 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 2/8
                         \tempo 4=60
                         \once \override Accidental.color = #red
@@ -7233,8 +7432,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         d'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -7247,8 +7446,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         f'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -7261,8 +7460,8 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override NoteHead.color = #blue
                         \once \override Stem.color = #blue
                         a'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         \once \override Accidental.color = #red
                         \once \override Beam.color = #red
                         \once \override Dots.color = #red
@@ -7270,7 +7469,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override Stem.color = #red
                         b'8
                         c''8
-                    } % measure
+                    }   % measure
                 }
 
         ..  container:: example
@@ -7325,10 +7524,13 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 2/8
                         \tempo 4=60
                         \once \override Accidental.color = #red
@@ -7338,19 +7540,19 @@ class Selection(AbjadValueObject, collections.Sequence):
                         \once \override Stem.color = #red
                         c'8
                         d'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         e'8
                         f'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         g'8
                         a'8
-                    } % measure
-                    { % measure
+                    }   % measure
+                    {   % measure
                         b'8
                         c''8
-                    } % measure
+                    }   % measure
                 }
 
         Interprets `fill` as `Exact` when `fill` is none.
@@ -7497,9 +7699,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -7587,9 +7792,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -7699,11 +7907,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -7733,7 +7944,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             <fs' gs'>4 ~
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -7789,11 +8000,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -7827,7 +8041,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             <fs' gs'>4 ~
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -7878,11 +8092,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -7935,7 +8152,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             \once \override Stem.color = #green
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -7991,11 +8208,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -8098,7 +8318,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             \once \override Stem.color = #red
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -8156,9 +8376,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -8267,11 +8490,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -8326,7 +8552,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             \once \override Stem.color = #green
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -8382,11 +8608,14 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
-                } {
-                    { % measure
+                }
+                {
+                    {   % measure
                         \time 7/4
                         \tweak text #tuplet-number::calc-fraction-text
                         \times 10/9 {
@@ -8495,7 +8724,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                             \once \override Stem.color = #red
                             <fs' gs'>16
                         }
-                    } % measure
+                    }   % measure
                 }
 
         '''
@@ -8544,9 +8773,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -8631,9 +8863,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -8721,10 +8956,13 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     \override SustainPedalLineSpanner.staff-padding = #6
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -8823,9 +9061,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red
@@ -8910,9 +9151,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \once \override Accidental.color = #red
                     \once \override Beam.color = #red
                     \once \override Dots.color = #red

--- a/abjad/tools/scoretools/Staff.py
+++ b/abjad/tools/scoretools/Staff.py
@@ -12,7 +12,8 @@ class Staff(Context):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'8
                 d'8
                 e'8
@@ -33,7 +34,8 @@ class Staff(Context):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 {
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 9/10 {

--- a/abjad/tools/scoretools/StaffGroup.py
+++ b/abjad/tools/scoretools/StaffGroup.py
@@ -14,15 +14,18 @@ class StaffGroup(Context):
         ..  docs::
 
             >>> abjad.f(staff_group)
-            \new StaffGroup <<
-                \new Staff {
+            \new StaffGroup
+            <<
+                \new Staff
+                {
                     c'4
                     d'4
                     e'4
                     f'4
                     g'1
                 }
-                \new Staff {
+                \new Staff
+                {
                     g2
                     f2
                     e1

--- a/abjad/tools/scoretools/Tuplet.py
+++ b/abjad/tools/scoretools/Tuplet.py
@@ -432,15 +432,21 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \override TupletNumber.text = \markup {
                         \score
                             {
-                                \new Score \with {
+                                \new Score
+                                \with
+                                {
                                     \override SpacingSpanner.spacing-increment = #0.5
                                     proportionalNotationDuration = ##f
-                                } <<
-                                    \new RhythmicStaff \with {
+                                }
+                                <<
+                                    \new RhythmicStaff
+                                    \with
+                                    {
                                         \remove Time_signature_engraver
                                         \remove Staff_symbol_engraver
                                         \override Stem.direction = #up
@@ -451,7 +457,8 @@ class Tuplet(Container):
                                         \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                         \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                         tupletFullLength = ##t
-                                    } {
+                                    }
+                                    {
                                         c'4
                                     }
                                 >>
@@ -512,7 +519,8 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \times 2/3 {
                         c'4
                         d'4
@@ -531,7 +539,8 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \scaleDurations #'(2 . 3) {
                         c'4
                         d'4
@@ -936,7 +945,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 3/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 6/5 {
@@ -946,7 +955,7 @@ class Tuplet(Container):
                         r32
                         r32
                     }
-                } % measure
+                }   % measure
 
             Allows tupletted leaves to return with dots when some `ratio`
             do not equal ``1``:
@@ -966,7 +975,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 3/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 12/11 {
@@ -976,7 +985,7 @@ class Tuplet(Container):
                         c'32.
                         c'32.
                     }
-                } % measure
+                }   % measure
 
             Interprets nonassignable `ratio` according to `decrease_monotonic`:
 
@@ -996,7 +1005,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 3/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 12/11 {
@@ -1006,7 +1015,7 @@ class Tuplet(Container):
                         c'64 ~
                         c'16
                     }
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -1028,7 +1037,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 3/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 8/5 {
@@ -1038,7 +1047,7 @@ class Tuplet(Container):
                         r64.
                         r64.
                     }
-                } % measure
+                }   % measure
 
             Interprets nonassignable `ratio` according to `decrease_monotonic`:
 
@@ -1058,7 +1067,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 3/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 16/11 {
@@ -1066,7 +1075,7 @@ class Tuplet(Container):
                         r128.
                         c'32...
                     }
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -1091,7 +1100,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 3/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/5 {
@@ -1101,7 +1110,7 @@ class Tuplet(Container):
                         r16
                         r16
                     }
-                } % measure
+                }   % measure
 
             Allows tupletted leaves to return with dots when some `ratio`
             do not equal ``1``:
@@ -1121,7 +1130,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 3/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 6/11 {
@@ -1131,7 +1140,7 @@ class Tuplet(Container):
                         c'16.
                         c'16.
                     }
-                } % measure
+                }   % measure
 
             Interprets nonassignable `ratio` according to `decrease_monotonic`:
 
@@ -1151,7 +1160,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 3/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 6/11 {
@@ -1161,7 +1170,7 @@ class Tuplet(Container):
                         c'32 ~
                         c'8
                     }
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -1183,7 +1192,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 3/16
                     \times 4/5 {
                         c'32.
@@ -1192,7 +1201,7 @@ class Tuplet(Container):
                         r32.
                         r32.
                     }
-                } % measure
+                }   % measure
 
             Interprets nonassignable `ratio` according to `direction`:
 
@@ -1212,14 +1221,14 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 3/16
                     \times 8/11 {
                         c'16...
                         r64.
                         c'16...
                     }
-                } % measure
+                }   % measure
 
         Reduces `ratio` relative to each other.
 
@@ -1623,12 +1632,12 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 7/16
                     {
                         c'4..
                     }
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -1649,13 +1658,13 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 7/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 1/1 {
                         c'4..
                     }
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -1674,14 +1683,14 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 7/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 7/6 {
                         c'8
                         c'4
                     }
-                } % measure
+                }   % measure
 
             >>> tuplet = abjad.Tuplet.from_ratio_and_pair(
             ...     abjad.NonreducedRatio((1, 2, 4)),
@@ -1696,7 +1705,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 7/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 1/1 {
@@ -1704,7 +1713,7 @@ class Tuplet(Container):
                         c'8
                         c'4
                     }
-                } % measure
+                }   % measure
 
             >>> tuplet = abjad.Tuplet.from_ratio_and_pair(
             ...     abjad.NonreducedRatio((1, 2, 4, 1)),
@@ -1719,7 +1728,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 7/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 7/8 {
@@ -1728,7 +1737,7 @@ class Tuplet(Container):
                         c'4
                         c'16
                     }
-                } % measure
+                }   % measure
 
             >>> tuplet = abjad.Tuplet.from_ratio_and_pair(
             ...     abjad.NonreducedRatio((1, 2, 4, 1, 2)),
@@ -1743,7 +1752,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 7/16
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 7/10 {
@@ -1753,7 +1762,7 @@ class Tuplet(Container):
                         c'16
                         c'8
                     }
-                } % measure
+                }   % measure
 
             >>> tuplet = abjad.Tuplet.from_ratio_and_pair(
             ...     abjad.NonreducedRatio((1, 2, 4, 1, 2, 4)),
@@ -1768,7 +1777,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(staff[0])
-                { % measure
+                {   % measure
                     \time 7/16
                     \times 1/2 {
                         c'16
@@ -1778,7 +1787,7 @@ class Tuplet(Container):
                         c'8
                         c'4
                     }
-                } % measure
+                }   % measure
 
         Interprets `d` as tuplet denominator.
 
@@ -2138,14 +2147,14 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 3/8
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/4 {
                         c'4
                         c'4
                     }
-                } % measure
+                }   % measure
 
             >>> tuplet.trivializable()
             True
@@ -2158,11 +2167,11 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 3/8
                     c'8.
                     c'8.
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -2175,7 +2184,7 @@ class Tuplet(Container):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 3/4
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 3/5 {
@@ -2185,7 +2194,7 @@ class Tuplet(Container):
                         c'4
                         c'4
                     }
-                } % measure
+                }   % measure
 
             >>> tuplet.trivializable()
             False

--- a/abjad/tools/scoretools/VerticalMoment.py
+++ b/abjad/tools/scoretools/VerticalMoment.py
@@ -18,15 +18,19 @@ class VerticalMoment(abctools.AbjadObject):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new PianoStaff <<
-                    \new Staff {
+            \new Score
+            <<
+                \new PianoStaff
+                <<
+                    \new Staff
+                    {
                         c'4
                         e'4
                         d'4
                         f'4
                     }
-                    \new Staff {
+                    \new Staff
+                    {
                         \clef "bass"
                         g2
                         f2

--- a/abjad/tools/scoretools/Voice.py
+++ b/abjad/tools/scoretools/Voice.py
@@ -12,7 +12,8 @@ class Voice(Context):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 c'8
                 d'8
                 e'8

--- a/abjad/tools/scoretools/test/test_scoretools_Chord_written_pitches.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Chord_written_pitches.py
@@ -36,7 +36,8 @@ def test_scoretools_Chord_written_pitches_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set Staff.instrumentName = \markup { Glockenspiel }
             \set Staff.shortInstrumentName = \markup { Gkspl. }
             <c' e'>4

--- a/abjad/tools/scoretools/test/test_scoretools_Component__get_in_my_logical_voice.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Component__get_in_my_logical_voice.py
@@ -95,23 +95,28 @@ def test_scoretools_Component__get_in_my_logical_voice_07():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             <<
-                \context Voice = "voiceOne" {
+                \context Voice = "voiceOne"
+                {
                     c''8
                     d''8
                 }
-                \context Voice = "voiceTwo" {
+                \context Voice = "voiceTwo"
+                {
                     c'8
                     d'8
                 }
             >>
             <<
-                \context Voice = "voiceOne" {
+                \context Voice = "voiceOne"
+                {
                     e''8
                     f''8
                 }
-                \context Voice = "voiceTwo" {
+                \context Voice = "voiceTwo"
+                {
                     e'8
                     f'8
                 }

--- a/abjad/tools/scoretools/test/test_scoretools_Component__get_nth_component_in_time_order_from.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Component__get_nth_component_in_time_order_from.py
@@ -7,7 +7,8 @@ def test_scoretools_Component__get_nth_component_in_time_order_from_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'4
             \times 2/3 {
                 d'8

--- a/abjad/tools/scoretools/test/test_scoretools_Component__is_immediate_temporal_successor_of.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Component__is_immediate_temporal_successor_of.py
@@ -42,7 +42,8 @@ def test_scoretools_Component__is_immediate_temporal_successor_of_05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8
@@ -71,7 +72,8 @@ def test_scoretools_Component__is_immediate_temporal_successor_of_06():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8
                 d'8
@@ -99,14 +101,17 @@ def test_scoretools_Component__is_immediate_temporal_successor_of_07():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \new Voice {
+        \new Staff
+        {
+            \new Voice
+            {
                 c'8
                 d'8
                 e'8
                 f'8
             }
-            \new Voice {
+            \new Voice
+            {
                 g'8
                 a'8
                 b'8
@@ -130,14 +135,17 @@ def test_scoretools_Component__is_immediate_temporal_successor_of_08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \context Voice = "foo" {
+        \new Staff
+        {
+            \context Voice = "foo"
+            {
                 c'8
                 d'8
                 e'8
                 f'8
             }
-            \context Voice = "foo" {
+            \context Voice = "foo"
+            {
                 g'8
                 a'8
                 b'8
@@ -161,14 +169,17 @@ def test_scoretools_Component__is_immediate_temporal_successor_of_09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \context Voice = "foo" {
+        \new Staff
+        {
+            \context Voice = "foo"
+            {
                 c'8
                 d'8
                 e'8
                 f'8
             }
-            \context Voice = "bar" {
+            \context Voice = "bar"
+            {
                 g'8
                 a'8
                 b'8
@@ -192,16 +203,20 @@ def test_scoretools_Component__is_immediate_temporal_successor_of_10():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \new Staff {
-                \new Voice {
+            \new Staff
+            {
+                \new Voice
+                {
                     c'8
                     d'8
                     e'8
                     f'8
                 }
             }
-            \new Staff {
-                \new Voice {
+            \new Staff
+            {
+                \new Voice
+                {
                     g'8
                     a'8
                     b'8
@@ -240,28 +255,34 @@ def test_scoretools_Component__is_immediate_temporal_successor_of_11():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \new Staff <<
-                \new Voice {
+            \new Staff
+            <<
+                \new Voice
+                {
                     c''8
                     d''8
                     e''8
                     f''8
                 }
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     d'8
                     e'8
                     f'8
                 }
             >>
-            \new Staff <<
-                \new Voice {
+            \new Staff
+            <<
+                \new Voice
+                {
                     g''8
                     a''8
                     b''8
                     c''8
                 }
-                \new Voice {
+                \new Voice
+                {
                     g'8
                     a'8
                     b'8
@@ -309,7 +330,8 @@ def test_scoretools_Component__is_immediate_temporal_successor_of_12():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 {
                     c'8

--- a/abjad/tools/scoretools/test/test_scoretools_Component__move_indicators.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Component__move_indicators.py
@@ -7,7 +7,8 @@ def test_scoretools_Component__move_indicators_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \clef "bass"
             c4 -\staccato
             d4
@@ -26,7 +27,8 @@ def test_scoretools_Component__move_indicators_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c4
             d4
             \clef "bass"

--- a/abjad/tools/scoretools/test/test_scoretools_Component__remove_and_shrink_durated_parent_containers.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Component__remove_and_shrink_durated_parent_containers.py
@@ -34,7 +34,8 @@ def test_scoretools_Component__remove_and_shrink_durated_parent_containers_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'4
             c'4
             c'4
@@ -57,7 +58,8 @@ def test_scoretools_Component__remove_and_shrink_durated_parent_containers_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'4
             c'4
             c'4

--- a/abjad/tools/scoretools/test/test_scoretools_Container___copy__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container___copy__.py
@@ -14,11 +14,13 @@ def test_scoretools_Container___copy___01():
     assert format(container_1) == abjad.String.normalize(
         r'''
         <<
-            \new Voice {
+            \new Voice
+            {
                 c'8
                 d'8
             }
-            \new Voice {
+            \new Voice
+            {
                 c''8
                 b'8
             }

--- a/abjad/tools/scoretools/test/test_scoretools_Container___delitem__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container___delitem__.py
@@ -12,7 +12,8 @@ def test_scoretools_Container___delitem___01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
                 d'8 )
@@ -31,7 +32,8 @@ def test_scoretools_Container___delitem___01():
     # container no longer appears in score
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 e'8 [ (
                 f'8 ] )
@@ -64,7 +66,8 @@ def test_scoretools_Container___delitem___02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             e'8
             f'8 ]
@@ -84,7 +87,8 @@ def test_scoretools_Container___delitem___03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             f'8 ]
         }
@@ -103,7 +107,8 @@ def test_scoretools_Container___delitem___04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             e'8 [
             f'8 ]
         }
@@ -122,7 +127,8 @@ def test_scoretools_Container___delitem___05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
         }
@@ -141,7 +147,8 @@ def test_scoretools_Container___delitem___06():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
         }
         '''
         )
@@ -179,7 +186,8 @@ def test_scoretools_Container___delitem___08():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             {
                 d'8 \glissando
@@ -195,7 +203,8 @@ def test_scoretools_Container___delitem___08():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             {
                 e'8 \glissando

--- a/abjad/tools/scoretools/test/test_scoretools_Container___setitem__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container___setitem__.py
@@ -12,7 +12,8 @@ def test_scoretools_Container___setitem___01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             d'8 ] \glissando
             e'8 \glissando
@@ -25,7 +26,8 @@ def test_scoretools_Container___setitem___01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             c''8 ] \glissando
             e'8 \glissando
@@ -48,7 +50,8 @@ def test_scoretools_Container___setitem___02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             d'8 ] \glissando
             e'8 \glissando
@@ -61,7 +64,8 @@ def test_scoretools_Container___setitem___02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             {
                 c'16 \glissando
@@ -87,7 +91,8 @@ def test_scoretools_Container___setitem___03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ \glissando
                 d'8 \glissando
@@ -104,7 +109,8 @@ def test_scoretools_Container___setitem___03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ \glissando
                 d'8 \glissando
@@ -128,7 +134,8 @@ def test_scoretools_Container___setitem___04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ \glissando
                 d'8 \glissando
@@ -145,7 +152,8 @@ def test_scoretools_Container___setitem___04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ \glissando
                 d'8 \glissando
@@ -172,7 +180,8 @@ def test_scoretools_Container___setitem___05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ \glissando
                 d'8 \glissando
@@ -189,7 +198,8 @@ def test_scoretools_Container___setitem___05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ \glissando
                 d'8 \glissando
@@ -213,7 +223,8 @@ def test_scoretools_Container___setitem___06():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8
@@ -234,7 +245,8 @@ def test_scoretools_Container___setitem___06():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8
@@ -263,7 +275,8 @@ def test_scoretools_Container___setitem___07():
 
     assert format(voice_1) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8 ]
@@ -276,7 +289,8 @@ def test_scoretools_Container___setitem___07():
 
     assert format(voice_2) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             f'8 [
             g'8
             a'8 ]
@@ -288,7 +302,8 @@ def test_scoretools_Container___setitem___07():
 
     assert format(voice_1) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             g'8
             e'8 ]
@@ -300,7 +315,8 @@ def test_scoretools_Container___setitem___07():
 
     assert format(voice_2) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             f'8 [
             a'8 ]
         }
@@ -323,7 +339,8 @@ def test_scoretools_Container___setitem___08():
 
     assert format(voice_1) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8 ]
@@ -340,7 +357,8 @@ def test_scoretools_Container___setitem___08():
 
     assert format(voice_2) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             f'8 \glissando
             {
                 g'8 \glissando (
@@ -355,7 +373,8 @@ def test_scoretools_Container___setitem___08():
 
     assert format(voice_1) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             {
                 g'8 (
@@ -370,7 +389,8 @@ def test_scoretools_Container___setitem___08():
 
     assert format(voice_2) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             f'8 \glissando
             b'8
         }
@@ -389,7 +409,8 @@ def test_scoretools_Container___setitem___09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             d'8
             g'8
@@ -414,7 +435,8 @@ def test_scoretools_Container___setitem___10():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             g'8
@@ -446,7 +468,8 @@ def test_scoretools_Container___setitem___11():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             g'8
@@ -459,7 +482,8 @@ def test_scoretools_Container___setitem___11():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             e'8
@@ -485,7 +509,8 @@ def test_scoretools_Container___setitem___12():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             c''8
             f'8 ]
@@ -508,7 +533,8 @@ def test_scoretools_Container___setitem___13():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             b'8
             a'8
@@ -529,7 +555,8 @@ def test_scoretools_Container___setitem___14():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 d'8
@@ -547,7 +574,8 @@ def test_scoretools_Container___setitem___14():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             {
@@ -571,7 +599,8 @@ def test_scoretools_Container___setitem___15():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 d'8
@@ -588,7 +617,8 @@ def test_scoretools_Container___setitem___15():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             {
                 d'8 [
@@ -617,7 +647,8 @@ def test_scoretools_Container___setitem___16():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 d'8
@@ -634,7 +665,8 @@ def test_scoretools_Container___setitem___16():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             d'8
             {
@@ -660,7 +692,8 @@ def test_scoretools_Container___setitem___17():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 d'8
@@ -679,7 +712,8 @@ def test_scoretools_Container___setitem___17():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             d'8
             {
@@ -704,7 +738,8 @@ def test_scoretools_Container___setitem___18():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             r8
             c'8 [
             d'8
@@ -716,7 +751,8 @@ def test_scoretools_Container___setitem___18():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             r8
             c'8 [
             d'8
@@ -738,7 +774,8 @@ def test_scoretools_Container___setitem___19():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8
@@ -769,7 +806,8 @@ def test_scoretools_Container___setitem___20():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             {
                 {
@@ -788,7 +826,8 @@ def test_scoretools_Container___setitem___20():
     # outer container is empty and remains in score
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             {
             }
@@ -816,7 +855,8 @@ def test_scoretools_Container___setitem___20():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             {
                 {
@@ -835,7 +875,8 @@ def test_scoretools_Container___setitem___20():
     # outer container is empty and remains in score (as before)
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             {
             }
@@ -883,7 +924,8 @@ def test_scoretools_Container___setitem___21():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             a'8
             {

--- a/abjad/tools/scoretools/test/test_scoretools_Container__get_spanners_that_dominate_slice.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container__get_spanners_that_dominate_slice.py
@@ -13,7 +13,8 @@ def test_scoretools_Container__get_spanners_that_dominate_slice_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             d'8 ] \glissando
             e'8 \glissando
@@ -40,7 +41,8 @@ def test_scoretools_Container__get_spanners_that_dominate_slice_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             d'8 ] \glissando
             e'8 \glissando
@@ -68,7 +70,8 @@ def test_scoretools_Container__get_spanners_that_dominate_slice_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             d'8 ] \glissando
             e'8 \glissando

--- a/abjad/tools/scoretools/test/test_scoretools_Container__split_by_duration.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container__split_by_duration.py
@@ -16,16 +16,17 @@ def test_scoretools_Container__split_by_duration_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -38,21 +39,22 @@ def test_scoretools_Container__split_by_duration_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/32
                 c'32 [ (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 7/32
                 c'16.
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -77,16 +79,17 @@ def test_scoretools_Container__split_by_duration_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -99,28 +102,30 @@ def test_scoretools_Container__split_by_duration_02():
 
     assert format(halves[0][0]) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/32
                 c'32 [ (
-            } % measure
+            }   % measure
         }
         '''
         ), format(halves[0][0])
 
     assert format(halves[1][0]) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 7/32
                 c'16.
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(halves[1][0])
@@ -147,16 +152,17 @@ def test_scoretools_Container__split_by_duration_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -169,21 +175,22 @@ def test_scoretools_Container__split_by_duration_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/32
                 c'32 ~ [ (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 7/32
                 c'16.
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -210,16 +217,17 @@ def test_scoretools_Container__split_by_duration_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -234,26 +242,27 @@ def test_scoretools_Container__split_by_duration_04():
     #       The tie after the d'16. is the incorrect one.
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/20
                 \scaleDurations #'(4 . 5) {
                     c'8 ~ [ (
                     c'32
                     d'16. ~
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/20
                 \scaleDurations #'(4 . 5) {
                     d'16 ]
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -280,16 +289,17 @@ def test_scoretools_Container__split_by_duration_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -302,26 +312,27 @@ def test_scoretools_Container__split_by_duration_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/20
                 \scaleDurations #'(4 . 5) {
                     c'8 ~ [ (
                     c'32
                     d'16. ~
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/20
                 \scaleDurations #'(4 . 5) {
                     d'16 ]
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -346,16 +357,17 @@ def test_scoretools_Container__split_by_duration_06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -368,21 +380,22 @@ def test_scoretools_Container__split_by_duration_06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/32
                 c'32 [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 7/32
                 c'16. [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -407,16 +420,17 @@ def test_scoretools_Container__split_by_duration_07():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -429,28 +443,30 @@ def test_scoretools_Container__split_by_duration_07():
 
     assert format(halves[0][0]) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/32
                 c'32 [ ]
-            } % measure
+            }   % measure
         }
         '''
         ), format(halves[0][0])
 
     assert format(halves[1][0]) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 7/32
                 c'16. [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(halves[1][0])
@@ -475,16 +491,17 @@ def test_scoretools_Container__split_by_duration_08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -497,21 +514,22 @@ def test_scoretools_Container__split_by_duration_08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 7/32
                 c'8 [ (
                 d'16. ] )
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 d'32 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -536,16 +554,17 @@ def test_scoretools_Container__split_by_duration_09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -557,19 +576,20 @@ def test_scoretools_Container__split_by_duration_09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/8
                 c'8 [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 d'8 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -595,16 +615,17 @@ def test_scoretools_Container__split_by_duration_10():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -617,21 +638,22 @@ def test_scoretools_Container__split_by_duration_10():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/32
                 c'32 ~ [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 7/32
                 c'16. [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -658,16 +680,17 @@ def test_scoretools_Container__split_by_duration_11():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -680,26 +703,27 @@ def test_scoretools_Container__split_by_duration_11():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/20
                 \scaleDurations #'(4 . 5) {
                     c'8 ~ [ (
                     c'32
                     d'16. ] )
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/20
                 \scaleDurations #'(4 . 5) {
                     d'16 [ ] (
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -726,16 +750,17 @@ def test_scoretools_Container__split_by_duration_12():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -748,26 +773,27 @@ def test_scoretools_Container__split_by_duration_12():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 4/20
                 \scaleDurations #'(4 . 5) {
                     c'8 ~ [ (
                     c'32
                     d'16. ~ ] )
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/20
                 \scaleDurations #'(4 . 5) {
                     d'16 [ ] (
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -796,18 +822,19 @@ def test_scoretools_Container__split_by_duration_13():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/8
                 c'8 [ (
                 d'8
                 e'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'8 [
                 d'8
                 e'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -819,8 +846,9 @@ def test_scoretools_Container__split_by_duration_13():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 14/40
                 \scaleDurations #'(4 . 5) {
                     c'8 ~ [ (
@@ -829,19 +857,19 @@ def test_scoretools_Container__split_by_duration_13():
                     d'32
                     e'8 ] )
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/40
                 \scaleDurations #'(4 . 5) {
                     e'32 [ ] (
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/8
                 c'8 [
                 d'8
                 e'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -870,16 +898,17 @@ def test_scoretools_Container__split_by_duration_14():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/16
                 c'8 * 1/2 [ (
                 d'8 * 1/2 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 * 1/2 [
                 f'8 * 1/2 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -891,19 +920,20 @@ def test_scoretools_Container__split_by_duration_14():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/16
                 c'8 * 1/2 [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 d'8 * 1/2 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/16
                 e'8 * 1/2 [
                 f'8 * 1/2 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -933,16 +963,17 @@ def test_scoretools_Container__split_by_duration_15():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/16
                 c'8 * 1/2 [ (
                 d'8 * 1/2 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 * 1/2 [
                 f'8 * 1/2 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -955,21 +986,22 @@ def test_scoretools_Container__split_by_duration_15():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/32
                 c'8 * 1/2 [ (
                 d'8 * 1/4 ] )
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 d'8 * 1/4 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/16
                 e'8 * 1/2 [
                 f'8 * 1/2 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1000,16 +1032,17 @@ def test_scoretools_Container__split_by_duration_16():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/16
                 c'8 * 1/2 [ (
                 d'8 * 1/2 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 * 1/2 [
                 f'8 * 1/2 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1022,25 +1055,26 @@ def test_scoretools_Container__split_by_duration_16():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/24
                 \scaleDurations #'(2 . 3) {
                     c'8. * 1/2 [ (
                     d'8. * 1/6 ] )
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/24
                 \scaleDurations #'(2 . 3) {
                     d'8. * 1/3 [ ] (
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/16
                 e'8 * 1/2 [
                 f'8 * 1/2 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1059,11 +1093,12 @@ def test_scoretools_Container__split_by_duration_17():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/16
                 s1 * 5/16
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1075,20 +1110,21 @@ def test_scoretools_Container__split_by_duration_17():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 16/80
                 \scaleDurations #'(4 . 5) {
                     s1 * 1/4
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 9/80
                 \scaleDurations #'(4 . 5) {
                     s1 * 1/16
                     s4 * 5/16
                 }
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1114,8 +1150,9 @@ def test_scoretools_Container__split_by_duration_18():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 15/80
                 \scaleDurations #'(4 . 5) {
                     c'32 [ (
@@ -1127,7 +1164,7 @@ def test_scoretools_Container__split_by_duration_18():
                     b'32
                     c''64 ] )
                 }
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1139,8 +1176,9 @@ def test_scoretools_Container__split_by_duration_18():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 14/80
                 \scaleDurations #'(4 . 5) {
                     c'32 [ (
@@ -1151,13 +1189,13 @@ def test_scoretools_Container__split_by_duration_18():
                     a'32
                     b'32 ] )
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/80
                 \scaleDurations #'(4 . 5) {
                     c''64 [ ]
                 }
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)

--- a/abjad/tools/scoretools/test/test_scoretools_Container_append.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container_append.py
@@ -13,7 +13,8 @@ def test_scoretools_Container_append_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
             {
@@ -74,7 +75,8 @@ def test_scoretools_Container_append_04():
 
     assert format(voice_1) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8 ]
@@ -88,7 +90,8 @@ def test_scoretools_Container_append_04():
 
     assert format(voice_2) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8
@@ -101,7 +104,8 @@ def test_scoretools_Container_append_04():
 
     assert format(voice_1) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8 ]
@@ -114,7 +118,8 @@ def test_scoretools_Container_append_04():
 
     assert format(voice_2) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8 ]
@@ -136,7 +141,8 @@ def test_scoretools_Container_append_05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8
@@ -149,7 +155,8 @@ def test_scoretools_Container_append_05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             e'8
             f'8 ]

--- a/abjad/tools/scoretools/test/test_scoretools_Container_extend.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container_extend.py
@@ -13,7 +13,8 @@ def test_scoretools_Container_extend_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
             c'8
@@ -40,7 +41,8 @@ def test_scoretools_Container_extend_02():
 
     assert format(voice_1) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
             e'8 [
@@ -63,7 +65,8 @@ def test_scoretools_Container_extend_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
         }
@@ -85,7 +88,8 @@ def test_scoretools_Container_extend_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
         }
@@ -138,7 +142,8 @@ def test_scoretools_Container_extend_07():
 
     assert format(voice_1) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
             e'8
@@ -151,7 +156,8 @@ def test_scoretools_Container_extend_07():
 
     assert format(voice_2) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
         }
@@ -178,7 +184,8 @@ def test_scoretools_Container_extend_08():
 
     assert format(voice_2) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8 (
@@ -191,7 +198,8 @@ def test_scoretools_Container_extend_08():
 
     assert format(voice_1) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
             e'8 (
@@ -204,7 +212,8 @@ def test_scoretools_Container_extend_08():
 
     assert format(voice_2) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
         }

--- a/abjad/tools/scoretools/test/test_scoretools_Container_insert.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container_insert.py
@@ -29,7 +29,8 @@ def test_scoretools_Container_insert_01():
     assert abjad.inspect(voice).is_well_formed()
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             r8
             c'8 [
             d'8
@@ -62,7 +63,8 @@ def test_scoretools_Container_insert_02():
     assert abjad.inspect(voice).is_well_formed()
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             cs'8
             d'8
@@ -96,7 +98,8 @@ def test_scoretools_Container_insert_03():
     assert abjad.inspect(staff).is_well_formed()
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             cs'8
             d'8
@@ -129,7 +132,8 @@ def test_scoretools_Container_insert_04():
     assert abjad.inspect(staff).is_well_formed()
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             cs'8
             d'8
@@ -162,7 +166,8 @@ def test_scoretools_Container_insert_05():
     assert abjad.inspect(voice).is_well_formed()
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8
@@ -195,7 +200,8 @@ def test_scoretools_Container_insert_06():
     assert abjad.inspect(voice).is_well_formed()
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             r8
             c'8 [
             d'8
@@ -242,7 +248,8 @@ def test_scoretools_Container_insert_08():
     assert abjad.inspect(staff).is_well_formed()
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             cs'8
             d'8
@@ -280,7 +287,8 @@ def test_scoretools_Container_insert_09():
     assert abjad.inspect(staff).is_well_formed()
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             r4
             c'8 [
             cs'8
@@ -313,7 +321,8 @@ def test_scoretools_Container_insert_10():
     assert abjad.inspect(staff).is_well_formed()
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ ]
             r4
             cs'8 [
@@ -346,7 +355,8 @@ def test_scoretools_Container_insert_11():
     assert abjad.inspect(staff).is_well_formed()
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff 
+        {
             c'8 [
             cs'8
             d'8
@@ -379,7 +389,8 @@ def test_scoretools_Container_insert_12():
     assert abjad.inspect(staff).is_well_formed()
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             cs'8
             d'8
@@ -412,7 +423,8 @@ def test_scoretools_Container_insert_13():
     assert abjad.inspect(staff).is_well_formed()
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             cs'8
             d'8 ]
@@ -434,7 +446,8 @@ def test_scoretools_Container_insert_14():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             r4
             c'8 [
             cs'8

--- a/abjad/tools/scoretools/test/test_scoretools_Container_is_simultaneous.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container_is_simultaneous.py
@@ -48,11 +48,13 @@ def test_scoretools_Container_is_simultaneous_04():
     assert format(container) == abjad.String.normalize(
         r'''
         <<
-            \new Voice {
+            \new Voice
+            {
                 c'8
                 cs'8
             }
-            \new Voice {
+            \new Voice
+            {
                 d'8
                 ef'8
             }

--- a/abjad/tools/scoretools/test/test_scoretools_Container_pop.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container_pop.py
@@ -16,7 +16,8 @@ def test_scoretools_Container_pop_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 (
             d'8 [ ]
             e'8
@@ -29,7 +30,8 @@ def test_scoretools_Container_pop_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 (
             e'8
             f'8 )
@@ -57,7 +59,8 @@ def test_scoretools_Container_pop_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 d'8
@@ -74,7 +77,8 @@ def test_scoretools_Container_pop_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 d'8 ]

--- a/abjad/tools/scoretools/test/test_scoretools_Container_remove.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Container_remove.py
@@ -18,7 +18,8 @@ def test_scoretools_Container_remove_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 (
             d'8 [ ]
             e'8
@@ -32,7 +33,8 @@ def test_scoretools_Container_remove_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 (
             e'8
             f'8 )
@@ -64,7 +66,8 @@ def test_scoretools_Container_remove_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 d'8
@@ -81,7 +84,8 @@ def test_scoretools_Container_remove_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 e'8 [
                 f'8 ]

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_get_duration.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_get_duration.py
@@ -23,20 +23,21 @@ def test_scoretools_Inspection_get_duration_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/12
                 \scaleDurations #'(2 . 3) {
                     \tempo 8=42
                     c'8 [ \<
                     d'8 \!
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 c'8 \>
                 d'8 ] \!
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -63,19 +64,20 @@ def test_scoretools_Inspection_get_duration_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/12
                 \scaleDurations #'(2 . 3) {
                     c'8 [ \<
                     d'8 \!
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 c'8 \>
                 d'8 ] \!
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -99,8 +101,10 @@ def test_scoretools_Inspection_get_duration_03():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \tempo 4=38
                 c'8
                 d'8
@@ -138,7 +142,8 @@ def test_scoretools_Inspection_get_duration_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \tempo 4=38
             c'8
             d'8

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_get_effective_staff.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_get_effective_staff.py
@@ -16,15 +16,18 @@ def test_scoretools_Inspection_get_effective_staff_01():
 
     assert format(staff_group) == abjad.String.normalize(
         r'''
-        \new PianoStaff <<
-            \context Staff = "RH" {
+        \new PianoStaff
+        <<
+            \context Staff = "RH"
+            {
                 \change Staff = LH
                 c'8
                 d'8
                 e'8
                 f'8
             }
-            \context Staff = "LH" {
+            \context Staff = "LH"
+            {
                 c'8
                 d'8
                 e'8
@@ -62,8 +65,10 @@ def test_scoretools_Inspection_get_effective_staff_02():
 
     assert format(staff_group) == abjad.String.normalize(
         r'''
-        \new PianoStaff <<
-            \context Staff = "RH" {
+        \new PianoStaff
+        <<
+            \context Staff = "RH"
+            {
                 \change Staff = LH
                 c'8
                 d'8
@@ -71,7 +76,8 @@ def test_scoretools_Inspection_get_effective_staff_02():
                 e'8
                 f'8
             }
-            \context Staff = "LH" {
+            \context Staff = "LH"
+            {
                 c'8
                 d'8
                 e'8
@@ -107,15 +113,18 @@ def test_scoretools_Inspection_get_effective_staff_03():
 
     assert format(staff_group) == abjad.String.normalize(
         r'''
-        \new PianoStaff <<
-            \context Staff = "RH" {
+        \new PianoStaff
+        <<
+            \context Staff = "RH"
+            {
                 c'8
                 d'8
                 e'8
                 \change Staff = LH
                 f'8
             }
-            \context Staff = "LH" {
+            \context Staff = "LH"
+            {
                 c'8
                 d'8
                 e'8
@@ -145,8 +154,10 @@ def test_scoretools_Inspection_get_effective_staff_04():
 
     assert format(staff_group) == abjad.String.normalize(
         r'''
-        \new PianoStaff <<
-            \context Staff = "RH" {
+        \new PianoStaff
+        <<
+            \context Staff = "RH"
+            {
                 \change Staff = LH
                 c'8
                 \change Staff = LH
@@ -154,7 +165,8 @@ def test_scoretools_Inspection_get_effective_staff_04():
                 e'8
                 f'8
             }
-            \context Staff = "LH" {
+            \context Staff = "LH"
+            {
                 c'8
                 d'8
                 e'8

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_get_indicator.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_get_indicator.py
@@ -83,7 +83,8 @@ def test_scoretools_Inspection_get_indicator_08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \slurDotted
             \slurUp
             c'8 (

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_get_indicators.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_get_indicators.py
@@ -13,7 +13,8 @@ def test_scoretools_Inspection_get_indicators_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \slurDotted
             \slurUp
             c'8 (
@@ -42,7 +43,8 @@ def test_scoretools_Inspection_get_indicators_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             % beginning of note content
             \slurDotted
             c'8 (
@@ -69,7 +71,8 @@ def test_scoretools_Inspection_get_indicators_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \clef "treble"
             c'8 \p
             d'8
@@ -93,7 +96,8 @@ def test_scoretools_Inspection_get_indicators_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             % comment 1
             % comment 2
             c'8

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_get_leaf.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_get_leaf.py
@@ -7,14 +7,17 @@ def test_scoretools_Inspection_get_leaf_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \new Voice {
+        \new Staff
+        {
+            \new Voice
+            {
                 c'8
                 d'8
                 e'8
                 f'8
             }
-            \new Voice {
+            \new Voice
+            {
                 g'8
                 a'8
                 b'8
@@ -55,7 +58,8 @@ def test_scoretools_Inspection_get_leaf_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8
             cs'8
             d'8
@@ -83,7 +87,8 @@ def test_scoretools_Inspection_get_leaf_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             cs'8
             d'8
@@ -156,7 +161,8 @@ def test_scoretools_Inspection_get_leaf_06():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 cs'8
@@ -194,7 +200,8 @@ def test_scoretools_Inspection_get_leaf_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8
                 cs'8
@@ -228,14 +235,17 @@ def test_scoretools_Inspection_get_leaf_08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \new Voice {
+        \new Staff
+        {
+            \new Voice
+            {
                 c'8
                 cs'8
                 d'8
                 ef'8
             }
-            \new Voice {
+            \new Voice
+            {
                 e'8
                 f'8
                 fs'8
@@ -261,14 +271,17 @@ def test_scoretools_Inspection_get_leaf_09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \context Voice = "My Voice" {
+        \new Staff
+        {
+            \context Voice = "My Voice"
+            {
                 c'8
                 cs'8
                 d'8
                 ef'8
             }
-            \context Voice = "My Voice" {
+            \context Voice = "My Voice"
+            {
                 e'8
                 f'8
                 fs'8
@@ -301,14 +314,17 @@ def test_scoretools_Inspection_get_leaf_10():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \context Voice = "Your Voice" {
+        \new Staff
+        {
+            \context Voice = "Your Voice"
+            {
                 c'8
                 cs'8
                 d'8
                 ef'8
             }
-            \context Voice = "My Voice" {
+            \context Voice = "My Voice"
+            {
                 e'8
                 f'8
                 fs'8
@@ -352,16 +368,20 @@ def test_scoretools_Inspection_get_leaf_11():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \context Staff = "mystaff" {
-                \context Voice = "low" {
+            \context Staff = "mystaff"
+            {
+                \context Voice = "low"
+                {
                     c'8
                     cs'8
                     d'8
                     ef'8
                 }
             }
-            \context Staff = "mystaff" {
-                \context Voice = "low" {
+            \context Staff = "mystaff"
+            {
+                \context Voice = "low"
+                {
                     e'8
                     f'8
                     fs'8
@@ -402,28 +422,34 @@ def test_scoretools_Inspection_get_leaf_12():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \context Staff = "mystaff" <<
-                \context Voice = "high" {
+            \context Staff = "mystaff"
+            <<
+                \context Voice = "high"
+                {
                     c''8
                     cs''8
                     d''8
                     ef''8
                 }
-                \context Voice = "low" {
+                \context Voice = "low"
+                {
                     c'8
                     cs'8
                     d'8
                     ef'8
                 }
             >>
-            \context Staff = "mystaff" <<
-                \context Voice = "low" {
+            \context Staff = "mystaff"
+            <<
+                \context Voice = "low"
+                {
                     e'8
                     f'8
                     fs'8
                     g'8
                 }
-                \context Voice = "high" {
+                \context Voice = "high"
+                {
                     e''8
                     f''8
                     fs''8
@@ -453,7 +479,8 @@ def test_scoretools_Inspection_get_leaf_13():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 {
                     c'8
@@ -498,7 +525,8 @@ def test_scoretools_Inspection_get_leaf_14():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 cs'8
@@ -543,7 +571,8 @@ def test_scoretools_Inspection_get_leaf_15():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 {
                     {
@@ -585,7 +614,8 @@ def test_scoretools_Inspection_get_leaf_16():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 cs'8
@@ -618,7 +648,8 @@ def test_scoretools_Inspection_get_leaf_17():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8
                 cs'8
@@ -680,14 +711,17 @@ def test_scoretools_Inspection_get_leaf_19():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \new Voice {
+        \new Staff
+        {
+            \new Voice
+            {
                 c'8
                 cs'8
                 d'8
             }
             ef'8
-            \new Voice {
+            \new Voice
+            {
                 e'8
                 f'8
                 fs'8
@@ -718,19 +752,23 @@ def test_scoretools_Inspection_get_leaf_20():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \context Voice = "My Voice" {
+        \new Staff
+        {
+            \context Voice = "My Voice"
+            {
                 c'8
                 cs'8
                 d'8
             }
-            \context Voice = "Your Voice" {
+            \context Voice = "Your Voice"
+            {
                 e'8
                 f'8
                 fs'8
                 g'8
             }
-            \context Voice = "My Voice" {
+            \context Voice = "My Voice"
+            {
                 e'8
                 f'8
                 fs'8
@@ -761,8 +799,10 @@ def test_scoretools_Inspection_get_leaf_21():
 
     assert format(outer_voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            \new Voice {
+        \new Voice
+        {
+            \new Voice
+            {
                 c'8
                 cs'8
                 d'8
@@ -790,9 +830,11 @@ def test_scoretools_Inspection_get_leaf_22():
 
     assert format(outer_voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8
-            \new Voice {
+            \new Voice
+            {
                 cs'8
                 d'8
                 ef'8
@@ -822,8 +864,10 @@ def test_scoretools_Inspection_get_leaf_23():
 
     assert format(outer_voice) == abjad.String.normalize(
         r'''
-        \context Voice = "My Voice" {
-            \context Voice = "My Voice" {
+        \context Voice = "My Voice"
+        {
+            \context Voice = "My Voice"
+            {
                 c'8
                 cs'8
                 d'8
@@ -853,9 +897,11 @@ def test_scoretools_Inspection_get_leaf_24():
 
     assert format(outer_voice) == abjad.String.normalize(
         r'''
-        \context Voice = "My Voice" {
+        \context Voice = "My Voice"
+        {
             c'8
-            \context Voice = "My Voice" {
+            \context Voice = "My Voice"
+            {
                 cs'8
                 d'8
                 ef'8
@@ -884,8 +930,10 @@ def test_scoretools_Inspection_get_leaf_25():
 
     assert format(outer_voice) == abjad.String.normalize(
         r'''
-        \context Voice = "My Voice" {
-            \context Voice = "Your Voice" {
+        \context Voice = "My Voice"
+        {
+            \context Voice = "Your Voice"
+            {
                 c'8
                 cs'8
                 d'8
@@ -915,9 +963,11 @@ def test_scoretools_Inspection_get_leaf_26():
 
     assert format(voice_1) == abjad.String.normalize(
         r'''
-        \context Voice = "Voice 1" {
+        \context Voice = "Voice 1"
+        {
             c'8
-            \context Voice = "Voice 2" {
+            \context Voice = "Voice 2"
+            {
                 cs'8
                 d'8
                 ef'8

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_get_markup.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_get_markup.py
@@ -13,7 +13,8 @@ def test_scoretools_Inspection_get_markup_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 (
                 - \markup {
                     \column

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_get_sounding_pitches.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_get_sounding_pitches.py
@@ -10,7 +10,8 @@ def test_scoretools_Inspection_get_sounding_pitches_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set Staff.instrumentName = \markup { Glockenspiel }
             \set Staff.shortInstrumentName = \markup { Gkspl. }
             <c' e'>4

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_get_timespan.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_get_timespan.py
@@ -308,7 +308,8 @@ def test_scoretools_Inspection_get_timespan_26():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \tempo 8=48
             c'8
             d'8

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_get_vertical_moment_at.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_get_vertical_moment_at.py
@@ -16,8 +16,10 @@ def test_scoretools_Inspection_get_vertical_moment_at_01():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 4/3 {
                     d''8
@@ -25,12 +27,15 @@ def test_scoretools_Inspection_get_vertical_moment_at_01():
                     b'8
                 }
             }
-            \new PianoStaff <<
-                \new Staff {
+            \new PianoStaff
+            <<
+                \new Staff
+                {
                     a'4
                     g'4
                 }
-                \new Staff {
+                \new Staff
+                {
                     \clef "bass"
                     f'8
                     e'8
@@ -73,8 +78,10 @@ def test_scoretools_Inspection_get_vertical_moment_at_02():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 4/3 {
                     d''8
@@ -82,12 +89,15 @@ def test_scoretools_Inspection_get_vertical_moment_at_02():
                     b'8
                 }
             }
-            \new PianoStaff <<
-                \new Staff {
+            \new PianoStaff
+            <<
+                \new Staff
+                {
                     a'4
                     g'4
                 }
-                \new Staff {
+                \new Staff
+                {
                     \clef "bass"
                     f'8
                     e'8

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_is_bar_line_crossing.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_is_bar_line_crossing.py
@@ -11,7 +11,8 @@ def test_scoretools_Inspection_is_bar_line_crossing_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \partial 8
             \time 2/8
             c'8

--- a/abjad/tools/scoretools/test/test_scoretools_Inspection_report_modifications.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Inspection_report_modifications.py
@@ -17,9 +17,12 @@ def test_scoretools_Inspection_report_modifications_01():
     assert format(voice) == abjad.String.normalize(
         r'''
         % Example voice
-        \new Voice \with {
+        \new Voice
+        \with
+        {
             \override NoteHead.color = #red
-        } {
+        }
+        {
             #(set-accidental-style 'forget)
             \override Beam.thickness = #3
             c'8 [
@@ -36,9 +39,12 @@ def test_scoretools_Inspection_report_modifications_01():
     assert format(result) == abjad.String.normalize(
         r'''
         % Example voice
-        \new Voice \with {
+        \new Voice
+        \with
+        {
             \override NoteHead.color = #red
-        } {
+        }
+        {
             #(set-accidental-style 'forget)
             %%% 4 components omitted %%%
         }

--- a/abjad/tools/scoretools/test/test_scoretools_Leaf__divide.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Leaf__divide.py
@@ -12,7 +12,8 @@ def test_scoretools_Leaf__divide_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             <d' ef' e'>4
             <d' ef' e'>4
             r4
@@ -34,7 +35,8 @@ def test_scoretools_Leaf__divide_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             <d' ef' e'>4
             <ef' e'>4
             d'4
@@ -56,7 +58,8 @@ def test_scoretools_Leaf__divide_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             <d' ef' e'>4
             e'4
             <d' ef'>4

--- a/abjad/tools/scoretools/test/test_scoretools_Leaf__set_duration.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Leaf__set_duration.py
@@ -11,7 +11,8 @@ def test_scoretools_Leaf__set_duration_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
             e'8
@@ -24,7 +25,8 @@ def test_scoretools_Leaf__set_duration_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ~
             d'32 ]
@@ -49,7 +51,8 @@ def test_scoretools_Leaf__set_duration_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 ~ [
             c'8 ]
             c'8
@@ -62,7 +65,8 @@ def test_scoretools_Leaf__set_duration_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 ~ [
             c'8 ~
             c'32 ]
@@ -86,7 +90,8 @@ def test_scoretools_Leaf__set_duration_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
             e'8
@@ -99,7 +104,8 @@ def test_scoretools_Leaf__set_duration_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8. ]
             e'8
@@ -122,7 +128,8 @@ def test_scoretools_Leaf__set_duration_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
             e'8
@@ -135,7 +142,8 @@ def test_scoretools_Leaf__set_duration_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             \tweak edge-height #'(0.7 . 0)
             \times 2/3 {
@@ -162,7 +170,8 @@ def test_scoretools_Leaf__set_duration_05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
             e'8
@@ -175,7 +184,8 @@ def test_scoretools_Leaf__set_duration_05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             \tweak edge-height #'(0.7 . 0)
             \times 2/3 {
@@ -285,7 +295,8 @@ def test_scoretools_Leaf__set_duration_11():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             r8
             e'8 ]
@@ -298,7 +309,8 @@ def test_scoretools_Leaf__set_duration_11():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             r8
             r32

--- a/abjad/tools/scoretools/test/test_scoretools_Leaf__split_by_durations.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Leaf__split_by_durations.py
@@ -12,7 +12,8 @@ def test_scoretools_Leaf__split_by_durations_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             e'8 ]
@@ -28,7 +29,8 @@ def test_scoretools_Leaf__split_by_durations_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'32
             d'16.
@@ -50,7 +52,8 @@ def test_scoretools_Leaf__split_by_durations_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             e'8 ]
@@ -66,7 +69,8 @@ def test_scoretools_Leaf__split_by_durations_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'32 ]
             d'16. [
@@ -88,7 +92,8 @@ def test_scoretools_Leaf__split_by_durations_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             e'8 ]
@@ -104,7 +109,8 @@ def test_scoretools_Leaf__split_by_durations_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'32 ~
             d'16.
@@ -132,7 +138,8 @@ def test_scoretools_Leaf__split_by_durations_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'32 ~ ]
             d'16. [
@@ -159,7 +166,8 @@ def test_scoretools_Leaf__split_by_durations_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             \times 2/3 {
                 d'16
@@ -189,7 +197,8 @@ def test_scoretools_Leaf__split_by_durations_06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \times 2/3 {
                 \times 4/5 {
                     c'16. ~ [
@@ -218,7 +227,8 @@ def test_scoretools_Leaf__split_by_durations_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             \times 2/3 {
                 d'8
@@ -236,7 +246,8 @@ def test_scoretools_Leaf__split_by_durations_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             \times 2/3 {
                 d'16
@@ -454,16 +465,17 @@ def test_scoretools_Leaf__split_by_durations_18():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -476,17 +488,18 @@ def test_scoretools_Leaf__split_by_durations_18():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'32 [ (
                 c'16.
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -512,16 +525,17 @@ def test_scoretools_Leaf__split_by_durations_19():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -534,17 +548,18 @@ def test_scoretools_Leaf__split_by_durations_19():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'32 ~ [ (
                 c'16.
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -569,16 +584,17 @@ def test_scoretools_Leaf__split_by_durations_20():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -591,17 +607,18 @@ def test_scoretools_Leaf__split_by_durations_20():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'32 [ ]
                 c'16. [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -628,16 +645,17 @@ def test_scoretools_Leaf__split_by_durations_21():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -650,17 +668,18 @@ def test_scoretools_Leaf__split_by_durations_21():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'32 ] )
                 d'16. [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -708,16 +727,17 @@ def test_scoretools_Leaf__split_by_durations_23():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -730,17 +750,18 @@ def test_scoretools_Leaf__split_by_durations_23():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'32 ~ [ ]
                 c'16. [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)

--- a/abjad/tools/scoretools/test/test_scoretools_LogicalTie__add_or_remove_notes_to_achieve_written_duration.py
+++ b/abjad/tools/scoretools/test/test_scoretools_LogicalTie__add_or_remove_notes_to_achieve_written_duration.py
@@ -19,7 +19,8 @@ def test_scoretools_LogicalTie__add_or_remove_notes_to_achieve_written_duration_
     assert abjad.inspect(staff).is_well_formed()
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 ~ [
             c'32 ]
         }
@@ -44,7 +45,8 @@ def test_scoretools_LogicalTie__add_or_remove_notes_to_achieve_written_duration_
     assert abjad.inspect(staff).is_well_formed()
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ ]
         }
         '''

--- a/abjad/tools/scoretools/test/test_scoretools_LogicalTie__fuse_leaves_by_immediate_parent.py
+++ b/abjad/tools/scoretools/test/test_scoretools_LogicalTie__fuse_leaves_by_immediate_parent.py
@@ -15,14 +15,15 @@ def test_scoretools_LogicalTie__fuse_leaves_by_immediate_parent_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'4 ~
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'4
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -41,7 +42,8 @@ def test_scoretools_LogicalTie__fuse_leaves_by_immediate_parent_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 ~
             c'8 ~
             c'8 ~
@@ -55,7 +57,8 @@ def test_scoretools_LogicalTie__fuse_leaves_by_immediate_parent_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'2
         }
         '''

--- a/abjad/tools/scoretools/test/test_scoretools_Measure___add__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure___add__.py
@@ -48,7 +48,8 @@ def test_scoretools_Measure___add___02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 \time 1/8
                 c'16 [
@@ -71,7 +72,8 @@ def test_scoretools_Measure___add___02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 \time 2/8
                 c'16 [

--- a/abjad/tools/scoretools/test/test_scoretools_Measure___delitem__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure___delitem__.py
@@ -13,12 +13,12 @@ def test_scoretools_Measure___delitem___01():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/8
             c'8
             c'8
             c'8
-        } % measure
+        }   % measure
         '''
         )
 
@@ -37,12 +37,12 @@ def test_scoretools_Measure___delitem___02():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/8
             c'8
             c'8
             c'8
-        } % measure
+        }   % measure
         '''
         )
 
@@ -61,11 +61,11 @@ def test_scoretools_Measure___delitem___03():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 2/8
             c'8
             c'8
-        } % measure
+        }   % measure
         '''
         )
 
@@ -84,13 +84,13 @@ def test_scoretools_Measure___delitem___04():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 7/16
             c'16
             c'8
             c'8
             c'8
-        } % measure
+        }   % measure
         '''
         )
 
@@ -110,14 +110,14 @@ def test_scoretools_Measure___delitem___05():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/9
             \scaleDurations #'(8 . 9) {
                 d'8
                 e'8
                 f'8
             }
-        } % measure
+        }   % measure
         '''
         )
 
@@ -136,7 +136,7 @@ def test_scoretools_Measure___delitem___06():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/9
             \scaleDurations #'(8 . 9) {
                 c'16
@@ -144,7 +144,7 @@ def test_scoretools_Measure___delitem___06():
                 e'8
                 f'8
             }
-        } % measure
+        }   % measure
         '''
         )
 
@@ -152,14 +152,14 @@ def test_scoretools_Measure___delitem___06():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 5/18
             \scaleDurations #'(8 . 9) {
                 d'16
                 e'8
                 f'8
             }
-        } % measure
+        }   % measure
         '''
         )
 

--- a/abjad/tools/scoretools/test/test_scoretools_Measure___setitem__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure___setitem__.py
@@ -20,10 +20,10 @@ def test_scoretools_Measure___setitem___02():
     assert not measure.is_underfull
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/8
             r8
             e'4
-        } % measure
+        }   % measure
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Measure_append.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure_append.py
@@ -24,12 +24,12 @@ def test_scoretools_Measure_append_02():
     assert not measure.is_misfilled
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 4/4
             c'4
             d'4
             e'4
             r4
-        } % measure
+        }   % measure
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Measure_duration.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure_duration.py
@@ -10,12 +10,12 @@ def test_scoretools_Measure_duration_01():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/8
             c'8
             d'8
             e'8
-        } % measure
+        }   % measure
         '''
         )
 
@@ -33,14 +33,14 @@ def test_scoretools_Measure_duration_02():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/10
             \scaleDurations #'(4 . 5) {
                 c'8
                 d'8
                 e'8
             }
-        } % measure
+        }   % measure
         '''
         )
 

--- a/abjad/tools/scoretools/test/test_scoretools_Measure_extend.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure_extend.py
@@ -24,13 +24,13 @@ def test_scoretools_Measure_extend_02():
     assert not measure.is_misfilled
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 5/4
             c'4
             d'4
             e'4
             f'4
             g'4
-        } % measure
+        }   % measure
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Measure_measure_number.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure_measure_number.py
@@ -41,20 +41,21 @@ def test_scoretools_Measure_measure_number_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 e'8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'8
                 d'8
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Measure_scale_and_adjust_time_signature.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure_scale_and_adjust_time_signature.py
@@ -12,14 +12,14 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_01():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/12
             \scaleDurations #'(2 . 3) {
                 c'8
                 d'8
                 e'8
             }
-        } % measure
+        }   % measure
         '''
         )
 
@@ -37,12 +37,12 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_02():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/8
             c'8
             d'8
             e'8
-        } % measure
+        }   % measure
         '''
         )
 
@@ -59,12 +59,12 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_03():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 9/16
             c'8.
             d'8.
             e'8.
-        } % measure
+        }   % measure
         '''
         )
 
@@ -82,12 +82,12 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_04():
     assert abjad.inspect(measure).is_well_formed()
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/8
             c'8
             d'8
             e'8
-        } % measure
+        }   % measure
         '''
         )
 
@@ -102,7 +102,7 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_05():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 9/24
             \scaleDurations #'(2 . 3) {
                 c'16
@@ -115,7 +115,7 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_05():
                 c''16
                 d''16
             }
-        } % measure
+        }   % measure
         '''
         )
 
@@ -132,12 +132,12 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_06():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/4
             c'4
             d'4
             e'4
-        } % measure
+        }   % measure
         '''
         )
 
@@ -156,7 +156,7 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_07():
     assert abjad.inspect(measure).is_well_formed()
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 6/32
             c'32
             d'32
@@ -164,7 +164,7 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_07():
             f'32
             g'32
             a'32
-        } % measure
+        }   % measure
         '''
         )
 
@@ -181,7 +181,7 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_08():
     assert abjad.inspect(measure).is_well_formed()
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 6/64
             c'64
             d'64
@@ -189,7 +189,7 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_08():
             f'64
             g'64
             a'64
-        } % measure
+        }   % measure
         '''
         )
 
@@ -206,7 +206,7 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_09():
     assert abjad.inspect(measure).is_well_formed()
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 6/8
             c'8
             d'8
@@ -214,7 +214,7 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_09():
             f'8
             g'8
             a'8
-        } % measure
+        }   % measure
         '''
         )
 
@@ -231,7 +231,7 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_10():
     assert abjad.inspect(measure).is_well_formed()
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 6/4
             c'4
             d'4
@@ -239,6 +239,6 @@ def test_scoretools_Measure_scale_and_adjust_time_signature_10():
             f'4
             g'4
             a'4
-        } % measure
+        }   % measure
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Measure_should_scale_contents.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure_should_scale_contents.py
@@ -8,7 +8,7 @@ def test_scoretools_Measure_should_scale_contents_01():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 5/12
             \tweak edge-height #'(0.7 . 0)
             \times 2/3 {
@@ -18,6 +18,6 @@ def test_scoretools_Measure_should_scale_contents_01():
                 f'8
                 g'8
             }
-        } % measure
+        }   % measure
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Measure_simultaneous.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure_simultaneous.py
@@ -17,20 +17,23 @@ def test_scoretools_Measure_simultaneous_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            << % measure
+        \new Staff
+        {
+            <<  % measure
                 \time 2/8
-                \new Voice {
+                \new Voice
+                {
                     \voiceOne
                     c'8
                     d'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     \voiceTwo
                     e'8
                     f'8
                 }
-            >> % measure
+            >>  % measure
         }
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Measure_time_signature_assignment.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure_time_signature_assignment.py
@@ -13,11 +13,11 @@ def test_scoretools_Measure_time_signature_assignment_01():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/8
             c'8
             d'8
             e'8
-        } % measure
+        }   % measure
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Measure_time_signature_update.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Measure_time_signature_update.py
@@ -13,12 +13,12 @@ def test_scoretools_Measure_time_signature_update_01():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 3/8
             c'8
             d'8
             e'8
-        } % measure
+        }   % measure
         '''
         )
 

--- a/abjad/tools/scoretools/test/test_scoretools_Mutation_copy.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Mutation_copy.py
@@ -19,21 +19,22 @@ def test_scoretools_Mutation_copy_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 \startTrillSpan
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8 ] ) \stopTrillSpan
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -43,7 +44,8 @@ def test_scoretools_Mutation_copy_01():
 
     assert format(new) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             e'8 [ (
             \startTrillSpan
             f'8 ] ) \stopTrillSpan
@@ -69,21 +71,22 @@ def test_scoretools_Mutation_copy_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 \startTrillSpan
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8 ] ) \stopTrillSpan
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -93,13 +96,14 @@ def test_scoretools_Mutation_copy_02():
 
     assert format(new) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 e'8 [ (
                 \startTrillSpan
                 f'8 ] ) \stopTrillSpan
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -122,21 +126,22 @@ def test_scoretools_Mutation_copy_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 \startTrillSpan
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8 ] ) \stopTrillSpan
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -146,7 +151,8 @@ def test_scoretools_Mutation_copy_03():
 
     assert format(new) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             f'8 [ (
             \startTrillSpan
             g'8
@@ -170,24 +176,25 @@ def test_scoretools_Mutation_copy_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 b'8
                 c''8 ] )
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -200,24 +207,25 @@ def test_scoretools_Mutation_copy_04():
 
     assert format(new_voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'8
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 b'8
                 c''8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -236,24 +244,25 @@ def test_scoretools_Mutation_copy_05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 b'8
                 c''8 ] )
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -265,20 +274,21 @@ def test_scoretools_Mutation_copy_05():
 
     assert format(new_voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 e'8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 b'8
                 c''8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -298,24 +308,25 @@ def test_scoretools_Mutation_copy_06():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 b'8
                 c''8 ] )
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -327,7 +338,8 @@ def test_scoretools_Mutation_copy_06():
 
     assert format(new_voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8
             d'8
             e'8
@@ -353,24 +365,25 @@ def test_scoretools_Mutation_copy_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 b'8
                 c''8 ] )
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -382,16 +395,17 @@ def test_scoretools_Mutation_copy_07():
 
     assert format(new_voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 g'8
                 a'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 b'8
                 c''8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -410,7 +424,8 @@ def test_scoretools_Mutation_copy_08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 \<
             cs'8
             d'8
@@ -428,7 +443,8 @@ def test_scoretools_Mutation_copy_08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 \<
             cs'8
             d'8

--- a/abjad/tools/scoretools/test/test_scoretools_Mutation_extract.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Mutation_extract.py
@@ -13,7 +13,8 @@ def test_scoretools_Mutation_extract_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             d'8 \glissando
             e'8 \glissando
@@ -27,7 +28,8 @@ def test_scoretools_Mutation_extract_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             e'8 \glissando
             f'8 ]
@@ -51,7 +53,8 @@ def test_scoretools_Mutation_extract_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             d'8 \glissando
             e'8 \glissando
@@ -66,7 +69,8 @@ def test_scoretools_Mutation_extract_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             e'8 [ \glissando
             f'8 ]
         }
@@ -92,7 +96,8 @@ def test_scoretools_Mutation_extract_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 d'8
@@ -110,7 +115,8 @@ def test_scoretools_Mutation_extract_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             {
@@ -141,7 +147,8 @@ def test_scoretools_Mutation_extract_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ \glissando
                 d'8 \glissando
@@ -164,7 +171,8 @@ def test_scoretools_Mutation_extract_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             d'8 \glissando
             e'8 \glissando

--- a/abjad/tools/scoretools/test/test_scoretools_Mutation_fuse.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Mutation_fuse.py
@@ -63,7 +63,8 @@ def test_scoretools_Mutation_fuse_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             s1 * 1/16
             s1 * 5/16
         }
@@ -76,7 +77,8 @@ def test_scoretools_Mutation_fuse_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             s1 * 3/8
         }
         '''
@@ -153,7 +155,8 @@ def test_scoretools_Mutation_fuse_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8 [
                 d'8
@@ -173,7 +176,8 @@ def test_scoretools_Mutation_fuse_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8 [
                 d'8
@@ -203,7 +207,8 @@ def test_scoretools_Mutation_fuse_08():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8 [
                 d'8
@@ -226,7 +231,8 @@ def test_scoretools_Mutation_fuse_08():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \tweak edge-height #'(0.7 . 0)
             \times 2/3 {
                 c'8 [
@@ -269,7 +275,8 @@ def test_scoretools_Mutation_fuse_10():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \tweak edge-height #'(0.7 . 0)
             \times 2/3 {
                 c'8 (
@@ -288,7 +295,8 @@ def test_scoretools_Mutation_fuse_10():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8 (
                 c'4
@@ -316,17 +324,18 @@ def test_scoretools_Mutation_fuse_11():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/8
                 c'16 [
                 d'16 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/16
                 c'16 (
                 d'16 )
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -339,13 +348,13 @@ def test_scoretools_Mutation_fuse_11():
 
     assert format(new) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 2/8
             c'16 [
             d'16 ]
             c'16 (
             d'16 )
-        } % measure
+        }   % measure
         '''
         )
 
@@ -365,17 +374,18 @@ def test_scoretools_Mutation_fuse_12():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 1/8
                 c'16 [
                 d'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/16
                 e'16
                 f'16 ]
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -384,14 +394,15 @@ def test_scoretools_Mutation_fuse_12():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'16 [
                 d'16
                 e'16
                 f'16 ]
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -412,17 +423,18 @@ def test_scoretools_Mutation_fuse_13():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 1/8
                 c'16 [
                 d'16 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/16
                 e'16
                 f'16
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -431,14 +443,15 @@ def test_scoretools_Mutation_fuse_13():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'16 [
                 d'16 ]
                 e'16
                 f'16
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -464,17 +477,18 @@ def test_scoretools_Mutation_fuse_14():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 1/8
                 c'8 [
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/12
                 \scaleDurations #'(2 . 3) {
                     d'8 ]
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -483,14 +497,15 @@ def test_scoretools_Mutation_fuse_14():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 5/24
                 \scaleDurations #'(2 . 3) {
                     c'8. [
                     d'8 ]
                 }
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -529,20 +544,21 @@ def test_scoretools_Mutation_fuse_17():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 1/8
                 c'16 [
                 d'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'16
                 f'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'16
                 a'16 ]
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -551,8 +567,9 @@ def test_scoretools_Mutation_fuse_17():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 3/8
                 c'16 [
                 d'16
@@ -560,7 +577,7 @@ def test_scoretools_Mutation_fuse_17():
                 f'16
                 g'16
                 a'16 ]
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -584,8 +601,9 @@ def test_scoretools_Mutation_fuse_18():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 9/80
                 \scaleDurations #'(4 . 5) {
                     c'64
@@ -598,12 +616,12 @@ def test_scoretools_Mutation_fuse_18():
                     c'64
                     c'64
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/16
                 c'16
                 c'16
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -612,8 +630,9 @@ def test_scoretools_Mutation_fuse_18():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 19/80
                 \scaleDurations #'(4 . 5) {
                     c'64
@@ -630,7 +649,7 @@ def test_scoretools_Mutation_fuse_18():
                     c'16 ~
                     c'64
                 }
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Mutation_replace.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Mutation_replace.py
@@ -17,7 +17,8 @@ def test_scoretools_Mutation_replace_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ \<
             d'8 ]
             e'8 [
@@ -32,7 +33,8 @@ def test_scoretools_Mutation_replace_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ ] \<
             c''16
             c''16
@@ -63,7 +65,8 @@ def test_scoretools_Mutation_replace_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ \<
             d'8 ]
             e'8 [
@@ -78,7 +81,8 @@ def test_scoretools_Mutation_replace_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c''16 [ \<
             c''16
             c''16
@@ -110,7 +114,8 @@ def test_scoretools_Mutation_replace_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ \<
             d'8 ]
             e'8 [
@@ -125,7 +130,8 @@ def test_scoretools_Mutation_replace_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c''16 [ \<
             c''16
             c''16
@@ -156,7 +162,8 @@ def test_scoretools_Mutation_replace_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ \<
             d'8 ]
             e'8 [
@@ -171,7 +178,8 @@ def test_scoretools_Mutation_replace_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c''16 \<
             c''16
             c''16
@@ -201,7 +209,8 @@ def test_scoretools_Mutation_replace_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ \<
             d'8 ]
             e'8 [
@@ -216,7 +225,8 @@ def test_scoretools_Mutation_replace_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c''16 \<
             c''16
             c''16
@@ -245,8 +255,10 @@ def test_scoretools_Mutation_replace_06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \new Voice {
+        \new Staff
+        {
+            \new Voice
+            {
                 c'8 [
                 d'8
                 e'8
@@ -262,7 +274,8 @@ def test_scoretools_Mutation_replace_06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             e'8

--- a/abjad/tools/scoretools/test/test_scoretools_Mutation_replace_measure_contents.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Mutation_replace_measure_contents.py
@@ -15,18 +15,19 @@ def test_scoretools_Mutation_replace_measure_contents_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/8
                 c'16
                 d'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/16
                 e'16
                 f'16
                 s1 * 1/16
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -48,25 +49,26 @@ def test_scoretools_Mutation_replace_measure_contents_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/16
                 s1 * 1/16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/16
                 c'8
                 s1 * 1/16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/16
                 s1 * 1/16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/16
                 d'8
                 s1 * 1/16
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -117,16 +119,17 @@ def test_scoretools_Mutation_replace_measure_contents_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/8
                 c'16
                 d'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'16
                 f'16
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -150,16 +153,17 @@ def test_scoretools_Mutation_replace_measure_contents_06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 5/16
                 c'4 ~
                 c'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/16
                 c'8.
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Mutation_scale.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Mutation_scale.py
@@ -10,7 +10,8 @@ def test_scoretools_Mutation_scale_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8.
             d'8.
             e'8.
@@ -31,7 +32,8 @@ def test_scoretools_Mutation_scale_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 ~
             c'32
             d'8 ~
@@ -56,7 +58,8 @@ def test_scoretools_Mutation_scale_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \tweak edge-height #'(0.7 . 0)
             \times 2/3 {
                 c'4
@@ -89,7 +92,8 @@ def test_scoretools_Mutation_scale_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \tweak edge-height #'(0.7 . 0)
             \times 2/3 {
                 c'8 ~
@@ -126,7 +130,8 @@ def test_scoretools_Mutation_scale_05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 ~
             c'32
             d'8 ~
@@ -143,7 +148,8 @@ def test_scoretools_Mutation_scale_05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8
             d'8
             e'8
@@ -165,16 +171,17 @@ def test_scoretools_Mutation_scale_06():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'8
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -183,16 +190,17 @@ def test_scoretools_Mutation_scale_06():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/4
                 c'4
                 d'4
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'4
                 f'4
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -210,16 +218,17 @@ def test_scoretools_Mutation_scale_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'8
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -228,20 +237,21 @@ def test_scoretools_Mutation_scale_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 20/64
                 c'8 ~
                 c'32
                 d'8 ~
                 d'32
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 ~
                 e'32
                 f'8 ~
                 f'32
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Mutation_splice.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Mutation_splice.py
@@ -16,7 +16,8 @@ def test_scoretools_Mutation_splice_01():
     assert result == voice[-4:]
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8
@@ -42,7 +43,8 @@ def test_scoretools_Mutation_splice_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             dqs'8
@@ -71,7 +73,8 @@ def test_scoretools_Mutation_splice_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8 [
                 d'8
@@ -105,7 +108,8 @@ def test_scoretools_Mutation_splice_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 c'8
@@ -138,7 +142,8 @@ def test_scoretools_Mutation_splice_05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8 ]
@@ -168,7 +173,8 @@ def test_scoretools_Mutation_splice_06():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             dqs'8
@@ -197,7 +203,8 @@ def test_scoretools_Mutation_splice_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'16 [
             d'16
             e'16
@@ -227,7 +234,8 @@ def test_scoretools_Mutation_splice_08():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             dqf'8
             d'8
@@ -257,7 +265,8 @@ def test_scoretools_Mutation_splice_09():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8 [
                 d'8
@@ -292,7 +301,8 @@ def test_scoretools_Mutation_splice_10():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8
@@ -326,7 +336,8 @@ def test_scoretools_Mutation_splice_11():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'16
             d'16
             e'16
@@ -356,7 +367,8 @@ def test_scoretools_Mutation_splice_12():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             dqf'8
             d'8

--- a/abjad/tools/scoretools/test/test_scoretools_Mutation_split.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Mutation_split.py
@@ -21,16 +21,17 @@ def test_scoretools_Mutation_split_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -44,18 +45,19 @@ def test_scoretools_Mutation_split_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'32. ~
                 d'32. ~
                 d'32 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -81,16 +83,17 @@ def test_scoretools_Mutation_split_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -103,20 +106,21 @@ def test_scoretools_Mutation_split_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'16. ~ [ (
                 c'32
                 d'16 ~
                 d'16 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'32 ~ [
                 e'16.
                 f'16. ~
                 f'32 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -142,16 +146,17 @@ def test_scoretools_Mutation_split_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -166,24 +171,25 @@ def test_scoretools_Mutation_split_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/32
                 c'16. [ (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'32
                 d'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/32
                 d'16 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -209,16 +215,17 @@ def test_scoretools_Mutation_split_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -233,34 +240,35 @@ def test_scoretools_Mutation_split_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/32
                 c'16. [ (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'32
                 d'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/32
                 d'16 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 e'32 [
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/32
                 e'16.
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 f'16.
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 f'32 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -297,34 +305,35 @@ def test_scoretools_Mutation_split_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/32
                 c'16. [
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'32
                 d'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/32
                 d'16 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 e'32 [
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/32
                 e'16.
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 f'16.
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 f'32 ]
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -350,16 +359,17 @@ def test_scoretools_Mutation_split_06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -374,19 +384,20 @@ def test_scoretools_Mutation_split_06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'32 ~
                 d'32 ~
                 d'32 ~
                 d'32 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -412,16 +423,17 @@ def test_scoretools_Mutation_split_07():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -435,20 +447,21 @@ def test_scoretools_Mutation_split_07():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'16 ~ [ (
                 c'16
                 d'16 ~
                 d'16 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'16 ~ [
                 e'16
                 f'16 ~
                 f'16 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -474,16 +487,17 @@ def test_scoretools_Mutation_split_08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -498,25 +512,26 @@ def test_scoretools_Mutation_split_08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff 
+        {
+            {   % measure
                 \time 1/16
                 c'16 ~ [ (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 d'16 ~
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 d'16 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -542,16 +557,17 @@ def test_scoretools_Mutation_split_09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -566,34 +582,35 @@ def test_scoretools_Mutation_split_09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/32
                 c'16. ~ [ (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'32
                 d'16 ~
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/32
                 d'16 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 e'32 ~ [
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/32
                 e'16.
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 f'16. ~
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 f'32 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -619,16 +636,17 @@ def test_scoretools_Mutation_split_10():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -642,18 +660,19 @@ def test_scoretools_Mutation_split_10():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'32. ~ ] )
                 d'32. ~ [ ]
                 d'32 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -679,16 +698,17 @@ def test_scoretools_Mutation_split_11():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -701,20 +721,21 @@ def test_scoretools_Mutation_split_11():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'16. ~ [ ]
                 c'32 [ (
                 d'16 ~ ] )
                 d'16 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'32 ~ ) [ ]
                 e'16. [ (
                 f'16. ~ ] )
                 f'32 [ ]
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -740,16 +761,17 @@ def test_scoretools_Mutation_split_12():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -764,24 +786,25 @@ def test_scoretools_Mutation_split_12():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/32
                 c'16. [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'32 [ (
                 d'16 ] )
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/32
                 d'16 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -807,16 +830,17 @@ def test_scoretools_Mutation_split_13():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -831,34 +855,35 @@ def test_scoretools_Mutation_split_13():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/32
                 c'16. [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'32 [ (
                 d'16 ] )
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/32
                 d'16 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 e'32 ) [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/32
                 e'16. [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 f'16. [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 f'32 [ ]
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -889,7 +914,8 @@ def test_scoretools_Mutation_split_14():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'16. ~
             c'32
             d'16 ~
@@ -933,34 +959,35 @@ def test_scoretools_Mutation_split_15():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/32
                 c'16. [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'32 [
                 d'16 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/32
                 d'16 [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 e'32 [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/32
                 e'16. [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 f'16. [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 f'32 [ ]
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -986,16 +1013,17 @@ def test_scoretools_Mutation_split_16():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1010,19 +1038,20 @@ def test_scoretools_Mutation_split_16():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'32 ~ ] )
                 d'32 ~ [ ]
                 d'32 ~ [ ]
                 d'32 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1048,16 +1077,17 @@ def test_scoretools_Mutation_split_17():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1071,20 +1101,21 @@ def test_scoretools_Mutation_split_17():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'16 ~ [ ]
                 c'16 [ (
                 d'16 ~ ] )
                 d'16 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'16 ~ ) [ ]
                 e'16 [ (
                 f'16 ~ ] )
                 f'16 [ ]
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1110,16 +1141,17 @@ def test_scoretools_Mutation_split_18():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1134,25 +1166,26 @@ def test_scoretools_Mutation_split_18():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/16
                 c'16 ~ [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'16 [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 d'16 ~ [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 d'16 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1178,16 +1211,17 @@ def test_scoretools_Mutation_split_19():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1202,34 +1236,35 @@ def test_scoretools_Mutation_split_19():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/32
                 c'16. ~ [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 c'32 [ (
                 d'16 ~ ] )
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/32
                 d'16 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 e'32 ~ ) [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/32
                 e'16. [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 f'16. ~ [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 f'32 [ ]
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1255,16 +1290,17 @@ def test_scoretools_Mutation_split_20():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1279,24 +1315,25 @@ def test_scoretools_Mutation_split_20():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/32
                 c'32 [ (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/32
                 c'16.
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 4/32
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1322,16 +1359,17 @@ def test_scoretools_Mutation_split_21():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1346,28 +1384,29 @@ def test_scoretools_Mutation_split_21():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/32
                 c'32 [ (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/32
                 c'16.
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 4/32
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 e'32 [
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 7/32
                 e'16.
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1393,16 +1432,17 @@ def test_scoretools_Mutation_split_22():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1417,24 +1457,25 @@ def test_scoretools_Mutation_split_22():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/32
                 c'32 [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/32
                 c'16. [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 4/32
                 d'8 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1460,16 +1501,17 @@ def test_scoretools_Mutation_split_23():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1485,28 +1527,29 @@ def test_scoretools_Mutation_split_23():
     assert len(result) == 4
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/32
                 c'32 [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 3/32
                 c'16. [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 4/32
                 d'8 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/32
                 e'32 ) [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 7/32
                 e'16. [ (
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -1533,7 +1576,8 @@ def test_scoretools_Mutation_split_24():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'32
             c'8 ~
             c'32
@@ -1556,7 +1600,8 @@ def test_scoretools_Mutation_split_25():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ ]
         }
         '''
@@ -1572,7 +1617,8 @@ def test_scoretools_Mutation_split_25():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff 
+        {
             c'64 [ ]
             c'16 ~ [
             c'64 ]
@@ -1605,7 +1651,8 @@ def test_scoretools_Mutation_split_26():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8 [
                 d'8
@@ -1648,22 +1695,23 @@ def test_scoretools_Mutation_split_27():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 3/8
                 c'8 [
                 d'8
                 e'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 g'8
                 a'8 ]
-            } % measure
+            }   % measure
         }
         '''
         ), format(voice)
@@ -1692,28 +1740,29 @@ def test_scoretools_Mutation_split_28():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 3/9
                 \scaleDurations #'(8 . 9) {
                     c'8 [
                     d'8
                     e'8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/9
                 \scaleDurations #'(8 . 9) {
                     f'8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/9
                 \scaleDurations #'(8 . 9) {
                     g'8
                     a'8 ]
                 }
-            } % measure
+            }   % measure
         }
         '''
         ), format(voice)
@@ -1739,7 +1788,8 @@ def test_scoretools_Mutation_split_29():
 
     assert format(voice_1) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8
             d'8
         }
@@ -1750,7 +1800,8 @@ def test_scoretools_Mutation_split_29():
 
     assert format(voice_2) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             e'8
             f'8
         }
@@ -1777,7 +1828,8 @@ def test_scoretools_Mutation_split_30():
 
     assert format(left) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8
             d'8
         }
@@ -1786,7 +1838,8 @@ def test_scoretools_Mutation_split_30():
 
     assert format(right) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             e'8
             f'8
         }
@@ -1795,19 +1848,23 @@ def test_scoretools_Mutation_split_30():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
         }
         '''
         ), format(voice)
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \new Voice {
+        \new Staff
+        {
+            \new Voice
+            {
                 c'8
                 d'8
             }
-            \new Voice {
+            \new Voice
+            {
                 e'8
                 f'8
             }
@@ -1840,7 +1897,8 @@ def test_scoretools_Mutation_split_31():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 d'8
@@ -1880,7 +1938,8 @@ def test_scoretools_Mutation_split_31():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 d'8
@@ -1946,7 +2005,8 @@ def test_scoretools_Mutation_split_32():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \tweak edge-height #'(0.7 . 0)
             \times 4/5 {
                 c'8 [
@@ -1964,8 +2024,10 @@ def test_scoretools_Mutation_split_32():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \new Voice {
+        \new Staff
+        {
+            \new Voice
+            {
                 \tweak edge-height #'(0.7 . 0)
                 \times 4/5 {
                     c'8 [
@@ -2001,7 +2063,8 @@ def test_scoretools_Mutation_split_33():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8 [
                 d'8
@@ -2047,7 +2110,8 @@ def test_scoretools_Mutation_split_33():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8 [
                 d'8
@@ -2085,18 +2149,19 @@ def test_scoretools_Mutation_split_34():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 3/8
                 c'8 [
                 d'8
                 e'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 f'8
                 g'8
                 a'8 ]
-            } % measure
+            }   % measure
         }
         '''
         ), format(voice)
@@ -2111,20 +2176,20 @@ def test_scoretools_Mutation_split_34():
 
     assert format(left) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 1/8
             f'8 ]
-        } % measure
+        }   % measure
         '''
         ), format(left)
 
     assert format(right) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 2/8
             g'8 [
             a'8 ]
-        } % measure
+        }   % measure
         '''
         ), format(right)
 
@@ -2132,22 +2197,23 @@ def test_scoretools_Mutation_split_34():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 3/8
                 c'8 [
                 d'8
                 e'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/8
                 f'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 g'8 [
                 a'8 ]
-            } % measure
+            }   % measure
         }
         '''
         ), format(voice)
@@ -2173,22 +2239,23 @@ def test_scoretools_Mutation_split_35():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 3/9
                 \scaleDurations #'(8 . 9) {
                     c'8 [
                     d'8
                     e'8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \scaleDurations #'(8 . 9) {
                     f'8
                     g'8
                     a'8 ]
                 }
-            } % measure
+            }   % measure
         }
         '''
         ), format(voice)
@@ -2203,24 +2270,24 @@ def test_scoretools_Mutation_split_35():
 
     assert format(left) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 1/9
             \scaleDurations #'(8 . 9) {
                 f'8 ]
             }
-        } % measure
+        }   % measure
         '''
         ), format(left)
 
     assert format(right) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 2/9
             \scaleDurations #'(8 . 9) {
                 g'8 [
                 a'8 ]
             }
-        } % measure
+        }   % measure
         '''
         ), format(right)
 
@@ -2228,28 +2295,29 @@ def test_scoretools_Mutation_split_35():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 3/9
                 \scaleDurations #'(8 . 9) {
                     c'8 [
                     d'8
                     e'8
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 1/9
                 \scaleDurations #'(8 . 9) {
                     f'8 ]
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/9
                 \scaleDurations #'(8 . 9) {
                     g'8 [
                     a'8 ]
                 }
-            } % measure
+            }   % measure
         }
         '''
         ), format(voice)
@@ -2269,7 +2337,8 @@ def test_scoretools_Mutation_split_36():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8
@@ -2288,7 +2357,8 @@ def test_scoretools_Mutation_split_36():
 
     assert format(left) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
         }
@@ -2297,7 +2367,8 @@ def test_scoretools_Mutation_split_36():
 
     assert format(right) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             e'8 [
             f'8 ]
         }
@@ -2306,7 +2377,8 @@ def test_scoretools_Mutation_split_36():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
         }
         '''
         ), format(voice)
@@ -2331,16 +2403,17 @@ def test_scoretools_Mutation_split_37():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [ (
                 d'8 ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -2356,19 +2429,20 @@ def test_scoretools_Mutation_split_37():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 1/8
                 c'8 [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 d'8 [ ] (
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \time 2/8
                 e'8 [
                 f'8 ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -2393,12 +2467,13 @@ def test_scoretools_Mutation_split_38():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/8
                 c'8. [ (
                 d'8. ] )
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -2411,14 +2486,15 @@ def test_scoretools_Mutation_split_38():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/16
                 c'8. [ ]
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 d'8. [ ]
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -2442,7 +2518,8 @@ def test_scoretools_Mutation_split_39():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
                 d'8
@@ -2466,7 +2543,8 @@ def test_scoretools_Mutation_split_39():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
             }
@@ -2503,7 +2581,8 @@ def test_scoretools_Mutation_split_40():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
                 d'8
@@ -2523,7 +2602,8 @@ def test_scoretools_Mutation_split_40():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
             }
@@ -2556,7 +2636,8 @@ def test_scoretools_Mutation_split_41():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
                 d'8
@@ -2576,7 +2657,8 @@ def test_scoretools_Mutation_split_41():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ ]
             }
@@ -2612,7 +2694,8 @@ def test_scoretools_Mutation_split_42():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
                 d'8
@@ -2632,7 +2715,8 @@ def test_scoretools_Mutation_split_42():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
                 d'8 ] )
@@ -2662,7 +2746,8 @@ def test_scoretools_Mutation_split_43():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
                 d'8
@@ -2682,7 +2767,8 @@ def test_scoretools_Mutation_split_43():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
                 d'8
@@ -2712,7 +2798,8 @@ def test_scoretools_Mutation_split_44():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
                 d'8
@@ -2732,7 +2819,8 @@ def test_scoretools_Mutation_split_44():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ (
                 d'8 ] )
@@ -2762,7 +2850,8 @@ def test_scoretools_Mutation_split_45():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \times 2/3 {
                 c'4 ~
                 c'16 ~
@@ -2791,14 +2880,15 @@ def test_scoretools_Mutation_split_46():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/12
                 \scaleDurations #'(2 . 3) {
                     c'8. [
                     d'8. ]
                 }
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)
@@ -2811,18 +2901,19 @@ def test_scoretools_Mutation_split_46():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 3/24
                 \scaleDurations #'(2 . 3) {
                     c'8. [ ]
                 }
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \scaleDurations #'(2 . 3) {
                     d'8. [ ]
                 }
-            } % measure
+            }   % measure
         }
         '''
         ), format(staff)

--- a/abjad/tools/scoretools/test/test_scoretools_Mutation_swap.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Mutation_swap.py
@@ -14,7 +14,8 @@ def test_scoretools_Mutation_swap_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8
@@ -36,7 +37,8 @@ def test_scoretools_Mutation_swap_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \tweak text #tuplet-number::calc-fraction-text
             \times 3/4 {
                 c'8 [
@@ -69,7 +71,8 @@ def test_scoretools_Mutation_swap_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \context Voice = "foo" {
+        \context Voice = "foo"
+        {
             {
                 c'8 [ \glissando
                 d'8 \glissando
@@ -92,12 +95,14 @@ def test_scoretools_Mutation_swap_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \context Voice = "foo" {
+        \context Voice = "foo"
+        {
             {
                 c'8 [ \glissando
                 d'8 \glissando
             }
-            \context Voice = "foo" {
+            \context Voice = "foo"
+            {
                 e'8 \glissando
                 f'8 \glissando
             }
@@ -125,7 +130,8 @@ def test_scoretools_Mutation_swap_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ \glissando
                 d'8 \glissando
@@ -148,7 +154,8 @@ def test_scoretools_Mutation_swap_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [ \glissando
                 d'8 \glissando
@@ -209,7 +216,8 @@ def test_scoretools_Mutation_swap_06():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8
@@ -239,13 +247,13 @@ def test_scoretools_Mutation_swap_07():
 
     assert format(measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 4/8
             c'8
             d'8
             e'8
             f'8
-        } % measure
+        }   % measure
         '''
         )
 
@@ -254,13 +262,13 @@ def test_scoretools_Mutation_swap_07():
 
     assert format(new_measure) == abjad.String.normalize(
         r'''
-        { % measure
+        {   % measure
             \time 4/8
             c'8
             d'8
             e'8
             f'8
-        } % measure
+        }   % measure
         '''
         )
 

--- a/abjad/tools/scoretools/test/test_scoretools_Note___copy__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Note___copy__.py
@@ -123,7 +123,8 @@ def test_scoretools_Note___copy___06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \grace {
                 d'16
             }
@@ -157,7 +158,8 @@ def test_scoretools_Note___copy___07():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 \<
             cs'8
             d'8
@@ -175,7 +177,8 @@ def test_scoretools_Note___copy___07():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 \<
             cs'8
             d'8

--- a/abjad/tools/scoretools/test/test_scoretools_Note_sounding_pitch.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Note_sounding_pitch.py
@@ -11,7 +11,8 @@ def test_scoretools_Note_sounding_pitch_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set Staff.instrumentName = \markup { Piccolo }
             \set Staff.shortInstrumentName = \markup { Picc. }
             d'8

--- a/abjad/tools/scoretools/test/test_scoretools_Note_written_pitch.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Note_written_pitch.py
@@ -11,7 +11,8 @@ def test_scoretools_Note_written_pitch_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set Staff.instrumentName = \markup { Piccolo }
             \set Staff.shortInstrumentName = \markup { Picc. }
             d'8

--- a/abjad/tools/scoretools/test/test_scoretools_Parentage__get_spanners_that_dominate_component_pair.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Parentage__get_spanners_that_dominate_component_pair.py
@@ -18,7 +18,8 @@ def test_scoretools_Parentage__get_spanners_that_dominate_component_pair_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 \startTrillSpan
@@ -57,7 +58,8 @@ def test_scoretools_Parentage__get_spanners_that_dominate_component_pair_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 \startTrillSpan
@@ -98,7 +100,8 @@ def test_scoretools_Parentage__get_spanners_that_dominate_component_pair_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 \startTrillSpan
@@ -139,7 +142,8 @@ def test_scoretools_Parentage__get_spanners_that_dominate_component_pair_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 \startTrillSpan

--- a/abjad/tools/scoretools/test/test_scoretools_Parentage_logical_voice.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Parentage_logical_voice.py
@@ -68,17 +68,22 @@ def test_scoretools_Parentage_logical_voice_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice \with {
+        \new Voice
+        \with
+        {
             \override NoteHead.color = #red
-        } {
+        }
+        {
             c'8
             d'8
             <<
-                \new Voice {
+                \new Voice
+                {
                     e'8
                     f'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     g'8
                     a'8
                 }
@@ -130,17 +135,22 @@ def test_scoretools_Parentage_logical_voice_05():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \context Voice = "foo" \with {
+        \context Voice = "foo"
+        \with
+        {
             \override NoteHead.color = #red
-        } {
+        }
+        {
             c'8
             d'8
             <<
-                \context Voice = "foo" {
+                \context Voice = "foo"
+                {
                     e'8
                     f'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     g'8
                     a'8
                 }
@@ -197,14 +207,18 @@ def test_scoretools_Parentage_logical_voice_06():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \context Staff = "staff1" {
-                \context Voice = "voicefoo" {
+            \context Staff = "staff1"
+            {
+                \context Voice = "voicefoo"
+                {
                     c'8 [
                     d'8 ]
                 }
             }
-            \context Staff = "staff2" {
-                \context Voice = "voicefoo" {
+            \context Staff = "staff2"
+            {
+                \context Voice = "voicefoo"
+                {
                     e'8 [
                     f'8 ]
                 }
@@ -259,22 +273,30 @@ def test_scoretools_Parentage_logical_voice_07():
         {
             c'8
             <<
-                \context Voice = "alto" {
+                \context Voice = "alto"
+                {
                     d'8
                 }
-                \context Voice = "soprano" \with {
+                \context Voice = "soprano"
+                \with
+                {
                     \override NoteHead.color = #red
-                } {
+                }
+                {
                     e'8
                 }
             >>
             {
-                \context Voice = "alto" {
+                \context Voice = "alto"
+                {
                     f'8
                 }
-                \context Voice = "soprano" \with {
+                \context Voice = "soprano"
+                \with
+                {
                     \override NoteHead.color = #red
-                } {
+                }
+                {
                     g'8
                 }
             }
@@ -354,7 +376,8 @@ def test_scoretools_Parentage_logical_voice_10():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 \time 2/8
                 c'8
@@ -385,11 +408,13 @@ def test_scoretools_Parentage_logical_voice_11():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \context Staff = "staff" {
+            \context Staff = "staff"
+            {
                 c'8
                 c'8
             }
-            \context Staff = "staff" {
+            \context Staff = "staff"
+            {
                 c'8
                 c'8
             }

--- a/abjad/tools/scoretools/test/test_scoretools_Rest___init__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Rest___init__.py
@@ -183,7 +183,8 @@ def test_scoretools_Rest___init___12():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             r8 [
             r8
             r8

--- a/abjad/tools/scoretools/test/test_scoretools_Selection___illustrate__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Selection___illustrate__.py
@@ -10,8 +10,10 @@ def test_scoretools_Selection___illustrate___01():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 e'4
                 f'4
                 g'4
@@ -32,8 +34,10 @@ def test_scoretools_Selection___illustrate___02():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 e'4 (
                 f'4
                 g'4

--- a/abjad/tools/scoretools/test/test_scoretools_Selection__attach_tie_spanner_to_leaf_pair.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Selection__attach_tie_spanner_to_leaf_pair.py
@@ -11,7 +11,8 @@ def test_scoretools_Selection__attach_tie_spanner_to_leaf_pair_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 ~
             c'8
             c'8
@@ -26,7 +27,8 @@ def test_scoretools_Selection__attach_tie_spanner_to_leaf_pair_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 ~
             c'8 ~
             c'8
@@ -50,7 +52,8 @@ def test_scoretools_Selection__attach_tie_spanner_to_leaf_pair_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 ~
             c'8
             c'8 ~
@@ -65,7 +68,8 @@ def test_scoretools_Selection__attach_tie_spanner_to_leaf_pair_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 ~
             c'8 ~
             c'8 ~
@@ -88,7 +92,8 @@ def test_scoretools_Selection__attach_tie_spanner_to_leaf_pair_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8
             c'8 ~
             c'8

--- a/abjad/tools/scoretools/test/test_scoretools_Selection__get_crossing_spanners.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Selection__get_crossing_spanners.py
@@ -17,7 +17,8 @@ def test_scoretools_Selection__get_crossing_spanners_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 \startTrillSpan
@@ -58,20 +59,21 @@ def test_scoretools_Selection__get_crossing_spanners_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
-            { % measure
+        \new Voice
+        {
+            {   % measure
                 \time 2/8
                 c'8
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8 [
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8 ]
                 a'8
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Selection__get_dominant_spanners.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Selection__get_dominant_spanners.py
@@ -22,7 +22,8 @@ def test_scoretools_Selection__get_dominant_spanners_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 \startTrillSpan

--- a/abjad/tools/scoretools/test/test_scoretools_Selection__give_dominant_spanners.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Selection__give_dominant_spanners.py
@@ -19,7 +19,8 @@ def test_scoretools_Selection__give_dominant_spanners_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \<
             d'8 ] (
             e'8 )
@@ -34,7 +35,8 @@ def test_scoretools_Selection__give_dominant_spanners_01():
 
     assert format(recipient) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'16 [
             c'16
             c'16 ]
@@ -49,7 +51,8 @@ def test_scoretools_Selection__give_dominant_spanners_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \<
             d'8 ]
             e'8
@@ -64,7 +67,8 @@ def test_scoretools_Selection__give_dominant_spanners_01():
 
     assert format(recipient) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'16 [ (
             c'16
             c'16 ] )

--- a/abjad/tools/scoretools/test/test_scoretools_Selection__withdraw_from_crossing_spanners.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Selection__withdraw_from_crossing_spanners.py
@@ -21,7 +21,8 @@ def test_scoretools_Selection__withdraw_from_crossing_spanners_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 \startTrillSpan
@@ -40,7 +41,8 @@ def test_scoretools_Selection__withdraw_from_crossing_spanners_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 \startTrillSpan
@@ -75,7 +77,8 @@ def test_scoretools_Selection__withdraw_from_crossing_spanners_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 \startTrillSpan
@@ -93,7 +96,8 @@ def test_scoretools_Selection__withdraw_from_crossing_spanners_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8 ]
@@ -130,7 +134,8 @@ def test_scoretools_Selection__withdraw_from_crossing_spanners_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 \startTrillSpan

--- a/abjad/tools/scoretools/test/test_scoretools_Selection_are_contiguous_logical_voice.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Selection_are_contiguous_logical_voice.py
@@ -101,7 +101,8 @@ def test_scoretools_Selection_are_contiguous_logical_voice_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8

--- a/abjad/tools/scoretools/test/test_scoretools_Selection_are_contiguous_same_parent.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Selection_are_contiguous_same_parent.py
@@ -44,7 +44,8 @@ def test_scoretools_Selection_are_contiguous_same_parent_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8

--- a/abjad/tools/scoretools/test/test_scoretools_Selection_are_logical_voice.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Selection_are_logical_voice.py
@@ -106,7 +106,8 @@ def test_scoretools_Selection_are_logical_voice_06():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8
@@ -145,7 +146,8 @@ def test_scoretools_Selection_are_logical_voice_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8
                 d'8
@@ -184,14 +186,17 @@ def test_scoretools_Selection_are_logical_voice_08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \new Voice {
+        \new Staff
+        {
+            \new Voice
+            {
                 c'8
                 d'8
                 e'8
                 f'8
             }
-            \new Voice {
+            \new Voice
+            {
                 g'8
                 a'8
                 b'8
@@ -229,14 +234,17 @@ def test_scoretools_Selection_are_logical_voice_09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \context Voice = "foo" {
+        \new Staff
+        {
+            \context Voice = "foo"
+            {
                 c'8
                 d'8
                 e'8
                 f'8
             }
-            \context Voice = "foo" {
+            \context Voice = "foo"
+            {
                 g'8
                 a'8
                 b'8
@@ -267,12 +275,15 @@ def test_scoretools_Selection_are_logical_voice_10():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \context Voice = "foo" {
+        \new Staff
+        {
+            \context Voice = "foo"
+            {
                 c'8
                 d'8
             }
-            \context Voice = "bar" {
+            \context Voice = "bar"
+            {
                 e'8
                 f'8
             }
@@ -307,14 +318,18 @@ def test_scoretools_Selection_are_logical_voice_11():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \new Staff {
-                \new Voice {
+            \new Staff
+            {
+                \new Voice
+                {
                     c'8
                     d'8
                 }
             }
-            \new Staff {
-                \new Voice {
+            \new Staff
+            {
+                \new Voice
+                {
                     e'8
                     f'8
                 }
@@ -358,22 +373,28 @@ def test_scoretools_Selection_are_logical_voice_12():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \new Staff <<
-                \new Voice {
+            \new Staff
+            <<
+                \new Voice
+                {
                     c'8
                     d'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     e'8
                     f'8
                 }
             >>
-            \new Staff <<
-                \new Voice {
+            \new Staff
+            <<
+                \new Voice
+                {
                     g'8
                     a'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     b'8
                     c''8
                 }
@@ -404,7 +425,8 @@ def test_scoretools_Selection_are_logical_voice_13():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8
@@ -444,13 +466,15 @@ def test_scoretools_Selection_are_logical_voice_14():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \context Staff = "foo" {
+            \context Staff = "foo"
+            {
                 c'8
                 cs'8
                 d'8
                 ef'8
             }
-            \context Staff = "foo" {
+            \context Staff = "foo"
+            {
                 e'8
                 f'8
                 fs'8
@@ -493,7 +517,8 @@ def test_scoretools_Selection_are_logical_voice_15():
                 e'8
                 f'8
             }
-            \new Voice {
+            \new Voice
+            {
                 g'8
                 a'8
                 b'8
@@ -531,7 +556,8 @@ def test_scoretools_Selection_are_logical_voice_16():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \new Voice {
+            \new Voice
+            {
                 c'8
                 d'8
                 e'8
@@ -617,7 +643,8 @@ def test_scoretools_Selection_are_logical_voice_18():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \context Voice = "foo" {
+            \context Voice = "foo"
+            {
                 c'8
                 d'8
                 e'8
@@ -667,7 +694,8 @@ def test_scoretools_Selection_are_logical_voice_19():
                 e'8
                 f'8
             }
-            \new Staff {
+            \new Staff
+            {
                 g'8
                 a'8
                 b'8
@@ -705,7 +733,8 @@ def test_scoretools_Selection_are_logical_voice_20():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \new Staff {
+            \new Staff
+            {
                 c'8
                 cs'8
                 d'8
@@ -751,7 +780,8 @@ def test_scoretools_Selection_are_logical_voice_21():
             cs'8
             d'8
             ef'8
-            \new Voice {
+            \new Voice
+            {
                 e'8
                 f'8
                 fs'8
@@ -787,7 +817,8 @@ def test_scoretools_Selection_are_logical_voice_22():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \new Voice {
+            \new Voice
+            {
                 c'8
                 cs'8
                 d'8
@@ -831,7 +862,8 @@ def test_scoretools_Selection_are_logical_voice_23():
             cs'8
             d'8
             ef'8
-            \context Voice = "foo" {
+            \context Voice = "foo"
+            {
                 e'8
                 f'8
                 fs'8
@@ -870,7 +902,8 @@ def test_scoretools_Selection_are_logical_voice_24():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \context Voice = "foo" {
+            \context Voice = "foo"
+            {
                 c'8
                 cs'8
                 d'8
@@ -914,7 +947,8 @@ def test_scoretools_Selection_are_logical_voice_25():
             cs'8
             d'8
             ef'8
-            \new Voice {
+            \new Voice
+            {
                 e'8
                 f'8
                 fs'8
@@ -950,7 +984,8 @@ def test_scoretools_Selection_are_logical_voice_26():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \new Staff {
+            \new Staff
+            {
                 c'8
                 d'8
                 e'8
@@ -983,7 +1018,8 @@ def test_scoretools_Selection_are_logical_voice_27():
         r'''
         {
             {
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     cs'8
                     d'8
@@ -1051,8 +1087,10 @@ def test_scoretools_Selection_are_logical_voice_29():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \context Voice = "bar" {
-                \context Voice = "foo" {
+            \context Voice = "bar"
+            {
+                \context Voice = "foo"
+                {
                     c'8
                     cs'8
                     d'8
@@ -1085,8 +1123,10 @@ def test_scoretools_Selection_are_logical_voice_30():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \new Voice {
-                \new Voice {
+            \new Voice
+            {
+                \new Voice
+                {
                     c'8
                     cs'8
                     d'8
@@ -1126,13 +1166,15 @@ def test_scoretools_Selection_are_logical_voice_31():
             d'8
             ef'8
             <<
-                \new Voice {
+                \new Voice
+                {
                     c''8
                     c''8
                     c''8
                     c''8
                 }
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     c'8
                     c'8
@@ -1177,13 +1219,15 @@ def test_scoretools_Selection_are_logical_voice_32():
         r'''
         {
             <<
-                \new Voice {
+                \new Voice
+                {
                     c'8
                     cs'8
                     d'8
                     ef'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     e'8
                     f'8
                     fs'8
@@ -1236,10 +1280,12 @@ def test_scoretools_Selection_are_logical_voice_33():
         {
             c'8
             cs'8
-            \new Voice {
+            \new Voice
+            {
                 d'8
                 ef'8
-                \new Voice {
+                \new Voice
+                {
                     e'8
                     f'8
                     fs'8
@@ -1291,13 +1337,16 @@ def test_scoretools_Selection_are_logical_voice_34():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             cs'8
-            \new Staff {
+            \new Staff
+            {
                 d'8
                 ef'8
-                \new Staff {
+                \new Staff
+                {
                     e'8
                     f'8
                     fs'8
@@ -1396,7 +1445,8 @@ def test_scoretools_Selection_are_logical_voice_36():
             cs'8
             {
                 {
-                    \context Voice = "foo" {
+                    \context Voice = "foo"
+                    {
                         d'8
                         ef'8
                         e'8
@@ -1445,7 +1495,8 @@ def test_scoretools_Selection_are_logical_voice_37():
         {
             {
                 {
-                    \context Voice = "foo" {
+                    \context Voice = "foo"
+                    {
                         c'8
                         cs'8
                         d'8
@@ -1493,13 +1544,15 @@ def test_scoretools_Selection_are_logical_voice_38():
 
     assert format(container) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 {
                     {
                         c'8
                         cs'8
-                        \new Voice {
+                        \new Voice
+                        {
                             d'8
                             ef'8
                             e'8
@@ -1555,7 +1608,8 @@ def test_scoretools_Selection_are_logical_voice_39():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \context Voice = "foo" {
+        \context Voice = "foo"
+        {
             c'8
             cs'8
             {
@@ -1564,7 +1618,8 @@ def test_scoretools_Selection_are_logical_voice_39():
                 {
                     e'8
                     f'8
-                    \context Voice = "bar" {
+                    \context Voice = "bar"
+                    {
                         fs'8
                         g'8
                         af'8
@@ -1617,13 +1672,15 @@ def test_scoretools_Selection_are_logical_voice_40():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \new Voice {
+            \new Voice
+            {
                 c'8
                 cs'8
                 d'8
                 ef'8
             }
-            \new Voice {
+            \new Voice
+            {
                 e'8
                 f'8
                 fs'8
@@ -1677,13 +1734,15 @@ def test_scoretools_Selection_are_logical_voice_41():
             c'8
             cs'8
             <<
-                \new Voice {
+                \new Voice
+                {
                     d'8
                     ef'8
                     e'8
                     f'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     fs'8
                     g'8
                     af'8

--- a/abjad/tools/scoretools/test/test_scoretools_Staff___copy__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Staff___copy__.py
@@ -16,10 +16,13 @@ def test_scoretools_Staff___copy___01():
 
     assert format(staff_2) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \override NoteHead.color = #red
             tupletFullLength = ##t
-        } {
+        }
+        {
         }
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Staff_engraver_consists.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Staff_engraver_consists.py
@@ -22,10 +22,13 @@ def test_scoretools_Staff_engraver_consists_01():
     assert abjad.inspect(staff).is_well_formed()
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \consists Horizontal_bracket_engraver
             \consists Instrument_name_engraver
-        } {
+        }
+        {
             c'8
             d'8
             e'8

--- a/abjad/tools/scoretools/test/test_scoretools_Staff_engraver_removals.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Staff_engraver_removals.py
@@ -9,10 +9,13 @@ def test_scoretools_Staff_engraver_removals_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             \remove Time_signature_engraver
             \remove Bar_number_engraver
-        } {
+        }
+        {
             c'8
             d'8
             e'8

--- a/abjad/tools/scoretools/test/test_scoretools_Staff_time_signature.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Staff_time_signature.py
@@ -11,7 +11,8 @@ def test_scoretools_Staff_time_signature_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \time 2/4
             c'4
             c'4

--- a/abjad/tools/scoretools/test/test_scoretools_Tuplet_get_timespan.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Tuplet_get_timespan.py
@@ -11,8 +11,10 @@ def test_scoretools_Tuplet_get_timespan_01():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \tempo 4=60
                 c'4
                 d'4

--- a/abjad/tools/scoretools/test/test_scoretools_Tuplet_timespan.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Tuplet_timespan.py
@@ -7,7 +7,8 @@ def test_scoretools_Tuplet_timespan_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'4
             d'4
             \times 2/3 {

--- a/abjad/tools/scoretools/test/test_scoretools_VerticalMoment___eq__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_VerticalMoment___eq__.py
@@ -63,8 +63,10 @@ def test_scoretools_VerticalMoment___eq___02():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 4/3 {
                     d''8
@@ -72,12 +74,15 @@ def test_scoretools_VerticalMoment___eq___02():
                     b'8
                 }
             }
-            \new PianoStaff <<
-                \new Staff {
+            \new PianoStaff
+            <<
+                \new Staff
+                {
                     a'4
                     g'4
                 }
-                \new Staff {
+                \new Staff
+                {
                     \clef "bass"
                     f'8
                     e'8

--- a/abjad/tools/scoretools/test/test_scoretools_Voice___copy__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Voice___copy__.py
@@ -18,12 +18,15 @@ def test_scoretools_Voice___copy___01():
 
     assert format(voice_2) == abjad.String.normalize(
         r'''
-        \context Voice = "SopranoVoice" \with {
+        \context Voice = "SopranoVoice"
+        \with
+        {
             \remove Forbid_line_break_engraver
             \consists Time_signature_engraver
             \override NoteHead.color = #red
             tupletFullLength = ##t
-        } {
+        }
+        {
         }
         '''
         )

--- a/abjad/tools/scoretools/test/test_scoretools_Voice___delitem__.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Voice___delitem__.py
@@ -16,7 +16,8 @@ def test_scoretools_Voice___delitem___01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             {
                 d'8 \glissando
@@ -32,7 +33,8 @@ def test_scoretools_Voice___delitem___01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [ \glissando
             f'8 ]
         }

--- a/abjad/tools/scoretools/test/test_scoretools_Voice_lilypond_voice_resolution.py
+++ b/abjad/tools/scoretools/test/test_scoretools_Voice_lilypond_voice_resolution.py
@@ -21,17 +21,22 @@ def test_scoretools_Voice_lilypond_voice_resolution_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice \with {
+        \new Voice
+        \with
+        {
             \override NoteHead.color = #red
-        } {
+        }
+        {
             c'8
             d'8
             <<
-                \new Voice {
+                \new Voice
+                {
                     e'8
                     f'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     g'8
                     a'8
                 }
@@ -60,17 +65,22 @@ def test_scoretools_Voice_lilypond_voice_resolution_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \context Voice = "foo" \with {
+        \context Voice = "foo"
+        \with
+        {
             \override NoteHead.color = #red
-        } {
+        }
+        {
             c'8
             d'8
             <<
-                \context Voice = "foo" {
+                \context Voice = "foo"
+                {
                     e'8
                     f'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     g'8
                     a'8
                 }
@@ -151,25 +161,33 @@ def test_scoretools_Voice_lilypond_voice_resolution_04():
         {
             c'8
             <<
-                \context Voice = "alto" {
+                \context Voice = "alto"
+                {
                     d'8
                     e'8
                 }
-                \context Voice = "soprano" \with {
+                \context Voice = "soprano"
+                \with
+                {
                     \override NoteHead.color = #red
-                } {
+                }
+                {
                     f'8
                     g'8
                 }
             >>
             <<
-                \context Voice = "alto" {
+                \context Voice = "alto"
+                {
                     a'8
                     b'8
                 }
-                \context Voice = "soprano" \with {
+                \context Voice = "soprano"
+                \with
+                {
                     \override NoteHead.color = #red
-                } {
+                }
+                {
                     c''8
                     d''8
                 }

--- a/abjad/tools/scoretools/test/test_scoretools_fuse_measures.py
+++ b/abjad/tools/scoretools/test/test_scoretools_fuse_measures.py
@@ -18,7 +18,8 @@ def test_scoretools_fuse_measures_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 \time 1/8
                 c'16 [
@@ -67,7 +68,8 @@ def test_scoretools_fuse_measures_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 \time 1/8
                 c'16 [
@@ -86,7 +88,8 @@ def test_scoretools_fuse_measures_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 \time 2/8
                 c'16 [
@@ -114,7 +117,8 @@ def test_scoretools_fuse_measures_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 \time 1/8
                 c'16 [
@@ -133,7 +137,8 @@ def test_scoretools_fuse_measures_03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 \time 2/8
                 c'16
@@ -165,7 +170,8 @@ def test_scoretools_fuse_measures_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 \time 1/8
                 c'8 [
@@ -184,7 +190,8 @@ def test_scoretools_fuse_measures_04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 \time 5/24
                 \scaleDurations #'(2 . 3) {
@@ -233,7 +240,8 @@ def test_scoretools_fuse_measures_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 \time 1/8
                 c'16 [
@@ -255,7 +263,8 @@ def test_scoretools_fuse_measures_07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 \time 3/8
                 c'16 [
@@ -283,7 +292,8 @@ def test_scoretools_fuse_measures_08():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 {
                     \time 2/8
@@ -331,7 +341,8 @@ def test_scoretools_fuse_measures_09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 \time 9/80
                 \scaleDurations #'(4 . 5) {
@@ -359,7 +370,8 @@ def test_scoretools_fuse_measures_09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 \time 19/80
                 \scaleDurations #'(4 . 5) {

--- a/abjad/tools/segmenttools/GroupedRhythmicStavesScoreTemplate.py
+++ b/abjad/tools/segmenttools/GroupedRhythmicStavesScoreTemplate.py
@@ -16,28 +16,38 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
         ..  docs::
 
             >>> abjad.f(template_1.__illustrate__()[abjad.Score])
-            \context Score = "Grouped Rhythmic Staves Score" <<
-                \context StaffGroup = "Grouped Rhythmic Staves Staff Group" <<
-                    \context RhythmicStaff = "Staff 1" {
-                        \context Voice = "Voice 1" {
+            \context Score = "Grouped Rhythmic Staves Score"
+            <<
+                \context StaffGroup = "Grouped Rhythmic Staves Staff Group"
+                <<
+                    \context RhythmicStaff = "Staff 1"
+                    {
+                        \context Voice = "Voice 1"
+                        {
                             \clef "percussion" %! ST3
                             s1
                         }
                     }
-                    \context RhythmicStaff = "Staff 2" {
-                        \context Voice = "Voice 2" {
+                    \context RhythmicStaff = "Staff 2"
+                    {
+                        \context Voice = "Voice 2"
+                        {
                             \clef "percussion" %! ST3
                             s1
                         }
                     }
-                    \context RhythmicStaff = "Staff 3" {
-                        \context Voice = "Voice 3" {
+                    \context RhythmicStaff = "Staff 3"
+                    {
+                        \context Voice = "Voice 3"
+                        {
                             \clef "percussion" %! ST3
                             s1
                         }
                     }
-                    \context RhythmicStaff = "Staff 4" {
-                        \context Voice = "Voice 4" {
+                    \context RhythmicStaff = "Staff 4"
+                    {
+                        \context Voice = "Voice 4"
+                        {
                             \clef "percussion" %! ST3
                             s1
                         }
@@ -49,22 +59,32 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
         >>> abjad.show(score) # doctest: +SKIP
 
         >>> abjad.f(score)
-        \context Score = "Grouped Rhythmic Staves Score" <<
-            \context StaffGroup = "Grouped Rhythmic Staves Staff Group" <<
-                \context RhythmicStaff = "Staff 1" {
-                    \context Voice = "Voice 1" {
+        \context Score = "Grouped Rhythmic Staves Score"
+        <<
+            \context StaffGroup = "Grouped Rhythmic Staves Staff Group"
+            <<
+                \context RhythmicStaff = "Staff 1"
+                {
+                    \context Voice = "Voice 1"
+                    {
                     }
                 }
-                \context RhythmicStaff = "Staff 2" {
-                    \context Voice = "Voice 2" {
+                \context RhythmicStaff = "Staff 2"
+                {
+                    \context Voice = "Voice 2"
+                    {
                     }
                 }
-                \context RhythmicStaff = "Staff 3" {
-                    \context Voice = "Voice 3" {
+                \context RhythmicStaff = "Staff 3"
+                {
+                    \context Voice = "Voice 3"
+                    {
                     }
                 }
-                \context RhythmicStaff = "Staff 4" {
-                    \context Voice = "Voice 4" {
+                \context RhythmicStaff = "Staff 4"
+                {
+                    \context Voice = "Voice 4"
+                    {
                     }
                 }
             >>
@@ -80,26 +100,36 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
         ..  docs::
 
             >>> abjad.f(template_2.__illustrate__()[abjad.Score])
-            \context Score = "Grouped Rhythmic Staves Score" <<
-                \context StaffGroup = "Grouped Rhythmic Staves Staff Group" <<
-                    \context RhythmicStaff = "Staff 1" <<
-                        \context Voice = "Voice 1-1" {
+            \context Score = "Grouped Rhythmic Staves Score"
+            <<
+                \context StaffGroup = "Grouped Rhythmic Staves Staff Group"
+                <<
+                    \context RhythmicStaff = "Staff 1"
+                    <<
+                        \context Voice = "Voice 1-1"
+                        {
                             s1
                         }
-                        \context Voice = "Voice 1-2" {
+                        \context Voice = "Voice 1-2"
+                        {
                             s1
                         }
                     >>
-                    \context RhythmicStaff = "Staff 2" {
-                        \context Voice = "Voice 2" {
+                    \context RhythmicStaff = "Staff 2"
+                    {
+                        \context Voice = "Voice 2"
+                        {
                             s1
                         }
                     }
-                    \context RhythmicStaff = "Staff 3" <<
-                        \context Voice = "Voice 3-1" {
+                    \context RhythmicStaff = "Staff 3"
+                    <<
+                        \context Voice = "Voice 3-1"
+                        {
                             s1
                         }
-                        \context Voice = "Voice 3-2" {
+                        \context Voice = "Voice 3-2"
+                        {
                             s1
                         }
                     >>
@@ -110,22 +140,32 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
         >>> abjad.show(score) # doctest: +SKIP
 
         >>> abjad.f(score)
-        \context Score = "Grouped Rhythmic Staves Score" <<
-            \context StaffGroup = "Grouped Rhythmic Staves Staff Group" <<
-                \context RhythmicStaff = "Staff 1" <<
-                    \context Voice = "Voice 1-1" {
+        \context Score = "Grouped Rhythmic Staves Score"
+        <<
+            \context StaffGroup = "Grouped Rhythmic Staves Staff Group"
+            <<
+                \context RhythmicStaff = "Staff 1"
+                <<
+                    \context Voice = "Voice 1-1"
+                    {
                     }
-                    \context Voice = "Voice 1-2" {
+                    \context Voice = "Voice 1-2"
+                    {
                     }
                 >>
-                \context RhythmicStaff = "Staff 2" {
-                    \context Voice = "Voice 2" {
+                \context RhythmicStaff = "Staff 2"
+                {
+                    \context Voice = "Voice 2"
+                    {
                     }
                 }
-                \context RhythmicStaff = "Staff 3" <<
-                    \context Voice = "Voice 3-1" {
+                \context RhythmicStaff = "Staff 3"
+                <<
+                    \context Voice = "Voice 3-1"
+                    {
                     }
-                    \context Voice = "Voice 3-2" {
+                    \context Voice = "Voice 3-2"
+                    {
                     }
                 >>
             >>

--- a/abjad/tools/segmenttools/GroupedStavesScoreTemplate.py
+++ b/abjad/tools/segmenttools/GroupedStavesScoreTemplate.py
@@ -14,25 +14,35 @@ class GroupedStavesScoreTemplate(ScoreTemplate):
         ..  docs::
 
             >>> abjad.f(template.__illustrate__()[abjad.Score])
-            \context Score = "Grouped Staves Score" <<
-                \context StaffGroup = "Grouped Staves Staff Group" <<
-                    \context Staff = "Staff 1" {
-                        \context Voice = "Voice 1" {
+            \context Score = "Grouped Staves Score"
+            <<
+                \context StaffGroup = "Grouped Staves Staff Group"
+                <<
+                    \context Staff = "Staff 1"
+                    {
+                        \context Voice = "Voice 1"
+                        {
                             s1
                         }
                     }
-                    \context Staff = "Staff 2" {
-                        \context Voice = "Voice 2" {
+                    \context Staff = "Staff 2"
+                    {
+                        \context Voice = "Voice 2"
+                        {
                             s1
                         }
                     }
-                    \context Staff = "Staff 3" {
-                        \context Voice = "Voice 3" {
+                    \context Staff = "Staff 3"
+                    {
+                        \context Voice = "Voice 3"
+                        {
                             s1
                         }
                     }
-                    \context Staff = "Staff 4" {
-                        \context Voice = "Voice 4" {
+                    \context Staff = "Staff 4"
+                    {
+                        \context Voice = "Voice 4"
+                        {
                             s1
                         }
                     }
@@ -41,22 +51,32 @@ class GroupedStavesScoreTemplate(ScoreTemplate):
 
         >>> score = template()
         >>> abjad.f(score)
-        \context Score = "Grouped Staves Score" <<
-            \context StaffGroup = "Grouped Staves Staff Group" <<
-                \context Staff = "Staff 1" {
-                    \context Voice = "Voice 1" {
+        \context Score = "Grouped Staves Score"
+        <<
+            \context StaffGroup = "Grouped Staves Staff Group"
+            <<
+                \context Staff = "Staff 1"
+                {
+                    \context Voice = "Voice 1"
+                    {
                     }
                 }
-                \context Staff = "Staff 2" {
-                    \context Voice = "Voice 2" {
+                \context Staff = "Staff 2"
+                {
+                    \context Voice = "Voice 2"
+                    {
                     }
                 }
-                \context Staff = "Staff 3" {
-                    \context Voice = "Voice 3" {
+                \context Staff = "Staff 3"
+                {
+                    \context Voice = "Voice 3"
+                    {
                     }
                 }
-                \context Staff = "Staff 4" {
-                    \context Voice = "Voice 4" {
+                \context Staff = "Staff 4"
+                {
+                    \context Voice = "Voice 4"
+                    {
                     }
                 }
             >>

--- a/abjad/tools/segmenttools/Job.py
+++ b/abjad/tools/segmenttools/Job.py
@@ -1,7 +1,11 @@
+from typing import Callable
 from typing import List
+from typing import Tuple
+from typing import Union
+from .Path import Path
+from .Tags import Tags
 from abjad.tools.abctools.AbjadObject import AbjadObject
 from abjad.tools.datastructuretools.String import String
-from .Tags import Tags
 abjad_tags = Tags()
 
 
@@ -15,6 +19,7 @@ class Job(AbjadObject):
         '_activate',
         '_deactivate',
         '_deactivate_first',
+        '_message_zero',
         '_path',
         '_title',
         )
@@ -23,17 +28,19 @@ class Job(AbjadObject):
 
     def __init__(
         self,
-        activate=None,
-        deactivate=None,
+        activate: Tuple[Union[str, Callable], str] = None,
+        deactivate: Tuple[Union[str, Callable], str] = None,
         deactivate_first: bool = None,
-        path=None,
+        message_zero: bool = None,
+        path: Path = None,
         title: str = None,
-        ):
-        self._activate = activate
-        self._deactivate = deactivate
-        self._deactivate_first = deactivate_first
-        self._path = path
-        self._title = title
+        ) -> None:
+        self._activate: Tuple[Union[str, Callable], str] = activate
+        self._deactivate: Tuple[Union[str, Callable], str] = deactivate
+        self._deactivate_first: bool = deactivate_first
+        self._message_zero: bool = message_zero
+        self._path: Path = path
+        self._title: str = title
 
     ### SPECIAL METHODS ###
 
@@ -43,6 +50,7 @@ class Job(AbjadObject):
         messages = []
         if self.title is not None:
             messages.append(String(self.title).capitalize_start())
+        total_count = 0
         if self.deactivate_first is True:
             if self.deactivate is not None:
                 assert isinstance(self.deactivate, tuple)
@@ -55,6 +63,7 @@ class Job(AbjadObject):
                         name=name,
                         )
                     messages.extend(messages_)
+                    total_count += count
         if self.activate is not None:
             assert isinstance(self.activate, tuple)
             match, name = self.activate
@@ -66,6 +75,7 @@ class Job(AbjadObject):
                     name=name,
                     )
                 messages.extend(messages_)
+                total_count += count
         if self.deactivate_first is not True:
             if self.deactivate is not None:
                 assert isinstance(self.deactivate, tuple)
@@ -78,19 +88,22 @@ class Job(AbjadObject):
                         name=name,
                         )
                     messages.extend(messages_)
+                    total_count += count
+        if total_count == 0 and not self.message_zero:
+            messages = []
         return messages
 
     ### PUBLIC PROPERTIES ###
 
     @property
-    def activate(self):
-        r'''Gets activate match.
+    def activate(self) -> Tuple[Union[str, Callable], str]:
+        r'''Gets activate match / message pair.
         '''
         return self._activate
 
     @property
-    def deactivate(self):
-        r'''Gets deactivate match.
+    def deactivate(self) -> Tuple[Union[str, Callable], str]:
+        r'''Gets deactivate match / message pair.
         '''
         return self._deactivate
 
@@ -101,7 +114,13 @@ class Job(AbjadObject):
         return self._deactivate_first
 
     @property
-    def path(self):
+    def message_zero(self) -> bool:
+        r'''Is true when job returns messages even when no matches are found.
+        '''
+        return self._message_zero
+
+    @property
+    def path(self) -> Path:
         r'''Gets path.
         '''
         return self._path

--- a/abjad/tools/segmenttools/PianoStaffSegmentMaker.py
+++ b/abjad/tools/segmenttools/PianoStaffSegmentMaker.py
@@ -75,25 +75,13 @@ class PianoStaffSegmentMaker(SegmentMaker):
 
     ### PRIVATE METHODS ###
 
-    def _add_global_context(self, score):
-        import abjad
-        time_signatures = self.time_signatures
-        if not time_signatures:
-            return
-        global_context = self._make_global_context()
-        maker = abjad.MeasureMaker()
-        measures = maker(time_signatures)
-        global_context.extend(measures)
-        score.insert(0, global_context)
-
     def _make_lilypond_file(self, midi=None):
         import abjad
         template = abjad.TwoStaffPianoScoreTemplate()
         score = template()
         self._score = score
-        self._add_global_context(score)
-        rh_voice = score['RH Voice']
-        lh_voice = score['LH Voice']
+        rh_voice = score['RHVoice']
+        lh_voice = score['LHVoice']
         self._populate_rhythms(rh_voice, self.rh_rhythm_maker)
         self._populate_rhythms(lh_voice, self.lh_rhythm_maker)
         self._populate_pitches(rh_voice, self.rh_pitch_range)

--- a/abjad/tools/segmenttools/ScoreTemplate.py
+++ b/abjad/tools/segmenttools/ScoreTemplate.py
@@ -6,6 +6,7 @@ from abjad.tools.indicatortools.Clef import Clef
 from abjad.tools.indicatortools.MarginMarkup import MarginMarkup
 from abjad.tools.instrumenttools.Instrument import Instrument
 from abjad.tools.lilypondfiletools.LilyPondFile import LilyPondFile
+from abjad.tools.scoretools.Context import Context
 from abjad.tools.scoretools.MultimeasureRest import MultimeasureRest
 from abjad.tools.scoretools.Rest import Rest
 from abjad.tools.scoretools.Score import Score
@@ -63,6 +64,25 @@ class ScoreTemplate(abctools.AbjadValueObject):
             includes=includes,
             )
         return lilypond_file
+
+    ### PRIVATE METHODS ###
+
+    def _make_global_context(self):
+        global_rests = Context(
+            lilypond_type='GlobalRests',
+            name='GlobalRests',
+            )
+        global_skips = Context(
+            lilypond_type='GlobalSkips',
+            name='GlobalSkips',
+            )
+        global_context = Context(
+            [global_rests, global_skips],
+            lilypond_type='GlobalContext',
+            is_simultaneous=True,
+            name='GlobalContext',
+            )
+        return global_context
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjad/tools/segmenttools/SegmentMaker.py
+++ b/abjad/tools/segmenttools/SegmentMaker.py
@@ -1,9 +1,19 @@
 from typing import List
+from typing import Optional
 from typing import Union as U
+from .Path import Path
+from abjad.tools import mathtools
 from abjad.tools.abctools.AbjadObject import AbjadObject
 from abjad.tools.datastructuretools.OrderedDict import OrderedDict
+from abjad.tools.datastructuretools.String import String
+from abjad.tools.indicatortools.Part import Part
 from abjad.tools.lilypondfiletools.LilyPondFile import LilyPondFile
-from .Path import Path
+from abjad.tools.scoretools.Container import Container
+from abjad.tools.scoretools.Context import Context
+from abjad.tools.scoretools.Score import Score
+from abjad.tools.scoretools.Voice import Voice
+from abjad.tools.topleveltools.inspect import inspect
+from abjad.tools.topleveltools.iterate import iterate
 
 
 class SegmentMaker(AbjadObject):
@@ -15,20 +25,27 @@ class SegmentMaker(AbjadObject):
     __documentation_section__ = 'Segment-makers'
 
     __slots__ = (
+        '_container_to_part',
+        '_environment',
         '_lilypond_file',
-        '_previous_metadata',
         '_metadata',
+        '_previous_metadata',
+        '_score',
+        '_segment_directory',
         )
 
     ### INITIALIZER ###
 
     def __init__(self):
-        self._lilypond_file = None
-        self._metadata = None
-        self._previous_metadata = None
+        self._container_to_part: OrderedDict = None
+        self._environment: str = None
+        self._lilypond_file: LilyPondFile = None
+        self._metadata: OrderedDict = None
+        self._previous_metadata: OrderedDict = None
+        self._score: Score = None
+        self._segment_directory: Path = None
 
     ### SPECIAL METHODS ###
-
 
     def __eq__(self, expr):
         r'''Is true if `expr` is a segment-maker with equivalent properties.
@@ -52,18 +69,59 @@ class SegmentMaker(AbjadObject):
         return lilypond_file
 
     ### PRIVATE METHODS ###
-    
+
+    def _add_parse_handles(self):
+        if getattr(self, '_environment', None) == 'docs':
+            return
+        segment_name = self.segment_name or ''
+        segment_name = String(segment_name).to_segment_lilypond_identifier()
+        contexts = []
+        try:
+            context = self.score['GlobalSkips']
+            contexts.append(context)
+        except ValueError:
+            pass
+        try:
+            context = self.score['GlobalRests']
+            contexts.append(context)
+        except ValueError:
+            pass
+        for voice in iterate(self.score).components(Voice):
+            contexts.append(voice)
+        container_to_part = OrderedDict()
+        for context in contexts:
+            context_identifier = f'{segment_name}_{context.name}'
+            context.identifier = f'%*% {context_identifier}'
+            part_container_count = 0
+            for container in iterate(context).components(Container):
+                if not container.identifier:
+                    continue
+                if container.identifier.startswith('%*% Part'):
+                    part_container_count += 1
+                    globals_ = globals()
+                    part = container.identifier.strip('%*% ')
+                    part = eval(part, globals_)
+                    suffix = String().base_26(part_container_count).lower()
+                    container_identifier = f'{context_identifier}_{suffix}'
+                    container_identifier = String(container_identifier)
+                    assert container_identifier.is_lilypond_identifier()
+                    assert container_identifier not in container_to_part
+                    timespan = inspect(container).get_timespan()
+                    pair = (part, timespan)
+                    container_to_part[container_identifier] = pair
+                    container.identifier = f'%*% {container_identifier}'
+        self._container_to_part = container_to_part
+
     def _make_global_context(self):
-        import abjad
-        global_rests = abjad.Context(
+        global_rests = Context(
             lilypond_type='GlobalRests',
             name='GlobalRests',
             )
-        global_skips = abjad.Context(
+        global_skips = Context(
             lilypond_type='GlobalSkips',
             name='GlobalSkips',
             )
-        global_context = abjad.Context(
+        global_context = Context(
             [global_rests, global_skips ],
             lilypond_type='GlobalContext',
             is_simultaneous=True,
@@ -83,6 +141,26 @@ class SegmentMaker(AbjadObject):
         Returns ordered dictionary or none.
         '''
         return self._metadata
+
+    @property
+    def score(self) -> Optional[Score]:
+        r'''Gets score.
+        '''
+        return self._score
+
+    @property
+    def segment_directory(self) -> Optional[Path]:
+        r'''Gets segment directory.
+        '''
+        return self._segment_directory
+
+    @property
+    def segment_name(self) -> Optional[str]:
+        r'''Gets segment name.
+        '''
+        if bool(self.segment_directory):
+            return self.segment_directory.name
+        return None
 
     ### PUBLIC METHODS ###
 

--- a/abjad/tools/segmenttools/StringOrchestraScoreTemplate.py
+++ b/abjad/tools/segmenttools/StringOrchestraScoreTemplate.py
@@ -11,223 +11,305 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         >>> abjad.show(template) # doctest: +SKIP
 
         >>> abjad.f(template.__illustrate__()[abjad.Score])
-        \context Score = "Score" <<
+        \context Score = "Score"
+        <<
             \tag #'(Violin1 Violin2 Violin3 Violin4 Violin5 Violin6 Viola1 Viola2 Viola3 Viola4 Cello1 Cello2 Cello3 Contrabass1 Contrabass2)
-            \context GlobalContext = "GlobalContext" {
+            \context GlobalContext = "GlobalContext"
+            {
             }
-            \context StaffGroup = "Outer Staff Group" <<
-                \context ViolinStaffGroup = "Violin Staff Group" <<
+            \context StaffGroup = "Outer Staff Group"
+            <<
+                \context ViolinStaffGroup = "Violin Staff Group"
+                <<
                     \tag #'Violin1
-                    \context StringPerformerStaffGroup = "Violin 1 Staff Group" <<
-                        \context BowingStaff = "Violin 1 Bowing Staff" <<
-                            \context BowingVoice = "Violin 1 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Violin 1 Staff Group"
+                    <<
+                        \context BowingStaff = "Violin 1 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Violin 1 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Violin 1 Fingering Staff" <<
-                            \context FingeringVoice = "Violin 1 Fingering Voice" {
+                        \context FingeringStaff = "Violin 1 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Violin 1 Fingering Voice"
+                            {
                                 \clef "treble" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Violin2
-                    \context StringPerformerStaffGroup = "Violin 2 Staff Group" <<
-                        \context BowingStaff = "Violin 2 Bowing Staff" <<
-                            \context BowingVoice = "Violin 2 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Violin 2 Staff Group"
+                    <<
+                        \context BowingStaff = "Violin 2 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Violin 2 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Violin 2 Fingering Staff" <<
-                            \context FingeringVoice = "Violin 2 Fingering Voice" {
+                        \context FingeringStaff = "Violin 2 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Violin 2 Fingering Voice"
+                            {
                                 \clef "treble" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Violin3
-                    \context StringPerformerStaffGroup = "Violin 3 Staff Group" <<
-                        \context BowingStaff = "Violin 3 Bowing Staff" <<
-                            \context BowingVoice = "Violin 3 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Violin 3 Staff Group"
+                    <<
+                        \context BowingStaff = "Violin 3 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Violin 3 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Violin 3 Fingering Staff" <<
-                            \context FingeringVoice = "Violin 3 Fingering Voice" {
+                        \context FingeringStaff = "Violin 3 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Violin 3 Fingering Voice"
+                            {
                                 \clef "treble" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Violin4
-                    \context StringPerformerStaffGroup = "Violin 4 Staff Group" <<
-                        \context BowingStaff = "Violin 4 Bowing Staff" <<
-                            \context BowingVoice = "Violin 4 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Violin 4 Staff Group"
+                    <<
+                        \context BowingStaff = "Violin 4 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Violin 4 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Violin 4 Fingering Staff" <<
-                            \context FingeringVoice = "Violin 4 Fingering Voice" {
+                        \context FingeringStaff = "Violin 4 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Violin 4 Fingering Voice"
+                            {
                                 \clef "treble" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Violin5
-                    \context StringPerformerStaffGroup = "Violin 5 Staff Group" <<
-                        \context BowingStaff = "Violin 5 Bowing Staff" <<
-                            \context BowingVoice = "Violin 5 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Violin 5 Staff Group"
+                    <<
+                        \context BowingStaff = "Violin 5 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Violin 5 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Violin 5 Fingering Staff" <<
-                            \context FingeringVoice = "Violin 5 Fingering Voice" {
+                        \context FingeringStaff = "Violin 5 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Violin 5 Fingering Voice"
+                            {
                                 \clef "treble" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Violin6
-                    \context StringPerformerStaffGroup = "Violin 6 Staff Group" <<
-                        \context BowingStaff = "Violin 6 Bowing Staff" <<
-                            \context BowingVoice = "Violin 6 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Violin 6 Staff Group"
+                    <<
+                        \context BowingStaff = "Violin 6 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Violin 6 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Violin 6 Fingering Staff" <<
-                            \context FingeringVoice = "Violin 6 Fingering Voice" {
+                        \context FingeringStaff = "Violin 6 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Violin 6 Fingering Voice"
+                            {
                                 \clef "treble" %! ST3
                                 s1
                             }
                         >>
                     >>
                 >>
-                \context ViolaStaffGroup = "Viola Staff Group" <<
+                \context ViolaStaffGroup = "Viola Staff Group"
+                <<
                     \tag #'Viola1
-                    \context StringPerformerStaffGroup = "Viola 1 Staff Group" <<
-                        \context BowingStaff = "Viola 1 Bowing Staff" <<
-                            \context BowingVoice = "Viola 1 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Viola 1 Staff Group"
+                    <<
+                        \context BowingStaff = "Viola 1 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Viola 1 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Viola 1 Fingering Staff" <<
-                            \context FingeringVoice = "Viola 1 Fingering Voice" {
+                        \context FingeringStaff = "Viola 1 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Viola 1 Fingering Voice"
+                            {
                                 \clef "alto" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Viola2
-                    \context StringPerformerStaffGroup = "Viola 2 Staff Group" <<
-                        \context BowingStaff = "Viola 2 Bowing Staff" <<
-                            \context BowingVoice = "Viola 2 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Viola 2 Staff Group"
+                    <<
+                        \context BowingStaff = "Viola 2 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Viola 2 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Viola 2 Fingering Staff" <<
-                            \context FingeringVoice = "Viola 2 Fingering Voice" {
+                        \context FingeringStaff = "Viola 2 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Viola 2 Fingering Voice"
+                            {
                                 \clef "alto" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Viola3
-                    \context StringPerformerStaffGroup = "Viola 3 Staff Group" <<
-                        \context BowingStaff = "Viola 3 Bowing Staff" <<
-                            \context BowingVoice = "Viola 3 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Viola 3 Staff Group"
+                    <<
+                        \context BowingStaff = "Viola 3 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Viola 3 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Viola 3 Fingering Staff" <<
-                            \context FingeringVoice = "Viola 3 Fingering Voice" {
+                        \context FingeringStaff = "Viola 3 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Viola 3 Fingering Voice"
+                            {
                                 \clef "alto" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Viola4
-                    \context StringPerformerStaffGroup = "Viola 4 Staff Group" <<
-                        \context BowingStaff = "Viola 4 Bowing Staff" <<
-                            \context BowingVoice = "Viola 4 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Viola 4 Staff Group"
+                    <<
+                        \context BowingStaff = "Viola 4 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Viola 4 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Viola 4 Fingering Staff" <<
-                            \context FingeringVoice = "Viola 4 Fingering Voice" {
+                        \context FingeringStaff = "Viola 4 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Viola 4 Fingering Voice"
+                            {
                                 \clef "alto" %! ST3
                                 s1
                             }
                         >>
                     >>
                 >>
-                \context CelloStaffGroup = "Cello Staff Group" <<
+                \context CelloStaffGroup = "Cello Staff Group"
+                <<
                     \tag #'Cello1
-                    \context StringPerformerStaffGroup = "Cello 1 Staff Group" <<
-                        \context BowingStaff = "Cello 1 Bowing Staff" <<
-                            \context BowingVoice = "Cello 1 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Cello 1 Staff Group"
+                    <<
+                        \context BowingStaff = "Cello 1 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Cello 1 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Cello 1 Fingering Staff" <<
-                            \context FingeringVoice = "Cello 1 Fingering Voice" {
+                        \context FingeringStaff = "Cello 1 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Cello 1 Fingering Voice"
+                            {
                                 \clef "bass" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Cello2
-                    \context StringPerformerStaffGroup = "Cello 2 Staff Group" <<
-                        \context BowingStaff = "Cello 2 Bowing Staff" <<
-                            \context BowingVoice = "Cello 2 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Cello 2 Staff Group"
+                    <<
+                        \context BowingStaff = "Cello 2 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Cello 2 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Cello 2 Fingering Staff" <<
-                            \context FingeringVoice = "Cello 2 Fingering Voice" {
+                        \context FingeringStaff = "Cello 2 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Cello 2 Fingering Voice"
+                            {
                                 \clef "bass" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Cello3
-                    \context StringPerformerStaffGroup = "Cello 3 Staff Group" <<
-                        \context BowingStaff = "Cello 3 Bowing Staff" <<
-                            \context BowingVoice = "Cello 3 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Cello 3 Staff Group"
+                    <<
+                        \context BowingStaff = "Cello 3 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Cello 3 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Cello 3 Fingering Staff" <<
-                            \context FingeringVoice = "Cello 3 Fingering Voice" {
+                        \context FingeringStaff = "Cello 3 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Cello 3 Fingering Voice"
+                            {
                                 \clef "bass" %! ST3
                                 s1
                             }
                         >>
                     >>
                 >>
-                \context ContrabassStaffGroup = "Contrabass Staff Group" <<
+                \context ContrabassStaffGroup = "Contrabass Staff Group"
+                <<
                     \tag #'Contrabass1
-                    \context StringPerformerStaffGroup = "Contrabass 1 Staff Group" <<
-                        \context BowingStaff = "Contrabass 1 Bowing Staff" <<
-                            \context BowingVoice = "Contrabass 1 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Contrabass 1 Staff Group"
+                    <<
+                        \context BowingStaff = "Contrabass 1 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Contrabass 1 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Contrabass 1 Fingering Staff" <<
-                            \context FingeringVoice = "Contrabass 1 Fingering Voice" {
+                        \context FingeringStaff = "Contrabass 1 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Contrabass 1 Fingering Voice"
+                            {
                                 \clef "bass_8" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Contrabass2
-                    \context StringPerformerStaffGroup = "Contrabass 2 Staff Group" <<
-                        \context BowingStaff = "Contrabass 2 Bowing Staff" <<
-                            \context BowingVoice = "Contrabass 2 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Contrabass 2 Staff Group"
+                    <<
+                        \context BowingStaff = "Contrabass 2 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Contrabass 2 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Contrabass 2 Fingering Staff" <<
-                            \context FingeringVoice = "Contrabass 2 Fingering Voice" {
+                        \context FingeringStaff = "Contrabass 2 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Contrabass 2 Fingering Voice"
+                            {
                                 \clef "bass_8" %! ST3
                                 s1
                             }
@@ -250,67 +332,93 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         >>> abjad.show(template) # doctest: +SKIP
 
         >>> abjad.f(template.__illustrate__()[abjad.Score])
-        \context Score = "Score" <<
+        \context Score = "Score"
+        <<
             \tag #'(Violin1 Violin2 Viola Cello)
-            \context GlobalContext = "GlobalContext" {
+            \context GlobalContext = "GlobalContext"
+            {
             }
-            \context StaffGroup = "Outer Staff Group" <<
-                \context ViolinStaffGroup = "Violin Staff Group" <<
+            \context StaffGroup = "Outer Staff Group"
+            <<
+                \context ViolinStaffGroup = "Violin Staff Group"
+                <<
                     \tag #'Violin1
-                    \context StringPerformerStaffGroup = "Violin 1 Staff Group" <<
-                        \context BowingStaff = "Violin 1 Bowing Staff" <<
-                            \context BowingVoice = "Violin 1 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Violin 1 Staff Group"
+                    <<
+                        \context BowingStaff = "Violin 1 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Violin 1 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Violin 1 Fingering Staff" <<
-                            \context FingeringVoice = "Violin 1 Fingering Voice" {
+                        \context FingeringStaff = "Violin 1 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Violin 1 Fingering Voice"
+                            {
                                 \clef "treble" %! ST3
                                 s1
                             }
                         >>
                     >>
                     \tag #'Violin2
-                    \context StringPerformerStaffGroup = "Violin 2 Staff Group" <<
-                        \context BowingStaff = "Violin 2 Bowing Staff" <<
-                            \context BowingVoice = "Violin 2 Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Violin 2 Staff Group"
+                    <<
+                        \context BowingStaff = "Violin 2 Bowing Staff"
+                        <<
+                            \context BowingVoice = "Violin 2 Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Violin 2 Fingering Staff" <<
-                            \context FingeringVoice = "Violin 2 Fingering Voice" {
+                        \context FingeringStaff = "Violin 2 Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Violin 2 Fingering Voice"
+                            {
                                 \clef "treble" %! ST3
                                 s1
                             }
                         >>
                     >>
                 >>
-                \context ViolaStaffGroup = "Viola Staff Group" <<
+                \context ViolaStaffGroup = "Viola Staff Group"
+                <<
                     \tag #'Viola
-                    \context StringPerformerStaffGroup = "Viola Staff Group" <<
-                        \context BowingStaff = "Viola Bowing Staff" <<
-                            \context BowingVoice = "Viola Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Viola Staff Group"
+                    <<
+                        \context BowingStaff = "Viola Bowing Staff"
+                        <<
+                            \context BowingVoice = "Viola Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Viola Fingering Staff" <<
-                            \context FingeringVoice = "Viola Fingering Voice" {
+                        \context FingeringStaff = "Viola Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Viola Fingering Voice"
+                            {
                                 \clef "alto" %! ST3
                                 s1
                             }
                         >>
                     >>
                 >>
-                \context CelloStaffGroup = "Cello Staff Group" <<
+                \context CelloStaffGroup = "Cello Staff Group"
+                <<
                     \tag #'Cello
-                    \context StringPerformerStaffGroup = "Cello Staff Group" <<
-                        \context BowingStaff = "Cello Bowing Staff" <<
-                            \context BowingVoice = "Cello Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Cello Staff Group"
+                    <<
+                        \context BowingStaff = "Cello Bowing Staff"
+                        <<
+                            \context BowingVoice = "Cello Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Cello Fingering Staff" <<
-                            \context FingeringVoice = "Cello Fingering Voice" {
+                        \context FingeringStaff = "Cello Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Cello Fingering Voice"
+                            {
                                 \clef "bass" %! ST3
                                 s1
                             }
@@ -333,21 +441,30 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         >>> abjad.show(template) # doctest: +SKIP
 
         >>> abjad.f(template.__illustrate__()[abjad.Score])
-        \context Score = "Score" <<
+        \context Score = "Score"
+        <<
             \tag #'(Cello)
-            \context GlobalContext = "GlobalContext" {
+            \context GlobalContext = "GlobalContext"
+            {
             }
-            \context StaffGroup = "Outer Staff Group" <<
-                \context CelloStaffGroup = "Cello Staff Group" <<
+            \context StaffGroup = "Outer Staff Group"
+            <<
+                \context CelloStaffGroup = "Cello Staff Group"
+                <<
                     \tag #'Cello
-                    \context StringPerformerStaffGroup = "Cello Staff Group" <<
-                        \context BowingStaff = "Cello Bowing Staff" <<
-                            \context BowingVoice = "Cello Bowing Voice" {
+                    \context StringPerformerStaffGroup = "Cello Staff Group"
+                    <<
+                        \context BowingStaff = "Cello Bowing Staff"
+                        <<
+                            \context BowingVoice = "Cello Bowing Voice"
+                            {
                                 s1
                             }
                         >>
-                        \context FingeringStaff = "Cello Fingering Staff" <<
-                            \context FingeringVoice = "Cello Fingering Voice" {
+                        \context FingeringStaff = "Cello Fingering Staff"
+                        <<
+                            \context FingeringVoice = "Cello Fingering Voice"
+                            {
                                 \clef "bass" %! ST3
                                 s1
                             }

--- a/abjad/tools/segmenttools/StringQuartetScoreTemplate.py
+++ b/abjad/tools/segmenttools/StringQuartetScoreTemplate.py
@@ -11,11 +11,15 @@ class StringQuartetScoreTemplate(ScoreTemplate):
         >>> abjad.show(template) # doctest: +SKIP
 
         >>> abjad.f(template.__illustrate__()[abjad.Score])
-        \context Score = "String Quartet Score" <<
-            \context StaffGroup = "String Quartet Staff Group" <<
+        \context Score = "String Quartet Score"
+        <<
+            \context StaffGroup = "String Quartet Staff Group"
+            <<
                 \tag #'first-violin
-                \context Staff = "First Violin Staff" {
-                    \context Voice = "First Violin Voice" {
+                \context Staff = "First Violin Staff"
+                {
+                    \context Voice = "First Violin Voice"
+                    {
                         \set Staff.instrumentName = \markup { Violin }   %! ST1
                         \set Staff.shortInstrumentName = \markup { Vn. } %! ST1
                         \clef "treble" %! ST3
@@ -23,8 +27,10 @@ class StringQuartetScoreTemplate(ScoreTemplate):
                     }
                 }
                 \tag #'second-violin
-                \context Staff = "Second Violin Staff" {
-                    \context Voice = "Second Violin Voice" {
+                \context Staff = "Second Violin Staff"
+                {
+                    \context Voice = "Second Violin Voice"
+                    {
                         \set Staff.instrumentName = \markup { Violin }   %! ST1
                         \set Staff.shortInstrumentName = \markup { Vn. } %! ST1
                         \clef "treble" %! ST3
@@ -32,8 +38,10 @@ class StringQuartetScoreTemplate(ScoreTemplate):
                     }
                 }
                 \tag #'viola
-                \context Staff = "Viola Staff" {
-                    \context Voice = "Viola Voice" {
+                \context Staff = "Viola Staff"
+                {
+                    \context Voice = "Viola Voice"
+                    {
                         \set Staff.instrumentName = \markup { Viola }    %! ST1
                         \set Staff.shortInstrumentName = \markup { Va. } %! ST1
                         \clef "alto" %! ST3
@@ -41,8 +49,10 @@ class StringQuartetScoreTemplate(ScoreTemplate):
                     }
                 }
                 \tag #'cello
-                \context Staff = "Cello Staff" {
-                    \context Voice = "Cello Voice" {
+                \context Staff = "Cello Staff"
+                {
+                    \context Voice = "Cello Voice"
+                    {
                         \set Staff.instrumentName = \markup { Cello }    %! ST1
                         \set Staff.shortInstrumentName = \markup { Vc. } %! ST1
                         \clef "bass" %! ST3
@@ -65,6 +75,13 @@ class StringQuartetScoreTemplate(ScoreTemplate):
         'va': 'Viola Voice',
         'vc': 'Cello Voice',
         })
+
+    _part_manifest = (
+        ('FirstViolin', 'VN_1'),
+        ('SecondViolin', 'VN_2'),
+        ('Viola', 'VA'),
+        ('Cello', 'VC'),
+        )
 
     ### INITIALIZER ###
 

--- a/abjad/tools/segmenttools/Tags.py
+++ b/abjad/tools/segmenttools/Tags.py
@@ -167,6 +167,8 @@ class Tags(AbjadValueObject):
 
         ### METRONOME MARKS ###
 
+        'METRONOME_MARK_SPANNER',
+
         'EXPLICIT_METRONOME_MARK',
         'EXPLICIT_METRONOME_MARK_WITH_COLOR',
 
@@ -349,7 +351,7 @@ class Tags(AbjadValueObject):
             self.REDUNDANT_DYNAMIC_REDRAW_COLOR,
             ]
 
-    def get_document_tag(self, string: str) -> bool:
+    def get_document_tag(self, string: str) -> str:
         r'''Gets document tag in ``string``.
 
         ..  container:: example
@@ -490,6 +492,31 @@ class Tags(AbjadValueObject):
             self.REDUNDANT_INSTRUMENT_ALERT,
             self.REDUNDANT_INSTRUMENT_COLOR,
             self.REDRAWN_REDUNDANT_INSTRUMENT_COLOR,
+            ]
+
+    def layout_removal_tags(self):
+        r'''Gets layout removal tags.
+
+        ..  container:: example
+
+            >>> for tag in abjad.tags.layout_removal_tags():
+            ...     tag
+            ...
+            'EMPTY_START_BAR'
+            'EXPLICIT_TIME_SIGNATURE_COLOR'
+            'MEASURE_NUMBER_MARKUP'
+            'METRONOME_MARK_SPANNER'
+            'REDUNDANT_TIME_SIGNATURE_COLOR'
+            'STAGE_NUMBER_MARKUP'
+
+        '''
+        return [
+            self.EMPTY_START_BAR,
+            self.EXPLICIT_TIME_SIGNATURE_COLOR,
+            self.MEASURE_NUMBER_MARKUP,
+            self.METRONOME_MARK_SPANNER,
+            self.REDUNDANT_TIME_SIGNATURE_COLOR,
+            self.STAGE_NUMBER_MARKUP,
             ]
 
     def margin_markup_color_tags(self, path=None) -> List[str]:

--- a/abjad/tools/segmenttools/TwoStaffPianoScoreTemplate.py
+++ b/abjad/tools/segmenttools/TwoStaffPianoScoreTemplate.py
@@ -11,17 +11,32 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
         >>> abjad.show(template) # doctest: +SKIP
 
         >>> abjad.f(template.__illustrate__()[abjad.Score])
-        \context Score = "Two-Staff Piano Score" <<
-            \context PianoStaff = "Piano Staff" <<
-                \context Staff = "RH Staff" {
-                    \context Voice = "RH Voice" {
+        \context Score = "TwoStaffPianoScore"
+        <<
+            \context GlobalContext = "GlobalContext"
+            <<
+                \context GlobalRests = "GlobalRests"
+                {
+                }
+                \context GlobalSkips = "GlobalSkips"
+                {
+                }
+            >>
+            \context PianoStaff = "PianoStaff"
+            <<
+                \context Staff = "RHStaff"
+                {
+                    \context Voice = "RHVoice"
+                    {
                         \set PianoStaff.instrumentName = \markup { Piano }    %! ST1
                         \set PianoStaff.shortInstrumentName = \markup { Pf. } %! ST1
                         s1
                     }
                 }
-                \context Staff = "LH Staff" {
-                    \context Voice = "LH Voice" {
+                \context Staff = "LHStaff"
+                {
+                    \context Voice = "LHVoice"
+                    {
                         \clef "bass" %! ST3
                         s1
                     }
@@ -38,8 +53,8 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
         )
 
     context_name_abbreviations = collections.OrderedDict({
-        'rh': 'RH Voice',
-        'lh': 'LH Voice',
+        'rh': 'RHVoice',
+        'lh': 'LHVoice',
         })
 
     ### INITIALIZER ###
@@ -55,18 +70,21 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
         Returns score.
         '''
         import abjad
+        # GLOBAL CONTEXT
+        global_context = self._make_global_context()
+
         # RH STAFF
-        rh_voice = abjad.Voice(name='RH Voice')
+        rh_voice = abjad.Voice(name='RHVoice')
         rh_staff = abjad.Staff(
             [rh_voice],
-            name='RH Staff',
+            name='RHStaff',
             )
 
         # LH STAFF
-        lh_voice = abjad.Voice(name='LH Voice')
+        lh_voice = abjad.Voice(name='LHVoice')
         lh_staff = abjad.Staff(
             [lh_voice],
-            name='LH Staff',
+            name='LHStaff',
             )
         abjad.annotate(
             lh_staff,
@@ -78,7 +96,7 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
         staff_group = abjad.StaffGroup(
             [rh_staff, lh_staff],
             lilypond_type='PianoStaff',
-            name='Piano Staff',
+            name='PianoStaff',
             )
         abjad.annotate(
             staff_group,
@@ -88,7 +106,7 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
 
         # SCORE
         score = abjad.Score(
-            [staff_group],
-            name='Two-Staff Piano Score',
+            [global_context, staff_group],
+            name='TwoStaffPianoScore',
             )
         return score

--- a/abjad/tools/segmenttools/test/test_custom_score_template_class.py
+++ b/abjad/tools/segmenttools/test/test_custom_score_template_class.py
@@ -28,9 +28,12 @@ def test_custom_score_template_class_01():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \context Score = "Green Score" <<
-            \context Staff = "Red Staff" {
-                \context Voice = "Blue Voice" {
+        \context Score = "Green Score"
+        <<
+            \context Staff = "Red Staff"
+            {
+                \context Voice = "Blue Voice"
+                {
                 }
             }
         >>
@@ -66,9 +69,12 @@ def test_custom_score_template_class_02():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new CustomStaff {
-                \new CustomVoice {
+        \new Score
+        <<
+            \new CustomStaff
+            {
+                \new CustomVoice
+                {
                 }
             }
         >>
@@ -137,9 +143,12 @@ def test_custom_score_template_class_02():
     assert format(lilypond_file.score_block) == abjad.String.normalize(
         r'''
         \score {
-            \new Score <<
-                \new CustomStaff {
-                    \new CustomVoice {
+            \new Score
+            <<
+                \new CustomStaff
+                {
+                    \new CustomVoice
+                    {
                         c'4 (
                         d'4
                         e'4

--- a/abjad/tools/spannertools/Beam.py
+++ b/abjad/tools/spannertools/Beam.py
@@ -13,9 +13,12 @@ class Beam(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8
                 d'8
                 e'8
@@ -32,9 +35,12 @@ class Beam(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8 [
                 d'8 ]
                 e'8 [
@@ -53,9 +59,12 @@ class Beam(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8
                 d'8
                 e'8
@@ -70,9 +79,12 @@ class Beam(Spanner):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             autoBeaming = ##f
-        } {
+        }
+        {
             c'8 [ %! BEAM
             d'8 ] %! BEAM
             e'8 [
@@ -91,9 +103,12 @@ class Beam(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8
                 d'8
                 e'8
@@ -108,9 +123,12 @@ class Beam(Spanner):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             autoBeaming = ##f
-        } {
+        }
+        {
             c'8 [ %! M1
             d'8 ] %! M1
             e'8 [
@@ -129,9 +147,12 @@ class Beam(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8
                 d'8
                 e'8
@@ -146,9 +167,12 @@ class Beam(Spanner):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff)
-        \new Staff \with {
+        \new Staff
+        \with
+        {
             autoBeaming = ##f
-        } {
+        }
+        {
             c'8 [ %! BEAM:M1
             d'8 ] %! BEAM:M1
             e'8 [
@@ -345,9 +369,12 @@ class Beam(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new RhythmicStaff \with {
+                \new RhythmicStaff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \override RhythmicStaff.Stem.stemlet-length = 2
                     r8 [
                     c'8

--- a/abjad/tools/spannertools/BowContactSpanner.py
+++ b/abjad/tools/spannertools/BowContactSpanner.py
@@ -39,7 +39,9 @@ class BowContactSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override BarLine.transparent = ##t
                 \override Dots.staff-position = #-8
                 \override Flag.Y-offset = #-8.5
@@ -52,7 +54,8 @@ class BowContactSpanner(Spanner):
                 \override Stem.length = #8
                 \override Stem.stem-begin-position = #-9
                 \override TimeSignature.stencil = ##f
-            } {
+            }
+            {
                 \once \override Glissando.style = #'dotted-line
                 \once \override NoteHead.Y-offset = -1.0
                 \once \override NoteHead.stencil = #ly:text-interface::print
@@ -144,7 +147,9 @@ class BowContactSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override BarLine.transparent = ##t
                 \override Dots.staff-position = #-8
                 \override Flag.Y-offset = #-8.5
@@ -157,7 +162,8 @@ class BowContactSpanner(Spanner):
                 \override Stem.length = #8
                 \override Stem.stem-begin-position = #-9
                 \override TimeSignature.stencil = ##f
-            } {
+            }
+            {
                 \once \override NoteHead.style = #'cross
                 \clef "percussion"
                 c'4

--- a/abjad/tools/spannertools/ClefSpanner.py
+++ b/abjad/tools/spannertools/ClefSpanner.py
@@ -21,7 +21,8 @@ class ClefSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \clef "treble"
                 c'4
                 d'4
@@ -52,7 +53,8 @@ class ClefSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \clef "treble"
                 r4
                 \clef "percussion"

--- a/abjad/tools/spannertools/ComplexBeam.py
+++ b/abjad/tools/spannertools/ComplexBeam.py
@@ -13,9 +13,12 @@ class ComplexBeam(Beam):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'16
                 e'16
                 r16
@@ -30,9 +33,12 @@ class ComplexBeam(Beam):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 \set stemLeftBeamCount = 0
                 \set stemRightBeamCount = 2
                 c'16 [
@@ -288,7 +294,8 @@ class ComplexBeam(Beam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [ ]
@@ -313,7 +320,8 @@ class ComplexBeam(Beam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [
@@ -340,7 +348,8 @@ class ComplexBeam(Beam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [ ]
@@ -365,7 +374,8 @@ class ComplexBeam(Beam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [
@@ -404,12 +414,12 @@ class ComplexBeam(Beam):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 1/16
                     \set stemLeftBeamCount = 2
                     \set stemRightBeamCount = 0
                     c'16 [ ]
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -423,12 +433,12 @@ class ComplexBeam(Beam):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 1/16
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 2
                     c'16 [ ]
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -442,12 +452,12 @@ class ComplexBeam(Beam):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 1/16
                     \set stemLeftBeamCount = 2
                     \set stemRightBeamCount = 2
                     c'16 [ ]
-                } % measure
+                }   % measure
 
         ..  container:: example
 
@@ -461,10 +471,10 @@ class ComplexBeam(Beam):
             ..  docs::
 
                 >>> abjad.f(measure)
-                { % measure
+                {   % measure
                     \time 1/16
                     c'16
-                } % measure
+                }   % measure
 
         Set to left, right, true or false.
 
@@ -491,9 +501,12 @@ class ComplexBeam(Beam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new RhythmicStaff \with {
+                \new RhythmicStaff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \override RhythmicStaff.Stem.stemlet-length = 2
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1

--- a/abjad/tools/spannertools/ComplexTrillSpanner.py
+++ b/abjad/tools/spannertools/ComplexTrillSpanner.py
@@ -12,7 +12,8 @@ class ComplexTrillSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4 ~
                 c'8
                 d'8
@@ -31,7 +32,8 @@ class ComplexTrillSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \pitchedTrill
                 c'4 ~ \startTrillSpan f'
                 c'8
@@ -151,7 +153,8 @@ class ComplexTrillSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'4
                     \pitchedTrill
                     d'4 \startTrillSpan f'

--- a/abjad/tools/spannertools/DuratedComplexBeam.py
+++ b/abjad/tools/spannertools/DuratedComplexBeam.py
@@ -22,9 +22,12 @@ class DuratedComplexBeam(ComplexBeam):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 \set stemLeftBeamCount = 0
                 \set stemRightBeamCount = 2
                 c'16 [
@@ -59,9 +62,12 @@ class DuratedComplexBeam(ComplexBeam):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 \set stemLeftBeamCount = 0
                 \set stemRightBeamCount = 2
                 c'16 [
@@ -264,7 +270,8 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [ ]
@@ -289,7 +296,8 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [
@@ -312,7 +320,8 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [ ]
@@ -337,7 +346,8 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [
@@ -361,7 +371,8 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 1
                     c'8 [
@@ -398,7 +409,8 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 2
                     c'16 [
@@ -433,9 +445,12 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff \with {
+                \new Staff
+                \with
+                {
                     autoBeaming = ##f
-                } {
+                }
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 2
                     c'16 [
@@ -486,7 +501,8 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 2
                     c'16 [
@@ -518,7 +534,8 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 2
                     c'16 [
@@ -562,7 +579,8 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 3
                     c'32 [
@@ -596,7 +614,8 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 3
                     c'32 [
@@ -630,7 +649,8 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 3
                     c'32 [
@@ -679,9 +699,12 @@ class DuratedComplexBeam(ComplexBeam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new RhythmicStaff \with {
+                \new RhythmicStaff
+                \with
+                {
                     \override Beam.positions = #'(4.5 . 4.5)
-                } {
+                }
+                {
                     \override RhythmicStaff.Stem.stemlet-length = 1.5
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 2

--- a/abjad/tools/spannertools/GeneralizedBeam.py
+++ b/abjad/tools/spannertools/GeneralizedBeam.py
@@ -17,9 +17,12 @@ class GeneralizedBeam(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 r4
                 c'8 [
                 \set stemLeftBeamCount = 1
@@ -46,9 +49,12 @@ class GeneralizedBeam(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 r4
                 c'8 [
                 \set stemLeftBeamCount = 1
@@ -73,9 +79,12 @@ class GeneralizedBeam(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 r4
                 c'8 [
                 \set stemLeftBeamCount = 1

--- a/abjad/tools/spannertools/Glissando.py
+++ b/abjad/tools/spannertools/Glissando.py
@@ -14,7 +14,8 @@ class Glissando(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'8 \glissando
                 d'8 \glissando
                 e'8 \glissando
@@ -35,7 +36,8 @@ class Glissando(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'8 \glissando
                 d'8 - \bendAfter #'-4.0
                 e'8 \glissando
@@ -179,7 +181,8 @@ class Glissando(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     a8
                     a8 \glissando
                     b8 ~
@@ -206,7 +209,8 @@ class Glissando(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     a8 \glissando
                     a8 \glissando
                     b8 ~
@@ -232,7 +236,8 @@ class Glissando(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     a8 \glissando
                     a8 \glissando
                     b8 ~ \glissando
@@ -268,7 +273,8 @@ class Glissando(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     a8
                     a8 \glissando
                     b8 ~
@@ -295,7 +301,8 @@ class Glissando(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     a8 \glissando
                     a8 \glissando
                     b8 ~
@@ -321,7 +328,8 @@ class Glissando(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     a8 \glissando
                     a8 \glissando
                     b8 ~ \glissando
@@ -356,7 +364,8 @@ class Glissando(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     a8
                     a8 \glissando
                     b8 ~
@@ -384,7 +393,8 @@ class Glissando(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     a8 \glissando
                     \parenthesize
                     a8 \glissando
@@ -413,7 +423,8 @@ class Glissando(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     a8
                     \parenthesize
                     a8 \glissando

--- a/abjad/tools/spannertools/Hairpin.py
+++ b/abjad/tools/spannertools/Hairpin.py
@@ -19,7 +19,8 @@ class Hairpin(Spanner):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 r8
                 d'8 \< \p
                 e'8
@@ -54,7 +55,8 @@ class Hairpin(Spanner):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 r8
                 d'8 \> \f
                 e'8
@@ -93,7 +95,8 @@ class Hairpin(Spanner):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 \once \override Hairpin.circled-tip = ##t
                 c'2. \> \f
                 r4 \!
@@ -115,7 +118,8 @@ class Hairpin(Spanner):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 \once \override Hairpin.circled-tip = ##t
                 c'2. \> \f
                 r4 \!
@@ -148,7 +152,8 @@ class Hairpin(Spanner):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 c'8 \p \<
                 d'8
                 e'8 \f \>
@@ -187,9 +192,12 @@ class Hairpin(Spanner):
             >>> hairpin.attach(abjad.Dynamic('p'), hairpin[0])
             >>> abjad.override(segment_1).dynamic_line_spanner.staff_padding = 4
             >>> abjad.f(segment_1, strict=True)
-            \context Voice = "MainVoice" \with {
+            \context Voice = "MainVoice"
+            \with
+            {
                 \override DynamicLineSpanner.staff-padding = #4
-            } {
+            }
+            {
                 c'4
                 \<
                 \p
@@ -210,7 +218,8 @@ class Hairpin(Spanner):
             >>> abjad.attach(hairpin, segment_2[:], left_broken='<')
             >>> hairpin.attach(abjad.Dynamic('f'), hairpin[-1])
             >>> abjad.f(segment_2, strict=True)
-            \context Voice = "MainVoice" {
+            \context Voice = "MainVoice"
+            {
                 c'4
                 \< %! LEFT_BROKEN_HAIRPIN_START
                 d'4
@@ -230,9 +239,12 @@ class Hairpin(Spanner):
             >>> text = abjad.LilyPondFormatManager.left_shift_tags(text)
             >>> print(text)
             {
-                \context Voice = "MainVoice" \with {
+                \context Voice = "MainVoice"
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #4
-                } {
+                }
+                {
                     c'4
                     \<
                     \p
@@ -241,7 +253,8 @@ class Hairpin(Spanner):
                     f'4
                     \! %! RIGHT_BROKEN_HAIRPIN_STOP
                 }
-                \context Voice = "MainVoice" {
+                \context Voice = "MainVoice"
+                {
                     c'4
                     \< %! LEFT_BROKEN_HAIRPIN_START
                     d'4
@@ -269,9 +282,12 @@ class Hairpin(Spanner):
             ...     )
             >>> print(text)
             {
-                \context Voice = "MainVoice" \with {
+                \context Voice = "MainVoice"
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #4
-                } {
+                }
+                {
                     c'4
                     \<
                     \p
@@ -280,7 +296,8 @@ class Hairpin(Spanner):
                     f'4
                 %%% \! %! RIGHT_BROKEN_HAIRPIN_STOP
                 }
-                \context Voice = "MainVoice" {
+                \context Voice = "MainVoice"
+                {
                     c'4
                 %%% \< %! LEFT_BROKEN_HAIRPIN_START
                     d'4
@@ -308,7 +325,8 @@ class Hairpin(Spanner):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice {
+            \new Voice
+            {
                 r8
                 d'8 \< _ #(make-dynamic-script
                     (markup
@@ -821,11 +839,15 @@ class Hairpin(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff <<
-                    \new Voice \with {
+                \new Staff
+                <<
+                    \new Voice
+                    \with
+                    {
                         \override DynamicLineSpanner.direction = #up
                         \override DynamicLineSpanner.staff-padding = #4
-                    } {
+                    }
+                    {
                         \voiceOne
                         e'8 \< \mf
                         f'8
@@ -837,9 +859,12 @@ class Hairpin(Spanner):
                         b'8
                         g'8 \mf
                     }
-                    \new Voice \with {
+                    \new Voice
+                    \with
+                    {
                         \override DynamicLineSpanner.staff-padding = #6
-                    } {
+                    }
+                    {
                         \voiceTwo
                         c'2 \< \pp
                         b2 ~
@@ -885,7 +910,8 @@ class Hairpin(Spanner):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
+                \new Voice
+                {
                     r8
                     d'8 \< \p
                     e'8
@@ -917,7 +943,8 @@ class Hairpin(Spanner):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
+                \new Voice
+                {
                     r8
                     d'8 ^ \< ^ \p
                     e'8
@@ -953,7 +980,8 @@ class Hairpin(Spanner):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
+                \new Voice
+                {
                     r8
                     d'8 \< \p
                     e'8
@@ -982,7 +1010,8 @@ class Hairpin(Spanner):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
+                \new Voice
+                {
                     r8
                     d'8 \< \p
                     e'8
@@ -1014,7 +1043,8 @@ class Hairpin(Spanner):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
+                \new Voice
+                {
                     r8
                     d'8 \< \p
                     e'8
@@ -1046,7 +1076,8 @@ class Hairpin(Spanner):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice {
+                \new Voice
+                {
                     r8
                     d'8 \< \p
                     e'8
@@ -1085,9 +1116,12 @@ class Hairpin(Spanner):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice \with {
+                \new Voice
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #4
-                } {
+                }
+                {
                     c'8 \< \p
                     d'8
                     e'8 \f \>
@@ -1128,9 +1162,12 @@ class Hairpin(Spanner):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice \with {
+                \new Voice
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #4
-                } {
+                }
+                {
                     c'8 \< _ #(make-dynamic-script
                         (markup
                             #:whiteout
@@ -1225,9 +1262,12 @@ class Hairpin(Spanner):
             ..  docs::
 
                 >>> abjad.f(voice)
-                \new Voice \with {
+                \new Voice
+                \with
+                {
                     \override DynamicLineSpanner.staff-padding = #4
-                } {
+                }
+                {
                     \once \override Hairpin.circled-tip = ##t
                     c'8 \> \f
                     d'8

--- a/abjad/tools/spannertools/HiddenStaffSpanner.py
+++ b/abjad/tools/spannertools/HiddenStaffSpanner.py
@@ -14,7 +14,8 @@ class HiddenStaffSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'8
                 \stopStaff
                 d'8

--- a/abjad/tools/spannertools/HorizontalBracketSpanner.py
+++ b/abjad/tools/spannertools/HorizontalBracketSpanner.py
@@ -15,9 +15,12 @@ class HorizontalBracketSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(voice)
-            \new Voice \with {
+            \new Voice
+            \with
+            {
                 \consists Horizontal_bracket_engraver
-            } {
+            }
+            {
                 c'4 \startGroup
                 d'4
                 e'4

--- a/abjad/tools/spannertools/MeasuredComplexBeam.py
+++ b/abjad/tools/spannertools/MeasuredComplexBeam.py
@@ -21,10 +21,13 @@ class MeasuredComplexBeam(ComplexBeam):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
-                { % measure
+            }
+            {
+                {   % measure
                     \time 2/16
                     \set stemLeftBeamCount = 0
                     \set stemRightBeamCount = 2
@@ -32,15 +35,15 @@ class MeasuredComplexBeam(ComplexBeam):
                     \set stemLeftBeamCount = 2
                     \set stemRightBeamCount = 1
                     d'16
-                } % measure
-                { % measure
+                }   % measure
+                {   % measure
                     \set stemLeftBeamCount = 1
                     \set stemRightBeamCount = 2
                     e'16
                     \set stemLeftBeamCount = 2
                     \set stemRightBeamCount = 0
                     f'16 ]
-                } % measure
+                }   % measure
             }
 
     Beams leaves in spanner explicitly.

--- a/abjad/tools/spannertools/MetronomeMarkSpanner.py
+++ b/abjad/tools/spannertools/MetronomeMarkSpanner.py
@@ -28,10 +28,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
                     \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -175,10 +179,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -336,10 +344,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
                     \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -499,10 +511,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -672,10 +688,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -819,10 +839,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.arrow-width = 0.25
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -968,10 +992,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
                     \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -1134,10 +1162,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
                     \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -1298,10 +1330,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
                     \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -1415,10 +1451,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
                     \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -1533,10 +1573,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
                     \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -1601,11 +1645,16 @@ class MetronomeMarkSpanner(Spanner):
                                                 #'(0.5 . 0.5)
                                                 \score
                                                     {
-                                                        \new Score \with {
+                                                        \new Score
+                                                        \with
+                                                        {
                                                             \override SpacingSpanner.spacing-increment = #0.5
                                                             proportionalNotationDuration = ##f
-                                                        } <<
-                                                            \new RhythmicStaff \with {
+                                                        }
+                                                        <<
+                                                            \new RhythmicStaff
+                                                            \with
+                                                            {
                                                                 \remove Time_signature_engraver
                                                                 \remove Staff_symbol_engraver
                                                                 \override Stem.direction = #up
@@ -1616,7 +1665,8 @@ class MetronomeMarkSpanner(Spanner):
                                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                                 tupletFullLength = ##t
-                                                            } {
+                                                            }
+                                                            {
                                                                 c4.
                                                             }
                                                         >>
@@ -1632,11 +1682,16 @@ class MetronomeMarkSpanner(Spanner):
                                                 #'(0.5 . 0.5)
                                                 \score
                                                     {
-                                                        \new Score \with {
+                                                        \new Score
+                                                        \with
+                                                        {
                                                             \override SpacingSpanner.spacing-increment = #0.5
                                                             proportionalNotationDuration = ##f
-                                                        } <<
-                                                            \new RhythmicStaff \with {
+                                                        }
+                                                        <<
+                                                            \new RhythmicStaff
+                                                            \with
+                                                            {
                                                                 \remove Time_signature_engraver
                                                                 \remove Staff_symbol_engraver
                                                                 \override Stem.direction = #up
@@ -1647,7 +1702,8 @@ class MetronomeMarkSpanner(Spanner):
                                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                                 tupletFullLength = ##t
-                                                            } {
+                                                            }
+                                                            {
                                                                 c4
                                                             }
                                                         >>
@@ -1699,10 +1755,14 @@ class MetronomeMarkSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
                     \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -1778,11 +1838,16 @@ class MetronomeMarkSpanner(Spanner):
                                                 #'(0.5 . 0.5)
                                                 \score
                                                     {
-                                                        \new Score \with {
+                                                        \new Score
+                                                        \with
+                                                        {
                                                             \override SpacingSpanner.spacing-increment = #0.5
                                                             proportionalNotationDuration = ##f
-                                                        } <<
-                                                            \new RhythmicStaff \with {
+                                                        }
+                                                        <<
+                                                            \new RhythmicStaff
+                                                            \with
+                                                            {
                                                                 \remove Time_signature_engraver
                                                                 \remove Staff_symbol_engraver
                                                                 \override Stem.direction = #up
@@ -1793,7 +1858,8 @@ class MetronomeMarkSpanner(Spanner):
                                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                                 tupletFullLength = ##t
-                                                            } {
+                                                            }
+                                                            {
                                                                 c4.
                                                             }
                                                         >>
@@ -1809,11 +1875,16 @@ class MetronomeMarkSpanner(Spanner):
                                                 #'(0.5 . 0.5)
                                                 \score
                                                     {
-                                                        \new Score \with {
+                                                        \new Score
+                                                        \with
+                                                        {
                                                             \override SpacingSpanner.spacing-increment = #0.5
                                                             proportionalNotationDuration = ##f
-                                                        } <<
-                                                            \new RhythmicStaff \with {
+                                                        }
+                                                        <<
+                                                            \new RhythmicStaff
+                                                            \with
+                                                            {
                                                                 \remove Time_signature_engraver
                                                                 \remove Staff_symbol_engraver
                                                                 \override Stem.direction = #up
@@ -1824,7 +1895,8 @@ class MetronomeMarkSpanner(Spanner):
                                                                 \override TupletBracket.shorten-pair = #'(-1 . -1.5)
                                                                 \override TupletNumber.text = #tuplet-number::calc-fraction-text
                                                                 tupletFullLength = ##t
-                                                            } {
+                                                            }
+                                                            {
                                                                 c4
                                                             }
                                                         >>
@@ -2316,10 +2388,14 @@ class MetronomeMarkSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff \with {
+                \new Score
+                <<
+                    \new Staff
+                    \with
+                    {
                         \override TextSpanner.staff-padding = #3
-                    } {
+                    }
+                    {
                         \once \override TextSpanner.Y-extent = ##f
                         \once \override TextSpanner.bound-details.left-broken.text = ##f
                         \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -2437,10 +2513,14 @@ class MetronomeMarkSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff \with {
+                \new Score
+                <<
+                    \new Staff
+                    \with
+                    {
                         \override TextSpanner.staff-padding = #3
-                    } {
+                    }
+                    {
                         \once \override TextSpanner.Y-extent = ##f
                         \once \override TextSpanner.bound-details.left-broken.text = ##f
                         \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -2562,10 +2642,14 @@ class MetronomeMarkSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff \with {
+                \new Score
+                <<
+                    \new Staff
+                    \with
+                    {
                         \override TextSpanner.staff-padding = #3
-                    } {
+                    }
+                    {
                         \once \override TextSpanner.Y-extent = ##f
                         \once \override TextSpanner.bound-details.left-broken.text = ##f
                         \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -2685,10 +2769,14 @@ class MetronomeMarkSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff \with {
+                \new Score
+                <<
+                    \new Staff
+                    \with
+                    {
                         \override TextSpanner.staff-padding = #3
-                    } {
+                    }
+                    {
                         \once \override TextSpanner.Y-extent = ##f
                         \once \override TextSpanner.bound-details.left-broken.text = ##f
                         \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -2819,10 +2907,14 @@ class MetronomeMarkSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff \with {
+                \new Score
+                <<
+                    \new Staff
+                    \with
+                    {
                         \override TextSpanner.staff-padding = #3
-                    } {
+                    }
+                    {
                         \once \override TextSpanner.Y-extent = ##f
                         \once \override TextSpanner.bound-details.left-broken.text = ##f
                         \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -2968,10 +3060,14 @@ class MetronomeMarkSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff \with {
+                \new Score
+                <<
+                    \new Staff
+                    \with
+                    {
                         \override TextSpanner.staff-padding = #3
-                    } {
+                    }
+                    {
                         \once \override TextSpanner.Y-extent = ##f
                         \once \override TextSpanner.bound-details.left-broken.text = ##f
                         \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -3168,10 +3264,14 @@ class MetronomeMarkSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score <<
-                    \new Staff \with {
+                \new Score
+                <<
+                    \new Staff
+                    \with
+                    {
                         \override TextSpanner.staff-padding = #3
-                    } {
+                    }
+                    {
                         \once \override TextSpanner.Y-extent = ##f
                         \once \override TextSpanner.bound-details.left-broken.text = ##f
                         \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -3315,32 +3415,36 @@ class MetronomeMarkSpanner(Spanner):
             >>> abjad.show(score) # doctest: +SKIP
 
             >>> abjad.f(score, strict=True)
-            \new Score <<
-                \new Staff \with {
+            \new Score
+            <<
+                \new Staff
+                \with
+                {
                     \override TextSpanner.staff-padding = #3
-                } {
+                }
+                {
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
                     \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
                     \once \override TextSpanner.bound-details.left.text = %! RED:M1
-                    \markup {                                             %! RED:M1
-                        \fontsize                                         %! RED:M1
-                            #-6                                           %! RED:M1
-                            \general-align                                %! RED:M1
-                                #Y                                        %! RED:M1
-                                #DOWN                                     %! RED:M1
-                                \note-by-number                           %! RED:M1
-                                    #2                                    %! RED:M1
-                                    #0                                    %! RED:M1
-                                    #1                                    %! RED:M1
-                        \upright                                          %! RED:M1
-                            {                                             %! RED:M1
-                                =                                         %! RED:M1
-                                60                                        %! RED:M1
-                            }                                             %! RED:M1
-                        \hspace                                           %! RED:M1
-                            #1                                            %! RED:M1
-                        }                                                 %! RED:M1
+                    \markup { %! RED:M1
+                        \fontsize %! RED:M1
+                            #-6 %! RED:M1
+                            \general-align %! RED:M1
+                                #Y %! RED:M1
+                                #DOWN %! RED:M1
+                                \note-by-number %! RED:M1
+                                    #2 %! RED:M1
+                                    #0 %! RED:M1
+                                    #1 %! RED:M1
+                        \upright %! RED:M1
+                            { %! RED:M1
+                                = %! RED:M1
+                                60 %! RED:M1
+                            } %! RED:M1
+                        \hspace %! RED:M1
+                            #1 %! RED:M1
+                        } %! RED:M1
                     \once \override TextSpanner.bound-details.right-broken.padding = 0
                     \once \override TextSpanner.bound-details.right-broken.text = ##f
                     \once \override TextSpanner.bound-details.right.padding = 1
@@ -3354,24 +3458,24 @@ class MetronomeMarkSpanner(Spanner):
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
                     \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
                     \once \override TextSpanner.bound-details.left.text = %! BLUE
-                    \markup {                                             %! BLUE
-                        \fontsize                                         %! BLUE
-                            #-6                                           %! BLUE
-                            \general-align                                %! BLUE
-                                #Y                                        %! BLUE
-                                #DOWN                                     %! BLUE
-                                \note-by-number                           %! BLUE
-                                    #2                                    %! BLUE
-                                    #0                                    %! BLUE
-                                    #1                                    %! BLUE
-                        \upright                                          %! BLUE
-                            {                                             %! BLUE
-                                =                                         %! BLUE
-                                90                                        %! BLUE
-                            }                                             %! BLUE
-                        \hspace                                           %! BLUE
-                            #1                                            %! BLUE
-                        }                                                 %! BLUE
+                    \markup { %! BLUE
+                        \fontsize %! BLUE
+                            #-6 %! BLUE
+                            \general-align %! BLUE
+                                #Y %! BLUE
+                                #DOWN %! BLUE
+                                \note-by-number %! BLUE
+                                    #2 %! BLUE
+                                    #0 %! BLUE
+                                    #1 %! BLUE
+                        \upright %! BLUE
+                            { %! BLUE
+                                = %! BLUE
+                                90 %! BLUE
+                            } %! BLUE
+                        \hspace %! BLUE
+                            #1 %! BLUE
+                        } %! BLUE
                     \once \override TextSpanner.bound-details.right-broken.padding = 0
                     \once \override TextSpanner.bound-details.right-broken.text = ##f
                     \once \override TextSpanner.bound-details.right.padding = 1
@@ -3380,25 +3484,25 @@ class MetronomeMarkSpanner(Spanner):
                     e'4.
                     \stopTextSpan
                     \startTextSpan
-                %@% \once \override TextSpanner.bound-details.left.text =     %! YELLOW
-                %@% \markup {                                                 %! YELLOW
-                %@%     \fontsize                                             %! YELLOW
-                %@%         #-6                                               %! YELLOW
-                %@%         \general-align                                    %! YELLOW
-                %@%             #Y                                            %! YELLOW
-                %@%             #DOWN                                         %! YELLOW
-                %@%             \note-by-number                               %! YELLOW
-                %@%                 #2                                        %! YELLOW
-                %@%                 #0                                        %! YELLOW
-                %@%                 #1                                        %! YELLOW
-                %@%     \upright                                              %! YELLOW
-                %@%         {                                                 %! YELLOW
-                %@%             =                                             %! YELLOW
-                %@%             72                                            %! YELLOW
-                %@%         }                                                 %! YELLOW
-                %@%     \hspace                                               %! YELLOW
-                %@%         #1                                                %! YELLOW
-                %@%     }                                                     %! YELLOW
+                %@% \once \override TextSpanner.bound-details.left.text = %! YELLOW
+                %@% \markup { %! YELLOW
+                %@%     \fontsize %! YELLOW
+                %@%         #-6 %! YELLOW
+                %@%         \general-align %! YELLOW
+                %@%             #Y %! YELLOW
+                %@%             #DOWN %! YELLOW
+                %@%             \note-by-number %! YELLOW
+                %@%                 #2 %! YELLOW
+                %@%                 #0 %! YELLOW
+                %@%                 #1 %! YELLOW
+                %@%     \upright %! YELLOW
+                %@%         { %! YELLOW
+                %@%             = %! YELLOW
+                %@%             72 %! YELLOW
+                %@%         } %! YELLOW
+                %@%     \hspace %! YELLOW
+                %@%         #1 %! YELLOW
+                %@%     } %! YELLOW
                     \once \override TextSpanner.Y-extent = ##f
                     \once \override TextSpanner.bound-details.left-broken.text = ##f
                     \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center

--- a/abjad/tools/spannertools/MultipartBeam.py
+++ b/abjad/tools/spannertools/MultipartBeam.py
@@ -17,9 +17,12 @@ class MultipartBeam(Beam):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8 [
                 d'8 ]
                 e'4
@@ -39,9 +42,12 @@ class MultipartBeam(Beam):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8
                 r8
                 d'8
@@ -168,9 +174,12 @@ class MultipartBeam(Beam):
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8 [
                 d'8 ]
                 r8
@@ -194,9 +203,12 @@ class MultipartBeam(Beam):
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8 [
                 d'8
                 r8
@@ -220,9 +232,12 @@ class MultipartBeam(Beam):
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8 [
                 d'8
                 r4.
@@ -246,9 +261,12 @@ class MultipartBeam(Beam):
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 autoBeaming = ##f
-            } {
+            }
+            {
                 c'8 [
                 d'8
                 s4.
@@ -291,9 +309,12 @@ class MultipartBeam(Beam):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new RhythmicStaff \with {
+                \new RhythmicStaff
+                \with
+                {
                     \override Beam.positions = #'(4.5 . 4.5)
-                } {
+                }
+                {
                     \override RhythmicStaff.Stem.stemlet-length = 1.5
                     c'16 [
                     r16

--- a/abjad/tools/spannertools/OctavationSpanner.py
+++ b/abjad/tools/spannertools/OctavationSpanner.py
@@ -16,7 +16,8 @@ class OctavationSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \ottava #1
                 c'4
                 d'4
@@ -37,7 +38,8 @@ class OctavationSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \ottava #1
                 c'4
                 \ottava #0
@@ -115,7 +117,7 @@ class OctavationSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(measure)
-                    { % measure
+                    {   % measure
                         \time 4/8
                         \ottava #1
                         c'''8
@@ -123,7 +125,7 @@ class OctavationSpanner(Spanner):
                         ef'''8
                         f'''8
                         \ottava #0
-                    } % measure
+                    }   % measure
 
         Adjusts start and stop according to the diatonic pitch number of
         the maximum pitch in spanner.

--- a/abjad/tools/spannertools/PhrasingSlur.py
+++ b/abjad/tools/spannertools/PhrasingSlur.py
@@ -16,7 +16,8 @@ class PhrasingSlur(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'8 \(
                 d'8
                 e'8
@@ -100,7 +101,8 @@ class PhrasingSlur(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 ^ \(
                     d'8
                     e'8
@@ -119,7 +121,8 @@ class PhrasingSlur(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 _ \(
                     d'8
                     e'8
@@ -138,7 +141,8 @@ class PhrasingSlur(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 \(
                     d'8
                     e'8

--- a/abjad/tools/spannertools/PianoPedalSpanner.py
+++ b/abjad/tools/spannertools/PianoPedalSpanner.py
@@ -14,7 +14,8 @@ class PianoPedalSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \set Staff.pedalSustainStyle = #'mixed
                 c'8 \sustainOn
                 d'8
@@ -122,7 +123,8 @@ class PianoPedalSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.pedalSustainStyle = #'mixed
                     c'8 \sustainOn
                     d'8
@@ -145,7 +147,8 @@ class PianoPedalSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.pedalSustainStyle = #'mixed
                     c'8 \sostenutoOn
                     d'8
@@ -168,7 +171,8 @@ class PianoPedalSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.pedalSustainStyle = #'mixed
                     c'8 \unaCorda
                     d'8
@@ -199,7 +203,8 @@ class PianoPedalSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.pedalSustainStyle = #'mixed
                     c'8 \sustainOn
                     d'8
@@ -222,7 +227,8 @@ class PianoPedalSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.pedalSustainStyle = #'bracket
                     c'8 \sustainOn
                     d'8
@@ -245,7 +251,8 @@ class PianoPedalSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \set Staff.pedalSustainStyle = #'text
                     c'8 \sustainOn
                     d'8

--- a/abjad/tools/spannertools/Slur.py
+++ b/abjad/tools/spannertools/Slur.py
@@ -15,7 +15,8 @@ class Slur(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4 (
                 d'4
                 e'4
@@ -98,12 +99,13 @@ class Slur(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 ^ (
                     d'8
                     e'8
                     f'8 )
-                    }
+                }
 
         ..  container:: example
 
@@ -117,7 +119,8 @@ class Slur(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 _ (
                     d'8
                     e'8
@@ -136,7 +139,8 @@ class Slur(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 (
                     d'8
                     e'8

--- a/abjad/tools/spannertools/StaffLinesSpanner.py
+++ b/abjad/tools/spannertools/StaffLinesSpanner.py
@@ -14,7 +14,8 @@ class StaffLinesSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'8
                 \stopStaff
                 \once \override Staff.StaffSymbol.line-count = 1
@@ -121,7 +122,8 @@ class StaffLinesSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \stopStaff
                 \once \override Staff.StaffSymbol.line-count = 1
                 \startStaff

--- a/abjad/tools/spannertools/StemTremoloSpanner.py
+++ b/abjad/tools/spannertools/StemTremoloSpanner.py
@@ -10,7 +10,8 @@ class StemTremoloSpanner(Spanner):
         >>> tremolo_spanner = abjad.StemTremoloSpanner()
         >>> abjad.attach(tremolo_spanner, staff[:])
         >>> abjad.f(staff)
-        \new Staff {
+        \new Staff
+        {
             c'32 :256
             d'16. :128
             e'8 :64

--- a/abjad/tools/spannertools/TextSpanner.py
+++ b/abjad/tools/spannertools/TextSpanner.py
@@ -16,9 +16,12 @@ class TextSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TextSpanner.staff-padding = #2.5
-            } {
+            }
+            {
                 \once \override TextSpanner.Y-extent = ##f
                 \once \override TextSpanner.bound-details.left-broken.text = ##f
                 \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -52,9 +55,12 @@ class TextSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TextSpanner.staff-padding = #2.5
-            } {
+            }
+            {
                 \once \override TextSpanner.Y-extent = ##f
                 \once \override TextSpanner.bound-details.left-broken.text = ##f
                 \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -89,9 +95,12 @@ class TextSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TextSpanner.staff-padding = #2.5
-            } {
+            }
+            {
                 \once \override TextSpanner.Y-extent = ##f
                 \once \override TextSpanner.bound-details.left-broken.text = ##f
                 \once \override TextSpanner.bound-details.left.stencil-align-dir-y = #center
@@ -136,9 +145,12 @@ class TextSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TextSpanner.staff-padding = #2.5
-            } {
+            }
+            {
                 \once \override TextSpanner.Y-extent = ##f
                 \once \override TextSpanner.arrow-width = 0.25
                 \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -192,9 +204,12 @@ class TextSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TextSpanner.staff-padding = #2.5
-            } {
+            }
+            {
                 \once \override TextSpanner.Y-extent = ##f
                 \once \override TextSpanner.arrow-width = 0.25
                 \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -284,9 +299,12 @@ class TextSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TextSpanner.staff-padding = #2.5
-            } {
+            }
+            {
                 \once \override TextSpanner.Y-extent = ##f
                 \once \override TextSpanner.arrow-width = 0.25
                 \once \override TextSpanner.bound-details.left-broken.text = ##f
@@ -379,10 +397,13 @@ class TextSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff \with {
+            \new Staff
+            \with
+            {
                 \override TextScript.staff-padding = #5
                 \override TextSpanner.staff-padding = #2.5
-            } {
+            }
+            {
                 \once \override TextScript.color = #blue
                 \once \override TextSpanner.Y-extent = ##f
                 \once \override TextSpanner.arrow-width = 0.25
@@ -600,7 +621,8 @@ class TextSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \override TextSpanner.bound-details.left.stencil-align-dir-y = #0
                     \override TextSpanner.bound-details.left.text = \markup {
                         \bold

--- a/abjad/tools/spannertools/Tie.py
+++ b/abjad/tools/spannertools/Tie.py
@@ -17,7 +17,8 @@ class Tie(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4 ~
                 c'4 ~
                 c'4 ~
@@ -35,7 +36,8 @@ class Tie(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4 ~
                 c'4 ~
                 c'4 ~
@@ -54,7 +56,8 @@ class Tie(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 <c'>4 ~
                 <c' d'>4 ~
                 <d'>4
@@ -68,19 +71,21 @@ class Tie(Spanner):
         >>> segment_1 = abjad.Voice("c'4 d' e' f'", name='MainVoice')
         >>> abjad.attach(abjad.Tie(), segment_1[-1:], right_broken=True)
         >>> abjad.f(segment_1, strict=True)
-        \context Voice = "MainVoice" {
+        \context Voice = "MainVoice"
+        {
             c'4
             d'4
             e'4
             f'4
-        %@% ~     %! RIGHT_BROKEN_TIE
+        %@% ~ %! RIGHT_BROKEN_TIE
         }
 
         >>> abjad.show(segment_1) # doctest: +SKIP
 
         >>> segment_2 = abjad.Voice("f'4 e' d' c'", name='MainVoice')
         >>> abjad.f(segment_2, strict=True)
-        \context Voice = "MainVoice" {
+        \context Voice = "MainVoice"
+        {
             f'4
             e'4
             d'4
@@ -92,14 +97,16 @@ class Tie(Spanner):
         >>> container = abjad.Container([segment_1, segment_2])
         >>> abjad.f(container, strict=True)
         {
-            \context Voice = "MainVoice" {
+            \context Voice = "MainVoice"
+            {
                 c'4
                 d'4
                 e'4
                 f'4
-            %@% ~     %! RIGHT_BROKEN_TIE
+            %@% ~ %! RIGHT_BROKEN_TIE
             }
-            \context Voice = "MainVoice" {
+            \context Voice = "MainVoice"
+            {
                 f'4
                 e'4
                 d'4
@@ -114,14 +121,16 @@ class Tie(Spanner):
         >>> text, count = abjad.activate(text, abjad.tags.RIGHT_BROKEN_TIE)
         >>> print(text)
         {
-            \context Voice = "MainVoice" {
+            \context Voice = "MainVoice"
+            {
                 c'4
                 d'4
                 e'4
                 f'4
                 ~     %! RIGHT_BROKEN_TIE %@%
             }
-            \context Voice = "MainVoice" {
+            \context Voice = "MainVoice"
+            {
                 f'4
                 e'4
                 d'4
@@ -144,9 +153,10 @@ class Tie(Spanner):
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> abjad.f(staff, strict=True)
-        \new Staff {
+        \new Staff
+        {
             c'4
-        %@% \repeatTie     %! LEFT_BROKEN_REPEAT_TIE
+        %@% \repeatTie %! LEFT_BROKEN_REPEAT_TIE
             c'4
             \repeatTie
             c'4
@@ -308,7 +318,8 @@ class Tie(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 ^ ~
                     c'8 ^ ~
                     c'8 ^ ~
@@ -330,7 +341,8 @@ class Tie(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 _ ~
                     c'8 _ ~
                     c'8 _ ~
@@ -352,7 +364,8 @@ class Tie(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8 ~
                     c'8 ~
                     c'8 ~
@@ -384,7 +397,8 @@ class Tie(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     c'8 ^ \repeatTie
                     c'8 ^ \repeatTie

--- a/abjad/tools/spannertools/TrillSpanner.py
+++ b/abjad/tools/spannertools/TrillSpanner.py
@@ -16,8 +16,10 @@ class TrillSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
-                c'8 \startTrillSpan
+            \new Staff
+            {
+                c'8
+                \startTrillSpan
                 d'8
                 e'8
                 f'8 \stopTrillSpan
@@ -35,9 +37,11 @@ class TrillSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 \pitchedTrill
-                c'8 \startTrillSpan cs'
+                c'8
+                \startTrillSpan cs'
                 d'8
                 e'8
                 f'8 \stopTrillSpan
@@ -64,7 +68,8 @@ class TrillSpanner(Spanner):
         >>> segment_1 = abjad.Voice("c'4 d' e' f'", name='MainVoice')
         >>> abjad.attach(abjad.TrillSpanner(), segment_1[:], right_broken=True)
         >>> abjad.f(segment_1, strict=True)
-        \context Voice = "MainVoice" {
+        \context Voice = "MainVoice"
+        {
             c'4
             \startTrillSpan
             d'4
@@ -78,7 +83,8 @@ class TrillSpanner(Spanner):
         >>> segment_2 = abjad.Voice("g'4 f'2 r4", name='MainVoice')
         >>> abjad.attach(abjad.TrillSpanner(), segment_2[:], left_broken=True)
         >>> abjad.f(segment_2, strict=True)
-        \context Voice = "MainVoice" {
+        \context Voice = "MainVoice"
+        {
             g'4
             \startTrillSpan %! LEFT_BROKEN_TRILL
             f'2
@@ -91,7 +97,8 @@ class TrillSpanner(Spanner):
         >>> container = abjad.Container([segment_1, segment_2])
         >>> abjad.f(container, strict=True)
         {
-            \context Voice = "MainVoice" {
+            \context Voice = "MainVoice"
+            {
                 c'4
                 \startTrillSpan
                 d'4
@@ -99,7 +106,8 @@ class TrillSpanner(Spanner):
                 f'4
                 \stopTrillSpan %! RIGHT_BROKEN_TRILL
             }
-            \context Voice = "MainVoice" {
+            \context Voice = "MainVoice"
+            {
                 g'4
                 \startTrillSpan %! LEFT_BROKEN_TRILL
                 f'2
@@ -119,7 +127,8 @@ class TrillSpanner(Spanner):
         >>> text, count = abjad.deactivate(text, match)
         >>> print(text)
         {
-            \context Voice = "MainVoice" {
+            \context Voice = "MainVoice"
+            {
                 c'4
                 \startTrillSpan
                 d'4
@@ -127,7 +136,8 @@ class TrillSpanner(Spanner):
                 f'4
             %%% \stopTrillSpan %! RIGHT_BROKEN_TRILL
             }
-            \context Voice = "MainVoice" {
+            \context Voice = "MainVoice"
+            {
                 g'4
             %%% \startTrillSpan %! LEFT_BROKEN_TRILL
                 f'2
@@ -155,7 +165,8 @@ class TrillSpanner(Spanner):
         ..  docs::
 
             >>> abjad.f(staff, strict=True)
-            \new Staff {
+            \new Staff
+            {
                 \pitchedTrill
                 c'4
                 ^ \markup { Allegro }
@@ -298,9 +309,11 @@ class TrillSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \pitchedTrill
-                    c'8 \startTrillSpan df'
+                    c'8
+                    \startTrillSpan df'
                     d'8
                     e'8
                     f'8 \stopTrillSpan
@@ -320,9 +333,11 @@ class TrillSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \pitchedTrill
-                    c'8 \startTrillSpan d'
+                    c'8
+                    \startTrillSpan d'
                     d'8
                     e'8
                     f'8 \stopTrillSpan
@@ -356,10 +371,12 @@ class TrillSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     \once \override TrillPitchHead.stencil = #(lambda (grob) (grob-interpret-markup grob #{ \markup \musicglyph #"noteheads.s0harmonic" #}))
                     \pitchedTrill
-                    c'8 \startTrillSpan d'
+                    c'8
+                    \startTrillSpan d'
                     d'8
                     e'8
                     f'8 \stopTrillSpan
@@ -390,8 +407,11 @@ class TrillSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    \pitchedTrill c'8 \startTrillSpan cs'
+                \new Staff
+                {
+                    \pitchedTrill
+                    c'8
+                    \startTrillSpan cs'
                     d'8 \stopTrillSpan
                     e'8
                     f'8
@@ -412,8 +432,10 @@ class TrillSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    c'8 \startTrillSpan
+                \new Staff
+                {
+                    c'8
+                    \startTrillSpan
                     d'8 \stopTrillSpan
                     e'8
                     f'8
@@ -449,8 +471,11 @@ class TrillSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    \pitchedTrill c'8 \startTrillSpan cs'
+                \new Staff
+                {
+                    \pitchedTrill
+                    c'8
+                    \startTrillSpan cs'
                     d'8 \stopTrillSpan
                     e'8
                     f'8
@@ -471,8 +496,10 @@ class TrillSpanner(Spanner):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
-                    c'8 \startTrillSpan
+                \new Staff
+                {
+                    c'8
+                    \startTrillSpan
                     d'8 \stopTrillSpan
                     e'8
                     f'8

--- a/abjad/tools/spannertools/test/test_spannertools_Beam___init__.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Beam___init__.py
@@ -10,7 +10,8 @@ def test_spannertools_Beam___init___01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             e'8
@@ -60,7 +61,8 @@ def test_spannertools_Beam___init___03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 c'8
@@ -91,7 +93,8 @@ def test_spannertools_Beam___init___04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 c'8
@@ -118,7 +121,8 @@ def test_spannertools_Beam___init___05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 c'8
@@ -146,7 +150,8 @@ def test_spannertools_Beam___init___06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
             }
             {
@@ -175,7 +180,8 @@ def test_spannertools_Beam___init___07():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 {
                     c'8 [
@@ -210,7 +216,8 @@ def test_spannertools_Beam___init___08():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 {
                     {
@@ -245,7 +252,8 @@ def test_spannertools_Beam___init___09():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 cs'8
@@ -273,7 +281,8 @@ def test_spannertools_Beam___init___10():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             \times 2/3 {
                 c'8 [
                 cs'8
@@ -329,14 +338,17 @@ def test_spannertools_Beam___init___12():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \new Voice {
+        \new Staff
+        {
+            \new Voice
+            {
                 c'8
                 cs'8
                 d'8
             }
             ef'8
-            \new Voice {
+            \new Voice
+            {
                 e'8
                 f'8
                 fs'8
@@ -364,14 +376,17 @@ def test_spannertools_Beam___init___13():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \context Voice = "foo" {
+        \new Staff
+        {
+            \context Voice = "foo"
+            {
                 c'8 [
                 cs'8
                 d'8
                 ef'8
             }
-            \context Voice = "foo" {
+            \context Voice = "foo"
+            {
                 e'8
                 f'8
                 fs'8
@@ -390,13 +405,15 @@ def test_spannertools_Beam___init___14():
 
     container = abjad.Container(r'''
         <<
-            \context Voice = "first" {
+            \context Voice = "first"
+            {
                 c'8
                 cs'8
                 d'8
                 ef'8
             }
-            \context Voice = "second" {
+            \context Voice = "second"
+            {
                 e'8
                 f'8
                 fs'8
@@ -404,13 +421,15 @@ def test_spannertools_Beam___init___14():
             }
         >>
         <<
-            \context Voice = "second" {
+            \context Voice = "second"
+            {
                 af'8
                 a'8
                 bf'8
                 b'8
             }
-            \context Voice = "first" {
+            \context Voice = "first"
+            {
                 c''8
                 cs''8
                 d''8
@@ -426,13 +445,15 @@ def test_spannertools_Beam___init___14():
         r'''
         {
             <<
-                \context Voice = "first" {
+                \context Voice = "first"
+                {
                     c'8 [
                     cs'8
                     d'8
                     ef'8
                 }
-                \context Voice = "second" {
+                \context Voice = "second"
+                {
                     e'8
                     f'8
                     fs'8
@@ -440,13 +461,15 @@ def test_spannertools_Beam___init___14():
                 }
             >>
             <<
-                \context Voice = "second" {
+                \context Voice = "second"
+                {
                     af'8
                     a'8
                     bf'8
                     b'8
                 }
-                \context Voice = "first" {
+                \context Voice = "first"
+                {
                     c''8
                     cs''8
                     d''8
@@ -497,13 +520,15 @@ def test_spannertools_Beam___init___15():
         r'''
         {
             <<
-                \context Voice = "first" {
+                \context Voice = "first"
+                {
                     c'8 [
                     cs'8
                     d'8
                     ef'8
                 }
-                \context Voice = "second" {
+                \context Voice = "second"
+                {
                     e'8
                     f'8
                     fs'8
@@ -511,7 +536,8 @@ def test_spannertools_Beam___init___15():
                 }
             >>
             <<
-                \context Voice = "first" {
+                \context Voice = "first"
+                {
                     af'8
                     a'8
                     bf'8
@@ -554,13 +580,15 @@ def test_spannertools_Beam___init___16():
     assert format(container) == abjad.String.normalize(
         r'''
         <<
-            \new Voice {
+            \new Voice
+            {
                 c'8 [
                 cs'8
                 d'8
                 ef'8 ]
             }
-            \new Voice {
+            \new Voice
+            {
                 e'8
                 f'8
                 fs'8
@@ -603,17 +631,20 @@ def test_spannertools_Beam___init___17():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             cs'8
             <<
-                \new Voice {
+                \new Voice
+                {
                     d'8
                     ef'8
                     e'8
                     f'8
                 }
-                \new Voice {
+                \new Voice
+                {
                     fs'8
                     g'8
                     af'8
@@ -671,28 +702,33 @@ def test_spannertools_Beam___init___18():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \context Voice = "foo" {
+        \new Staff
+        {
+            \context Voice = "foo"
+            {
                 c'8 [
                 cs'8
                 d'8
                 ef'8
             }
             <<
-                \context Voice = "foo" {
+                \context Voice = "foo"
+                {
                     e'8
                     f'8
                     fs'8
                     g'8
                 }
-                \context Voice = "bar" {
+                \context Voice = "bar"
+                {
                     af'8
                     a'8
                     bf'8
                     b'8
                 }
             >>
-            \context Voice = "foo" {
+            \context Voice = "foo"
+            {
                 c''8
                 cs''8
                 d''8
@@ -715,14 +751,17 @@ def test_spannertools_Beam___init___19():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            \context Voice = "foo" {
+        \new Staff
+        {
+            \context Voice = "foo"
+            {
                 c'8
                 cs'8
                 d'8
                 ef'8
             }
-            \context Voice = "bar" {
+            \context Voice = "bar"
+            {
                 e'8
                 f'8
                 fs'8

--- a/abjad/tools/spannertools/test/test_spannertools_Beam__fracture.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Beam__fracture.py
@@ -14,7 +14,8 @@ def test_spannertools_Beam__fracture_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             e'8
@@ -39,7 +40,8 @@ def test_spannertools_Beam__fracture_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ ]
             d'8 [
             e'8
@@ -68,7 +70,8 @@ def test_spannertools_Beam__fracture_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             e'8
@@ -93,7 +96,8 @@ def test_spannertools_Beam__fracture_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8 ]
             e'8 [
@@ -120,7 +124,8 @@ def test_spannertools_Beam__fracture_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             cs'8 ]
             d'8 [ ]
@@ -147,7 +152,8 @@ def test_spannertools_Beam__fracture_06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ ]
             cs'8 [
             d'8
@@ -174,7 +180,8 @@ def test_spannertools_Beam__fracture_07():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             cs'8
             d'8
@@ -201,7 +208,8 @@ def test_spannertools_Beam__fracture_08():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             cs'8
             d'8
@@ -255,7 +263,8 @@ def test_spannertools_Beam__fracture_09():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             {
                 c'8 [
                 cs'8

--- a/abjad/tools/spannertools/test/test_spannertools_Beam__fuse_by_reference.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Beam__fuse_by_reference.py
@@ -14,7 +14,8 @@ def test_spannertools_Beam__fuse_by_reference_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             d'8
             e'8

--- a/abjad/tools/spannertools/test/test_spannertools_Beam_detach.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Beam_detach.py
@@ -11,7 +11,8 @@ def test_spannertools_Beam_detach_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [ ]
             cs'8
             d'8
@@ -28,7 +29,8 @@ def test_spannertools_Beam_detach_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             cs'8
             d'8
@@ -54,7 +56,8 @@ def test_spannertools_Beam_detach_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 [
             cs'8
             d'8
@@ -71,7 +74,8 @@ def test_spannertools_Beam_detach_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             cs'8
             d'8

--- a/abjad/tools/spannertools/test/test_spannertools_Beam_direction.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Beam_direction.py
@@ -9,7 +9,8 @@ def test_spannertools_Beam_direction_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 ^ [
             d'8
             e'8
@@ -28,7 +29,8 @@ def test_spannertools_Beam_direction_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 _ [
             d'8
             e'8
@@ -47,7 +49,8 @@ def test_spannertools_Beam_direction_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 - [
             d'8
             e'8

--- a/abjad/tools/spannertools/test/test_spannertools_ComplexBeam_direction.py
+++ b/abjad/tools/spannertools/test/test_spannertools_ComplexBeam_direction.py
@@ -9,7 +9,8 @@ def test_spannertools_ComplexBeam_direction_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set stemLeftBeamCount = 0
             \set stemRightBeamCount = 2
             c'16 ^ [
@@ -34,7 +35,8 @@ def test_spannertools_ComplexBeam_direction_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set stemLeftBeamCount = 0
             \set stemRightBeamCount = 2
             c'16 _ [

--- a/abjad/tools/spannertools/test/test_spannertools_Glissando.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Glissando.py
@@ -9,7 +9,8 @@ def test_spannertools_Glissando_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 \glissando
             cs'8 \glissando
             d'8 \glissando

--- a/abjad/tools/spannertools/test/test_spannertools_HiddenStaffSpanner___init__.py
+++ b/abjad/tools/spannertools/test/test_spannertools_HiddenStaffSpanner___init__.py
@@ -18,20 +18,21 @@ def test_spannertools_HiddenStaffSpanner___init___02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -41,22 +42,23 @@ def test_spannertools_HiddenStaffSpanner___init___02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \stopStaff
                 e'8
                 f'8
                 \startStaff
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'8
                 a'8
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/spannertools/test/test_spannertools_MeasuredComplexBeam.py
+++ b/abjad/tools/spannertools/test/test_spannertools_MeasuredComplexBeam.py
@@ -8,20 +8,21 @@ def test_spannertools_MeasuredComplexBeam_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/16
                 c'16
                 d'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'16
                 f'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'16
                 a'16
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -32,8 +33,9 @@ def test_spannertools_MeasuredComplexBeam_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/16
                 \set stemLeftBeamCount = 0
                 \set stemRightBeamCount = 2
@@ -41,23 +43,23 @@ def test_spannertools_MeasuredComplexBeam_01():
                 \set stemLeftBeamCount = 2
                 \set stemRightBeamCount = 1
                 d'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \set stemLeftBeamCount = 1
                 \set stemRightBeamCount = 2
                 e'16
                 \set stemLeftBeamCount = 2
                 \set stemRightBeamCount = 1
                 f'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \set stemLeftBeamCount = 1
                 \set stemRightBeamCount = 2
                 g'16
                 \set stemLeftBeamCount = 2
                 \set stemRightBeamCount = 0
                 a'16 ]
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/spannertools/test/test_spannertools_MeasuredComplexBeam_direction.py
+++ b/abjad/tools/spannertools/test/test_spannertools_MeasuredComplexBeam_direction.py
@@ -10,20 +10,21 @@ def test_spannertools_MeasuredComplexBeam_direction_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/16
                 c'16
                 d'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'16
                 f'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 g'16
                 a'16
-            } % measure
+            }   % measure
         }
         '''
         )
@@ -34,8 +35,9 @@ def test_spannertools_MeasuredComplexBeam_direction_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/16
                 \set stemLeftBeamCount = 0
                 \set stemRightBeamCount = 2
@@ -43,23 +45,23 @@ def test_spannertools_MeasuredComplexBeam_direction_01():
                 \set stemLeftBeamCount = 2
                 \set stemRightBeamCount = 1
                 d'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \set stemLeftBeamCount = 1
                 \set stemRightBeamCount = 2
                 e'16
                 \set stemLeftBeamCount = 2
                 \set stemRightBeamCount = 1
                 f'16
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 \set stemLeftBeamCount = 1
                 \set stemRightBeamCount = 2
                 g'16
                 \set stemLeftBeamCount = 2
                 \set stemRightBeamCount = 0
                 a'16 ]
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/spannertools/test/test_spannertools_OctavationSpanner.py
+++ b/abjad/tools/spannertools/test/test_spannertools_OctavationSpanner.py
@@ -14,7 +14,8 @@ def test_spannertools_OctavationSpanner_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \ottava #1
             c'8
             c'8
@@ -36,7 +37,8 @@ def test_spannertools_OctavationSpanner_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \ottava #1
             c'8
             cs'8
@@ -62,7 +64,8 @@ def test_spannertools_OctavationSpanner_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \ottava #1
             c'8
             cs'8
@@ -94,7 +97,8 @@ def test_spannertools_OctavationSpanner_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \ottava #1
             c'8
             \ottava #0
@@ -126,7 +130,8 @@ def test_spannertools_OctavationSpanner_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \ottava #1
             c'8
             cs'8

--- a/abjad/tools/spannertools/test/test_spannertools_PhrasingSlur___init__.py
+++ b/abjad/tools/spannertools/test/test_spannertools_PhrasingSlur___init__.py
@@ -17,7 +17,8 @@ def test_spannertools_PhrasingSlur___init___02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 \(
             d'8
             e'8

--- a/abjad/tools/spannertools/test/test_spannertools_PhrasingSlur_direction.py
+++ b/abjad/tools/spannertools/test/test_spannertools_PhrasingSlur_direction.py
@@ -9,7 +9,8 @@ def test_spannertools_PhrasingSlur_direction_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 ^ \(
             d'8
             e'8
@@ -29,7 +30,8 @@ def test_spannertools_PhrasingSlur_direction_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8 _ \(
             d'8
             e'8

--- a/abjad/tools/spannertools/test/test_spannertools_PianoPedalSpanner.py
+++ b/abjad/tools/spannertools/test/test_spannertools_PianoPedalSpanner.py
@@ -10,7 +10,8 @@ def test_spannertools_PianoPedalSpanner_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set Staff.pedalSustainStyle = #'mixed
             c'8 \sustainOn
             c'8
@@ -35,7 +36,8 @@ def test_spannertools_PianoPedalSpanner_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set Staff.pedalSustainStyle = #'mixed
             c'8 \sostenutoOn
             c'8
@@ -58,7 +60,8 @@ def test_spannertools_PianoPedalSpanner_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set Staff.pedalSustainStyle = #'mixed
             c'8 \unaCorda
             c'8
@@ -84,7 +87,8 @@ def test_spannertools_PianoPedalSpanner_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set Staff.pedalSustainStyle = #'text
             c'8 \sustainOn
             c'8
@@ -110,7 +114,8 @@ def test_spannertools_PianoPedalSpanner_05():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set Staff.pedalSustainStyle = #'bracket
             c'8 \sustainOn
             c'8
@@ -135,7 +140,8 @@ def test_spannertools_PianoPedalSpanner_06():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \set Staff.pedalSustainStyle = #'mixed
             c'8 \sustainOn
             c'8

--- a/abjad/tools/spannertools/test/test_spannertools_Slur___init__.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Slur___init__.py
@@ -54,28 +54,34 @@ def test_spannertools_Slur___init___02():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \context Staff = "foo" <<
-                \context Voice = "first" {
+            \context Staff = "foo"
+            <<
+                \context Voice = "first"
+                {
                     c'8 (
                     cs'8
                     d'8
                     ef'8
                 }
-                \context Voice = "second" {
+                \context Voice = "second"
+                {
                     e'8
                     f'8
                     fs'8
                     g'8
                 }
             >>
-            \context Staff = "foo" <<
-                \context Voice = "first" {
+            \context Staff = "foo"
+            <<
+                \context Voice = "first"
+                {
                     af'8
                     a'8
                     bf'8
                     b'8 )
                 }
-                \context Voice = "second" {
+                \context Voice = "second"
+                {
                     c''8
                     cs''8
                     d''8
@@ -122,16 +128,20 @@ def test_spannertools_Slur___init___03():
     assert format(container) == abjad.String.normalize(
         r'''
         {
-            \context Staff = "foo" {
-                \context Voice = "bar" {
+            \context Staff = "foo"
+            {
+                \context Voice = "bar"
+                {
                     c'8 (
                     cs'8
                     d'8
                     ef'8
                 }
             }
-            \context Staff = "foo" {
-                \context Voice = "bar" {
+            \context Staff = "foo"
+            {
+                \context Voice = "bar"
+                {
                     e'8
                     f'8
                     fs'8

--- a/abjad/tools/spannertools/test/test_spannertools_Spanner___getitem__.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Spanner___getitem__.py
@@ -12,7 +12,8 @@ def test_spannertools_Spanner___getitem___01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8
@@ -43,7 +44,8 @@ def test_spannertools_Spanner___getitem___02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8
@@ -74,7 +76,8 @@ def test_spannertools_Spanner___getitem___03():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8
@@ -105,7 +108,8 @@ def test_spannertools_Spanner___getitem___04():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8

--- a/abjad/tools/spannertools/test/test_spannertools_Spanner___in__.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Spanner___in__.py
@@ -11,7 +11,8 @@ def test_spannertools_Spanner___in___01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8

--- a/abjad/tools/spannertools/test/test_spannertools_Spanner___len__.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Spanner___len__.py
@@ -11,7 +11,8 @@ def test_spannertools_Spanner___len___01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8
@@ -42,7 +43,8 @@ def test_spannertools_Spanner___len___02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8

--- a/abjad/tools/spannertools/test/test_spannertools_Spanner__append.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Spanner__append.py
@@ -11,7 +11,8 @@ def test_spannertools_Spanner__append_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8
@@ -33,7 +34,8 @@ def test_spannertools_Spanner__append_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8
@@ -61,7 +63,8 @@ def test_spannertools_Spanner__append_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8
@@ -82,7 +85,8 @@ def test_spannertools_Spanner__append_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8

--- a/abjad/tools/spannertools/test/test_spannertools_Spanner__append_left.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Spanner__append_left.py
@@ -14,7 +14,8 @@ def test_spannertools_Spanner__append_left_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8
@@ -46,7 +47,8 @@ def test_spannertools_Spanner__append_left_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8 [

--- a/abjad/tools/spannertools/test/test_spannertools_Spanner__get_my_nth_leaf.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Spanner__get_my_nth_leaf.py
@@ -13,16 +13,17 @@ def test_spannertools_Spanner__get_my_nth_leaf_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
-            { % measure
+        \new Staff
+        {
+            {   % measure
                 \time 2/8
                 c'8 [
                 d'8
-            } % measure
-            { % measure
+            }   % measure
+            {   % measure
                 e'8
                 f'8 ]
-            } % measure
+            }   % measure
         }
         '''
         )

--- a/abjad/tools/spannertools/test/test_spannertools_Spanner__remove.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Spanner__remove.py
@@ -16,7 +16,8 @@ def test_spannertools_Spanner__remove_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8
@@ -31,7 +32,8 @@ def test_spannertools_Spanner__remove_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8
             e'8
@@ -58,7 +60,8 @@ def test_spannertools_Spanner__remove_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8
@@ -80,7 +83,8 @@ def test_spannertools_Spanner__remove_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8

--- a/abjad/tools/spannertools/test/test_spannertools_Spanner_extend.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Spanner_extend.py
@@ -13,7 +13,8 @@ def test_spannertools_Spanner_extend_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8
@@ -45,7 +46,8 @@ def test_spannertools_Spanner_extend_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8

--- a/abjad/tools/spannertools/test/test_spannertools_Spanner_extend_left.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Spanner_extend_left.py
@@ -13,7 +13,8 @@ def test_spannertools_Spanner_extend_left_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8 [
                 d'8

--- a/abjad/tools/spannertools/test/test_spannertools_Spanner_format.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Spanner_format.py
@@ -17,7 +17,8 @@ def test_spannertools_Spanner_format_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             d'8
             e'8

--- a/abjad/tools/spannertools/test/test_spannertools_Spanner_insert.py
+++ b/abjad/tools/spannertools/test/test_spannertools_Spanner_insert.py
@@ -15,7 +15,8 @@ def test_spannertools_Spanner_insert_01():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             c'8 [
             d'8 ]
             e'8
@@ -41,7 +42,8 @@ def test_spannertools_Spanner_insert_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8
@@ -62,7 +64,8 @@ def test_spannertools_Spanner_insert_02():
 
     assert format(voice) == abjad.String.normalize(
         r'''
-        \new Voice {
+        \new Voice
+        {
             {
                 c'8
                 d'8 [

--- a/abjad/tools/spannertools/test/test_spannertools_StaffLinesSpanner_format.py
+++ b/abjad/tools/spannertools/test/test_spannertools_StaffLinesSpanner_format.py
@@ -13,7 +13,8 @@ def test_spannertools_StaffLinesSpanner_format_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             d'8
             \stopStaff
@@ -45,7 +46,8 @@ def test_spannertools_StaffLinesSpanner_format_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             d'8
             \stopStaff
@@ -72,7 +74,8 @@ def test_spannertools_StaffLinesSpanner_format_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             \stopStaff
             \once \override Staff.StaffSymbol.line-positions = #'(-1.5 0 1.5)

--- a/abjad/tools/spannertools/test/test_spannertools_TextSpanner_position.py
+++ b/abjad/tools/spannertools/test/test_spannertools_TextSpanner_position.py
@@ -11,7 +11,8 @@ def test_spannertools_TextSpanner_position_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \textSpannerNeutral
             c'8 \startTextSpan
             c'8
@@ -32,7 +33,8 @@ def test_spannertools_TextSpanner_position_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \textSpannerUp
             c'8 \startTextSpan
             c'8
@@ -53,7 +55,8 @@ def test_spannertools_TextSpanner_position_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \textSpannerDown
             c'8 \startTextSpan
             c'8

--- a/abjad/tools/spannertools/test/test_spannertools_TrillSpanner_pitch.py
+++ b/abjad/tools/spannertools/test/test_spannertools_TrillSpanner_pitch.py
@@ -11,7 +11,8 @@ def test_spannertools_TrillSpanner_pitch_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             \pitchedTrill
             c'8
             \startTrillSpan cs'
@@ -35,7 +36,8 @@ def test_spannertools_TrillSpanner_pitch_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             \startTrillSpan
             d'8 \stopTrillSpan

--- a/abjad/tools/systemtools/test/test_systemtools_AbjadConfiguration_set_default_accidental_spelling.py
+++ b/abjad/tools/systemtools/test/test_systemtools_AbjadConfiguration_set_default_accidental_spelling.py
@@ -8,7 +8,8 @@ def test_systemtools_AbjadConfiguration_set_default_accidental_spelling_01():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             cs'8
             d'8
@@ -33,7 +34,8 @@ def test_systemtools_AbjadConfiguration_set_default_accidental_spelling_02():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             cs'8
             d'8
@@ -60,7 +62,8 @@ def test_systemtools_AbjadConfiguration_set_default_accidental_spelling_03():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             df'8
             d'8
@@ -89,7 +92,8 @@ def test_systemtools_AbjadConfiguration_set_default_accidental_spelling_04():
 
     assert format(staff) == abjad.String.normalize(
         r'''
-        \new Staff {
+        \new Staff
+        {
             c'8
             cs'8
             d'8

--- a/abjad/tools/timespantools/TimespanTimespanTimeRelation.py
+++ b/abjad/tools/timespantools/TimespanTimespanTimeRelation.py
@@ -16,8 +16,10 @@ class TimespanTimespanTimeRelation(TimeRelation):
         ..  docs::
 
             >>> abjad.f(score)
-            \new Score <<
-                \new Staff {
+            \new Score
+            <<
+                \new Staff
+                {
                     \times 2/3 {
                         c'4
                         d'4
@@ -29,7 +31,8 @@ class TimespanTimespanTimeRelation(TimeRelation):
                         a'4
                     }
                 }
-                \new Staff {
+                \new Staff
+                {
                     c'2.
                     d'4
                 }

--- a/abjad/tools/tonalanalysistools/Scale.py
+++ b/abjad/tools/tonalanalysistools/Scale.py
@@ -280,7 +280,8 @@ class Scale(PitchClassSegment):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     d'8
                     e'8
@@ -312,10 +313,14 @@ class Scale(PitchClassSegment):
             ..  docs::
 
                 >>> abjad.f(score)
-                \new Score \with {
+                \new Score
+                \with
+                {
                     tempoWholesPerMinute = #(ly:make-moment 30 1)
-                } <<
-                    \new Staff {
+                }
+                <<
+                    \new Staff
+                    {
                         \key e \major
                         e'8
                         fs'8

--- a/abjad/tools/tonalanalysistools/TonalAnalysis.py
+++ b/abjad/tools/tonalanalysistools/TonalAnalysis.py
@@ -16,7 +16,8 @@ class TonalAnalysis(abctools.AbjadObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4
                 d'4
                 e'4
@@ -35,7 +36,8 @@ class TonalAnalysis(abctools.AbjadObject):
         ..  docs::
 
             >>> abjad.f(staff)
-            \new Staff {
+            \new Staff
+            {
                 c'4
                 d'4
                 e'4
@@ -274,7 +276,8 @@ class TonalAnalysis(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     <c' e' g'>4
                     <e' g' c''>4
                     <g' c'' e''>4
@@ -302,7 +305,8 @@ class TonalAnalysis(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     <a' c'' e''>4
                     <c'' e'' a''>4
                     <e'' a'' c'''>4
@@ -331,7 +335,8 @@ class TonalAnalysis(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     <c' e' g' bf'>4
                     <e' g' bf' c''>4
                     <g' bf' c'' e''>4
@@ -363,7 +368,8 @@ class TonalAnalysis(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     <c' e' g' bf' d''>4
                     <e' g' bf' c'' d''>4
                     <g' bf' c'' d'' e''>4
@@ -481,7 +487,8 @@ class TonalAnalysis(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     d'8
                     e'8
@@ -512,7 +519,8 @@ class TonalAnalysis(abctools.AbjadObject):
             ..  docs::
 
                 >>> abjad.f(staff)
-                \new Staff {
+                \new Staff
+                {
                     c'8
                     d'8
                     e'8

--- a/abjad/tools/topleveltools/test/test_topleveltools_setting.py
+++ b/abjad/tools/topleveltools/test/test_topleveltools_setting.py
@@ -13,10 +13,14 @@ def test_topleveltools_setting_01():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score \with {
+        \new Score
+        \with
+        {
             tempoWholesPerMinute = #(ly:make-moment 24 1)
-        } <<
-            \new Staff {
+        }
+        <<
+            \new Staff
+            {
                 c'8
                 d'8
                 e'8
@@ -41,8 +45,10 @@ def test_topleveltools_setting_02():
 
     assert format(score) == abjad.String.normalize(
         r'''
-        \new Score <<
-            \new Staff {
+        \new Score
+        <<
+            \new Staff
+            {
                 c'8
                 \set Score.tempoWholesPerMinute = #(ly:make-moment 24 1)
                 d'8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ ipython
 jupyter
 ply
 pytest
+roman
 six
 sphinx
 sphinx-rtd-theme


### PR DESCRIPTION
Context open-statement formatting is now strictly one-per-line.

OLD:

    \new Score \with {
        \override BarLine.stencil = ##f
        \override BarNumber.transparent = ##t
        \override SpanBar.stencil = ##f
        \override TimeSignature.stencil = ##f
    } <<
        \new PianoStaff <<
            \context Staff = "Treble Staff" {
                \clef "treble"
                r16
                r16
                r16
                r16
                r16
                c'16
                d'16
                e'16
                f'16
                g'16
            }
            \context Staff = "Bass Staff" {
                \clef "bass"
                c16
                d16
                e16
                f16
                g16
                r16
                r16
                r16
                r16
                r16
            }
        >>
    >>

NEW:

    \new Score
    \with
    {
        \override BarLine.stencil = ##f
        \override BarNumber.transparent = ##t
        \override SpanBar.stencil = ##f
        \override TimeSignature.stencil = ##f
    }
    <<
        \new PianoStaff
        <<
            \context Staff = "Treble Staff"
            {
                \clef "treble"
                r16
                r16
                r16
                r16
                r16
                c'16
                d'16
                e'16
                f'16
                g'16
            }
            \context Staff = "Bass Staff"
            {
                \clef "bass"
                c16
                d16
                e16
                f16
                g16
                r16
                r16
                r16
                r16
                r16
            }
        >>
    >>

MODEL. Note that this makes lexical postprocessing incredibly easy. Any chunk
of anything can be parsed out of Abjad's LilyPond output *as a sequence of
consecutive lines*. Target application might be anything from assignment to
variables (for externalization in complex scores) or tagging parts of LilyPond
files on and off.

NEW. Added abjad.Container.identifier property. Use to set parse handles on any
Abjad container:

    >>> container = abjad.Container("c'4 d' e' f'")
    >>> container.identifier = '%*% AB'

    >>> abjad.f(container)
    {   %*% AB
        c'4
        d'4
        e'4
        f'4
    }   %*% AB

NEW: added abjad.String.base_26():

    Use for alpha-only LilyPond identifiers (including rehearsal marks):

    >>> abjad.String.base_26(1)
    'A'

    >>> abjad.String.base_26(2)
    'B'

    >>> abjad.String.base_26(3)
    'C'

    >>> abjad.String.base_26(26)
    'Z'

    >>> abjad.String.base_26(27)
    'AA'

    >>> abjad.String.base_26(28)
    'AB'

    >>> abjad.String.base_26(52)
    'AZ'

    >>> abjad.String.base_26(53)
    'BA'

    >>> abjad.String.base_26(54)
    'BB'

    >>> abjad.String.base_26(78)
    'BZ'

    >>> abjad.String.base_26(79)
    'CA'

    >>> abjad.String.base_26(80)
    'CB'

NEW: added abjad.String.to_segment_lilypond_identifier().

    >>> abjad.String('_').to_segment_lilypond_identifier()
    'i'

    >>> abjad.String('_1').to_segment_lilypond_identifier()
    'i_a'

    >>> abjad.String('_2').to_segment_lilypond_identifier()
    'i_b'

    >>> abjad.String('A').to_segment_lilypond_identifier()
    'A'

    >>> abjad.String('A1').to_segment_lilypond_identifier()
    'A_a'

    >>> abjad.String('A2').to_segment_lilypond_identifier()
    'A_b'

    >>> abjad.String('B').to_segment_lilypond_identifier()
    'B'

    >>> abjad.String('B1').to_segment_lilypond_identifier()
    'B_a'

    >>> abjad.String('B2').to_segment_lilypond_identifier()
    'B_b'

    >>> abjad.String('AA').to_segment_lilypond_identifier()
    'AA'

    >>> abjad.String('AA1').to_segment_lilypond_identifier()
    'AA_a'

    >>> abjad.String('AA2').to_segment_lilypond_identifier()
    'AA_b'

NEW. Added Vim @r macro to renumber to-do lists.

DEPENDENCIES. Added roman package to Abjad dependencies.