### PR TITLE
3.0 FEATURE SET #17: layered text spanners + tweak expressions

### DIFF
--- a/abjad/__init__.py
+++ b/abjad/__init__.py
@@ -12,6 +12,7 @@ except ImportError:
 
 from abjad.enumerations import *
 from abjad.exceptions import *
+from abjad.typings import *
 
 # ensure that the ~/.abjad directory and friends are setup
 # and instantiate Abjad's configuration singleton

--- a/abjad/core/Context.py
+++ b/abjad/core/Context.py
@@ -1,4 +1,6 @@
 import copy
+from abjad.lilypondnames.LilyPondContext import LilyPondContext
+from abjad.system.LilyPondFormatManager import LilyPondFormatManager
 from .Container import Container
 
 
@@ -95,7 +97,6 @@ class Context(Container):
 
         Returns new component.
         """
-        import abjad
         new_context = Container.__copy__(self)
         new_context._consists_commands = copy.copy(self.consists_commands)
         new_context._remove_commands = copy.copy(self.remove_commands)
@@ -138,22 +139,19 @@ class Context(Container):
     def _format_consists_commands(self):
         result = []
         for engraver in self.consists_commands:
-            string = r'\consists {}'.format(engraver)
+            string = rf'\consists {engraver}'
             result.append(string)
         return result
 
     def _format_invocation(self):
         if self.name is not None:
-            string = r'\context {} = "{}"'
-            string = string.format(self.lilypond_type, self.name)
+            string = rf'\context {self.lilypond_type} = "{self.name}"'
         else:
-            string = r'\new {}'
-            string = string.format(self.lilypond_type)
+            string = rf'\new {self.lilypond_type}'
         return string
 
     def _format_open_brackets_slot(context, bundle):
-        import abjad
-        indent = abjad.LilyPondFormatManager.indent
+        indent = LilyPondFormatManager.indent
         result = []
         if context.is_simultaneous:
             if context.identifier:
@@ -228,7 +226,6 @@ class Context(Container):
         return self._format_component()
 
     def _get_persistent_wrappers(self):
-        import abjad
         self._update_now(indicators=True)
         wrappers = {}
         for wrapper in self._dependent_wrappers:
@@ -311,11 +308,10 @@ class Context(Container):
 
         Returns LilyPond context instance.
         """
-        import abjad
         try:
-            lilypond_context = abjad.LilyPondContext(name=self.lilypond_type)
+            lilypond_context = LilyPondContext(name=self.lilypond_type)
         except AssertionError:
