### PR TITLE
Update manager optimzation

### DIFF
--- a/abjad/tools/indicatortools/MetronomeMark.py
+++ b/abjad/tools/indicatortools/MetronomeMark.py
@@ -1147,6 +1147,7 @@ class MetronomeMark(AbjadValueObject):
         '''
         return self._textual_indication
 
+    # TODO: restrict units_per_minute to inf, fraction and NOT float
     @property
     def units_per_minute(self) -> typing.Union[int, float, Fraction, None]:
         '''


### PR DESCRIPTION
OLD: Abjad pytest battery ran in 90 seconds.

NEW: Abjad pytest battery runs in 38 seconds.

Optimizes UpdatedManager calculation of offsets in seconds.