### PR TITLE
3.0 FEATURE SET 13: textual dynamics, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,35 @@
-*.py[cod]
-
 # C extensions
 *.so
+
+# Emacs
+*~
+\#*\#
+
+# Installer logs
+pip-log.txt
+
+# IPython
+.ipynb_checkpoints
+
+# LaTeX intermediate files
+*.synctex.gz
+
+# Misc.
+*.bak
+*.pkl
+.cache
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+/.settings
+
+# MyPy
+.mypy_cache
+
+# OS X
+.DS_Store
 
 # Packages
 *.egg
@@ -20,36 +48,22 @@ lib
 lib64
 __pycache__
 
-# Installer logs
-pip-log.txt
+# Pycharm
+.idea/
+
+# Pytest
+.pytest_cache
+
+# Python
+*.py[cod]
+
+# Translations
+*.mo
 
 # Unit test / coverage reports
 .coverage
 .tox
 nosetests.xml
-
-# Translations
-*.mo
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-/.settings
-
-# LaTeX intermediate files
-*.synctex.gz
-
-# Misc.
-*.bak
-*.pkl
-.cache
-
-# OS X
-.DS_Store
-
-# IPython
-.ipynb_checkpoints
 
 # Virtual Environments
 venv/
@@ -57,15 +71,3 @@ Envs/
 ENV/
 .virtualenvs
 .python-version
-
-# IDE's and Text Editors
-
-# Pycharm
-.idea/
-
-# Emacs
-*~
-\#*\#
-
-# MyPy
-.mypy_cache

--- a/abjad/boilerplate/__make_layout_ly__.py
+++ b/abjad/boilerplate/__make_layout_ly__.py
@@ -49,12 +49,17 @@ if __name__ == '__main__':
             string = 'first_measure_number'
             first_measure_number = buildspace_directory.get_metadatum(string)
             if not bool(first_measure_number):
-                raise Exception('can not find first measure number ...')
+                print('Can not find first measure number ...')
+                first_measure_number = False
             assert isinstance(first_measure_number, int)
         else:
             first_measure_number = 1
     except:
         traceback.print_exc()
+        sys.exit(1)
+
+    if first_measure_number is False:
+        print('Skipping layout ...')
         sys.exit(1)
         
     try:

--- a/abjad/boilerplate/part-preface.tex
+++ b/abjad/boilerplate/part-preface.tex
@@ -1,12 +1,10 @@
 \documentclass[10pt]{{article}}
+\usepackage[T1]{{fontenc}}
+\usepackage[margin=1in, papersize={paper_size}]{{geometry}}
 \usepackage[utf8]{{inputenc}}
-\usepackage[papersize={paper_size}]{{geometry}}
-\usepackage{{nopageno}}
-\usepackage{{tabu}}
-\usepackage{{xltxtra,fontspec,xunicode}}
+\usepackage{{fontspec, nopageno, xltxtra, xunicode}}
 \parindent=0pt
 \parskip=12pt
-\tabulinesep=1.0mm
 \setmainfont{{Palatino}}
 \begin{{document}}
 

--- a/abjad/boilerplate/score-preface.tex
+++ b/abjad/boilerplate/score-preface.tex
@@ -1,12 +1,10 @@
 \documentclass[10pt]{{article}}
+\usepackage[T1]{{fontenc}}
+\usepackage[margin=1in, papersize={paper_size}]{{geometry}}
 \usepackage[utf8]{{inputenc}}
-\usepackage[papersize={paper_size}]{{geometry}}
-\usepackage{{nopageno}}
-\usepackage{{tabu}}
-\usepackage{{xltxtra,fontspec,xunicode}}
+\usepackage{{fontspec, nopageno, xltxtra, xunicode}}
 \parindent=0pt
 \parskip=12pt
-\tabulinesep=1.0mm
 \setmainfont{{Palatino}}
 \begin{{document}}
 

--- a/abjad/docs/source/_stylesheets/default.ly
+++ b/abjad/docs/source/_stylesheets/default.ly
@@ -12,33 +12,44 @@
     \context {
         \Score
         \remove Bar_number_engraver
+
         \override Beam.beam-thickness = 0.75
         \override Beam.breakable = ##t
         \override Beam.length-fraction = 1.5
+
         \override Glissando.breakable = ##t
         \override Glissando.thickness = 2
+
         \override NoteCollision.merge-differently-dotted = ##t
         \override NoteCollision.merge-differently-headed = ##t
+
         \override NoteColumn.ignore-collision = ##t
+
         \override SpacingSpanner.uniform-stretching = ##t
+
         \override StaffSymbol.color = #(x11-color 'grey50)
         \override StaffSymbol.layer = -1
+
         \override TextScript.outside-staff-padding = 1
+
         \override TimeSignature.style = #'numbered
+
         \override TupletBracket.bracket-visibility = ##t
         \override TupletBracket.breakable = ##t
         \override TupletBracket.minimum-length = 3
         \override TupletBracket.outside-staff-padding = 1.5
-        \override TupletBracket.padding = 1.5
+        \override TupletBracket.padding = 1.25
         \override TupletBracket.springs-and-rods = #ly:spanner::set-spacing-rods
-        \override TupletBracket.staff-padding = 2.25
+
         \override TupletNumber.text = #tuplet-number::calc-fraction-text
+
         \override VerticalAxisGroup.staff-staff-spacing = #'(
             (basic-distance . 8)
             (minimum-distance . 14)
             (padding . 4)
             (stretchability . 0)
             )
+
         proportionalNotationDuration = #(ly:make-moment 1 20)
         tupletFullLength = ##t
     }

--- a/abjad/tools/datastructuretools/Expression.py
+++ b/abjad/tools/datastructuretools/Expression.py
@@ -2,7 +2,7 @@ import inspect
 import itertools
 import numbers
 from typing import List  # noqa
-from abjad.tools import systemtools
+from abjad.tools.systemtools.Signature import Signature
 from abjad.tools.abctools.AbjadValueObject import AbjadValueObject
 
 
@@ -201,7 +201,7 @@ class Expression(AbjadValueObject):
 
     ### SPECIAL METHODS ###
 