-            lilypond_context = abjad.LilyPondContext(
+            lilypond_context = LilyPondContext(
                 name=self._default_lilypond_type,
                 )
         return lilypond_context

--- a/abjad/indicators/Accelerando.py
+++ b/abjad/indicators/Accelerando.py
@@ -1,6 +1,6 @@
 import typing
-from abjad.enumerations import Up
 from abjad.abctools.AbjadValueObject import AbjadValueObject
+from abjad.enumerations import Up
 from abjad.markup.Markup import Markup
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 from abjad.top.new import new

--- a/abjad/indicators/Arpeggio.py
+++ b/abjad/indicators/Arpeggio.py
@@ -1,14 +1,12 @@
 import typing
+from abjad.abctools.AbjadValueObject import AbjadValueObject
 from abjad.enumerations import (
     Center,
     Down,
     Up,
     VerticalAlignment,
     )
-from abjad.lilypondnames.LilyPondTweakManager import (
-    LilyPondTweakManager,
-    )
-from abjad.abctools.AbjadValueObject import AbjadValueObject
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 
 

--- a/abjad/indicators/ArrowLineSegment.py
+++ b/abjad/indicators/ArrowLineSegment.py
@@ -1,8 +1,9 @@
 import typing
-from abjad.enumerations import Center, VerticalAlignment
+from abjad.enumerations import Center
+from abjad.enumerations import VerticalAlignment
 from abjad.markup.Markup import Markup
+from abjad.typings import Number
 from .LineSegment import LineSegment
-Number = typing.Union[int, float]
 
 
 class ArrowLineSegment(LineSegment):

--- a/abjad/indicators/Articulation.py
+++ b/abjad/indicators/Articulation.py
@@ -1,18 +1,16 @@
 import copy
 import typing
+from abjad.abctools.AbjadValueObject import AbjadValueObject
 from abjad.enumerations import Center
 from abjad.enumerations import Down
 from abjad.enumerations import Up
 from abjad.enumerations import VerticalAlignment
-from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.utilities.String import String
-from abjad.lilypondnames.LilyPondTweakManager import (
-    LilyPondTweakManager,
-    )
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.system.FormatSpecification import FormatSpecification
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 from abjad.system.StorageFormatManager import StorageFormatManager
 from abjad.top.attach import attach
+from abjad.utilities.String import String
 
 
 class Articulation(AbjadValueObject):

--- a/abjad/indicators/BendAfter.py
+++ b/abjad/indicators/BendAfter.py
@@ -1,10 +1,10 @@
 import typing
-from abjad.enumerations import Right, HorizontalAlignment
-from abjad.lilypondnames.LilyPondTweakManager import \
-    LilyPondTweakManager
 from abjad.abctools.AbjadValueObject import AbjadValueObject
+from abjad.enumerations import HorizontalAlignment
+from abjad.enumerations import Right
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
-Number = typing.Union[int, float]
+from abjad.typings import Number
 
 
 class BendAfter(AbjadValueObject):

--- a/abjad/indicators/BowContactPoint.py
+++ b/abjad/indicators/BowContactPoint.py
@@ -1,8 +1,8 @@
 import functools
 import typing
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.utilities.Multiplier import Multiplier
 from abjad.markup.Markup import Markup
+from abjad.utilities.Multiplier import Multiplier
 
 
 @functools.total_ordering

--- a/abjad/indicators/BreathMark.py
+++ b/abjad/indicators/BreathMark.py
@@ -1,9 +1,8 @@
 import typing
-from abjad.enumerations import HorizontalAlignment, Right
-from abjad.lilypondnames.LilyPondTweakManager import (
-    LilyPondTweakManager,
-    )
 from abjad.abctools.AbjadValueObject import AbjadValueObject
+from abjad.enumerations import HorizontalAlignment
+from abjad.enumerations import Right
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 
 

--- a/abjad/indicators/ColorFingering.py
+++ b/abjad/indicators/ColorFingering.py
@@ -1,10 +1,9 @@
 import functools
 import typing
-from abjad.enumerations import Up
 from abjad import mathtools
+from abjad.enumerations import Up
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.lilypondnames.LilyPondTweakManager import \
-    LilyPondTweakManager
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.markup.Markup import Markup
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 from abjad.top.new import new

--- a/abjad/indicators/Dynamic.py
+++ b/abjad/indicators/Dynamic.py
@@ -1,15 +1,15 @@
 import typing
-from abjad.enumerations import Down, Up, VerticalAlignment
 from abjad import mathtools
+from abjad.enumerations import Down
+from abjad.enumerations import Up
+from abjad.enumerations import VerticalAlignment
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.utilities.String import String
-from abjad.lilypondnames.LilyPondTweakManager import (
-    LilyPondTweakManager,
-    )
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.mathtools.Infinity import Infinity
 from abjad.mathtools.NegativeInfinity import NegativeInfinity
 from abjad.system.FormatSpecification import FormatSpecification
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
+from abjad.utilities.String import String
 
 
 class Dynamic(AbjadValueObject):

--- a/abjad/indicators/Fermata.py
+++ b/abjad/indicators/Fermata.py
@@ -1,8 +1,6 @@
 import typing
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.lilypondnames.LilyPondTweakManager import (
-    LilyPondTweakManager,
-    )
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 
 

--- a/abjad/indicators/KeyCluster.py
+++ b/abjad/indicators/KeyCluster.py
@@ -1,10 +1,10 @@
+from abjad.abctools.AbjadValueObject import AbjadValueObject
 from abjad.enumerations import (
     Center,
     Down,
     Up,
     VerticalAlignment,
     )
-from abjad.abctools.AbjadValueObject import AbjadValueObject
 from abjad.markup.Markup import Markup
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 

--- a/abjad/indicators/KeySignature.py
+++ b/abjad/indicators/KeySignature.py
@@ -1,7 +1,6 @@
 import typing
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.lilypondnames.LilyPondTweakManager import \
-    LilyPondTweakManager
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.pitch.NamedPitchClass import NamedPitchClass
 from abjad.system.FormatSpecification import FormatSpecification
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle

--- a/abjad/indicators/LaissezVibrer.py
+++ b/abjad/indicators/LaissezVibrer.py
@@ -1,9 +1,8 @@
 import typing
-from abjad.enumerations import HorizontalAlignment, Right
+from abjad.enumerations import HorizontalAlignment
+from abjad.enumerations import Right
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.lilypondnames.LilyPondTweakManager import (
-    LilyPondTweakManager,
-    )
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 
 

--- a/abjad/indicators/LilyPondLiteral.py
+++ b/abjad/indicators/LilyPondLiteral.py
@@ -1,7 +1,6 @@
 import typing
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.lilypondnames.LilyPondTweakManager import \
-    LilyPondTweakManager
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.system.FormatSpecification import FormatSpecification
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 from abjad.system.StorageFormatManager import StorageFormatManager

--- a/abjad/indicators/LineSegment.py
+++ b/abjad/indicators/LineSegment.py
@@ -1,13 +1,12 @@
 import typing
-from abjad.enumerations import Center, VerticalAlignment
+from abjad.enumerations import Center
+from abjad.enumerations import VerticalAlignment
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.lilypondnames.LilyPondGrobOverride import (
-    LilyPondGrobOverride,
-)
+from abjad.lilypondnames.LilyPondGrobOverride import LilyPondGrobOverride
 from abjad.markup.Markup import Markup
 from abjad.scheme.Scheme import Scheme
 from abjad.system.LilyPondFormatManager import LilyPondFormatManager
-Number = typing.Union[int, float]
+from abjad.typings import Number
 
 
 class LineSegment(AbjadValueObject):

--- a/abjad/indicators/MetricModulation.py
+++ b/abjad/indicators/MetricModulation.py
@@ -1,14 +1,14 @@
 import collections
 import typing
-from abjad.enumerations import Up
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.utilities.Duration import Duration
+from abjad.enumerations import Up
 from abjad.markup.Markup import Markup
 from abjad.mathtools.Ratio import Ratio
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 from abjad.top.inspect import inspect
 from abjad.top.new import new
 from abjad.top.select import select
+from abjad.utilities.Duration import Duration
 
 
 class MetricModulation(AbjadValueObject):

--- a/abjad/indicators/MetronomeMark.py
+++ b/abjad/indicators/MetronomeMark.py
@@ -7,12 +7,10 @@ except ImportError:
 import functools
 import math
 import typing
-from abjad.enumerations import Down
-from abjad.exceptions import ImpreciseMetronomeMarkError
 from abjad import mathtools
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.utilities.Duration import Duration
-from abjad.utilities.Multiplier import Multiplier
+from abjad.enumerations import Down
+from abjad.exceptions import ImpreciseMetronomeMarkError
 from abjad.markup.Markup import Markup
 from abjad.mathtools.Enumerator import Enumerator
 from abjad.mathtools.NonreducedFraction import NonreducedFraction
@@ -22,7 +20,9 @@ from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 from abjad.system.StorageFormatManager import StorageFormatManager
 from abjad.top.new import new
 from abjad.top.sequence import sequence
-Number = typing.Union[int, float]
+from abjad.typings import Number
+from abjad.utilities.Duration import Duration
+from abjad.utilities.Multiplier import Multiplier
 
 
 @functools.total_ordering

--- a/abjad/indicators/RehearsalMark.py
+++ b/abjad/indicators/RehearsalMark.py
@@ -1,9 +1,7 @@
 import copy
 import typing
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.lilypondnames.LilyPondTweakManager import (
-    LilyPondTweakManager,
-    )
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.markup.Markup import Markup
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 from abjad.top.new import new

--- a/abjad/indicators/Ritardando.py
+++ b/abjad/indicators/Ritardando.py
@@ -1,6 +1,6 @@
 import typing
-from abjad.enumerations import Up
 from abjad.abctools.AbjadValueObject import AbjadValueObject
+from abjad.enumerations import Up
 from abjad.markup.Markup import Markup
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 from abjad.top.new import new

--- a/abjad/indicators/Staccatissimo.py
+++ b/abjad/indicators/Staccatissimo.py
@@ -1,13 +1,16 @@
 import typing
-from abjad.enumerations import (
-    Center, Down, Right, Up, HorizontalAlignment, VerticalAlignment,
-)
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.utilities.String import String
-from abjad.lilypondnames.LilyPondTweakManager import (
-    LilyPondTweakManager,
+from abjad.enumerations import (
+    Center,
+    Down,
+    HorizontalAlignment,
+    Right,
+    Up,
+    VerticalAlignment,
     )
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
+from abjad.utilities.String import String
 
 
 class Staccatissimo(AbjadValueObject):

--- a/abjad/indicators/Staccato.py
+++ b/abjad/indicators/Staccato.py
@@ -1,13 +1,16 @@
 import typing
-from abjad.enumerations import (
-    Center, Down, Right, Up, HorizontalAlignment, VerticalAlignment,
-)
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.utilities.String import String
-from abjad.lilypondnames.LilyPondTweakManager import (
-    LilyPondTweakManager,
+from abjad.enumerations import (
+    Center,
+    Down,
+    HorizontalAlignment,
+    Right,
+    Up,
+    VerticalAlignment,
     )
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
+from abjad.utilities.String import String
 
 
 class Staccato(AbjadValueObject):

--- a/abjad/indicators/StaffChange.py
+++ b/abjad/indicators/StaffChange.py
@@ -1,4 +1,5 @@
-from abjad.enumerations import HorizontalAlignment, Right
+from abjad.enumerations import HorizontalAlignment
+from abjad.enumerations import Right
 from abjad.abctools.AbjadValueObject import AbjadValueObject
 from abjad.scheme.Scheme import Scheme
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle

--- a/abjad/indicators/TimeSignature.py
+++ b/abjad/indicators/TimeSignature.py
@@ -2,11 +2,11 @@ import collections
 import typing
 from abjad import mathtools
 from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.utilities.Duration import Duration
-from abjad.utilities.Multiplier import Multiplier
 from abjad.mathtools.NonreducedFraction import NonreducedFraction
 from abjad.system.FormatSpecification import FormatSpecification
 from abjad.system.StorageFormatManager import StorageFormatManager
+from abjad.utilities.Duration import Duration
+from abjad.utilities.Multiplier import Multiplier
 
 
 class TimeSignature(AbjadValueObject):

--- a/abjad/indicators/test/test_MetronomeMark_attach.py
+++ b/abjad/indicators/test/test_MetronomeMark_attach.py
@@ -4,7 +4,8 @@ import pytest
 
 def test_MetronomeMark_attach_01():
 
-    score = abjad.Score(r"\new Staff { c'' d'' e'' f'' } \new Staff { c' d' e' f' }")
+    score = abjad.Score(
+        r"\new Staff { c'' d'' e'' f'' } \new Staff { c' d' e' f' }")
     mark_1 = abjad.MetronomeMark((1, 8), 52)
     mark_2 = abjad.MetronomeMark((1, 8), 73)
     abjad.attach(mark_1, score[0][0])

--- a/abjad/lilypondnames/LilyPondContextSetting.py
+++ b/abjad/lilypondnames/LilyPondContextSetting.py
@@ -1,6 +1,7 @@
 import typing
 from abjad.abctools.AbjadValueObject import AbjadValueObject
 from abjad.scheme.Scheme import Scheme
+from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 
 
 class LilyPondContextSetting(AbjadValueObject):
@@ -23,8 +24,8 @@ class LilyPondContextSetting(AbjadValueObject):
     ### CLASS VARIABLES ###
 
     __slots__ = (
-        '_lilypond_type',
         '_context_property',
+        '_lilypond_type',
         '_is_unset',
         '_value',
         )
@@ -70,8 +71,7 @@ class LilyPondContextSetting(AbjadValueObject):
     ### PRIVATE METHODS ###
 
     def _get_lilypond_format_bundle(self, component=None):
-        import abjad
-        bundle = abjad.LilyPondFormatBundle()
+        bundle = LilyPondFormatBundle()
         string = '\n'.join(self.format_pieces)
         bundle.context_settings.append(string)
         return bundle
@@ -95,7 +95,7 @@ class LilyPondContextSetting(AbjadValueObject):
     @property
     def format_pieces(self) -> typing.Tuple[str, ...]:
         r"""
-        Gets LilyPond context setting \set or \unset format pieces.
+        Gets LilyPond context setting ``\set`` or ``\unset`` format pieces.
         """
         result = []
         if not self.is_unset:
@@ -108,8 +108,8 @@ class LilyPondContextSetting(AbjadValueObject):
         else:
             result.append(self.context_property)
         result.append('=')
-        value_pieces = Scheme.format_embedded_scheme_value(self.value)
-        value_pieces = value_pieces.split('\n')
+        string = Scheme.format_embedded_scheme_value(self.value)
+        value_pieces = string.split('\n')
         result.append(value_pieces[0])
         result[:] = [' '.join(result)]
         result.extend(value_pieces[1:])

--- a/abjad/lilypondnames/LilyPondGrobNameManager.py
+++ b/abjad/lilypondnames/LilyPondGrobNameManager.py
@@ -1,6 +1,6 @@
 import typing
-from abjad.utilities.String import String
 from abjad.system.LilyPondFormatManager import LilyPondFormatManager
+from abjad.utilities.String import String
 from .LilyPondNameManager import LilyPondNameManager
 
 

--- a/abjad/lilypondnames/LilyPondGrobOverride.py
+++ b/abjad/lilypondnames/LilyPondGrobOverride.py
@@ -271,8 +271,8 @@ class LilyPondGrobOverride(AbjadValueObject):
         result.append(r'\override')
         result.append(self._override_property_path_string())
         result.append('=')
-        value_pieces = Scheme.format_embedded_scheme_value(self.value)
-        value_pieces = value_pieces.split('\n')
+        string = Scheme.format_embedded_scheme_value(self.value)
+        value_pieces = string.split('\n')
         result.append(value_pieces[0])
         result[:] = [' '.join(result)]
         result.extend(value_pieces[1:])

--- a/abjad/lilypondnames/LilyPondNameManager.py
+++ b/abjad/lilypondnames/LilyPondNameManager.py
@@ -12,7 +12,7 @@ class LilyPondNameManager(object):
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when `argument` is a LilyPond name manager with attribute
+        Is true when ``argument`` is a LilyPond name manager with attribute
         pairs equal to those of this LilyPond name manager.
         """
         if isinstance(argument, type(self)):
@@ -42,7 +42,7 @@ class LilyPondNameManager(object):
         body_string = ''
         pairs = self._get_attribute_pairs()
         pairs = [str(_) for _ in pairs]
-        body_string = ''.join(pairs)
+        body_string = ', '.join(pairs)
         return f'{type(self).__name__}({body_string})'
 
     def __setstate__(self, state) -> None:

--- a/abjad/lilypondnames/LilyPondTweakManager.py
+++ b/abjad/lilypondnames/LilyPondTweakManager.py
@@ -1,7 +1,7 @@
 import copy
 import typing
-from abjad.utilities.String import String
 from abjad.system.LilyPondFormatManager import LilyPondFormatManager
+from abjad.utilities.String import String
 from .LilyPondNameManager import LilyPondNameManager
 
 
@@ -37,7 +37,7 @@ class LilyPondTweakManager(LilyPondNameManager):
         >>> abjad.tweak(beam).foo
         Traceback (most recent call last):
             ...
-        AttributeError: 'LilyPondTweakManager' object has no attribute: 'foo'.
+        AttributeError: LilyPondTweakManager object has no attribute 'foo'.
         
     """
 
@@ -98,16 +98,34 @@ class LilyPondTweakManager(LilyPondNameManager):
                     \f
                 }
 
+        ..  container:: example
+
+            Tweak expressions work like this:
+
+            >>> abjad.tweak('red').color
+            LilyPondTweakManager(('color', 'red'))
+
+            >>> abjad.tweak(6).Y_offset
+            LilyPondTweakManager(('Y_offset', 6))
+
+            >>> abjad.tweak(False).bound_details__left_broken__text
+            LilyPondTweakManager(('bound_details__left_broken__text', False))
+
         """
         from abjad.ly import contexts
         from abjad.ly import grob_interfaces
+        if '_pending_value' in vars(self):
+            _pending_value = self._pending_value
+            self.__setattr__(name, _pending_value)
+            delattr(self, '_pending_value')
+            return self
         camel_name = String(name).to_upper_camel_case()
         if name.startswith('_'):
             try:
                 return vars(self)[name]
             except KeyError:
                 type_name = type(self).__name__
-                message = '{type_name!r} object has no attribute: {name!r}.'
+                message = f'{type_name} object has no attribute {name!r}.'
                 raise AttributeError(message)
         elif camel_name in grob_interfaces:
             try:
@@ -120,7 +138,7 @@ class LilyPondTweakManager(LilyPondNameManager):
                 return vars(self)[name]
             except KeyError:
                 type_name = type(self).__name__
-                message = f'{type_name!r} object has no attribute: {name!r}.'
+                message = f'{type_name} object has no attribute {name!r}.'
                 raise AttributeError(message)
 
     ### PRIVATE METHODS ###

--- a/abjad/lilypondnames/test/test_LilyPondGrobNameManager___eq__.py
+++ b/abjad/lilypondnames/test/test_LilyPondGrobNameManager___eq__.py
@@ -1,5 +1,5 @@
-import copy
 import abjad
+import copy
 
 
 def test_LilyPondGrobNameManager___eq___01():

--- a/abjad/lilypondnames/test/test_LilyPondGrobNameManager___getattr__.py
+++ b/abjad/lilypondnames/test/test_LilyPondGrobNameManager___getattr__.py
@@ -1,5 +1,5 @@
-import pytest
 import abjad
+import pytest
 
 
 def test_LilyPondGrobNameManager___getattr___01():

--- a/abjad/lilypondnames/test/test_LilyPondNameManager___eq__.py
+++ b/abjad/lilypondnames/test/test_LilyPondNameManager___eq__.py
@@ -1,5 +1,5 @@
-import copy
 import abjad
+import copy
 
 
 def test_LilyPondNameManager___eq___01():

--- a/abjad/lilypondnames/test/test_LilyPondSettingNameManager___eq__.py
+++ b/abjad/lilypondnames/test/test_LilyPondSettingNameManager___eq__.py
@@ -1,5 +1,5 @@
-import copy
 import abjad
+import copy
 
 
 def test_LilyPondSettingNameManager___eq___01():

--- a/abjad/markup/Markup.py
+++ b/abjad/markup/Markup.py
@@ -2,20 +2,18 @@ import collections
 import numbers
 import typing
 from abjad import Fraction
+from abjad import mathtools
+from abjad import scheme as abjad_scheme
+from abjad.abctools.AbjadValueObject import AbjadValueObject
 from abjad.enumerations import Center
 from abjad.enumerations import Down
 from abjad.enumerations import Up
 from abjad.enumerations import VerticalAlignment
-from abjad import mathtools
-from abjad import scheme as abjad_scheme
-from abjad.abctools.AbjadValueObject import AbjadValueObject
-from abjad.utilities.String import String
-from abjad.lilypondnames.LilyPondTweakManager import (
-    LilyPondTweakManager,
-    )
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.markup.MarkupCommand import MarkupCommand
 from abjad.markup.Postscript import Postscript
 from abjad.scheme.Scheme import Scheme
+from abjad.utilities.String import String
 from abjad.top import new
 
 
@@ -1058,8 +1056,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('center-align', contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def center_column(markup_list, direction=None):
+    @classmethod
+    def center_column(class_, markup_list, direction=None):
         r"""
         LilyPond ``\center-column`` markup command.
 
@@ -1103,7 +1101,7 @@ class Markup(AbjadValueObject):
         for markup in markup_list:
             contents.append(Markup._parse_markup_command_argument(markup))
         command = MarkupCommand('center-column', contents)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
     def circle(self):
         r"""
@@ -1132,8 +1130,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('circle', contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def column(markup_list, direction=None):
+    @classmethod
+    def column(class_, markup_list, direction=None):
         r"""
         LilyPond ``\column`` markup command.
 
@@ -1159,10 +1157,10 @@ class Markup(AbjadValueObject):
         for markup in markup_list:
             contents.extend(markup.contents)
         command = MarkupCommand('column', contents)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
-    @staticmethod
-    def combine(markup_list, direction=None):
+    @classmethod
+    def combine(class_, markup_list, direction=None):
         r"""
         LilyPond ``\combine`` markup command.
 
@@ -1189,13 +1187,13 @@ class Markup(AbjadValueObject):
             message = message.format(markup_list)
             raise Exception(message)
         markup_1, markup_2 = markup_list
-        contents_1 = Markup._parse_markup_command_argument(markup_1)
-        contents_2 = Markup._parse_markup_command_argument(markup_2)
+        contents_1 = class_._parse_markup_command_argument(markup_1)
+        contents_2 = class_._parse_markup_command_argument(markup_2)
         command = MarkupCommand('combine', contents_1, contents_2)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
-    @staticmethod
-    def concat(markup_list, direction=None):
+    @classmethod
+    def concat(class_, markup_list, direction=None):
         r"""
         LilyPond ``\concat`` markup command.
 
@@ -1228,10 +1226,10 @@ class Markup(AbjadValueObject):
             contents = Markup._parse_markup_command_argument(markup)
             result.append(contents)
         command = MarkupCommand('concat', result)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
-    @staticmethod
-    def draw_circle(radius, thickness, direction=None, filled=False):
+    @classmethod
+    def draw_circle(class_, radius, thickness, direction=None, filled=False):
         r"""
         LilyPond ``\draw-circle`` markup command.
 
@@ -1251,10 +1249,10 @@ class Markup(AbjadValueObject):
         Returns new markup
         """
         command = MarkupCommand('draw-circle', radius, thickness, filled)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
-    @staticmethod
-    def draw_line(x, y, direction=None):
+    @classmethod
+    def draw_line(class_, x, y, direction=None):
         r"""
         LilyPond ``\draw-line`` markup command.
 
@@ -1273,7 +1271,7 @@ class Markup(AbjadValueObject):
         """
         pair = abjad_scheme.SchemePair((x, y))
         command = MarkupCommand('draw-line', pair)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
     def dynamic(self):
         r"""
@@ -1297,8 +1295,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('dynamic', contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def filled_box(x_extent, y_extent, blot=0, direction=None):
+    @classmethod
+    def filled_box(class_, x_extent, y_extent, blot=0, direction=None):
         r"""
         LilyPond ``filled-box`` markup command.
 
@@ -1321,7 +1319,7 @@ class Markup(AbjadValueObject):
         y_extent = abjad_scheme.SchemePair(y_extent)
         blot = float(blot)
         command = MarkupCommand('filled-box', x_extent, y_extent, blot)
-        return Markup(command, direction=direction)
+        return class_(command, direction=direction)
 
     def finger(self):
         r"""
@@ -1345,8 +1343,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('finger', contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def flat(direction=None):
+    @classmethod
+    def flat(class_, direction=None):
         r"""
         LilyPond ``\flat`` markup command.
 
@@ -1363,7 +1361,7 @@ class Markup(AbjadValueObject):
         Returns new markup.
         """
         command = MarkupCommand('flat')
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
     def fontsize(self, fontsize):
         r"""
@@ -1390,8 +1388,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('fontsize', fontsize, contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def fraction(numerator, denominator, direction=None):
+    @classmethod
+    def fraction(class_, numerator, denominator, direction=None):
         r"""
         LilyPond ``\fraction`` markup command.
 
@@ -1426,10 +1424,10 @@ class Markup(AbjadValueObject):
         Returns new markup
         """
         command = MarkupCommand('fraction', str(numerator), str(denominator))
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
-    @staticmethod
-    def from_literal(string, direction=None, stack_priority=0):
+    @classmethod
+    def from_literal(class_, string, direction=None, stack_priority=0):
         r"""
         Makes markup from literal ``string`` and bypasses parser.
 
@@ -1443,7 +1441,7 @@ class Markup(AbjadValueObject):
 
         Returns new markup.
         """
-        markup = Markup(
+        markup = class_(
             contents='',
             direction=direction,
             stack_priority=stack_priority,
@@ -1554,8 +1552,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('hcenter-in', length, contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def hspace(amount, direction=None):
+    @classmethod
+    def hspace(class_, amount, direction=None):
         r"""
         LilyPond ``\hspace`` markup command.
 
@@ -1573,7 +1571,7 @@ class Markup(AbjadValueObject):
         Returns new markup.
         """
         command = MarkupCommand('hspace', amount)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
     def huge(self):
         r"""
@@ -1641,8 +1639,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('larger', contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def left_column(markup_list, direction=None):
+    @classmethod
+    def left_column(class_, markup_list, direction=None):
         r"""
         LilyPond ``\left-column`` markup command.
 
@@ -1668,10 +1666,11 @@ class Markup(AbjadValueObject):
         for markup in markup_list:
             contents.append(Markup._parse_markup_command_argument(markup))
         command = MarkupCommand('left-column', contents)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
-    @staticmethod
+    @classmethod
     def line(
+        class_,
         markup_list,
         direction=None,
         deactivate=None,
@@ -1705,10 +1704,10 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('line', contents)
         command.deactivate = deactivate
         command.tag = tag
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
-    @staticmethod
-    def make_improper_fraction_markup(rational, direction=None):
+    @classmethod
+    def make_improper_fraction_markup(class_, rational, direction=None):
         r"""
         Makes improper fraction markup.
 
@@ -1762,8 +1761,8 @@ class Markup(AbjadValueObject):
         markup = integer_markup + fraction_markup
         return markup
 
-    @staticmethod
-    def musicglyph(glyph_name=None, direction=None):
+    @classmethod
+    def musicglyph(class_, glyph_name=None, direction=None):
         r"""
         LilyPond ``\musicglyph`` markup command.
 
@@ -1789,10 +1788,10 @@ class Markup(AbjadValueObject):
         assert glyph_name in music_glyphs, message
         glyph_scheme = abjad_scheme.Scheme(glyph_name, force_quotes=True)
         command = MarkupCommand('musicglyph', glyph_scheme)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
-    @staticmethod
-    def natural(direction=None):
+    @classmethod
+    def natural(class_, direction=None):
         r"""
         LilyPond ``\natural`` markup command.
 
@@ -1809,7 +1808,7 @@ class Markup(AbjadValueObject):
         Returns new markup.
         """
         command = MarkupCommand('natural')
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
     def normal_text(self):
         r"""
@@ -1836,8 +1835,8 @@ class Markup(AbjadValueObject):
             )
         return new(self, contents=command)
 
-    @staticmethod
-    def note_by_number(log, dot_count, stem_direction, direction=None):
+    @classmethod
+    def note_by_number(class_, log, dot_count, stem_direction, direction=None):
         r"""
         LilyPond ``\note-by-number`` markup command.
 
@@ -1862,10 +1861,10 @@ class Markup(AbjadValueObject):
             dot_count,
             stem_direction,
             )
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
-    @staticmethod
-    def null(direction=None):
+    @classmethod
+    def null(class_, direction=None):
         r"""
         LilyPond ``\null`` markup command.
 
@@ -1882,10 +1881,10 @@ class Markup(AbjadValueObject):
         Returns new markup.
         """
         command = MarkupCommand('null')
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
-    @staticmethod
-    def overlay(markup_list, direction=None):
+    @classmethod
+    def overlay(class_, markup_list, direction=None):
         r"""
         LilyPond ``\overlay`` markup command.
 
@@ -1911,7 +1910,7 @@ class Markup(AbjadValueObject):
         for markup in markup_list:
             contents.append(Markup._parse_markup_command_argument(markup))
         command = MarkupCommand('overlay', contents)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
     def override(self, pair):
         r"""
@@ -2148,8 +2147,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('parenthesize', contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def postscript(postscript, direction=None):
+    @classmethod
+    def postscript(class_, postscript, direction=None):
         r"""
         LilyPond ``\postscript`` markup command.
 
@@ -2182,7 +2181,7 @@ class Markup(AbjadValueObject):
             postscript = str(postscript)
         assert isinstance(postscript, str)
         command = MarkupCommand('postscript', postscript)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
     def raise_(self, amount):
         r"""
@@ -2207,8 +2206,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('raise', amount, contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def right_column(markup_list, direction=None):
+    @classmethod
+    def right_column(class_, markup_list, direction=None):
         r"""
         LilyPond ``\right-column`` markup command.
 
@@ -2237,7 +2236,7 @@ class Markup(AbjadValueObject):
         for markup in markup_list:
             contents.append(Markup._parse_markup_command_argument(markup))
         command = MarkupCommand('right-column', contents)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
     def rotate(self, angle):
         r"""
@@ -2308,8 +2307,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('scale', factor_pair, contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def sharp(direction=None):
+    @classmethod
+    def sharp(class_, direction=None):
         r"""
         LilyPond ``\sharp`` markup command.
 
@@ -2326,7 +2325,7 @@ class Markup(AbjadValueObject):
         Returns new markup.
         """
         command = MarkupCommand('sharp')
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
     def small(self):
         r"""
@@ -2477,8 +2476,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('translate', offset_pair, contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def triangle(direction=None, is_filled=True):
+    @classmethod
+    def triangle(class_, direction=None, is_filled=True):
         r"""
         LilyPond ``\triangle`` markup command.
 
@@ -2496,7 +2495,7 @@ class Markup(AbjadValueObject):
         Returns new markup
         """
         command = MarkupCommand('triangle', bool(is_filled))
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
     def upright(self):
         r"""
@@ -2542,8 +2541,8 @@ class Markup(AbjadValueObject):
         command = MarkupCommand('vcenter', contents)
         return new(self, contents=command)
 
-    @staticmethod
-    def vspace(amount, direction=None):
+    @classmethod
+    def vspace(class_, amount, direction=None):
         r"""
         LilyPond ``\vspace`` markup command.
 
@@ -2561,7 +2560,7 @@ class Markup(AbjadValueObject):
         Returns new markup.
         """
         command = MarkupCommand('vspace', amount)
-        return Markup(contents=command, direction=direction)
+        return class_(contents=command, direction=direction)
 
     def whiteout(self):
         r"""

--- a/abjad/scheme/SchemeAssociativeList.py
+++ b/abjad/scheme/SchemeAssociativeList.py
@@ -1,4 +1,6 @@
+import typing
 from .Scheme import Scheme
+from .SchemePair import SchemePair
 
 
 class SchemeAssociativeList(Scheme):
@@ -31,18 +33,19 @@ class SchemeAssociativeList(Scheme):
 
     ### INITIALIZER ###
 
-    def __init__(self, value=None):
-        import abjad
+    def __init__(
+        self,
+        value: typing.List = None,
+        ) -> None:
         value = value or []
         pairs = []
         for item in value:
             if isinstance(item, tuple):
-                pair = abjad.SchemePair(item)
-            elif isinstance(item, abjad.SchemePair):
+                pair = SchemePair(item)
+            elif isinstance(item, SchemePair):
                 pair = item
             else:
-                message = 'must be Python pair or Scheme pair: {!r}.'
-                message = message.format(item)
+                message = f'must be Python pair or Scheme pair: {item!r}.'
                 raise TypeError(message)
             pairs.append(pair)
         Scheme.__init__(self, value=pairs, quoting="'")

--- a/abjad/scheme/SchemeColor.py
+++ b/abjad/scheme/SchemeColor.py
@@ -30,10 +30,9 @@ class SchemeColor(Scheme):
 
     __slots__ = ()
 
-    ### PRIVATE PROPERTIES ###
+    ### PRIVATE METHODS ###
 
-    @property
-    def _formatted_value(self):
+    def _get_formatted_value(self):
         string = "(x11-color '{})"
         string = string.format(self._value)
         return string

--- a/abjad/scheme/SchemeMoment.py
+++ b/abjad/scheme/SchemeMoment.py
@@ -1,4 +1,7 @@
 import functools
+import typing
+from abjad.mathtools.NonreducedFraction import NonreducedFraction
+from abjad.system.FormatSpecification import FormatSpecification
 from .Scheme import Scheme
 
 
@@ -23,15 +26,16 @@ class SchemeMoment(Scheme):
 
     ### INITIALIZER ###
 
-    def __init__(self, duration=(0, 1)):
-        import abjad
-        duration = abjad.NonreducedFraction(duration)
-        pair = duration.pair
+    def __init__(
+        self,
+        duration: typing.Union[typing.Tuple[int, int]] = (0, 1),
+        ) -> None:
+        pair = NonreducedFraction(duration).pair
         Scheme.__init__(self, pair)
 
     ### SPECIAL METHODS ###
 
-    def __eq__(self, argument):
+    def __eq__(self, argument) -> bool:
         """
         Is true when ``argument`` is a scheme moment with the same value as
         that of this scheme moment.
@@ -48,19 +52,18 @@ class SchemeMoment(Scheme):
             >>> abjad.SchemeMoment((2, 54)) == abjad.SchemeMoment((2, 68))
             False
 
-        Returns true or false.
         """
         return super(SchemeMoment, self).__eq__(argument)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """
         Hashes scheme moment.
 
-        Returns integer.
+        Redefined in tandem with ``__eq__``.
         """
         return super(SchemeMoment, self).__hash__()
 
-    def __lt__(self, argument):
+    def __lt__(self, argument) -> bool:
         """
         Is true when ``argument`` is a scheme moment with value greater than
         that of this scheme moment.
@@ -77,37 +80,31 @@ class SchemeMoment(Scheme):
             >>> abjad.SchemeMoment((1, 68)) < abjad.SchemeMoment((1, 78))
             False
 
-        Returns true or false.
         """
         if isinstance(argument, type(self)):
             if self.duration < argument.duration:
                 return True
         return False
 
-    ### PRIVATE PROPERTIES ###
-
-    @property
-    def _formatted_value(self):
-        pair = self.duration.pair
-        string = '(ly:make-moment {} {})'
-        string = string.format(*pair)
-        return string
-
     ### PRIVATE METHODS ###
 
     def _get_format_specification(self):
-        import abjad
         values = [self.value]
-        return abjad.FormatSpecification(
+        return FormatSpecification(
             client=self,
             storage_format_args_values=values,
             storage_format_kwargs_names=[],
             )
 
+    def _get_formatted_value(self):
+        pair = self.duration.pair
+        string = f'(ly:make-moment {pair[0]} {pair[1]})'
+        return string
+
     ### PUBLIC PROPERTIES ###
 
     @property
-    def duration(self):
+    def duration(self) -> NonreducedFraction:
         """
         Gets duration of Scheme moment.
 
@@ -116,7 +113,5 @@ class SchemeMoment(Scheme):
             >>> abjad.SchemeMoment((2, 68)).duration
             NonreducedFraction(2, 68)
 
-        Returns nonreduced fraction.
         """
-        import abjad
-        return abjad.NonreducedFraction(self.value)
+        return NonreducedFraction(self.value)

--- a/abjad/scheme/SchemePair.py
+++ b/abjad/scheme/SchemePair.py
@@ -1,3 +1,5 @@
+import typing
+from abjad.system.FormatSpecification import FormatSpecification
 from .Scheme import Scheme
 
 
@@ -32,18 +34,23 @@ class SchemePair(Scheme):
 
     ### CLASS VARIABLES ##
 
-    __slots__ = ()
+    __slots__ = (
+        '_value',
+        )
 
     ### INITIALIZER ##
 
-    def __init__(self, value=(None, None)):
+    def __init__(
+        self,
+        value = (None, None),
+        ) -> None:
         assert isinstance(value, tuple), repr(value)
         assert len(value) == 2, repr(value)
         Scheme.__init__(self, value=value)
 
     ### SPECIAL METHODS ###
 
-    def __format__(self, format_specification=''):
+    def __format__(self, format_specification='') -> str:
         """
         Formats Scheme pair.
 
@@ -57,54 +64,53 @@ class SchemePair(Scheme):
             >>> abjad.f(scheme_pair)
             abjad.SchemePair((-1, 1))
 
-        Returns string.
         """
         return super(SchemePair, self).__format__(
             format_specification=format_specification,
             )
 
-    ### PRIVATE PROPERTIES ###
-
-    @property
-    def _formatted_value(self):
-        import abjad
-        assert len(self._value) == 2
-        lhs = abjad.Scheme.format_scheme_value(self._value[0])
-        # need to force quotes around pairs like
-        # \override #'(font-name . "Times")
-        rhs = abjad.Scheme.format_scheme_value(
-            self._value[-1],
-            force_quotes=True,
-            )
-        return '({} . {})'.format(lhs, rhs)
-
     ### PRIVATE METHODS ###
 
     def _get_format_specification(self):
-        import abjad
         values = [self.value]
-        return abjad.FormatSpecification(
+        return FormatSpecification(
             client=self,
             repr_is_indented=False,
             storage_format_is_indented=False,
             storage_format_args_values=values,
             )
 
+    def _get_formatted_value(self):
+        assert len(self._value) == 2
+        lhs = Scheme.format_scheme_value(self._value[0])
+        # need to force quotes around pairs like
+        # \override #'(font-name . "Times")
+        rhs = Scheme.format_scheme_value(
+            self._value[-1],
+            force_quotes=True,
+            )
+        return f'({lhs} . {rhs})'
+
     def _get_lilypond_format(self):
-        return "#'%s" % self._formatted_value
+        string = self._get_formatted_value()
+        return f"#'{string}"
 
     ### PUBLIC PROPERTIES ###
 
     @property
-    def left(self):
+    def left(self) -> typing.Any:
         """
         Gets left value.
         """
-        return self._value[0]
+        pair = self.value
+        assert isinstance(pair, tuple)
+        return pair[0]
 
     @property
-    def right(self):
+    def right(self) -> typing.Any:
         """
         Gets right value.
         """
-        return self._value[-1]
+        pair = self.value
+        assert isinstance(pair, tuple)
+        return pair[-1]

--- a/abjad/scheme/SchemeSymbol.py
+++ b/abjad/scheme/SchemeSymbol.py
@@ -1,4 +1,4 @@
-from abjad import system
+from abjad.system.FormatSpecification import FormatSpecification
 from .Scheme import Scheme
 
 
@@ -23,7 +23,10 @@ class SchemeSymbol(Scheme):
 
     ### INITIALIZER ###
 
-    def __init__(self, symbol='cross'):
+    def __init__(
+        self,
+        symbol: str = 'cross',
+        ) -> None:
         symbol = str(symbol)
         Scheme.__init__(self, value=symbol, quoting="'")
 
@@ -31,7 +34,7 @@ class SchemeSymbol(Scheme):
 
     def _get_format_specification(self):
         values = [self.symbol]
-        return system.FormatSpecification(
+        return FormatSpecification(
             client=self,
             storage_format_args_values=values,
             storage_format_kwargs_names=[],
@@ -40,10 +43,9 @@ class SchemeSymbol(Scheme):
     ### PUBLIC PROPERTIES ###
 
     @property
-    def symbol(self):
+    def symbol(self) -> str:
         """
         Gets symbol string.
-
-        Returns string.
         """
-        return self._value
+        assert isinstance(self.value, str)
+        return self.value

--- a/abjad/scheme/SchemeVector.py
+++ b/abjad/scheme/SchemeVector.py
@@ -1,5 +1,6 @@
-from abjad import system
-from abjad import utilities
+import typing
+from abjad.system.FormatSpecification import FormatSpecification
+from abjad.utilities.String import String
 from .Scheme import Scheme
 
 
@@ -37,16 +38,19 @@ class SchemeVector(Scheme):
 
     ### INITIALIZER ###
 
-    def __init__(self, value=[]):
+    def __init__(
+        self,
+        value: typing.List = [],
+        ) -> None:
         Scheme.__init__(self, value, quoting="'")
 
     ### PRIVATE METHODS ###
 
     def _get_format_specification(self):
         values = self._value
-        if utilities.String.is_string(self._value):
+        if String.is_string(self._value):
             values = [self._value]
-        return system.FormatSpecification(
+        return FormatSpecification(
             client=self,
             storage_format_args_values=values,
             storage_format_kwargs_names=[],

--- a/abjad/scheme/SchemeVectorConstant.py
+++ b/abjad/scheme/SchemeVectorConstant.py
@@ -1,5 +1,6 @@
-from abjad import system
-from abjad import utilities
+import typing
+from abjad.system.FormatSpecification import FormatSpecification
+from abjad.utilities.String import String
 from .Scheme import Scheme
 
 
@@ -27,16 +28,19 @@ class SchemeVectorConstant(Scheme):
 
     ### INITIALIZER ###
 
-    def __init__(self, value=[]):
+    def __init__(
+        self,
+        value: typing.List = [],
+        ) -> None:
         Scheme.__init__(self, value, quoting="'#")
 
     ### PRIVATE METHODS ###
 
     def _get_format_specification(self):
         values = self._value
-        if utilities.String.is_string(self._value):
+        if String.is_string(self._value):
             values = [self._value]
-        return system.FormatSpecification(
+        return FormatSpecification(
             client=self,
             storage_format_args_values=values,
             storage_format_kwargs_names=[],

--- a/abjad/scheme/SpacingVector.py
+++ b/abjad/scheme/SpacingVector.py
@@ -1,3 +1,4 @@
+from abjad.typings import Number
 from .SchemeVector import SchemeVector
 from .SchemePair import SchemePair
 
@@ -42,11 +43,11 @@ class SpacingVector(SchemeVector):
 
     def __init__(
         self,
-        basic_distance=0,
-        minimum_distance=0,
-        padding=12,
-        stretchability=0,
-        ):
+        basic_distance: Number = 0,
+        minimum_distance: Number = 0,
+        padding: Number = 12,
+        stretchability: Number = 0,
+        ) -> None:
         pairs = [
             SchemePair(('basic-distance', basic_distance)),
             SchemePair(('minimum-distance', minimum_distance)),

--- a/abjad/segments/Path.py
+++ b/abjad/segments/Path.py
@@ -7,24 +7,24 @@ from .Line import Line
 from .Part import Part
 from .PartManifest import PartManifest
 from .Tags import Tags
-from abjad.indicators.Clef import Clef
-from abjad.indicators.LilyPondLiteral import LilyPondLiteral
-from abjad.indicators.MarginMarkup import MarginMarkup
-from abjad.indicators.TimeSignature import TimeSignature
-from abjad.utilities.CyclicTuple import CyclicTuple
-from abjad.utilities.OrderedDict import OrderedDict
-from abjad.utilities.String import String
 from abjad.core.MultimeasureRest import MultimeasureRest
 from abjad.core.Container import Container
 from abjad.core.Score import Score
 from abjad.core.Staff import Staff
 from abjad.core.StaffGroup import StaffGroup
+from abjad.indicators.Clef import Clef
+from abjad.indicators.LilyPondLiteral import LilyPondLiteral
+from abjad.indicators.MarginMarkup import MarginMarkup
+from abjad.indicators.TimeSignature import TimeSignature
 from abjad.system.IOManager import IOManager
 from abjad.system.LilyPondFormatManager import LilyPondFormatManager
 from abjad.top.activate import activate
 from abjad.top.attach import attach
 from abjad.top.deactivate import deactivate
 from abjad.top.iterate import iterate
+from abjad.utilities.CyclicTuple import CyclicTuple
+from abjad.utilities.OrderedDict import OrderedDict
+from abjad.utilities.String import String
 
 
 class Path(pathlib.PosixPath):
@@ -1020,6 +1020,21 @@ class Path(pathlib.PosixPath):
             >>> path.stylesheets.coerce('SEGMENT_STYLESHEET')
             'segment-stylesheet.ily'
 
+        ..  container:: example
+
+            Does not coerce in unknown directory:
+
+            >>> path = abjad.Path(
+            ...     '/unknown/path',
+            ...     )
+
+            >>> path.coerce('custom-script')
+            'custom-script'
+            >>> path.coerce('custom_script')
+            'custom_script'
+            >>> path.coerce('CUSTOM_SCRIPT')
+            'CUSTOM_SCRIPT'
+
         Returns string.
         """
         name = String(name).strip_diacritics()
@@ -1067,8 +1082,6 @@ class Path(pathlib.PosixPath):
             pass
         elif self.is_external():
             pass
-        else:
-            raise ValueError(self)
         return name
 
     def count(
@@ -2416,10 +2429,22 @@ class Path(pathlib.PosixPath):
             >>> path.segments('segment_01').is_segment()
             True
 
+        ..  container:: example
+
+            REGRESSION. Abjad segments directory is excluded:
+
+            >>> path = abjad.Path(
+            ...     '/path/to/abjad/abjad/segments',
+            ...     )
+            >>> path /= 'segment_01'
+            >>> path.is_segment()
+            False
+
         """
         if self.name[0] == '.':
             return False
-        return self.parent.name == 'segments'
+        return (self.parent.name == 'segments' and
+            self.parent.parent.name != 'abjad')
 
     @staticmethod
     def is_segment_name(string) -> bool:
@@ -2537,8 +2562,16 @@ class Path(pathlib.PosixPath):
             >>> path.segments.is_segments()
             True
 
+            Excludes Abjad segments directory:
+
+            >>> path = abjad.Path(
+            ...     '/path/to/abjad/abjad/segments',
+            ...     )
+            >>> path.is_segments()
+            False
+
         """
-        return self.name == 'segments'
+        return self.name == 'segments' and self.parent.name != 'abjad'
 
     def is_stylesheets(self) -> bool:
         """

--- a/abjad/spanners/Beam.py
+++ b/abjad/spanners/Beam.py
@@ -160,6 +160,7 @@ class Beam(Spanner):
 
     def __init__(
         self,
+        *,
         direction: typing.Union[str, VerticalAlignment] = None,
         leak: bool = None,
         stemlet_length: Number = None,

--- a/abjad/spanners/ComplexBeam.py
+++ b/abjad/spanners/ComplexBeam.py
@@ -75,6 +75,7 @@ class ComplexBeam(Beam):
 
     def __init__(
         self,
+        *,
         beam_rests: bool = None,
         direction: typing.Union[str, VerticalAlignment] = None,
         isolated_nib_direction: typing.Union[bool, HorizontalAlignment] = None,

--- a/abjad/spanners/ComplexTrillSpanner.py
+++ b/abjad/spanners/ComplexTrillSpanner.py
@@ -90,6 +90,7 @@ class ComplexTrillSpanner(Spanner):
 
     def __init__(
         self,
+        *,
         interval: str = None,
         ) -> None:
         Spanner.__init__(self)

--- a/abjad/spanners/DuratedComplexBeam.py
+++ b/abjad/spanners/DuratedComplexBeam.py
@@ -116,6 +116,7 @@ class DuratedComplexBeam(ComplexBeam):
 
     def __init__(
         self,
+        *,
         beam_rests: bool = None,
         direction: typing.Union[str, VerticalAlignment] = None,
         durations: typing.Iterable[Duration] = None,

--- a/abjad/spanners/Glissando.py
+++ b/abjad/spanners/Glissando.py
@@ -78,6 +78,7 @@ class Glissando(Spanner):
 
     def __init__(
         self,
+        *,
         allow_repeats: bool = None,
         allow_ties: bool = None,
         parenthesize_repeats: bool = None,

--- a/abjad/spanners/HorizontalBracketSpanner.py
+++ b/abjad/spanners/HorizontalBracketSpanner.py
@@ -73,6 +73,7 @@ class HorizontalBracketSpanner(Spanner):
 
     def __init__(
         self,
+        *,
         leak: bool = None,
         markup: Markup = None,
         ) -> None:

--- a/abjad/spanners/MeasuredComplexBeam.py
+++ b/abjad/spanners/MeasuredComplexBeam.py
@@ -70,6 +70,7 @@ class MeasuredComplexBeam(ComplexBeam):
 
     def __init__(
         self,
+        *,
         direction: VerticalAlignment = None,
         isolated_nib_direction: typing.Union[bool, HorizontalAlignment] = False,
         span_beam_count: int = 1,

--- a/abjad/spanners/MetronomeMarkSpanner.py
+++ b/abjad/spanners/MetronomeMarkSpanner.py
@@ -1970,6 +1970,7 @@ class MetronomeMarkSpanner(Spanner):
 
     def __init__(
         self,
+        *,
         left_broken_padding: Number = None,
         left_broken_text: typing.Union[bool, Markup] = False,
         left_hspace: Number = 1,

--- a/abjad/spanners/MultipartBeam.py
+++ b/abjad/spanners/MultipartBeam.py
@@ -82,7 +82,8 @@ class MultipartBeam(Beam):
 
     def __init__(
         self,
-        beam_rests: bool = False,
+        *,
+        beam_rests: bool = None,
         direction: VerticalAlignment = None,
         stemlet_length: Number = None,
         ) -> None:
@@ -91,7 +92,9 @@ class MultipartBeam(Beam):
             direction=direction,
             stemlet_length=stemlet_length,
             )
-        self._beam_rests = bool(beam_rests)
+        if beam_rests is not None:
+            beam_rests = bool(beam_rests)
+        self._beam_rests = beam_rests
 
     ### PRIVATE METHODS ###
 

--- a/abjad/spanners/OctavationSpanner.py
+++ b/abjad/spanners/OctavationSpanner.py
@@ -66,6 +66,7 @@ class OctavationSpanner(Spanner):
 
     def __init__(
         self,
+        *,
         start: int = 1,
         stop: int = 0,
         ) -> None:

--- a/abjad/spanners/PhrasingSlur.py
+++ b/abjad/spanners/PhrasingSlur.py
@@ -59,6 +59,7 @@ class PhrasingSlur(Spanner):
 
     def __init__(
         self,
+        *,
         direction: typing.Union[str, VerticalAlignment] = None,
         leak: bool = None,
         ) -> None:

--- a/abjad/spanners/PianoPedalSpanner.py
+++ b/abjad/spanners/PianoPedalSpanner.py
@@ -59,6 +59,7 @@ class PianoPedalSpanner(Spanner):
 
     def __init__(
         self,
+        *,
         kind: str = 'sustain',
         leak: bool = None,
         style: str = 'mixed',

--- a/abjad/spanners/Slur.py
+++ b/abjad/spanners/Slur.py
@@ -81,6 +81,7 @@ class Slur(Spanner):
 
     def __init__(
         self,
+        *,
         direction: typing.Union[str, VerticalAlignment] = None,
         ) -> None:
         Spanner.__init__(self)

--- a/abjad/spanners/Spanner.py
+++ b/abjad/spanners/Spanner.py
@@ -1,23 +1,25 @@
 import copy
 import typing
-from abjad.enumerations import Left, Right
-from abjad.timespans import Timespan
 from abjad.abctools.AbjadObject import AbjadObject
-from abjad.utilities.Duration import Duration
 from abjad.core.Leaf import Leaf
 from abjad.core.Selection import Selection
-from abjad.system.LilyPondFormatManager import LilyPondFormatManager
-from abjad.system.Wrapper import Wrapper
+from abjad.enumerations import Left
+from abjad.enumerations import Right
 from abjad.segments.Tags import Tags
 from abjad.system.FormatSpecification import FormatSpecification
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
+from abjad.system.LilyPondFormatManager import LilyPondFormatManager
 from abjad.system.StorageFormatManager import StorageFormatManager
+from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.system.Tag import Tag
+from abjad.system.Wrapper import Wrapper
+from abjad.timespans import Timespan
 from abjad.top.inspect import inspect
 from abjad.top.override import override
 from abjad.top.select import select
 from abjad.top.setting import setting
 from abjad.top.tweak import tweak
+from abjad.utilities.Duration import Duration
 abjad_tags = Tags()
 
 
@@ -59,6 +61,7 @@ class Spanner(AbjadObject):
 
     def __init__(
         self,
+        *,
         leak: bool = None,
         ) -> None:
         self._contiguity_constraint = 'logical voice'
@@ -115,10 +118,8 @@ class Spanner(AbjadObject):
     def __getnewargs__(self) -> typing.Tuple:
         """
         Gets new arguments.
-
-        Returns empty tuple.
         """
-        return (self.leak,)
+        return ()
 
     def __getstate__(self) -> dict:
         """
@@ -643,6 +644,13 @@ class Spanner(AbjadObject):
                 message = f'spanners attach only to leaves (not {leaf!s}).'
                 raise Exception(message)
         return select(self._leaves)
+
+    @property
+    def tweaks(self) -> typing.Optional[LilyPondTweakManager]:
+        """
+        Gets tweaks.
+        """
+        return self._lilypond_tweak_manager
 
     ### PUBLC METHODS ###
 

--- a/abjad/spanners/Tie.py
+++ b/abjad/spanners/Tie.py
@@ -159,6 +159,7 @@ class Tie(Spanner):
 
     def __init__(
         self,
+        *,
         direction: typing.Union[str, VerticalAlignment] = None,
         repeat: bool = None,
         ) -> None:

--- a/abjad/spanners/TrillSpanner.py
+++ b/abjad/spanners/TrillSpanner.py
@@ -111,6 +111,7 @@ class TrillSpanner(Spanner):
 
     def __init__(
         self,
+        *,
         interval: typing.Union[str, NamedInterval] = None,
         is_harmonic: bool = None,
         leak: bool = None,

--- a/abjad/system/IOManager.py
+++ b/abjad/system/IOManager.py
@@ -1,13 +1,15 @@
+import cProfile
 import datetime
+import io
 import os
 import pathlib
 import platform
+import pstats
 import re
 import shutil
 import subprocess
 import sys
 from abjad.abctools.AbjadObject import AbjadObject
-from io import StringIO
 
 
 class IOManager(AbjadObject):
@@ -633,8 +635,6 @@ class IOManager(AbjadObject):
 
         Returns string when ``print_to_terminal`` is true.
         """
-        import cProfile
-        import pstats
         now_string = datetime.datetime.today().strftime('%a %b %d %H:%M:%S %Y')
         profile = cProfile.Profile()
         if global_context is None:
@@ -647,7 +647,7 @@ class IOManager(AbjadObject):
                 global_context,
                 local_context,
                 )
-        stats_stream = StringIO()
+        stats_stream = io.StringIO()
         stats = pstats.Stats(profile, stream=stats_stream)
         if sort_by == 'cum':
             if platform.python_version() == '2.7.5':  # why so specific?

--- a/abjad/system/LilyPondFormatManager.py
+++ b/abjad/system/LilyPondFormatManager.py
@@ -1,6 +1,13 @@
 import typing
-from abjad.enumerations import Up, Down, Left, Right, Center
 from abjad.abctools.AbjadObject import AbjadObject
+from abjad.enumerations import Center
+from abjad.enumerations import Down
+from abjad.enumerations import Left
+from abjad.enumerations import Right
+from abjad.enumerations import Up
+from abjad.scheme.Scheme import Scheme
+from abjad.scheme.SchemePair import SchemePair
+from abjad.utilities.String import String
 from .LilyPondFormatBundle import LilyPondFormatBundle
 
 
@@ -14,29 +21,6 @@ class LilyPondFormatManager(AbjadObject):
     __documentation_section__ = 'LilyPond formatting'
 
     __slots__ = ()
-
-    lilypond_color_constants = (
-        'black',
-        'blue',
-        'center',
-        'cyan',
-        'darkblue',
-        'darkcyan',
-        'darkgreen',
-        'darkmagenta',
-        'darkred',
-        'darkyellow',
-        'down',
-        'green',
-        'grey',
-        'left',
-        'magenta',
-        'red',
-        'right',
-        'up',
-        'white',
-        'yellow',
-        )
 
     indent = 4 * ' '
 
@@ -390,9 +374,8 @@ class LilyPondFormatManager(AbjadObject):
         Formats LilyPond ``argument`` according to Scheme formatting
         conventions.
         """
-        from abjad.scheme.Scheme import Scheme
-        from abjad.scheme.SchemePair import SchemePair
-        if '_get_lilypond_format' in dir(argument) and not isinstance(argument, str):
+        if ('_get_lilypond_format' in dir(argument) and 
+            not isinstance(argument, str)):
             pass
         elif argument in (True, False):
             argument = Scheme(argument)
@@ -400,7 +383,9 @@ class LilyPondFormatManager(AbjadObject):
             argument = Scheme(repr(argument).lower())
         elif isinstance(argument, int) or isinstance(argument, float):
             argument = Scheme(argument)
-        elif argument in LilyPondFormatManager.lilypond_color_constants:
+        elif argument in Scheme.lilypond_color_constants:
+            argument = Scheme(argument)
+        elif isinstance(argument, str) and argument.startswith('#'):
             argument = Scheme(argument)
         elif isinstance(argument, str) and '::' in argument:
             argument = Scheme(argument)
@@ -450,7 +435,6 @@ class LilyPondFormatManager(AbjadObject):
         """
         Makes Lilypond override string.
         """
-        from abjad.utilities.String import String
         grob = String(grob).to_upper_camel_case()
         attribute = LilyPondFormatManager.format_lilypond_attribute(attribute)
         value = LilyPondFormatManager.format_lilypond_value(value)
@@ -479,7 +463,6 @@ class LilyPondFormatManager(AbjadObject):
             '\\revert Glissando.bound-details.right.arrow'
 
         """
-        from abjad.utilities.String import String
         grob = String(grob).to_upper_camel_case()
         dotted = LilyPondFormatManager.format_lilypond_attribute(attribute)
         if context is not None:
@@ -502,7 +485,6 @@ class LilyPondFormatManager(AbjadObject):
 
         Returns string.
         """
-        from abjad.utilities.String import String
         if grob is not None:
             grob = String(grob).to_upper_camel_case()
             grob += '.'

--- a/abjad/system/PersistenceManager.py
+++ b/abjad/system/PersistenceManager.py
@@ -2,10 +2,10 @@ import os
 import re
 import shutil
 import tempfile
-from abjad import abctools
+from abjad.abctools.AbjadObject import AbjadObject
 
 
-class PersistenceManager(abctools.AbjadObject):
+class PersistenceManager(AbjadObject):
     """
     Persistence manager.
 

--- a/abjad/system/Signature.py
+++ b/abjad/system/Signature.py
@@ -1,7 +1,7 @@
-from abjad import abctools
+from abjad.abctools.AbjadValueObject import AbjadValueObject
 
 
-class Signature(abctools.AbjadValueObject):
+class Signature(AbjadValueObject):
     """
     Signature.
 

--- a/abjad/system/UpdateManager.py
+++ b/abjad/system/UpdateManager.py
@@ -1,6 +1,6 @@
-from abjad.enumerations import Left
 from abjad.abctools.AbjadObject import AbjadObject
 from abjad.exceptions import MissingMetronomeMarkError
+from abjad.enumerations import Left
 
 
 class UpdateManager(AbjadObject):

--- a/abjad/top/tweak.py
+++ b/abjad/top/tweak.py
@@ -1,3 +1,9 @@
+from abjad.enumerations import Down
+from abjad.enumerations import Left
+from abjad.enumerations import Right
+from abjad.enumerations import Up
+
+
 def tweak(argument):
     r"""
     Makes LilyPond tweak manager.
@@ -238,8 +244,27 @@ def tweak(argument):
         >>> abjad.tweak(markup_1)
         LilyPondTweakManager(('color', 'red'))
 
+    ..  container:: example
+
+        Tweak expressions work like this:
+
+        >>> abjad.tweak('red').color
+        LilyPondTweakManager(('color', 'red'))
+
+        >>> abjad.tweak(6).Y_offset
+        LilyPondTweakManager(('Y_offset', 6))
+
+        >>> abjad.tweak(False).bound_details__left_broken__text
+        LilyPondTweakManager(('bound_details__left_broken__text', False))
+
     """
     import abjad
+    constants = (Down, Left, Right, Up)
+    prototype = (bool, int, float, str, tuple, abjad.Scheme)
+    if argument in constants or isinstance(argument, prototype):
+        manager = abjad.LilyPondTweakManager()
+        manager._pending_value = argument
+        return manager
     if not hasattr(argument, '_lilypond_tweak_manager'):
         name = type(argument).__name__
         raise NotImplementedError(f'{name} does not allow tweaks (yet).')

--- a/abjad/typings.py
+++ b/abjad/typings.py
@@ -1,0 +1,6 @@
+import typing
+
+
+Number = typing.Union[int, float]
+
+NumberPair = typing.Tuple[Number, Number]

--- a/abjad/utilities/CyclicTuple.py
+++ b/abjad/utilities/CyclicTuple.py
@@ -1,10 +1,10 @@
-import collections
+import typing
 from abjad.abctools.AbjadObject import AbjadObject
 
 
-class CyclicTuple(collections.Sequence, AbjadObject):
+class CyclicTuple(AbjadObject):
     """
-    Cylic tuple.
+    Cyclic tuple.
 
     ..  container:: example
 
@@ -42,27 +42,26 @@ class CyclicTuple(collections.Sequence, AbjadObject):
 
     ### INITIALIZER ###
 
-    def __init__(self, items=None):
+    def __init__(
+        self,
+        items: typing.Sequence = None,
+        ) -> None:
         items = items or ()
         items = tuple(items)
-        self._items = items
+        self._items: typing.Tuple = items
 
     ### SPECIAL METHODS ###
 
-    def __contains__(self, item):
+    def __contains__(self, item) -> bool:
         """
         Is true when cyclic tuple contains ``item``.
-
-        Returns true or false.
         """
         return self._items.__contains__(item)
 
-    def __eq__(self, argument):
+    def __eq__(self, argument) -> bool:
         """
         Is true when ``argument`` is a tuple with items equal to those of this
         cyclic tuple.
-
-        Returns true or false.
         """
         if isinstance(argument, tuple):
             return self._items == argument
@@ -70,7 +69,7 @@ class CyclicTuple(collections.Sequence, AbjadObject):
             return self._items == argument._items
         return False
 
-    def __getitem__(self, argument):
+    def __getitem__(self, argument) -> typing.Any:
         """
         Gets item or slice identified by ``argument``.
 
@@ -93,8 +92,6 @@ class CyclicTuple(collections.Sequence, AbjadObject):
             (0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2)
 
         Raises index error when ``argument`` can not be found in cyclic tuple.
-
-        Returns item.
         """
         if isinstance(argument, slice):
             if ((argument.stop is not None and argument.stop < 0) or
@@ -107,7 +104,7 @@ class CyclicTuple(collections.Sequence, AbjadObject):
         argument = argument % len(self)
         return self._items.__getitem__(argument)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """
         Hashes cyclic tuple.
 
@@ -115,7 +112,7 @@ class CyclicTuple(collections.Sequence, AbjadObject):
         """
         return super(CyclicTuple, self).__hash__()
 
-    def __iter__(self):
+    def __iter__(self) -> typing.Iterator:
         """
         Iterates cyclic tuple.
 
@@ -125,16 +122,14 @@ class CyclicTuple(collections.Sequence, AbjadObject):
         """
         return self._items.__iter__()
 
-    def __len__(self):
+    def __len__(self) -> int:
         """
         Gets length of cyclic tuple.
-
-        Returns nonnegative integer.
         """
         assert isinstance(self._items, tuple)
         return self._items.__len__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Gets string representation of cyclic tuple.
 
@@ -152,12 +147,11 @@ class CyclicTuple(collections.Sequence, AbjadObject):
             >>> str(abjad.CyclicTuple([1, 2, 3, 4]))
             '(1, 2, 3, 4)'
 
-        Returns string.
         """
         if self:
             contents = [str(item) for item in self._items]
-            contents = ', '.join(contents)
-            string = f'({contents!s})'
+            string = ', '.join(contents)
+            string = f'({string})'
             return string
         return '()'
 
@@ -187,7 +181,7 @@ class CyclicTuple(collections.Sequence, AbjadObject):
     ### PUBLIC PROPERTIES ###
 
     @property
-    def items(self):
+    def items(self) -> typing.Tuple:
         """
         Gets items in cyclic tuple.
 
@@ -207,6 +201,5 @@ class CyclicTuple(collections.Sequence, AbjadObject):
             >>> tuple_.items
             (1, 2, 3, 4)
 
-        Returns tuple.
         """
         return self._items

--- a/abjad/utilities/Expression.py
+++ b/abjad/utilities/Expression.py
@@ -1427,6 +1427,28 @@ class Expression(AbjadValueObject):
         return self._is_postfix
 
     @property
+    def is_selector(self):
+        """
+        Is true when expression is selector.
+
+        ..  container:: example
+
+            >>> expression = abjad.select().leaf(0)
+            >>> expression.is_selector
+            True
+
+            >>> expression = abjad.sequence().rotate(n=-1)
+            >>> expression.is_selector
+            False
+
+        """
+        if self.callbacks:
+            first_callback = self.callbacks[0]
+            if '.Selection' in first_callback.evaluation_template:
+                return True
+        return False
+
+    @property
     def keywords(self):
         """
         Gets keywords.


### PR DESCRIPTION
NEW SPANNER ENHANCEMENTS:

    Added abjad.TextSpanner.commands property.

    Use to set text spanner start- and stop-commands when extending LilyPond
    with custom spanner IDs.

    EXAMPLE.

    Assuming the following custom spanner definition:

        %%% In custom LilyPond include file %%%

        startParameterXYZTextSpan =
        #(make-music 'TextSpanEvent 'span-direction START 'spanner-id "XYZ")

        stopParameterXYZTextSpan =
        #(make-music 'TextSpanEvent 'span-direction STOP 'spanner-id "XYZ")

        %%% end .ily %%%

    Use abjad.TextSpanner.commands this way:

        >>> start_command = r'\startParameterXYZTextSpan'
        >>> stop_command = r'\stopParameterXYZTextSpan'
        >>> spanner = abjad.TextSpanner(
        ...     commands=(start_command, stop_command),
        ...     )
        >>> spanner.commands
        ('\\startParameterXYZTextSpan', '\\stopParameterXYZTextSpan')

        >>> staff = abjad.Staff("c'4 d' e' f'")
        >>> abjad.attach(spanner, staff[:])
        >>> abjad.f(staff)
        \new Staff
        {
            c'4
            \startParameterXYZTextSpan
            d'4
            e'4
            f'4
            \stopParameterXYZTextSpan
        }

NEW TWEAK ENHANCEMENTS:

    * Added support for tweak expressions; use the abjad.tweak() factory
      function

    EXAMPLES:

        >>> abjad.tweak('red').color
        LilyPondTweakManager(('color', 'red'))

        >>> abjad.tweak(6).Y_offset
        LilyPondTweakManager(('Y_offset', 6))

        >>> abjad.tweak(False).bound_details__left_broken__text
        LilyPondTweakManager(('bound_details__left_broken__text', False))

    * Activated tweaks on piecewise hairpins

NEW MARKUP ENHANCEMENTS:

    * Made abjad.Markup subclassable: static methods are now class methods.

NEW UTILITIES:

    * Added abjad/typings.py module.