-    @systemtools.Signature(
+    @Signature(
         markup_maker_callback='_make_expression_add_markup',
         )
     def __add__(self, i):

--- a/abjad/tools/datastructuretools/Offset.py
+++ b/abjad/tools/datastructuretools/Offset.py
@@ -1,9 +1,8 @@
-from abjad.tools import systemtools
 from .Duration import Duration
 
 
 class Offset(Duration):
-    '''Offset.
+    r'''Offset.
 
     ..  container:: example
 
@@ -595,6 +594,8 @@ class Offset(Duration):
     ### PRIVATE METHODS ###
 
     def _get_format_specification(self):
+        from abjad.tools.systemtools.FormatSpecification import \
+            FormatSpecification
         is_indented = False
         names = []
         values = [self.numerator, self.denominator]
@@ -602,7 +603,7 @@ class Offset(Duration):
             is_indented = True
             names = ['grace_displacement']
             values = [(self.numerator, self.denominator)]
-        return systemtools.FormatSpecification(
+        return FormatSpecification(
             client=self,
             repr_is_indented=is_indented,
             storage_format_args_values=values,

--- a/abjad/tools/datastructuretools/OrderedDict.py
+++ b/abjad/tools/datastructuretools/OrderedDict.py
@@ -1,5 +1,4 @@
 import collections
-from abjad.tools import systemtools
 from abjad.tools.datastructuretools.TypedCollection import TypedCollection
 
 
@@ -208,6 +207,7 @@ class OrderedDict(TypedCollection, collections.MutableMapping):
     ### PRIVATE METHODS ###
 
     def _get_format_specification(self):
+        from abjad.tools import systemtools
         agent = systemtools.StorageFormatManager(self)
         names = list(agent.signature_keyword_names)
         if 'items' in names:

--- a/abjad/tools/datastructuretools/OrdinalConstant.py
+++ b/abjad/tools/datastructuretools/OrdinalConstant.py
@@ -1,5 +1,4 @@
 import functools
-from abjad.tools import systemtools
 from abjad.tools.abctools.AbjadValueObject import AbjadValueObject
 
 
@@ -130,12 +129,13 @@ class OrdinalConstant(AbjadValueObject):
 
     # can only compare like-dimensioned ordinal constants
     def _check_comparator(self, argument):
-        if not isinstance(argument, type(self)) or \
-            self._dimension != argument._dimension:
+        if (not isinstance(argument, type(self)) or
+            self._dimension != argument._dimension):
             message = 'can only compare like-dimensioned ordinal constants.'
             raise Exception(message)
 
     def _get_format_specification(self):
+        from abjad.tools import systemtools
         storage_format_text = repr_text = self._representation or None
         return systemtools.FormatSpecification(
             client=self,

--- a/abjad/tools/datastructuretools/Sequence.py
+++ b/abjad/tools/datastructuretools/Sequence.py
@@ -5,9 +5,9 @@ import math
 import numbers
 import sys
 from abjad.tools import abctools
-from abjad.tools import systemtools
 from abjad.tools import mathtools
 from abjad.tools.datastructuretools import Exact
+from abjad.tools.systemtools.Signature import Signature
 
 
 class Sequence(abctools.AbjadValueObject, collections.Sequence):
@@ -87,7 +87,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
 
     ### SPECIAL METHODS ###
 
-    @systemtools.Signature(
+    @Signature(
         markup_maker_callback='_make___add___markup',
         string_template_callback='_make___add___string_template',
         )
@@ -329,7 +329,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
         superclass = super(Sequence, self)
         return superclass.__format__(format_specification=format_specification)
 
-    @systemtools.Signature(
+    @Signature(
         markup_maker_callback='_make___getitem___markup',
         string_template_callback='_make___getitem___string_template',
         )
@@ -581,7 +581,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
         '''
         return len(self._items)
 
-    @systemtools.Signature(
+    @Signature(
         markup_maker_callback='_make___radd___markup',
         string_template_callback='_make___radd___string_template',
         )
@@ -1052,7 +1052,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
 
     ### PUBLIC METHODS ###
 
-    @systemtools.Signature()
+    @Signature()
     def filter(self, predicate=None):
         r'''Filters sequence by `predicate`.
 
@@ -1133,7 +1133,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
         return type(self)(items)
 
     # TODO: remove indices=None parameter
-    @systemtools.Signature()
+    @Signature()
     def flatten(self, classes=None, depth=1, indices=None):
         r'''Flattens sequence.
 
@@ -1634,7 +1634,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
         except TypeError:
             return False
 
-    @systemtools.Signature()
+    @Signature()
     def join(self):
         r'''Join subsequences in `sequence`.
 
@@ -1690,7 +1690,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
         cumulative_sum = abjad.mathtools.cumulative_sums(self, start=None)[-1]
         return type(self)([cumulative_sum])
 
-    @systemtools.Signature(
+    @Signature(
         markup_maker_callback='_make_map_markup',
         string_template_callback='_make_map_string_template',
         )
@@ -1974,7 +1974,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
                     yield type(self)(item_buffer)
                     item_buffer.pop(0)
 
-    @systemtools.Signature(
+    @Signature(
         argument_list_callback='_make_partition_indicator',
         method_name='partition',
         )
@@ -3331,7 +3331,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
             result = result_
         return type(self)(result)
 
-    @systemtools.Signature(
+    @Signature(
         argument_list_callback='_make_partition_ratio_indicator',
         method_name='partition',
         )
@@ -3872,7 +3872,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
             message = message.format(allow_part_weights)
             raise ValueError(message)
 
-    @systemtools.Signature()
+    @Signature()
     def permute(self, permutation):
         r'''Permutes sequence by `permutation`.
 
@@ -4038,7 +4038,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
                 items.append(item)
         return type(self)(items)
 
-    @systemtools.Signature()
+    @Signature()
     def repeat(self, n=1):
         r'''Repeats sequence.
 
@@ -4495,7 +4495,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
                 items.append(item)
         return type(self)(items=items)
 
-    @systemtools.Signature(
+    @Signature(
         is_operator=True,
         method_name_callback='_make_reverse_method_name',
         )
@@ -4605,7 +4605,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
         items = _reverse_helper(self.items)
         return type(self)(items=items)
 
-    @systemtools.Signature(
+    @Signature(
         is_operator=True,
         method_name='r',
         subscript='n',
@@ -4773,7 +4773,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
         items.sort(key=key, reverse=reverse)
         return type(self)(items=items)
 
-    @systemtools.Signature(
+    @Signature(
         argument_list_callback='_make_split_indicator',
         )
     def split(self, weights, cyclic=False, overhang=False):
@@ -4912,7 +4912,7 @@ class Sequence(abctools.AbjadValueObject, collections.Sequence):
                 result.append(last_piece)
         return type(self)(items=result)
 
-    @systemtools.Signature()
+    @Signature()
     def sum(self):
         r'''Sums sequence.
 

--- a/abjad/tools/datastructuretools/String.py
+++ b/abjad/tools/datastructuretools/String.py
@@ -7,8 +7,8 @@ import textwrap
 import typing
 import unicodedata
 from abjad.tools import mathtools
-from abjad.tools.datastructuretools.OrdinalConstant import OrdinalConstant
-from abjad.tools.datastructuretools.TypedList import TypedList
+from .OrdinalConstant import OrdinalConstant
+from .TypedList import TypedList
 
 
 class String(str):
@@ -1765,7 +1765,7 @@ class String(str):
     @staticmethod
     def to_tridirectional_lilypond_symbol(
         argument: typing.Any,
-        ) -> typing.Union[None, OrdinalConstant, 'String']:
+        ) -> typing.Optional['String']:
         r'''Changes `argument` to tridirectional LilyPond symbol.
 
         ..  container:: example

--- a/abjad/tools/datastructuretools/TreeContainer.py
+++ b/abjad/tools/datastructuretools/TreeContainer.py
@@ -1,5 +1,4 @@
-from abjad.tools import systemtools
-from abjad.tools.datastructuretools.TreeNode import TreeNode
+from .TreeNode import TreeNode
 
 
 class TreeContainer(TreeNode):
@@ -299,6 +298,7 @@ class TreeContainer(TreeNode):
     ### PRIVATE METHODS ###
 
     def _get_format_specification(self):
+        from abjad.tools import systemtools
         agent = systemtools.StorageFormatManager(self)
         names = list(agent.signature_keyword_names)
         template_names = names[:]

--- a/abjad/tools/datastructuretools/TreeNode.py
+++ b/abjad/tools/datastructuretools/TreeNode.py
@@ -1,5 +1,4 @@
 import copy
-from abjad.tools import systemtools
 from abjad.tools.abctools.AbjadObject import AbjadObject
 
 
@@ -28,7 +27,7 @@ class TreeNode(AbjadObject):
     def __copy__(self):
         r'''Copies tree node.
         '''
-        import copy
+        from abjad.tools import systemtools
         agent = systemtools.StorageFormatManager(self)
         arguments = []
         for value in agent.get_template_dict().values():
@@ -54,6 +53,7 @@ class TreeNode(AbjadObject):
         return name_dictionary
 
     def _get_format_specification(self):
+        from abjad.tools import systemtools
         agent = systemtools.StorageFormatManager(self)
         names = agent.signature_names
         return systemtools.FormatSpecification(

--- a/abjad/tools/datastructuretools/TypedCollection.py
+++ b/abjad/tools/datastructuretools/TypedCollection.py
@@ -1,5 +1,4 @@
 import abc
-from abjad.tools import systemtools
 from abjad.tools.abctools.AbjadObject import AbjadObject
 
 
@@ -91,6 +90,7 @@ class TypedCollection(AbjadObject):
     ### PRIVATE METHODS ###
 
     def _get_format_specification(self):
+        from abjad.tools import systemtools
         agent = systemtools.StorageFormatManager(self)
         names = list(agent.signature_keyword_names)
         if 'items' in names:

--- a/abjad/tools/datastructuretools/TypedCounter.py
+++ b/abjad/tools/datastructuretools/TypedCounter.py
@@ -1,6 +1,5 @@
 import collections
-from abjad.tools import systemtools
-from abjad.tools.datastructuretools.TypedCollection import TypedCollection
+from .TypedCollection import TypedCollection
 
 
 class TypedCounter(TypedCollection, collections.MutableMapping):
@@ -163,6 +162,7 @@ class TypedCounter(TypedCollection, collections.MutableMapping):
         return the_items, itemdict
 
     def _get_format_specification(self):
+        from abjad.tools import systemtools
         agent = systemtools.StorageFormatManager(self)
         names = list(agent.signature_keyword_names)
         if 'items' in names:

--- a/abjad/tools/datastructuretools/TypedFrozenset.py
+++ b/abjad/tools/datastructuretools/TypedFrozenset.py
@@ -1,5 +1,5 @@
 import collections
-from abjad.tools.datastructuretools.TypedCollection import TypedCollection
+from .TypedCollection import TypedCollection
 
 
 class TypedFrozenset(TypedCollection, collections.Set):

--- a/abjad/tools/datastructuretools/TypedList.py
+++ b/abjad/tools/datastructuretools/TypedList.py
@@ -1,6 +1,5 @@
 import collections
-from abjad.tools import systemtools
-from abjad.tools.datastructuretools.TypedCollection import TypedCollection
+from .TypedCollection import TypedCollection
 
 
 class TypedList(TypedCollection, collections.MutableSequence):
@@ -204,6 +203,7 @@ class TypedList(TypedCollection, collections.MutableSequence):
     ### PRIVATE METHODS ###
 
     def _get_format_specification(self):
+        from abjad.tools import systemtools
         agent = systemtools.StorageFormatManager(self)
         names = list(agent.signature_keyword_names)
         if 'items' in names:

--- a/abjad/tools/datastructuretools/TypedTuple.py
+++ b/abjad/tools/datastructuretools/TypedTuple.py
@@ -1,6 +1,6 @@
 import collections
-from abjad.tools.datastructuretools.TypedCollection import TypedCollection
-from abjad.tools.topleveltools import new
+from abjad.tools.topleveltools.new import new
+from .TypedCollection import TypedCollection
 
 
 class TypedTuple(TypedCollection, collections.Sequence):

--- a/abjad/tools/datastructuretools/test/test_datastructuretools_Duration__group_by_implied_prolation.py
+++ b/abjad/tools/datastructuretools/test/test_datastructuretools_Duration__group_by_implied_prolation.py
@@ -1,5 +1,5 @@
-import pytest
 import abjad
+import pytest
 
 
 def test_datastructuretools_Duration__group_by_implied_prolation_01():

--- a/abjad/tools/datastructuretools/test/test_datastructuretools_TreeContainer_name.py
+++ b/abjad/tools/datastructuretools/test/test_datastructuretools_TreeContainer_name.py
@@ -1,5 +1,5 @@
-import pytest
 import abjad
+import pytest
 
 
 def test_datastructuretools_TreeContainer_name_01():

--- a/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict___copy__.py
+++ b/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict___copy__.py
@@ -1,5 +1,5 @@
-import copy
 import abjad
+import copy
 
 
 def test_datastructuretools_OrderedDict___copy___01():

--- a/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict___deepcopy__.py
+++ b/abjad/tools/datastructuretools/test/test_datastructuretools_TypedOrderedDict___deepcopy__.py
@@ -1,5 +1,5 @@
-import copy
 import abjad
+import copy
 
 
 def test_datastructuretools_OrderedDict___deepcopy___01():

--- a/abjad/tools/indicatortools/LineSegment.py
+++ b/abjad/tools/indicatortools/LineSegment.py
@@ -37,6 +37,7 @@ class LineSegment(AbjadValueObject):
         '_right_broken_text',
         '_right_padding',
         '_right_stencil_align_direction_y',
+        '_right_text',
         '_style',
         )
 
@@ -60,6 +61,7 @@ class LineSegment(AbjadValueObject):
         right_broken_text=None,
         right_padding=None,
         right_stencil_align_direction_y=None,
+        right_text=None,
         style=None,
         ):
         self._arrow_width = arrow_width
@@ -76,6 +78,7 @@ class LineSegment(AbjadValueObject):
         self._right_broken_text = right_broken_text
         self._right_padding = right_padding
         self._right_stencil_align_direction_y = right_stencil_align_direction_y
+        self._right_text = right_text
         self._style = style
 
     ### PRIVATE METHODS ###
@@ -233,6 +236,18 @@ class LineSegment(AbjadValueObject):
                 value=self.right_stencil_align_direction_y,
                 )
             overrides.append(override.override_string)
+        if self.right_text is not None:
+            override = abjad.LilyPondGrobOverride(
+                grob_name='TextSpanner',
+                once=True,
+                property_path=(
+                    'bound-details',
+                    'right',
+                    'text',
+                    ),
+                value=self.right_text,
+                )
+            overrides.append(override.override_string)
         if self.style is not None:
             style = abjad.Scheme(self.style, quoting="'")
             override = abjad.LilyPondGrobOverride(
@@ -361,6 +376,14 @@ class LineSegment(AbjadValueObject):
         Returns float or none.
         '''
         return self._right_stencil_align_direction_y
+
+    @property
+    def right_text(self):
+        r'''Gets right text.
+
+        Returns markup or none.
+        '''
+        return self._right_text
 
     @property
     def style(self):

--- a/abjad/tools/indicatortools/MarginMarkup.py
+++ b/abjad/tools/indicatortools/MarginMarkup.py
@@ -33,8 +33,6 @@ class MarginMarkup(AbjadValueObject):
 
     ### CLASS VARIABLES ###
 
-    __documentation_section__ = '(5) Utilities'
-
     __slots__ = (
         '_context',
         '_format_slot',

--- a/abjad/tools/indicatortools/StartMarkup.py
+++ b/abjad/tools/indicatortools/StartMarkup.py
@@ -29,8 +29,6 @@ class StartMarkup(AbjadValueObject):
 
     ### CLASS VARIABLES ###
 
-    __documentation_section__ = '(5) Utilities'
-
     __slots__ = (
         '_context',
         '_format_slot',

--- a/abjad/tools/mathtools/Ratio.py
+++ b/abjad/tools/mathtools/Ratio.py
@@ -193,3 +193,22 @@ class Ratio(NonreducedRatio):
         Returns tuple of two or more numbers.
         '''
         return self._numbers
+
+    @property
+    def reciprocal(self):
+        r'''Gets reciprocal.
+
+        ..  container:: example
+
+            Gets reciprocal:
+
+            >>> abjad.Ratio((3, 2)).reciprocal
+            Ratio((2, 3))
+
+            >>> abjad.Ratio((3, 2, 7)).reciprocal
+            Ratio((7, 2, 3))
+
+        Returns new ratio.
+        '''
+        numbers = list(reversed(self.numbers))
+        return type(self)(numbers)

--- a/abjad/tools/pitchtools/NamedPitch.py
+++ b/abjad/tools/pitchtools/NamedPitch.py
@@ -126,6 +126,68 @@ class NamedPitch(Pitch):
                 cs''1 * 1/4
             }
 
+    ..  container:: example
+
+        REGRESSION. Small floats just less than a C initialize in the correct
+        octave.
+
+        Initializes c / C3:
+
+        >>> pitch = abjad.NamedPitch(-12.1)
+        >>> abjad.show(pitch) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> staff = pitch.__illustrate__()[abjad.Staff]
+            >>> abjad.f(staff)
+            \new Staff
+            \with
+            {
+                \override TimeSignature.stencil = ##f
+            }
+            {
+                \clef "bass"
+                c1 * 1/4
+            }
+
+        Initializes c' / C4:
+
+        >>> pitch = abjad.NamedPitch(-0.1)
+        >>> abjad.show(pitch) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> staff = pitch.__illustrate__()[abjad.Staff]
+            >>> abjad.f(staff)
+            \new Staff
+            \with
+            {
+                \override TimeSignature.stencil = ##f
+            }
+            {
+                \clef "treble"
+                c'1 * 1/4
+            }
+
+        Initializes c'' / C5:
+
+        >>> pitch = abjad.NamedPitch(11.9)
+        >>> abjad.show(pitch) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> staff = pitch.__illustrate__()[abjad.Staff]
+            >>> abjad.f(staff)
+            \new Staff
+            \with
+            {
+                \override TimeSignature.stencil = ##f
+            }
+            {
+                \clef "treble"
+                c''1 * 1/4
+            }
+
     '''
 
     ### CLASS VARIABLES ###
@@ -156,6 +218,10 @@ class NamedPitch(Pitch):
             number = getattr(name, 'number', name)
             named_pitch_class = abjad.NamedPitchClass(number)
             octave = number // 12 + 4
+            if named_pitch_class == 'c':
+                rounded = 12 * (octave - 4) + named_pitch_class.number
+                if 0.5 <= abs(number - rounded):
+                    octave += 1
             name = named_pitch_class.name + abjad.Octave(octave).ticks
         elif isinstance(name, abjad.Note):
             name = name.written_pitch.name
@@ -639,8 +705,12 @@ class NamedPitch(Pitch):
             >>> abjad.NamedPitch.from_hertz(440)
             NamedPitch("a'")
 
+        ..  container:: example
+
+            REGRESSION. Returns c'' (C5) and not c' (C4):
+
             >>> abjad.NamedPitch.from_hertz(519)
-            NamedPitch("c'")
+            NamedPitch("c''")
 
         Returns newly constructed named pitch.
         '''
@@ -724,7 +794,6 @@ class NamedPitch(Pitch):
 
         ..  container:: example
 
-
             >>> abjad.NamedPitch.from_pitch_number(13, 'b')
             NamedPitch("bss'")
             >>> abjad.NamedPitch.from_pitch_number(13, 'c')
@@ -733,7 +802,6 @@ class NamedPitch(Pitch):
             NamedPitch("df''")
 
         ..  container:: example
-
 
             >>> abjad.NamedPitch.from_pitch_number(14, 'c')
             NamedPitch("css''")

--- a/abjad/tools/pitchtools/NumberedPitch.py
+++ b/abjad/tools/pitchtools/NumberedPitch.py
@@ -405,8 +405,12 @@ class NumberedPitch(Pitch):
             >>> abjad.NumberedPitch.from_hertz(440)
             NumberedPitch(9)
 
+        ..  container:: example
+
+            REGRESSION. Returns 12 (not 0):
+
             >>> abjad.NumberedPitch.from_hertz(519)
-            NumberedPitch(0)
+            NumberedPitch(12)
 
         Returns newly constructed numbered pitch.
         '''

--- a/abjad/tools/rhythmmakertools/EvenDivisionRhythmMaker.py
+++ b/abjad/tools/rhythmmakertools/EvenDivisionRhythmMaker.py
@@ -2538,7 +2538,157 @@ class EvenDivisionRhythmMaker(RhythmMaker):
     def tuplet_specifier(self):
         r'''Gets tuplet specifier.
 
-        ..  note:: not yet implemented.
+        ..  container:: example
+
+            No tuplet specifier:
+
+            >>> rhythm_maker = abjad.rhythmmakertools.EvenDivisionRhythmMaker(
+            ...     denominators=[4],
+            ...     extra_counts_per_division=[0, 0, 1],
+            ...     )
+
+            >>> divisions = [(5, 8), (6, 8), (6, 8)]
+            >>> selections = rhythm_maker(divisions)
+            >>> lilypond_file = abjad.LilyPondFile.rhythm(
+            ...     selections,
+            ...     divisions,
+            ...     )
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(lilypond_file[abjad.Staff])
+                \new RhythmicStaff
+                {
+                    {   % measure
+                        \time 5/8
+                        \tweak text #tuplet-number::calc-fraction-text
+                        \times 5/4 {
+                            c'4
+                            c'4
+                        }
+                    }   % measure
+                    {   % measure
+                        \time 6/8
+                        \tweak text #tuplet-number::calc-fraction-text
+                        \times 3/3 {
+                            c'4
+                            c'4
+                            c'4
+                        }
+                    }   % measure
+                    {   % measure
+                        \tweak text #tuplet-number::calc-fraction-text
+                        \times 3/4 {
+                            c'4
+                            c'4
+                            c'4
+                            c'4
+                        }
+                    }   % measure
+                }
+
+        ..  container:: example
+
+            Extracts trivial tuplets:
+
+            >>> rhythm_maker = abjad.rhythmmakertools.EvenDivisionRhythmMaker(
+            ...     denominators=[4],
+            ...     extra_counts_per_division=[0, 0, 1],
+            ...     tuplet_specifier=abjad.rhythmmakertools.TupletSpecifier(
+            ...         extract_trivial=True,
+            ...         ),
+            ...     )
+
+            >>> divisions = [(5, 8), (6, 8), (6, 8)]
+            >>> selections = rhythm_maker(divisions)
+            >>> lilypond_file = abjad.LilyPondFile.rhythm(
+            ...     selections,
+            ...     divisions,
+            ...     )
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(lilypond_file[abjad.Staff])
+                \new RhythmicStaff
+                {
+                    {   % measure
+                        \time 5/8
+                        \tweak text #tuplet-number::calc-fraction-text
+                        \times 5/4 {
+                            c'4
+                            c'4
+                        }
+                    }   % measure
+                    {   % measure
+                        \time 6/8
+                        c'4
+                        c'4
+                        c'4
+                    }   % measure
+                    {   % measure
+                        \tweak text #tuplet-number::calc-fraction-text
+                        \times 3/4 {
+                            c'4
+                            c'4
+                            c'4
+                            c'4
+                        }
+                    }   % measure
+                }
+
+        ..  container:: example
+
+            Extracts trivial tuplets and spells tuplet denominators according
+            to division numerators:
+
+            >>> rhythm_maker = abjad.rhythmmakertools.EvenDivisionRhythmMaker(
+            ...     denominators=[4],
+            ...     extra_counts_per_division=[0, 0, 1],
+            ...     tuplet_specifier=abjad.rhythmmakertools.TupletSpecifier(
+            ...         denominator='divisions',
+            ...         extract_trivial=True,
+            ...         ),
+            ...     )
+
+            >>> divisions = [(5, 8), (6, 8), (6, 8)]
+            >>> selections = rhythm_maker(divisions)
+            >>> lilypond_file = abjad.LilyPondFile.rhythm(
+            ...     selections,
+            ...     divisions,
+            ...     )
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(lilypond_file[abjad.Staff])
+                \new RhythmicStaff
+                {
+                    {   % measure
+                        \time 5/8
+                        \tweak text #tuplet-number::calc-fraction-text
+                        \times 5/4 {
+                            c'4
+                            c'4
+                        }
+                    }   % measure
+                    {   % measure
+                        \time 6/8
+                        c'4
+                        c'4
+                        c'4
+                    }   % measure
+                    {   % measure
+                        \tweak text #tuplet-number::calc-fraction-text
+                        \times 6/8 {
+                            c'4
+                            c'4
+                            c'4
+                            c'4
+                        }
+                    }   % measure
+                }
 
         Returns tuplet specifier or none.
         '''

--- a/abjad/tools/rhythmmakertools/TieSpecifier.py
+++ b/abjad/tools/rhythmmakertools/TieSpecifier.py
@@ -124,7 +124,7 @@ class TieSpecifier(AbjadValueObject):
                 abjad.detach(abjad.Tie, leaf)
             tie = abjad.Tie(repeat=self.repeat_ties)
             tie._unconstrain_contiguity()
-            if tie._attachment_test_all(combined_logical_tie):
+            if tie._attachment_test_all(combined_logical_tie) is True:
                 try:
                     abjad.attach(tie, combined_logical_tie)
                 except:
@@ -156,7 +156,7 @@ class TieSpecifier(AbjadValueObject):
                 if len(subgroup) == 1:
                     continue
                 tie = abjad.Tie()
-                assert tie._attachment_test_all(subgroup)
+                assert tie._attachment_test_all(subgroup) is True
                 abjad.attach(tie, abjad.select(subgroup))
 
     ### PUBLIC PROPERTIES ###

--- a/abjad/tools/scoretools/Note.py
+++ b/abjad/tools/scoretools/Note.py
@@ -1,5 +1,9 @@
 import copy
+from abjad.tools.datastructuretools.Duration import Duration
+from abjad.tools.pitchtools.NamedPitch import NamedPitch
+from .DrumNoteHead import DrumNoteHead
 from .Leaf import Leaf
+from .NoteHead import NoteHead
 
 
 class Note(Leaf):
@@ -8,16 +12,12 @@ class Note(Leaf):
     ..  container:: example
 
         >>> note = abjad.Note("cs''8.")
-        >>> measure = abjad.Measure((3, 16), [note])
-        >>> abjad.show(measure) # doctest: +SKIP
+        >>> abjad.show(note) # doctest: +SKIP
 
         ..  docs::
 
-            >>> abjad.f(measure)
-            {   % measure
-                \time 3/16
-                cs''8.
-            }   % measure
+            >>> abjad.f(note)
+            cs''8.
 
     '''
 
@@ -63,21 +63,21 @@ class Note(Leaf):
             written_pitch, written_duration = arguments
         elif len(arguments) == 0:
             written_pitch = 'C4'
-            written_duration = abjad.Duration(1, 4)
+            written_duration = Duration(1, 4)
         else:
             message = 'can not initialize note from {!r}.'
             raise ValueError(message.format(arguments))
         Leaf.__init__(self, written_duration)
         if written_pitch is not None:
             if written_pitch not in drums:
-                self.note_head = abjad.NoteHead(
+                self.note_head = NoteHead(
                     written_pitch=written_pitch,
                     is_cautionary=is_cautionary,
                     is_forced=is_forced,
                     is_parenthesized=is_parenthesized,
                     )
             else:
-                self.note_head = abjad.DrumNoteHead(
+                self.note_head = DrumNoteHead(
                     written_pitch=written_pitch,
                     is_cautionary=is_cautionary,
                     is_forced=is_forced,
@@ -128,68 +128,81 @@ class Note(Leaf):
             if instrument:
                 sounding_pitch = instrument.middle_c_sounding_pitch
             else:
-                sounding_pitch = abjad.NamedPitch('C4')
-            interval = abjad.NamedPitch('C4') - sounding_pitch
+                sounding_pitch = NamedPitch('C4')
+            interval = NamedPitch('C4') - sounding_pitch
             sounding_pitch = interval.transpose(self.written_pitch)
             return sounding_pitch
 
     ### PUBLIC PROPERTIES ###
 
     @property
-    def note_head(self):
-        r'''Gets and sets note-head of note.
+    def note_head(self) -> NoteHead:
+        r'''Gets and sets note-head.
 
         .. container:: example
 
-            Gets note-head:
-
-            >>> note = abjad.Note(13, (3, 16))
+            >>> note = abjad.Note("cs''8.")
             >>> note.note_head
             NoteHead("cs''")
 
-        ..  container:: example
+            >>> abjad.show(note) # doctest: +SKIP
+            
+            ..  docs::
+            
+                >>> abjad.f(note)
+                cs''8.
+                
+            >>> note.note_head = 'D5'
+            >>> note.note_head
+            NoteHead("d''")
 
-            Sets note-head:
+            >>> abjad.show(note) # doctest: +SKIP
 
-            >>> note = abjad.Note(13, (3, 16))
-            >>> note.note_head = 14
-            >>> note
-            Note("d''8.")
+            ..  docs::
 
-        Returns note-head.
+                >>> abjad.f(note)
+                d''8.
+
         '''
         return self._note_head
 
     @note_head.setter
     def note_head(self, argument):
-        import abjad
         if isinstance(argument, type(None)):
             self._note_head = None
-        elif isinstance(argument, abjad.NoteHead):
+        elif isinstance(argument, NoteHead):
             self._note_head = argument
         else:
-            note_head = abjad.NoteHead(client=self, written_pitch=argument)
+            note_head = NoteHead(client=self, written_pitch=argument)
             self._note_head = note_head
 
     @property
-    def written_duration(self):
-        r'''Gets and sets written duration of note.
+    def written_duration(self) -> Duration:
+        r'''Gets and sets written duration.
 
         ..  container:: example
 
-            Gets written duration of note.
-
-            >>> note = abjad.Note("c'4")
+            >>> note = abjad.Note("cs''8.")
             >>> note.written_duration
-            Duration(1, 4)
+            Duration(3, 16)
 
-        ..  container:: example
+            >>> abjad.show(note) # doctest: +SKIP
 
-            Sets written duration of note:
+            ..  docs::
 
-            >>> note.written_duration = abjad.Duration(1, 16)
+                >>> abjad.f(note)
+                cs''8.
+
+            >>> note.written_duration = (1, 16)
             >>> note.written_duration
             Duration(1, 16)
+
+            >>> abjad.show(note) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(note)
+                cs''16
 
         Returns duration
         '''
@@ -200,40 +213,68 @@ class Note(Leaf):
         return Leaf.written_duration.fset(self, argument)
 
     @property
-    def written_pitch(self):
-        r'''Gets and sets written pitch of note.
+    def written_pitch(self) -> NamedPitch:
+        r'''Gets and sets written pitch.
 
         ..  container:: example
 
-            Gets written pitch of note.
-
-            >>> note = abjad.Note(13, (3, 16))
+            >>> note = abjad.Note("cs''8.")
             >>> note.written_pitch
             NamedPitch("cs''")
 
-        ..  container:: example
+            >>> abjad.show(note) # doctest: +SKIP
 
-            Sets written pitch of note:
+            ..  docs::
 
-            >>> note = abjad.Note(13, (3, 16))
-            >>> note.written_pitch = 14
-            >>> note
-            Note("d''8.")
+                >>> abjad.f(note)
+                cs''8.
+
+            >>> note.written_pitch = 'D5'
+            >>> note.written_pitch
+            NamedPitch("d''")
+
+            >>> abjad.show(note) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(note)
+                d''8.
 
         Returns named pitch.
         '''
         if self.note_head is not None:
             return self.note_head.written_pitch
+        else:
+            return None
 
     @written_pitch.setter
     def written_pitch(self, argument):
-        import abjad
         if argument is None:
             if self.note_head is not None:
                 self.note_head.written_pitch = None
         else:
             if self.note_head is None:
-                self.note_head = abjad.NoteHead(self, written_pitch=None)
+                self.note_head = NoteHead(self, written_pitch=None)
             else:
-                pitch = abjad.NamedPitch(argument)
+                pitch = NamedPitch(argument)
                 self.note_head.written_pitch = pitch
+
+    ### PUBLIC METHODS ###
+
+    @staticmethod
+    def from_pitch_and_duration(pitch, duration):
+        r'''Makes note from ``pitch`` and ``duration``.
+
+        ..  container:: example
+
+            >>> note = abjad.Note.from_pitch_and_duration('C#5', (3, 16))
+            >>> abjad.show(note) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(note)
+                cs''8.
+
+        '''
+        note = Note(pitch, duration)
+        return note

--- a/abjad/tools/scoretools/NoteHead.py
+++ b/abjad/tools/scoretools/NoteHead.py
@@ -248,7 +248,7 @@ class NoteHead(AbjadObject):
     ### PUBLIC PROPERTIES ###
 
     @property
-    def alternative(self) -> typing.Tuple['NoteHead', str]:
+    def alternative(self) -> typing.Tuple['NoteHead', str, str]:
         r'''Gets and sets note-head alternative.
 
         ..  container:: example

--- a/abjad/tools/scoretools/Selection.py
+++ b/abjad/tools/scoretools/Selection.py
@@ -18,6 +18,7 @@ class Selection(AbjadValueObject, collections.Sequence):
 
             >>> string = r"c'4 \times 2/3 { d'8 r8 e'8 } r16 f'16 g'8 a'4"
             >>> staff = abjad.Staff(string)
+            >>> abjad.setting(staff).auto_beaming = False
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> result = abjad.select(staff).runs()
@@ -40,7 +41,6 @@ class Selection(AbjadValueObject, collections.Sequence):
             Run([Note("f'16"), Note("g'8"), Note("a'4")])
 
             >>> selector.color(result)
-            >>> abjad.setting(staff).auto_beaming = False
             >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -173,6 +173,7 @@ class Selection(AbjadValueObject, collections.Sequence):
 
                 >>> string = r"c'8 d'8 ~ d'8 e'8 ~ e'8 ~ e'8 r8 f'8"
                 >>> staff = abjad.Staff(string)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> pattern = abjad.index([0], 2)
@@ -196,7 +197,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Rest('r8')
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -243,6 +243,7 @@ class Selection(AbjadValueObject, collections.Sequence):
 
                 >>> string = r"c'8 d'8 ~ d'8 e'8 ~ e'8 ~ e'8 r8 f'8"
                 >>> staff = abjad.Staff(string)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> pattern = abjad.index([0], 2)
@@ -264,7 +265,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 LogicalTie([Note("e'8"), Note("e'8"), Note("e'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -313,6 +313,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff(r"c'8 d'8 ~ d'8 e'8 ~ e'8 ~ e'8 r8 f'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> getter = abjad.select().leaves()[abjad.index([1])]
@@ -340,7 +341,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection(items=())
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -1298,6 +1298,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -1326,6 +1327,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -1388,6 +1390,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -1434,6 +1437,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -1528,6 +1532,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'4 d'8 ~ d'16 e'16 ~ e'8 r4 g'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).components(abjad.Note)
@@ -1548,7 +1553,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> result = selector(staff)
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> selector.print(result)
@@ -1629,6 +1633,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> inequality = abjad.DurationInequality('==', (2, 8))
@@ -1645,7 +1650,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> result = selector(staff)
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> selector.print(result)
@@ -1698,6 +1702,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).runs()
@@ -1718,7 +1723,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Run([Note("d'8"), Note("e'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -1757,6 +1761,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).runs()
@@ -1779,7 +1784,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Run([Note("d'8"), Note("e'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -1833,6 +1837,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).runs().filter_length('>', 1)
@@ -1853,7 +1858,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Run([Note("f'8"), Note("g'8"), Note("a'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -1907,6 +1911,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).runs().filter_length('<', 3)
@@ -1927,7 +1932,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Run([Note("d'8"), Note("e'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -1980,6 +1984,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 d'8 ~ d'8 e'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> staff.extend("r8 <c' e' g'>8 ~ <c' e' g'>4")
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2005,7 +2010,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Chord("<c' e' g'>4")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2048,6 +2052,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 d'8 ~ d'8 e'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> staff.extend("r8 <c' e' g'>8 ~ <c' e' g'>4")
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2075,7 +2080,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Chord("<c' e' g'>4")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2123,6 +2127,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 d'8 ~ d'8 e'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> staff.extend("r8 <c' e' g'>8 ~ <c' e' g'>4")
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2146,7 +2151,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 LogicalTie([Chord("<c' e' g'>8"), Chord("<c' e' g'>4")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2199,6 +2203,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).runs()
@@ -2219,7 +2224,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Run([Note("d'8"), Note("e'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2258,6 +2262,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).runs()
@@ -2280,7 +2285,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Run([Note("d'8"), Note("e'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2348,6 +2352,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -2382,6 +2387,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -2452,6 +2458,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -2493,6 +2500,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -2567,6 +2575,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     c'8 ~ c'16 c'16 r8 c'16 c'16
                 ...     d'8 ~ d'16 d'16 r8 d'16 d'16
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves(pitched=True)
@@ -2586,7 +2595,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Selection([Note("c'8"), Note("c'16"), Note("c'16"), Note("c'16"), Note("c'16"), Note("d'8"), Note("d'16"), Note("d'16"), Note("d'16"), Note("d'16")])])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2691,6 +2699,7 @@ class Selection(AbjadValueObject, collections.Sequence):
 
                 >>> string = r"c'8 d' r \times 2/3 { e' r f' } g' a' r"
                 >>> staff = abjad.Staff(string)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> staff.extend("r8 <c' e' g'>8 ~ <c' e' g'>4")
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2718,7 +2727,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Chord("<c' e' g'>8"), Chord("<c' e' g'>4")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2793,6 +2801,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'4 d'16 d' d' d' e'4 f'16 f' f' f'")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves()
@@ -2823,6 +2832,10 @@ class Selection(AbjadValueObject, collections.Sequence):
 
                 >>> abjad.f(staff)
                 \new Staff
+                \with
+                {
+                    autoBeaming = ##f
+                }
                 {
                     c'4
                     \once \override Accidental.color = #red
@@ -2884,6 +2897,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'4 d'8 ~ d'16 e'16 ~ e'8 f'4 g'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).logical_ties()
@@ -2909,7 +2923,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Note("g'8")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2951,6 +2964,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     c'8 ~ c'16 c'16 r8 c'16 c'16
                 ...     d'8 ~ d'16 d'16 r8 d'16 d'16
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves(pitched=True)
@@ -2982,7 +2996,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("d'16"), Note("d'16")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3069,6 +3082,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     c'8 ~ c'16 c'16 r8 c'16 c'16
                 ...     d'8 ~ d'16 d'16 r8 d'16 d'16
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> getter = abjad.select().group_by_pitch()
@@ -3099,7 +3113,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([LogicalTie([Note("d'16")]), LogicalTie([Note("d'16")])])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3447,6 +3460,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 d' e' f' g' a' b' c''")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.attach(abjad.TimeSignature((2, 8)), staff[0])
                 >>> abjad.attach(abjad.TimeSignature((3, 8)), staff[4])
                 >>> abjad.attach(abjad.TimeSignature((1, 8)), staff[7])
@@ -3476,7 +3490,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("c''8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3543,11 +3556,114 @@ class Selection(AbjadValueObject, collections.Sequence):
 
         ..  container:: example
 
+            Groups leaves by logical measure and joins pairs of consecutive
+            groups:
+
+            ..  container:: example
+
+                >>> staff = abjad.Staff("c'8 d' e' f' g' a' b' c''")
+                >>> abjad.setting(staff).auto_beaming = False
+                >>> abjad.attach(abjad.TimeSignature((2, 8)), staff[0])
+                >>> abjad.attach(abjad.TimeSignature((3, 8)), staff[4])
+                >>> abjad.attach(abjad.TimeSignature((1, 8)), staff[7])
+                >>> abjad.show(staff) # doctest: +SKIP
+
+                >>> result = abjad.select(staff).leaves()
+                >>> result = result.group_by_measure()
+                >>> result = result.partition_by_counts([2], cyclic=True)
+                >>> result = result.map(abjad.select().flatten())
+
+                >>> for item in result:
+                ...     item
+                ...
+                Selection([Note("c'8"), Note("d'8"), Note("e'8"), Note("f'8")])
+                Selection([Note("g'8"), Note("a'8"), Note("b'8"), Note("c''8")])
+
+            ..  container:: example expression
+
+                >>> selector = abjad.select().leaves()
+                >>> selector = selector.group_by_measure()
+                >>> selector = selector.partition_by_counts([2], cyclic=True)
+                >>> selector = selector.map(abjad.select().flatten())
+                >>> result = selector(staff)
+
+                >>> selector.print(result)
+                Selection([Note("c'8"), Note("d'8"), Note("e'8"), Note("f'8")])
+                Selection([Note("g'8"), Note("a'8"), Note("b'8"), Note("c''8")])
+
+                >>> selector.color(result)
+                >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                \with
+                {
+                    autoBeaming = ##f
+                }
+                {
+                    \once \override Accidental.color = #red
+                    \once \override Beam.color = #red
+                    \once \override Dots.color = #red
+                    \once \override NoteHead.color = #red
+                    \once \override Stem.color = #red
+                    \time 2/8
+                    c'8
+                    \once \override Accidental.color = #red
+                    \once \override Beam.color = #red
+                    \once \override Dots.color = #red
+                    \once \override NoteHead.color = #red
+                    \once \override Stem.color = #red
+                    d'8
+                    \once \override Accidental.color = #red
+                    \once \override Beam.color = #red
+                    \once \override Dots.color = #red
+                    \once \override NoteHead.color = #red
+                    \once \override Stem.color = #red
+                    e'8
+                    \once \override Accidental.color = #red
+                    \once \override Beam.color = #red
+                    \once \override Dots.color = #red
+                    \once \override NoteHead.color = #red
+                    \once \override Stem.color = #red
+                    f'8
+                    \once \override Accidental.color = #blue
+                    \once \override Beam.color = #blue
+                    \once \override Dots.color = #blue
+                    \once \override NoteHead.color = #blue
+                    \once \override Stem.color = #blue
+                    \time 3/8
+                    g'8
+                    \once \override Accidental.color = #blue
+                    \once \override Beam.color = #blue
+                    \once \override Dots.color = #blue
+                    \once \override NoteHead.color = #blue
+                    \once \override Stem.color = #blue
+                    a'8
+                    \once \override Accidental.color = #blue
+                    \once \override Beam.color = #blue
+                    \once \override Dots.color = #blue
+                    \once \override NoteHead.color = #blue
+                    \once \override Stem.color = #blue
+                    b'8
+                    \once \override Accidental.color = #blue
+                    \once \override Beam.color = #blue
+                    \once \override Dots.color = #blue
+                    \once \override NoteHead.color = #blue
+                    \once \override Stem.color = #blue
+                    \time 1/8
+                    c''8
+                }
+
+        ..  container:: example
+
             Groups leaves by logical measure; then gets item 0 in each group:
 
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 d' e' f' g' a' b' c''")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.attach(abjad.TimeSignature((2, 8)), staff[0])
                 >>> abjad.attach(abjad.TimeSignature((3, 8)), staff[4])
                 >>> abjad.attach(abjad.TimeSignature((1, 8)), staff[7])
@@ -3578,7 +3694,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Note("c''8")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3630,6 +3745,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 d' e' f' g' a' b' c''")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.attach(abjad.TimeSignature((2, 8)), staff[0])
                 >>> abjad.attach(abjad.TimeSignature((3, 8)), staff[4])
                 >>> abjad.attach(abjad.TimeSignature((1, 8)), staff[7])
@@ -3661,7 +3777,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Note("c''8")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3713,6 +3828,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'4 d' e' f' g' a' b' c''")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> score = abjad.Score([staff])
                 >>> scheme = abjad.SchemeMoment((1, 16))
                 >>> abjad.setting(score).proportional_notation_duration = scheme
@@ -3738,7 +3854,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("g'4"), Note("a'4"), Note("b'4"), Note("c''4")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3962,6 +4077,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -3990,6 +4106,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -4055,6 +4172,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { r8 d' e' } f' r
                 ...     r f' \times 2/3 { e' d' r8 }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves()
@@ -4091,7 +4209,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Rest('r8')
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4167,6 +4284,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { r8 d' e' } f' r
                 ...     r f' \times 2/3 { e' d' r8 }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves(pitched=True)
@@ -4195,7 +4313,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Note("d'8")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4265,6 +4382,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { r8 d' e' } f' r
                 ...     r f' \times 2/3 { e' d' r8 }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves(trim=True)
@@ -4299,7 +4417,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> abjad.attach(abjad.OctavationSpanner(), result)
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4374,6 +4491,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { c'8 d' e' } f' r
                 ...     r f' \times 2/3 { e' d' c' }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves(trim=True)
@@ -4410,7 +4528,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Note("c'8")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4492,6 +4609,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { r8 d' e' } f' r
                 ...     r f' \times 2/3 { e' d' r8 }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).components(abjad.Tuplet)
@@ -4522,7 +4640,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Rest('r8')
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4584,6 +4701,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { r8 d' e' } f' r
                 ...     r f' \times 2/3 { e' d' r8 }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).components(abjad.Tuplet)
@@ -4610,7 +4728,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Note("d'8")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4670,6 +4787,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { c'8 d' ~ d' } e' r
                 ...     r e' \times 2/3 { d' ~ d' c' }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).components(abjad.Tuplet)
@@ -4696,7 +4814,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Note("c'8")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4756,6 +4873,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { c'8 d' ~ d' } e' r
                 ...     r e' \times 2/3 { d' ~ d' c' }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).components(abjad.Tuplet)
@@ -4783,7 +4901,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Note("c'8")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4843,6 +4960,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { <c' e' g'>8 ~ <c' e' g'> d' } e' r
                 ...     r <g d' fs'> \times 2/3 { e' <c' d'> ~ <c' d'> }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).components(abjad.Tuplet)
@@ -4865,7 +4983,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Chord("<c' d'>8")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4937,6 +5054,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 d' ~ { d' e' r f'~ } f' r")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).logical_ties()
@@ -4965,7 +5083,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 LogicalTie([Rest('r8')])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5030,6 +5147,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 d' ~ { d' e' r f'~ } f' r")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).logical_ties(pitched=True)
@@ -5054,7 +5172,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 LogicalTie([Note("f'8"), Note("f'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5115,6 +5232,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 d' ~ { d' e' r f'~ } f' r")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).logical_ties(
@@ -5140,7 +5258,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 LogicalTie([Note("f'8"), Note("f'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5195,6 +5312,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { f' g' a' ~ } a' b' ~
                 ...     \times 2/3 { b' c'' d'' }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> getter = abjad.select().logical_ties(pitched=True)
@@ -5220,7 +5338,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([LogicalTie([Note("c''8")]), LogicalTie([Note("d''8")])])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5310,6 +5427,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { f' g' a' ~ } a' b' ~
                 ...     \times 2/3 { b' c'' d'' }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> getter = abjad.select().logical_ties(pitched=True)
@@ -5333,7 +5451,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([LogicalTie([Note("c''8")]), LogicalTie([Note("d''8")])])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5417,6 +5534,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { r8 d' e' } f' r
                 ...     r f' \times 2/3 { e' d' r8 }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).components(abjad.Tuplet)
@@ -5439,7 +5557,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Tuplet(Multiplier(2, 3), "e'8 d'8 r8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5501,6 +5618,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     \times 2/3 { r8 d' e' } f' r
                 ...     r f' \times 2/3 { e' d' r8 }
                 ...     """)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = staff[:].map(abjad.select().leaves())
@@ -5529,7 +5647,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("e'8"), Note("d'8"), Rest('r8')])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5603,6 +5720,7 @@ class Selection(AbjadValueObject, collections.Sequence):
 
                 >>> string = r"c'4 \times 2/3 { d'8 r8 e'8 } r16 f'16 g'8 a'4"
                 >>> staff = abjad.Staff(string)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).runs()
@@ -5627,7 +5745,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Note("f'16")
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5697,6 +5814,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -5725,6 +5843,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -5787,6 +5906,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -5827,6 +5947,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -5906,6 +6027,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).runs().nontrivial()
@@ -5926,7 +6048,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Run([Note("f'8"), Note("g'8"), Note("a'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5998,6 +6119,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves()
@@ -6026,7 +6148,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("c'8"), Rest('r8'), Note("d'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6068,6 +6189,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves().partition_by_counts(
@@ -6096,7 +6218,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("e'8"), Rest('r8'), Note("f'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6150,6 +6271,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves().partition_by_counts(
@@ -6180,7 +6302,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("g'8"), Note("a'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6244,6 +6365,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves().partition_by_counts(
@@ -6274,7 +6396,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("e'8"), Rest('r8'), Note("f'8"), Note("g'8"), Note("a'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6339,6 +6460,7 @@ class Selection(AbjadValueObject, collections.Sequence):
 
                 >>> string = "c'8 r8 d'8 e'8 r8 f'8 g'8 a'8 b'8 r8 c''8"
                 >>> staff = abjad.Staff(string)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves().partition_by_counts(
@@ -6375,7 +6497,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Rest('r8'), Note("c''8")])
 
                 >>> selector.color(result, ['red', 'blue', 'cyan'])
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6507,6 +6628,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     "abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |"
                 ...     "| 2/8 g'8 a'8 || 2/8 b'8 c''8 |"
                 ...     )
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves().partition_by_durations(
@@ -6541,7 +6663,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("b'8"), Note("c''8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6623,6 +6744,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     "abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |"
                 ...     "| 2/8 g'8 a'8 || 2/8 b'8 c''8 |"
                 ...     )
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves()
@@ -6655,7 +6777,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("c'8"), Note("d'8"), Note("e'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6712,6 +6833,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     "abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |"
                 ...     "| 2/8 g'8 a'8 || 2/8 b'8 c''8 |"
                 ...     )
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves()
@@ -6752,7 +6874,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("b'8"), Note("c''8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6834,6 +6955,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     "abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |"
                 ...     "| 2/8 g'8 a'8 || 2/8 b'8 c''8 |"
                 ...     )
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves()
@@ -6878,7 +7000,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("b'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6955,6 +7076,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     "abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |"
                 ...     "| 2/8 g'8 a'8 || 2/8 b'8 c''8 |"
                 ...     )
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves()
@@ -6987,7 +7109,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("c'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7034,6 +7155,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     "abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |"
                 ...     "| 2/8 g'8 a'8 || 2/8 b'8 c''8 |"
                 ...     )
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
                 >>> leaf = abjad.inspect(staff).get_leaf(0)
                 >>> abjad.attach(mark, leaf, context='Staff')
@@ -7071,7 +7193,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("f'8"), Note("g'8"), Note("a'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7144,6 +7265,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     "abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |"
                 ...     "| 2/8 g'8 a'8 || 2/8 b'8 c''8 |"
                 ...     )
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
                 >>> leaf = abjad.inspect(staff).get_leaf(0)
                 >>> abjad.attach(mark, leaf, context='Staff')
@@ -7182,7 +7304,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("b'8"), Note("c''8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7265,6 +7386,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     "abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |"
                 ...     "| 2/8 g'8 a'8 || 2/8 b'8 c''8 |"
                 ...     )
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
                 >>> leaf = abjad.inspect(staff).get_leaf(0)
                 >>> abjad.attach(mark, leaf, context='Staff')
@@ -7300,7 +7422,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("c'8"), Note("d'8"), Note("e'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7358,6 +7479,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     "abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |"
                 ...     "| 2/8 g'8 a'8 || 2/8 b'8 c''8 |"
                 ...     )
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
                 >>> leaf = abjad.inspect(staff).get_leaf(0)
                 >>> abjad.attach(mark, leaf, context='Staff')
@@ -7405,7 +7527,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("b'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7483,6 +7604,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     "abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |"
                 ...     "| 2/8 g'8 a'8 || 2/8 b'8 c''8 |"
                 ...     )
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
                 >>> leaf = abjad.inspect(staff).get_leaf(0)
                 >>> abjad.attach(mark, leaf, context='Staff')
@@ -7518,7 +7640,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("c'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7671,6 +7792,7 @@ class Selection(AbjadValueObject, collections.Sequence):
 
                 >>> string = r"c'8 d' r \times 2/3 { e' r f' } g' a' r"
                 >>> staff = abjad.Staff(string)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves()
@@ -7693,7 +7815,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("f'8"), Note("g'8"), Note("a'8"), Rest('r8')])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7762,6 +7883,7 @@ class Selection(AbjadValueObject, collections.Sequence):
 
                 >>> string = r"c'8 d' r \times 2/3 { e' r f' } g' a' r"
                 >>> staff = abjad.Staff(string)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves()
@@ -7786,7 +7908,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("g'8"), Note("a'8"), Rest('r8')])
 
                 >>> selector.color(result, ['red', 'blue', 'cyan'])
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7884,6 +8005,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -7912,6 +8034,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -7971,6 +8094,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -8005,6 +8129,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -8069,6 +8194,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -8097,6 +8223,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -8179,6 +8306,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -8213,6 +8341,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -8340,6 +8469,7 @@ class Selection(AbjadValueObject, collections.Sequence):
 
                 >>> string = r"c'8 d' r \times 2/3 { e' r f' } g' a' r"
                 >>> staff = abjad.Staff(string)
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).leaves().top()
@@ -8370,7 +8500,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Rest('r8')
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -8467,6 +8596,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -8495,6 +8625,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -8579,6 +8710,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> tuplets = [abjad.select(tuplets)]
                 >>> lilypond_file = abjad.LilyPondFile.rhythm(tuplets)
                 >>> staff = lilypond_file[abjad.Staff]
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.override(staff).tuplet_bracket.direction = abjad.Up
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 3
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -8613,6 +8745,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 {
                     \override TupletBracket.direction = #up
                     \override TupletBracket.staff-padding = #3
+                    autoBeaming = ##f
                 }
                 {
                     {   % measure
@@ -8743,6 +8876,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).runs()
@@ -8767,7 +8901,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("f'8"), Note("g'8"), Note("a'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -8830,6 +8963,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff(r"c'8 r d' ~ d' e' ~ e' r8 f'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> getter = abjad.select()[-1].select().with_next_leaf()
@@ -8857,7 +8991,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Note("f'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -8918,6 +9051,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff(r"c'8 r d' ~ d' e' ~ e' r8 f'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> result = abjad.select(staff).logical_ties(pitched=True)
@@ -8950,7 +9084,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 >>> selector.color(result)
                 >>> manager = abjad.override(staff).sustain_pedal_line_spanner
                 >>> manager.staff_padding = 6
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -9032,6 +9165,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> getter = abjad.select().with_previous_leaf()
@@ -9055,7 +9189,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Rest('r8'), Note("f'8"), Note("g'8"), Note("a'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -9118,6 +9251,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             ..  container:: example
 
                 >>> staff = abjad.Staff(r"c'8 r d' ~ d' e' ~ e' r8 f'8")
+                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> getter = abjad.select()[0].select().with_previous_leaf()
@@ -9145,7 +9279,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                 Selection([Rest('r8'), Note("f'8")])
 
                 >>> selector.color(result)
-                >>> abjad.setting(staff).auto_beaming = False
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::

--- a/abjad/tools/segmenttools/PersistentOverride.py
+++ b/abjad/tools/segmenttools/PersistentOverride.py
@@ -29,8 +29,6 @@ class PersistentOverride(AbjadObject):
 
     ### CLASS VARIABLES ###
 
-    __documentation_section__ = '(5) Utilities'
-
     __slots__ = (
         '_after',
         '_attribute',

--- a/abjad/tools/spannertools/PhrasingSlur.py
+++ b/abjad/tools/spannertools/PhrasingSlur.py
@@ -33,9 +33,9 @@ class PhrasingSlur(Spanner):
         >>> abjad.attach(phrasing_slur, staff[:1])
         Traceback (most recent call last):
             ...
-        Exception: PhrasingSlur() attachment test fails for ...
-        <BLANKLINE>
-        Selection([Note("c'8")])
+        Exception: PhrasingSlur()._attachment_test_all():
+          Requires at least two leaves.
+          Not just Note("c'8").
 
     Formats LilyPond ``\(`` command on first leaf in spanner.
 

--- a/abjad/tools/spannertools/Slur.py
+++ b/abjad/tools/spannertools/Slur.py
@@ -31,9 +31,9 @@ class Slur(Spanner):
         >>> abjad.attach(abjad.Slur(), staff[:1])
         Traceback (most recent call last):
             ...
-        Exception: Slur() attachment test fails for ...
-        <BLANKLINE>
-        Selection([Note("c'4")])
+        Exception: Slur()._attachment_test_all():
+          Requires at least two leaves.
+          Not just Note("c'4").
 
     Formats LilyPond ``(`` command on first leaf in spanner.
 

--- a/abjad/tools/spannertools/TextSpanner.py
+++ b/abjad/tools/spannertools/TextSpanner.py
@@ -444,9 +444,26 @@ class TextSpanner(Spanner):
         >>> abjad.attach(spanner, staff[:1])
         Traceback (most recent call last):
             ...
-        Exception: TextSpanner() attachment test fails for ...
-        <BLANKLINE>
-        Selection([Note("c'4")])
+        Exception: TextSpanner()._attachment_test_all():
+          Requires at least two leaves.
+          Not just Note("c'4").
+
+    ..  container:: example
+
+        Raises exception on noncontiguous leaves:
+
+        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> spanner = abjad.TextSpanner()
+        >>> abjad.attach(spanner, staff[:1] + staff[-1:])
+        Traceback (most recent call last):
+            ...
+        Exception: TextSpanner() leaves must be contiguous:
+          abjad.Selection(
+            [
+                abjad.Note("c'4"),
+                abjad.Note("f'4"),
+                ]
+            )
 
     '''
 
@@ -622,7 +639,9 @@ class TextSpanner(Spanner):
                     c'4 \startTextSpan
                     d'4
                     e'4
-                    \revert TextSpanner.bound-details
+                    \revert TextSpanner.bound-details.left.stencil-align-dir-y
+                    \revert TextSpanner.bound-details.left.text
+                    \revert TextSpanner.bound-details.right.padding
                     \revert TextSpanner.color
                     \override TextSpanner.bound-details.left.stencil-align-dir-y = #0
                     \override TextSpanner.bound-details.left.text = \markup {
@@ -634,7 +653,8 @@ class TextSpanner(Spanner):
                     c'4
                     d'4
                     e'4
-                    \revert TextSpanner.bound-details
+                    \revert TextSpanner.bound-details.left.stencil-align-dir-y
+                    \revert TextSpanner.bound-details.left.text
                     f'4 \stopTextSpan
                 }
 

--- a/abjad/tools/systemtools/LilyPondFormatManager.py
+++ b/abjad/tools/systemtools/LilyPondFormatManager.py
@@ -452,12 +452,12 @@ class LilyPondFormatManager(AbjadObject):
 
         Returns string.
         '''
-        import abjad
-        grob = abjad.String(grob).to_upper_camel_case()
+        from abjad.tools.datastructuretools.String import String
+        grob = String(grob).to_upper_camel_case()
         attribute = LilyPondFormatManager.format_lilypond_attribute(attribute)
         value = LilyPondFormatManager.format_lilypond_value(value)
         if context is not None:
-            context = abjad.String(context).capitalize_start() + '.'
+            context = String(context).capitalize_start() + '.'
         else:
             context = ''
         if once is True:
@@ -469,22 +469,28 @@ class LilyPondFormatManager(AbjadObject):
         return result
 
     @staticmethod
-    def make_lilypond_revert_string(grob, attribute, context=None):
+    def make_lilypond_revert_string(grob, attribute, context=None) -> str:
         r'''Makes LilyPond revert string.
 
-        Returns string.
+        ..  container:: example
+
+            >>> abjad.LilyPondFormatManager.make_lilypond_revert_string(
+            ...     'glissando',
+            ...     'bound_details__right__arrow',
+            ...     )
+            '\\revert Glissando.bound-details.right.arrow'
+
         '''
-        import abjad
-        grob = abjad.String(grob).to_upper_camel_case()
-        attribute = LilyPondFormatManager.format_lilypond_attribute(attribute)
-        attribute = attribute.split('.')[0]
+        from abjad.tools.datastructuretools.String import String
+        grob = String(grob).to_upper_camel_case()
+        dotted = LilyPondFormatManager.format_lilypond_attribute(attribute)
         if context is not None:
-            context = abjad.String(context).to_upper_camel_case()
+            context = String(context).to_upper_camel_case()
             context += '.'
         else:
             context = ''
         result = r'\revert {}{}.{}'
-        result = result.format(context, grob, attribute)
+        result = result.format(context, grob, dotted)
         return result
 
     @staticmethod
@@ -493,9 +499,9 @@ class LilyPondFormatManager(AbjadObject):
 
         Returns string.
         '''
-        import abjad
+        from abjad.tools.datastructuretools.String import String
         if grob is not None:
-            grob = abjad.String(grob).to_upper_camel_case()
+            grob = String(grob).to_upper_camel_case()
             grob += '.'
         else:
             grob = ''

--- a/abjad/tools/topleveltools/attach.py
+++ b/abjad/tools/topleveltools/attach.py
@@ -237,10 +237,13 @@ def attach(
         attachable._before_attach(target)
 
     if hasattr(attachable, '_attachment_test_all'):
-        if not attachable._attachment_test_all(target):
-            message = '{!r} attachment test fails for ...'.format(attachable)
-            message += '\n\n'
-            message += '{!r}'.format(target)
+        result = attachable._attachment_test_all(target)
+        if result is not True:
+            assert isinstance(result, list)
+            result = ['  ' + _ for _ in result]
+            message = f'{attachable!r}._attachment_test_all():'
+            result.insert(0, message)
+            message = '\n'.join(result)
             raise Exception(message)
 
     grace_container = (abjad.AfterGraceContainer, abjad.GraceContainer)


### PR DESCRIPTION
NEW: Added abjad.Dynamic.name_is_textual property.

    The property allows for ad hoc dynamic indications of the type like "barely
    audible", "extremely quiet", "extremely loud", etc.

    Textual dynamics format like this when initialized without an explicit
    command:

    >>> voice = abjad.Voice("c'4 d' e' f'")
    >>> dynamic = abjad.Dynamic('appena udibile', name_is_textual=True)
    >>> abjad.attach(dynamic, voice[0])

    >>> abjad.f(voice)
    \new Voice
    {
        c'4 _ #(make-dynamic-script (markup #:whiteout #:normal-text #:italic "appena udibile"))
        d'4
        e'4
        f'4
    }

    Textual dynamics format like this when initialized with an explicit
    command:

    >>> voice = abjad.Voice("c'4 d' e' f'")
    >>> dynamic = abjad.Dynamic(
    ...     'appena udibile',
    ...     command=r'\appena_udibile',
    ...     name_is_textual=True,
    ...     )
    >>> abjad.attach(dynamic, voice[0])

    >>> abjad.f(voice)
    \new Voice
    {
        c'4 \appena_udibile
        d'4
        e'4
        f'4
    }

    Also added abjad.Hairpin.[start|stop]_dynamic_is_textual.

NEW:

    * Made abjad.Dynamic.ordinal settable

    * Added abjad.Ratio.reciprocal

    * Added abjad.rhythmmakertools.DurationSpecifier.rewrite_rest_filled

FIXED:

    Fixed #925.

    OLD:

        >>> abjad.NamedPitch(23.9)
        NamedPitch("c''") # C5

    FIXED:

        >>> abjad.NamedPitch(23.9)
        NamedPitch("c'''") # C6

    Closes #925.

INTERFACE:

    * Made spanner attach() error messaging conform to #879:

    Example 1:

    >>> staff = abjad.Staff("c'4 d' e'8 ~ e'8 r4")
    >>> abjad.attach(abjad.Tie(), staff[:2])
    Traceback (most recent call last):
        File "<stdin>", line 1, in <module>
        File "/Users/trevorbaca/abjad/abjad/tools/topleveltools/attach.py", line 247, in attach
        raise Exception(message)
    Exception: Tie()._attachment_test_all():
        Pitch {0} does not equal pitch {2}.

    Example 2:

    >>> staff = abjad.Staff("c'4 d' e'8 ~ e'8 r4")
    >>> abjad.attach(abjad.Tie(), staff[-2:])
    Traceback (most recent call last):
        File "<stdin>", line 1, in <module>
        File "/Users/trevorbaca/abjad/abjad/tools/topleveltools/attach.py", line 247, in attach
        raise Exception(message)
    Exception: Tie()._attachment_test_all():
        Can only tie notes and chords.
        Not Rest('r4').

    * Wrote TupletSpecifier examples

    * Wrote abjad.Tuplet.force_fraction examples

    * Wrote abjad.TupletSpecifier.force_fraction examples

    * Wrote selector examples

    * Wrote abjad.LilyPondFormatManager tests.