### PR TITLE
BREAKING CHANGE: Removed 'get_' from abjad.inspect() methods.

### DIFF
--- a/abjad/boilerplate/__make_layout_ly__.py
+++ b/abjad/boilerplate/__make_layout_ly__.py
@@ -126,7 +126,7 @@ if __name__ == '__main__':
         prototype = abjad.LilyPondLiteral
         skips = abjad.iterate(score['GlobalSkips']).leaves(abjad.Skip)
         for i, skip in enumerate(skips):
-            for literal in abjad.inspect(skip).get_indicators(prototype):
+            for literal in abjad.inspect(skip).indicators(prototype):
                 if literal.argument in (r'\break', r'\pageBreak'):
                     measure_number = first_measure_number + i
                     bol_measure_numbers.append(measure_number)

--- a/abjad/boilerplate/__make_segment_pdf__.py
+++ b/abjad/boilerplate/__make_segment_pdf__.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
             time_signatures = []
             prototype = abjad.TimeSignature
             for skip in context:
-                time_signature = abjad.inspect(skip).get_effective(prototype)
+                time_signature = abjad.inspect(skip).effective(prototype)
                 assert isinstance(time_signature, prototype)
                 time_signatures.append(str(time_signature))
         else:

--- a/abjad/core/Chord.py
+++ b/abjad/core/Chord.py
@@ -180,7 +180,7 @@ class Chord(Leaf):
             for note_head in note_heads:
                 durated_pitch = format(note_head) + duration_string
                 durated_pitches.append(durated_pitch)
-            tremolo = abjad.inspect(self).get_indicator(abjad.Tremolo)
+            tremolo = abjad.inspect(self).indicator(abjad.Tremolo)
             if tremolo.is_slurred:
                 durated_pitches[0] = durated_pitches[0] + r' \('
                 durated_pitches[-1] = durated_pitches[-1] + r' \)'
@@ -204,7 +204,7 @@ class Chord(Leaf):
 
     def _format_repeat_tremolo_command(self):
         import abjad
-        tremolo = abjad.inspect(self).get_indicator(abjad.Tremolo)
+        tremolo = abjad.inspect(self).indicator(abjad.Tremolo)
         reattack_duration = self._get_tremolo_reattack_duration()
         repeat_count = self.written_duration / reattack_duration / 2
         if not mathtools.is_integer_equivalent(repeat_count):
@@ -232,7 +232,7 @@ class Chord(Leaf):
 
     def _get_sounding_pitches(self):
         import abjad
-        if 'sounding pitch' in abjad.inspect(self).get_indicators(str):
+        if 'sounding pitch' in abjad.inspect(self).indicators(str):
             return self.written_pitches
         else:
             instrument = self._get_effective(abjad.Instrument)
@@ -252,7 +252,7 @@ class Chord(Leaf):
 
     def _get_tremolo_reattack_duration(self):
         import abjad
-        tremolos = abjad.inspect(self).get_indicators(abjad.Tremolo)
+        tremolos = abjad.inspect(self).indicators(abjad.Tremolo)
         if not tremolos:
             return
         tremolo = tremolos[0]

--- a/abjad/core/Component.py
+++ b/abjad/core/Component.py
@@ -80,7 +80,7 @@ class Component(AbjadObject):
         if getattr(self, '_lilypond_setting_name_manager', None) is not None:
             manager = copy.copy(abjad.setting(self))
             new_component._lilypond_setting_name_manager = manager
-        for wrapper in abjad.inspect(self).annotations():
+        for wrapper in abjad.inspect(self).annotation_wrappers():
             new_wrapper = copy.copy(wrapper)
             abjad.attach(new_wrapper, new_component)
         for wrapper in abjad.inspect(self).wrappers():
@@ -154,7 +154,7 @@ class Component(AbjadObject):
 
     def _as_graphviz_node(self):
         import abjad
-        score_index = abjad.inspect(self).get_parentage().score_index
+        score_index = abjad.inspect(self).parentage().score_index
         score_index = '_'.join(str(_) for _ in score_index)
         class_name = type(self).__name__
         if score_index:
@@ -191,7 +191,7 @@ class Component(AbjadObject):
 
     def _check_for_cycles(self, components):
         import abjad
-        parentage = abjad.inspect(self).get_parentage()
+        parentage = abjad.inspect(self).parentage()
         for component in components:
             if component in parentage:
                 return True
@@ -296,7 +296,7 @@ class Component(AbjadObject):
         if in_seconds:
             return self._get_duration_in_seconds()
         else:
-            parentage = abjad.inspect(self).get_parentage(include_self=False)
+            parentage = abjad.inspect(self).parentage(include_self=False)
             return parentage.prolation * self._get_preprolated_duration()
 
     def _get_effective(self, prototype, unwrap=True, n=0):
@@ -312,7 +312,7 @@ class Component(AbjadObject):
                     return
         self._update_now(indicators=True)
         candidate_wrappers = {}
-        parentage = abjad.inspect(self).get_parentage(
+        parentage = abjad.inspect(self).parentage(
             include_self=True,
             grace_notes=True,
             )
@@ -345,7 +345,7 @@ class Component(AbjadObject):
         if not candidate_wrappers:
             return
         all_offsets = sorted(candidate_wrappers)
-        start_offset = abjad.inspect(self).get_timespan().start_offset
+        start_offset = abjad.inspect(self).timespan().start_offset
         index = bisect.bisect(all_offsets, start_offset) - 1 + int(n)
         if index < 0:
             return
@@ -362,7 +362,7 @@ class Component(AbjadObject):
         if staff_change is not None:
             effective_staff = staff_change.staff
         else:
-            parentage = abjad.inspect(self).get_parentage()
+            parentage = abjad.inspect(self).parentage()
             effective_staff = parentage.get_first(abjad.Staff)
         return effective_staff
 
@@ -489,7 +489,7 @@ class Component(AbjadObject):
     def _get_next_measure(self):
         import abjad
         if isinstance(self, abjad.Leaf):
-            for parent in abjad.inspect(self).get_parentage(
+            for parent in abjad.inspect(self).parentage(
                 include_self=False):
                 if isinstance(parent, abjad.Measure):
                     return parent
@@ -518,14 +518,14 @@ class Component(AbjadObject):
         assert mathtools.is_integer_equivalent(n)
         def next(component):
             if component is not None:
-                for parent in abjad.inspect(component).get_parentage(
+                for parent in abjad.inspect(component).parentage(
                     include_self=True):
                     next_sibling = parent._get_sibling(1)
                     if next_sibling is not None:
                         return next_sibling
         def previous(component):
             if component is not None:
-                for parent in abjad.inspect(component).get_parentage(
+                for parent in abjad.inspect(component).parentage(
                     include_self=True):
                     next_sibling = parent._get_sibling(-1)
                     if next_sibling is not None:
@@ -550,7 +550,7 @@ class Component(AbjadObject):
     def _get_previous_measure(self):
         import abjad
         if isinstance(self, abjad.Leaf):
-            for parent in abjad.inspect(self).get_parentage(
+            for parent in abjad.inspect(self).parentage(
                 include_self=False):
                 if isinstance(parent, abjad.Measure):
                     return parent
@@ -609,9 +609,9 @@ class Component(AbjadObject):
 
     def _get_vertical_moment(self, governor=None):
         import abjad
-        offset = abjad.inspect(self).get_timespan().start_offset
+        offset = abjad.inspect(self).timespan().start_offset
         if governor is None:
-            governor = abjad.inspect(self).get_parentage().root
+            governor = abjad.inspect(self).parentage().root
         return abjad.VerticalMoment(governor, offset)
 
     def _get_vertical_moment_at(self, offset):
@@ -649,7 +649,7 @@ class Component(AbjadObject):
     def _remove_and_shrink_durated_parent_containers(self):
         import abjad
         prolated_leaf_duration = self._get_duration()
-        parentage = abjad.inspect(self).get_parentage(include_self=False)
+        parentage = abjad.inspect(self).parentage(include_self=False)
         prolations = parentage._prolations
         current_prolation, i = Duration(1), 0
         parent = self._parent
@@ -683,7 +683,7 @@ class Component(AbjadObject):
                         abjad.mutate(x).wrap(tuplet)
             parent = parent._parent
             i += 1
-        parentage = abjad.inspect(self).get_parentage(include_self=False)
+        parentage = abjad.inspect(self).parentage(include_self=False)
         parent = self._parent
         if parent:
             index = parent.index(self)
@@ -697,7 +697,7 @@ class Component(AbjadObject):
     def _remove_from_parent(self):
         import abjad
         self._update_later(offsets=True)
-        for component in abjad.inspect(self).get_parentage(include_self=False):
+        for component in abjad.inspect(self).parentage(include_self=False):
             if not isinstance(component, abjad.Context):
                 continue
             for wrapper in component._dependent_wrappers[:]:
@@ -710,7 +710,7 @@ class Component(AbjadObject):
     def _remove_named_children_from_parentage(self, name_dictionary):
         import abjad
         if self._parent is not None and name_dictionary:
-            for parent in abjad.inspect(self).get_parentage(
+            for parent in abjad.inspect(self).parentage(
                 include_self=False):
                 named_children = parent._named_children
                 for name in name_dictionary:
@@ -722,7 +722,7 @@ class Component(AbjadObject):
     def _restore_named_children_to_parentage(self, name_dictionary):
         import abjad
         if self._parent is not None and name_dictionary:
-            for parent in abjad.inspect(self).get_parentage(
+            for parent in abjad.inspect(self).parentage(
                 include_self=False):
                 named_children = parent._named_children
                 for name in name_dictionary:
@@ -753,13 +753,13 @@ class Component(AbjadObject):
         selection = abjad.select(self)
         if direction is enums.Right:
             if grow_spanners:
-                insert_offset = abjad.inspect(self).get_timespan().stop_offset
+                insert_offset = abjad.inspect(self).timespan().stop_offset
                 receipt = selection._get_dominant_spanners()
                 for spanner, index in receipt:
                     insert_component = None
                     for component in spanner:
                         start_offset = abjad.inspect(
-                            component).get_timespan().start_offset
+                            component).timespan().start_offset
                         if start_offset == insert_offset:
                             insert_component = component
                             break
@@ -786,11 +786,11 @@ class Component(AbjadObject):
             return [self] + components
         else:
             if grow_spanners:
-                offset = abjad.inspect(self).get_timespan().start_offset
+                offset = abjad.inspect(self).timespan().start_offset
                 receipt = selection._get_dominant_spanners()
                 for spanner, x in receipt:
                     for component in spanner:
-                        timespan = abjad.inspect(component).get_timespan()
+                        timespan = abjad.inspect(component).timespan()
                         if timespan.start_offset == offset:
                             index = spanner._index(component)
                             break
@@ -817,7 +817,7 @@ class Component(AbjadObject):
     def _update_later(self, offsets=False, offsets_in_seconds=False):
         import abjad
         assert offsets or offsets_in_seconds
-        for component in abjad.inspect(self).get_parentage(include_self=True):
+        for component in abjad.inspect(self).parentage(include_self=True):
             if offsets:
                 component._offsets_are_current = False
             elif offsets_in_seconds:

--- a/abjad/core/Context.py
+++ b/abjad/core/Context.py
@@ -232,10 +232,10 @@ class Context(Container):
             if wrapper.annotation:
                 continue
             indicator = wrapper.indicator
-            if not getattr(indicator, 'persistent', False):
+            if not getattr(indicator, 'parameter', False):
                 continue
-            if isinstance(indicator.persistent, str):
-                key = indicator.persistent
+            if isinstance(indicator.parameter, str):
+                key = indicator.parameter
             else:
                 key = str(type(indicator))
             if (key not in wrappers or

--- a/abjad/core/Descendants.py
+++ b/abjad/core/Descendants.py
@@ -41,7 +41,7 @@ class Descendants(AbjadObject, collections.Sequence):
                 }
             >>
 
-        >>> for component in abjad.inspect(score).get_descendants():
+        >>> for component in abjad.inspect(score).descendants():
         ...     component
         ...
         <Score<<2>>>
@@ -54,7 +54,7 @@ class Descendants(AbjadObject, collections.Sequence):
 
         >>> bass_voice = score['Bass Voice']
         >>> agent = abjad.inspect(bass_voice)
-        >>> for component in agent.get_descendants():
+        >>> for component in agent.descendants():
         ...     component
         ...
         Voice('b,4', name='Bass Voice')
@@ -90,8 +90,8 @@ class Descendants(AbjadObject, collections.Sequence):
         else:
             for component in components:
                 append_x = True
-                if not (abjad.inspect(component).get_timespan().start_offset < cross_offset and
-                    cross_offset < abjad.inspect(component).get_timespan().stop_offset):
+                if not (abjad.inspect(component).timespan().start_offset < cross_offset and
+                    cross_offset < abjad.inspect(component).timespan().stop_offset):
                     append_x = False
                 if append_x:
                     result.append(component)

--- a/abjad/core/Inspection.py
+++ b/abjad/core/Inspection.py
@@ -1598,13 +1598,17 @@ class Inspection(AbjadObject):
         """
         if isinstance(self.client, Component):
             return self.client._get_timespan(in_seconds=in_seconds)
-        assert isinstance(self.client, collections.Sequence), repr(self.client)
-        timespan = Inspection(self.client[0]).timespan(
-            in_seconds=in_seconds,
-            )
+        assert isinstance(self.client, collections.Iterable), repr(self.client)
+        remaining_items = []
+        for i, item in enumerate(self.client):
+            if i == 0:
+                first_item = item
+            else:
+                remaining_items.append(item)
+        timespan = Inspection(first_item).timespan(in_seconds=in_seconds)
         start_offset = timespan.start_offset
         stop_offset = timespan.stop_offset
-        for item in self.client[1:]:
+        for item in remaining_items:
             timespan = Inspection(item).timespan(in_seconds=in_seconds)
             if timespan.start_offset < start_offset:
                 start_offset = timespan.start_offset

--- a/abjad/core/Inspection.py
+++ b/abjad/core/Inspection.py
@@ -1,10 +1,33 @@
 import collections
 import typing
 from abjad import exceptions
+from abjad.indicators.TimeSignature import TimeSignature
+from abjad.markups import Markup
+from abjad.pitch.NamedPitch import NamedPitch
+from abjad.pitch.PitchSet import PitchSet
 from abjad.spanners.Spanner import Spanner
 from abjad.system.AbjadObject import AbjadObject
+from abjad.system.LilyPondFormatManager import LilyPondFormatManager
+from abjad.system.WellformednessManager import WellformednessManager
+from abjad.system.Wrapper import Wrapper
+from abjad.timespans.Timespan import Timespan
 from abjad.top.inspect import inspect
+from abjad.top.iterate import iterate
+from abjad.utilities.Duration import Duration
+from .AfterGraceContainer import AfterGraceContainer
+from .Chord import Chord
+from .Component import Component
 from .Container import Container
+from .GraceContainer import GraceContainer
+from .Leaf import Leaf
+from .Lineage import Lineage
+from .LogicalTie import LogicalTie
+from .Note import Note
+from .Parentage import Parentage
+from .Selection import Selection
+from .Staff import Staff
+from .Tuplet import Tuplet
+from .VerticalMoment import VerticalMoment
 
 
 class Inspection(AbjadObject):
@@ -31,20 +54,24 @@ class Inspection(AbjadObject):
 
     ### INITIALIZER ###
 
-    def __init__(self, client=None):
-        import abjad
+    def __init__(
+        self,
+        client: typing.Union[Component, typing.Iterable[Component]] = None,
+        ) -> None:
         assert not isinstance(client, str), repr(client)
-        prototype = (abjad.Component, collections.Iterable, type(None))
+        prototype = (Component, collections.Iterable, type(None))
         if not isinstance(client, prototype):
-            message = 'must be component, nonstring iterable or none: {!r}.'
-            message = message.format(client)
+            message = 'must be component, nonstring iterable or none:'
+            message += f' (not {client!r}).'
             raise TypeError(message)
         self._client = client
 
     ### PUBLIC PROPERTIES ###
 
     @property
-    def client(self):
+    def client(self) -> typing.Union[
+        Component, typing.Iterable[Component], None
+        ]:
         r"""
         Gets client of inspection.
 
@@ -79,13 +106,119 @@ class Inspection(AbjadObject):
             >>> abjad.inspect(staff).client
             <Staff{2}>
 
-        Returns component.
         """
         return self._client
 
     ### PUBLIC METHODS ###
 
-    def annotations(self):
+    def after_grace_container(self) -> typing.Optional[
+        AfterGraceContainer]:
+        r"""
+        Gets after grace containers attached to leaf.
+
+        ..  container:: example
+
+            Get after grace container attached to note:
+
+            >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
+            >>> note = abjad.Note("ds'16")
+            >>> container = abjad.AfterGraceContainer([note])
+            >>> abjad.attach(container, staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'8
+                    \afterGrace
+                    d'8
+                    {
+                        ds'16
+                    }
+                    e'8
+                    f'8
+                }
+
+            >>> abjad.inspect(staff[1]).after_grace_container()
+            AfterGraceContainer("ds'16")
+
+        """
+        return getattr(self.client, '_after_grace_container', None)
+
+    def annotation(
+        self,
+        annotation,
+        default=None,
+        unwrap=True,
+        ) -> typing.Any:
+        r"""
+        Gets annotation.
+
+        ..  container:: example
+
+            >>> staff = abjad.Staff("c'4 e' e' f'")
+            >>> abjad.annotate(staff[0], 'default_instrument', abjad.Cello())
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'4
+                    e'4
+                    e'4
+                    f'4
+                }
+
+            >>> string = 'default_instrument'
+            >>> abjad.inspect(staff[0]).annotation(string)
+            Cello()
+
+            >>> abjad.inspect(staff[1]).annotation(string) is None
+            True
+
+            >>> abjad.inspect(staff[2]).annotation(string) is None
+            True
+
+            >>> abjad.inspect(staff[3]).annotation(string) is None
+            True
+
+            Returns default when no annotation is found:
+
+            >>> abjad.inspect(staff[3]).annotation(string, abjad.Violin())
+            Violin()
+
+        ..  container:: example
+
+            REGRESSION: annotation is not picked up as effective indicator:
+
+            >>> prototype = abjad.Instrument
+            >>> abjad.inspect(staff[0]).effective(prototype) is None
+            True
+
+            >>> abjad.inspect(staff[1]).effective(prototype) is None
+            True
+
+            >>> abjad.inspect(staff[2]).effective(prototype) is None
+            True
+
+            >>> abjad.inspect(staff[3]).effective(prototype) is None
+            True
+
+        """
+        assert isinstance(annotation, str), repr(annotation)
+        for wrapper in self.annotation_wrappers():
+            if wrapper.annotation == annotation:
+                if unwrap is True:
+                    return wrapper.indicator
+                else:
+                    return wrapper
+        return default
+
+    def annotation_wrappers(self) -> typing.List[Wrapper]:
         r"""
         Gets annotation wrappers.
 
@@ -107,7 +240,7 @@ class Inspection(AbjadObject):
                     f'4
                 }
 
-            >>> for wrapper in abjad.inspect(staff[0]).annotations():
+            >>> for wrapper in abjad.inspect(staff[0]).annotation_wrappers():
             ...     abjad.f(wrapper)
             ...
             abjad.Wrapper(
@@ -146,7 +279,6 @@ class Inspection(AbjadObject):
                 tag=abjad.Tag(),
                 )
 
-        Returns list of annotations or list of wrappers.
         """
         result = []
         for wrapper in getattr(self.client, '_wrappers', []):
@@ -154,7 +286,387 @@ class Inspection(AbjadObject):
                 result.append(wrapper)
         return result
 
-    def effective_wrapper(self, prototype=None, n=0):
+    def badly_formed_components(self) -> typing.List[Component]:
+        r"""
+        Gets badly formed components.
+        """
+        manager = WellformednessManager()
+        violators: typing.List[Component] = []
+        for violators_, total, check_name in manager(self.client):
+            violators.extend(violators_)
+        return violators
+
+    def contents(self, include_self=True) -> typing.Optional[Selection]:
+        r"""
+        Gets contents.
+
+        ..  container:: example
+
+            >>> staff = abjad.Staff(r"\times 2/3 { c'8 d'8 e'8 } f'4")
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    \times 2/3 {
+                        c'8
+                        d'8
+                        e'8
+                    }
+                    f'4
+                }
+
+            >>> for component in abjad.inspect(staff).contents():
+            ...     component
+            ...
+            <Staff{2}>
+            Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
+            Note("f'4")
+
+            >>> for component in abjad.inspect(staff).contents(
+            ...     include_self=False,
+            ...     ):
+            ...     component
+            ...
+            Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
+            Note("f'4")
+
+        """
+        if not isinstance(self.client, Component):
+            raise Exception('can only get contents of component.')
+        return self.client._get_contents(include_self=include_self)
+
+    def descendants(self, include_self=True) -> Selection:
+        r"""
+        Gets descendants.
+
+        ..  container:: example
+
+            >>> staff = abjad.Staff(r"\times 2/3 { c'8 d'8 e'8 } f'4")
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    \times 2/3 {
+                        c'8
+                        d'8
+                        e'8
+                    }
+                    f'4
+                }
+
+            >>> for component in abjad.inspect(staff).descendants():
+            ...     component
+            ...
+            <Staff{2}>
+            Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
+            Note("c'8")
+            Note("d'8")
+            Note("e'8")
+            Note("f'4")
+
+            >>> for component in abjad.inspect(staff).descendants(
+            ...     include_self=False,
+            ...     ):
+            ...     component
+            ...
+            Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
+            Note("c'8")
+            Note("d'8")
+            Note("e'8")
+            Note("f'4")
+
+            >>> for component in abjad.inspect(staff[:1]).descendants(
+            ...     include_self=False,
+            ...     ):
+            ...     component
+            ...
+            Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
+            Note("c'8")
+            Note("d'8")
+            Note("e'8")
+
+        """
+        if isinstance(self.client, Component):
+            return self.client._get_descendants(include_self=include_self)
+        descendants: typing.List[Component] = []
+        assert isinstance(self.client, Selection)
+        for argument in self.client:
+            descendants_ = Inspection(argument).descendants()
+            for descendant_ in descendants_:
+                if descendant_ not in descendants:
+                    descendants.append(descendant_)
+        result = Selection(descendants)
+        return result
+
+    def duration(self, in_seconds=False) -> Duration:
+        r"""
+        Gets duration.
+
+        ..  container:: example
+
+            >>> staff = abjad.Staff("c'4 d' e' f'")
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'4
+                    d'4
+                    e'4
+                    f'4
+                }
+
+            >>> selection = staff[:3]
+            >>> abjad.inspect(selection).duration()
+            Duration(3, 4)
+
+        """
+        if isinstance(self.client, Component):
+            return self.client._get_duration(in_seconds=in_seconds)
+        assert isinstance(self.client, collections.Iterable), repr(self.client)
+        durations = [
+            Inspection(_).duration(in_seconds=in_seconds)
+            for _ in self.client
+            ]
+        return Duration(sum(durations))
+
+    def effective(
+        self,
+        prototype=None,
+        unwrap=True,
+        n=0,
+        default=None,
+        ) -> typing.Any:
+        r"""
+        Gets effective indicator.
+
+        ..  container:: example
+
+            Gets effective clef:
+
+            >>> staff = abjad.Staff("c'4 d' e' f'")
+            >>> abjad.attach(abjad.Clef('alto'), staff[0])
+            >>> abjad.attach(abjad.AcciaccaturaContainer("fs'16"), staff[-1])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    \clef "alto"
+                    c'4
+                    d'4
+                    e'4
+                    \acciaccatura {
+                        fs'16
+                    }
+                    f'4
+                }
+
+            >>> for component in abjad.iterate(staff).components():
+            ...     clef = abjad.inspect(component).effective(abjad.Clef)
+            ...     print(component, clef)
+            ...
+            Staff("c'4 d'4 e'4 f'4") Clef('alto')
+            c'4 Clef('alto')
+            d'4 Clef('alto')
+            e'4 Clef('alto')
+            fs'16 Clef('alto')
+            f'4 Clef('alto')
+
+        ..  container:: example
+
+            Arbitrary objects (like strings) can be contexted:
+
+            >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
+            >>> abjad.attach('color', staff[1], context='Staff')
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'8
+                    d'8
+                    e'8
+                    f'8
+                }
+
+            >>> for component in abjad.iterate(staff).components():
+            ...     string = abjad.inspect(component).effective(str)
+            ...     print(component, repr(string))
+            ...
+            Staff("c'8 d'8 e'8 f'8") None
+            c'8 None
+            d'8 'color'
+            e'8 'color'
+            f'8 'color'
+
+        ..  container:: example
+
+            Scans forwards or backwards when ``n`` is set: 
+
+            >>> staff = abjad.Staff("c'8 d'8 e'8 f'8 g'8")
+            >>> abjad.attach('red', staff[0], context='Staff')
+            >>> abjad.attach('blue', staff[2], context='Staff')
+            >>> abjad.attach('yellow', staff[4], context='Staff')
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'8
+                    d'8
+                    e'8
+                    f'8
+                    g'8
+                }
+                
+            >>> for n in (-1, 0, 1):
+            ...     color = abjad.inspect(staff[0]).effective(str, n=n)
+            ...     print(n, repr(color))
+            ...
+            -1 None
+            0 'red'
+            1 'blue'
+
+            >>> for n in (-1, 0, 1):
+            ...     color = abjad.inspect(staff[1]).effective(str, n=n)
+            ...     print(n, repr(color))
+            ...
+            -1 None
+            0 'red'
+            1 'blue'
+
+            >>> for n in (-1, 0, 1):
+            ...     color = abjad.inspect(staff[2]).effective(str, n=n)
+            ...     print(n, repr(color))
+            ...
+            -1 'red'
+            0 'blue'
+            1 'yellow'
+
+            >>> for n in (-1, 0, 1):
+            ...     color = abjad.inspect(staff[3]).effective(str, n=n)
+            ...     print(n, repr(color))
+            ...
+            -1 'red'
+            0 'blue'
+            1 'yellow'
+
+            >>> for n in (-1, 0, 1):
+            ...     color = abjad.inspect(staff[4]).effective(str, n=n)
+            ...     print(n, repr(color))
+            ...
+            -1 'blue'
+            0 'yellow'
+            1 None
+
+        ..  container:: example
+
+            Synthetic offsets works this way:
+
+            >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
+            >>> abjad.attach(
+            ...     'red',
+            ...     staff[-1],
+            ...     context='Staff',
+            ...     synthetic_offset=-1,
+            ...     )
+            >>> abjad.attach('blue', staff[0], context='Staff')
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'8
+                    d'8
+                    e'8
+                    f'8
+                }
+
+            Entire staff is effectively blue:
+
+            >>> abjad.inspect(staff).effective(str)
+            'blue'
+
+            The (synthetic) offset just prior to (start of) staff is red:
+
+            >>> abjad.inspect(staff).effective(str, n=-1)
+            'red'
+
+        ..  container:: example
+
+            Gets effective time signature:
+
+            >>> staff = abjad.Staff("c'4 d' e' f'")
+            >>> leaves = abjad.select(staff).leaves()
+            >>> abjad.attach(abjad.TimeSignature((3, 8)), leaves[0])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    \time 3/8
+                    c'4
+                    d'4
+                    e'4
+                    f'4
+                }
+
+            >>> prototype = abjad.TimeSignature
+            >>> for component in abjad.iterate(staff).components():
+            ...     inspection = abjad.inspect(component)
+            ...     time_signature = inspection.effective(prototype)
+            ...     print(component, time_signature)
+            ...
+            Staff("c'4 d'4 e'4 f'4") 3/8
+            c'4 3/8
+            d'4 3/8
+            e'4 3/8
+            f'4 3/8
+
+        """
+        if not isinstance(self.client, Component):
+            raise Exception('can only get effective on components.')
+        result = self.client._get_effective(
+            prototype=prototype,
+            unwrap=unwrap,
+            n=n,
+            )
+        if result is None:
+            result = default
+        return result
+
+    def effective_staff(self) -> typing.Optional[Staff]:
+        """
+        Gets effective staff.
+        """
+        if not isinstance(self.client, Component):
+            raise Exception('can only get effective staff on components.')
+        return self.client._get_effective_staff()
+
+    def effective_wrapper(
+        self,
+        prototype=None,
+        n=0,
+        ) -> typing.Optional[Wrapper]:
         r"""
         Gets effective wrapper.
 
@@ -194,494 +706,10 @@ class Inspection(AbjadObject):
             fs'16 Wrapper(context='Staff', indicator=Clef('alto'), tag=Tag())
             f'4 Wrapper(context='Staff', indicator=Clef('alto'), tag=Tag())
 
-        Returns wrapper or none.
         """
-        return self.get_effective(prototype=prototype, n=n, unwrap=False)
+        return self.effective(prototype=prototype, n=n, unwrap=False)
 
-    def get_after_grace_container(self):
-        r"""
-        Gets after grace containers attached to leaf.
-
-        ..  container:: example
-
-            Get after grace container attached to note:
-
-            >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-            >>> note = abjad.Note("ds'16")
-            >>> container = abjad.AfterGraceContainer([note])
-            >>> abjad.attach(container, staff[1])
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                {
-                    c'8
-                    \afterGrace
-                    d'8
-                    {
-                        ds'16
-                    }
-                    e'8
-                    f'8
-                }
-
-            >>> abjad.inspect(staff[1]).get_after_grace_container()
-            AfterGraceContainer("ds'16")
-
-        Returns after grace container or none.
-        """
-        return getattr(self.client, '_after_grace_container', None)
-
-    def get_annotation(self, annotation, default=None, unwrap=True):
-        r"""
-        Gets annotation.
-
-        ..  container:: example
-
-            >>> staff = abjad.Staff("c'4 e' e' f'")
-            >>> abjad.annotate(staff[0], 'default_instrument', abjad.Cello())
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                {
-                    c'4
-                    e'4
-                    e'4
-                    f'4
-                }
-
-            >>> string = 'default_instrument'
-            >>> abjad.inspect(staff[0]).get_annotation(string)
-            Cello()
-
-            >>> abjad.inspect(staff[1]).get_annotation(string) is None
-            True
-
-            >>> abjad.inspect(staff[2]).get_annotation(string) is None
-            True
-
-            >>> abjad.inspect(staff[3]).get_annotation(string) is None
-            True
-
-            Returns default when no annotation is found:
-
-            >>> abjad.inspect(staff[3]).get_annotation(string, abjad.Violin())
-            Violin()
-
-        ..  container:: example
-
-            Regression: annotation is not picked up as effective indicator:
-
-            >>> prototype = abjad.Instrument
-            >>> abjad.inspect(staff[0]).get_effective(prototype) is None
-            True
-
-            >>> abjad.inspect(staff[1]).get_effective(prototype) is None
-            True
-
-            >>> abjad.inspect(staff[2]).get_effective(prototype) is None
-            True
-
-            >>> abjad.inspect(staff[3]).get_effective(prototype) is None
-            True
-
-        Returns annotation (or default).
-        """
-        assert isinstance(annotation, str), repr(annotation)
-        for wrapper in self.annotations():
-            if wrapper.annotation == annotation:
-                if unwrap is True:
-                    return wrapper.indicator
-                else:
-                    return wrapper
-        return default
-
-    def get_badly_formed_components(self):
-        r"""
-        Gets badly formed components.
-
-        Returns list.
-        """
-        import abjad
-        manager, violators = abjad.WellformednessManager(), []
-        for violators_, total, check_name in manager(self.client):
-            violators.extend(violators_)
-        return violators
-
-    def get_contents(self, include_self=True):
-        r"""
-        Gets contents.
-
-        ..  container:: example
-
-            >>> staff = abjad.Staff(r"\times 2/3 { c'8 d'8 e'8 } f'4")
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                {
-                    \times 2/3 {
-                        c'8
-                        d'8
-                        e'8
-                    }
-                    f'4
-                }
-
-            >>> for component in abjad.inspect(staff).get_contents():
-            ...     component
-            ...
-            <Staff{2}>
-            Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
-            Note("f'4")
-
-            >>> for component in abjad.inspect(staff).get_contents(
-            ...     include_self=False,
-            ...     ):
-            ...     component
-            ...
-            Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
-            Note("f'4")
-
-        Returns selection.
-        """
-        if hasattr(self.client, '_get_contents'):
-            return self.client._get_contents(include_self=include_self)
-
-    def get_descendants(self, include_self=True):
-        r"""
-        Gets descendants.
-
-        ..  container:: example
-
-            >>> staff = abjad.Staff(r"\times 2/3 { c'8 d'8 e'8 } f'4")
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                {
-                    \times 2/3 {
-                        c'8
-                        d'8
-                        e'8
-                    }
-                    f'4
-                }
-
-            >>> for component in abjad.inspect(staff).get_descendants():
-            ...     component
-            ...
-            <Staff{2}>
-            Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
-            Note("c'8")
-            Note("d'8")
-            Note("e'8")
-            Note("f'4")
-
-            >>> for component in abjad.inspect(staff).get_descendants(
-            ...     include_self=False,
-            ...     ):
-            ...     component
-            ...
-            Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
-            Note("c'8")
-            Note("d'8")
-            Note("e'8")
-            Note("f'4")
-
-            >>> for component in abjad.inspect(staff[:1]).get_descendants(
-            ...     include_self=False,
-            ...     ):
-            ...     component
-            ...
-            Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
-            Note("c'8")
-            Note("d'8")
-            Note("e'8")
-
-        Returns selection.
-        """
-        import abjad
-        if hasattr(self.client, '_get_descendants'):
-            descendants = self.client._get_descendants(
-                include_self=include_self,
-                )
-        else:
-            descendants = []
-            for argument in self.client:
-                descendants_ = abjad.inspect(argument).get_descendants()
-                for descendant_ in descendants_:
-                    if descendant_ not in descendants:
-                        descendants.append(descendant_)
-            descendants = abjad.select(descendants)
-        return descendants
-
-    def get_duration(self, in_seconds=False):
-        r"""
-        Gets duration.
-
-        ..  container:: example
-
-            >>> staff = abjad.Staff("c'4 d' e' f'")
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                {
-                    c'4
-                    d'4
-                    e'4
-                    f'4
-                }
-
-            >>> selection = staff[:3]
-            >>> abjad.inspect(selection).get_duration()
-            Duration(3, 4)
-
-        Returns duration.
-        """
-        import abjad
-        if hasattr(self.client, 'get_duration'):
-            return self.client.get_duration(in_seconds=in_seconds)
-        if hasattr(self.client, '_get_duration'):
-            return self.client._get_duration(in_seconds=in_seconds)
-        assert isinstance(self.client, collections.Iterable), repr(self.client)
-        return sum([
-            abjad.inspect(_).get_duration(in_seconds=in_seconds)
-            for _ in self.client
-            ])
-
-    def get_effective(self, prototype=None, unwrap=True, n=0, default=None):
-        r"""
-        Gets effective indicator.
-
-        ..  container:: example
-
-            Gets effective clef:
-
-            >>> staff = abjad.Staff("c'4 d' e' f'")
-            >>> abjad.attach(abjad.Clef('alto'), staff[0])
-            >>> abjad.attach(abjad.AcciaccaturaContainer("fs'16"), staff[-1])
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                {
-                    \clef "alto"
-                    c'4
-                    d'4
-                    e'4
-                    \acciaccatura {
-                        fs'16
-                    }
-                    f'4
-                }
-
-            >>> for component in abjad.iterate(staff).components():
-            ...     clef = abjad.inspect(component).get_effective(abjad.Clef)
-            ...     print(component, clef)
-            ...
-            Staff("c'4 d'4 e'4 f'4") Clef('alto')
-            c'4 Clef('alto')
-            d'4 Clef('alto')
-            e'4 Clef('alto')
-            fs'16 Clef('alto')
-            f'4 Clef('alto')
-
-        ..  container:: example
-
-            Arbitrary objects (like strings) can be contexted:
-
-            >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-            >>> abjad.attach('color', staff[1], context='Staff')
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                {
-                    c'8
-                    d'8
-                    e'8
-                    f'8
-                }
-
-            >>> for component in abjad.iterate(staff).components():
-            ...     string = abjad.inspect(component).get_effective(str)
-            ...     print(component, repr(string))
-            ...
-            Staff("c'8 d'8 e'8 f'8") None
-            c'8 None
-            d'8 'color'
-            e'8 'color'
-            f'8 'color'
-
-        ..  container:: example
-
-            Scans forwards or backwards when ``n`` is set: 
-
-            >>> staff = abjad.Staff("c'8 d'8 e'8 f'8 g'8")
-            >>> abjad.attach('red', staff[0], context='Staff')
-            >>> abjad.attach('blue', staff[2], context='Staff')
-            >>> abjad.attach('yellow', staff[4], context='Staff')
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                {
-                    c'8
-                    d'8
-                    e'8
-                    f'8
-                    g'8
-                }
-                
-            >>> for n in (-1, 0, 1):
-            ...     color = abjad.inspect(staff[0]).get_effective(str, n=n)
-            ...     print(n, repr(color))
-            ...
-            -1 None
-            0 'red'
-            1 'blue'
-
-            >>> for n in (-1, 0, 1):
-            ...     color = abjad.inspect(staff[1]).get_effective(str, n=n)
-            ...     print(n, repr(color))
-            ...
-            -1 None
-            0 'red'
-            1 'blue'
-
-            >>> for n in (-1, 0, 1):
-            ...     color = abjad.inspect(staff[2]).get_effective(str, n=n)
-            ...     print(n, repr(color))
-            ...
-            -1 'red'
-            0 'blue'
-            1 'yellow'
-
-            >>> for n in (-1, 0, 1):
-            ...     color = abjad.inspect(staff[3]).get_effective(str, n=n)
-            ...     print(n, repr(color))
-            ...
-            -1 'red'
-            0 'blue'
-            1 'yellow'
-
-            >>> for n in (-1, 0, 1):
-            ...     color = abjad.inspect(staff[4]).get_effective(str, n=n)
-            ...     print(n, repr(color))
-            ...
-            -1 'blue'
-            0 'yellow'
-            1 None
-
-        ..  container:: example
-
-            Synthetic offsets works this way:
-
-            >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-            >>> abjad.attach(
-            ...     'red',
-            ...     staff[-1],
-            ...     context='Staff',
-            ...     synthetic_offset=-1,
-            ...     )
-            >>> abjad.attach('blue', staff[0], context='Staff')
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                {
-                    c'8
-                    d'8
-                    e'8
-                    f'8
-                }
-
-            Entire staff is effectively blue:
-
-            >>> abjad.inspect(staff).get_effective(str)
-            'blue'
-
-            The (synthetic) offset just prior to (start of) staff is red:
-
-            >>> abjad.inspect(staff).get_effective(str, n=-1)
-            'red'
-
-        ..  container:: example
-
-            Gets effective time signature:
-
-            >>> staff = abjad.Staff("c'4 d' e' f'")
-            >>> leaves = abjad.select(staff).leaves()
-            >>> abjad.attach(abjad.TimeSignature((3, 8)), leaves[0])
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                {
-                    \time 3/8
-                    c'4
-                    d'4
-                    e'4
-                    f'4
-                }
-
-            >>> prototype = abjad.TimeSignature
-            >>> for component in abjad.iterate(staff).components():
-            ...     inspection = abjad.inspect(component)
-            ...     time_signature = inspection.get_effective(prototype)
-            ...     print(component, time_signature)
-            ...
-            Staff("c'4 d'4 e'4 f'4") 3/8
-            c'4 3/8
-            d'4 3/8
-            e'4 3/8
-            f'4 3/8
-
-        Returns indicator or none.
-        """
-        if hasattr(self.client, '_get_effective'):
-            result = self.client._get_effective(
-                prototype=prototype,
-                unwrap=unwrap,
-                n=n,
-                )
-            if result is None:
-                return default
-            return result
-
-    def get_effective_staff(self):
-        """
-        Gets effective staff.
-
-        Returns staff or none.
-        """
-        if hasattr(self.client, '_get_effective_staff'):
-            return self.client._get_effective_staff()
-
-    def get_grace_container(self):
+    def grace_container(self) -> typing.Optional[GraceContainer]:
         r"""
         Gets grace container attached to leaf.
 
@@ -709,21 +737,44 @@ class Inspection(AbjadObject):
                     f'8
                 }
 
-            >>> abjad.inspect(staff[1]).get_grace_container()
+            >>> abjad.inspect(staff[1]).grace_container()
             AcciaccaturaContainer("cs'16")
 
-        Returns grace container, acciaccatura container, appoggiatura container
-        or none.
         """
-        if hasattr(self.client, '_grace_container'):
-            return self.client._grace_container
+        if not isinstance(self.client, Leaf):
+            raise Exception('can only get grace container on leaf.')
+        return self.client._grace_container
 
-    def get_indicator(
+    def has_effective_indicator(self, prototype=None) -> bool:
+        """
+        Is true when client has effective indicator.
+        """
+        if not isinstance(self.client, Component):
+            raise Exception('can only get effective indicator on component.')
+        return self.client._has_effective_indicator(prototype=prototype)
+
+    def has_indicator(self, prototype=None) -> bool:
+        """
+        Is true when client has one or more indicators.
+        """
+        if not isinstance(self.client, Component):
+            raise Exception('can only get indicator on component.')
+        return self.client._has_indicator(prototype=prototype)
+
+    def has_spanner(self, prototype=None) -> bool:
+        """
+        Is true when client has one or more spanners.
+        """
+        if not isinstance(self.client, Leaf):
+            raise Exception('can only get spanner on leaf.')
+        return self.client._has_spanner(prototype=prototype)
+
+    def indicator(
         self,
         prototype=None,
         default=None,
         unwrap=True,
-        ):
+        ) -> typing.Any:
         """
         Gets indicator.
 
@@ -731,9 +782,9 @@ class Inspection(AbjadObject):
         to client.
 
         Returns default when no indicator of ``prototype`` attaches to client.
-
-        Returns indicator or default.
         """
+        if not isinstance(self.client, Component):
+            raise Exception('can only get indicator on component.')
         indicators = self.client._get_indicators(
             prototype=prototype,
             unwrap=unwrap,
@@ -743,10 +794,9 @@ class Inspection(AbjadObject):
         elif len(indicators) == 1:
             return list(indicators)[0]
         else:
-            message = 'multiple indicators attached to client.'
-            raise Exception(message)
+            raise Exception('multiple indicators attached to client.')
 
-    def get_indicators(self, prototype=None, unwrap=True):
+    def indicators(self, prototype=None, unwrap=True) -> typing.List:
         r"""
         Get indicators.
 
@@ -774,21 +824,117 @@ class Inspection(AbjadObject):
                     -\marcato
                 }
 
-            >>> abjad.inspect(staff).get_indicators(abjad.Articulation)
-            ()
+            >>> abjad.inspect(staff).indicators(abjad.Articulation)
+            []
 
-            >>> abjad.inspect(staff[0]).get_indicators(abjad.Articulation)
-            (Articulation('^'),)
+            >>> abjad.inspect(staff[0]).indicators(abjad.Articulation)
+            [Articulation('^')]
 
-        Returns tuple.
         """
-        if hasattr(self.client, '_get_indicators'):
-            return self.client._get_indicators(
-                prototype=prototype,
-                unwrap=unwrap,
-                )
+        # TODO: extend to any non-none client
+        if not isinstance(self.client, Component):
+            raise Exception('can only get indicators on component.')
+        result = self.client._get_indicators(
+            prototype=prototype,
+            unwrap=unwrap,
+            )
+        return list(result)
 
-    def get_leaf(self, n=0):
+    def is_bar_line_crossing(self) -> bool:
+        r"""
+        Is true when client crosses bar line.
+
+        ..  container:: example
+
+            >>> staff = abjad.Staff("c'4 d'4 e'4")
+            >>> time_signature = abjad.TimeSignature((3, 8))
+            >>> abjad.attach(time_signature, staff[0])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    \time 3/8
+                    c'4
+                    d'4
+                    e'4
+                }
+
+            >>> for note in staff:
+            ...     result = abjad.inspect(note).is_bar_line_crossing()
+            ...     print(note, result)
+            ...
+            c'4 False
+            d'4 True
+            e'4 False
+
+        """
+        if not isinstance(self.client, Component):
+            raise Exception('can only get indicator on component.')
+        time_signature = self.client._get_effective(TimeSignature)
+        if time_signature is None:
+            time_signature_duration = Duration(4, 4)
+        else:
+            time_signature_duration = time_signature.duration
+        partial = getattr(time_signature, 'partial', 0)
+        partial = partial or 0
+        start_offset = Inspection(self.client).timespan().start_offset
+        shifted_start = start_offset - partial
+        shifted_start %= time_signature_duration
+        stop_offset = self.client._get_duration() + shifted_start
+        if time_signature_duration < stop_offset:
+            return True
+        return False
+
+    def is_grace_note(self) -> bool:
+        """
+        Is true when client is grace note.
+        """
+        if not isinstance(self.client, Leaf):
+            return False
+        prototype = (AfterGraceContainer, GraceContainer)
+        for component in Inspection(self.client).parentage():
+            if isinstance(component, prototype):
+                return True
+        return False
+
+    def is_well_formed(
+        self,
+        check_beamed_long_notes=True,
+        check_discontiguous_spanners=True,
+        check_duplicate_ids=True,
+        check_empty_containers=True,
+        check_misdurated_measures=True,
+        check_misfilled_measures=True,
+        check_mismatched_enchained_hairpins=True,
+        check_mispitched_ties=True,
+        check_misrepresented_flags=True,
+        check_missing_parents=True,
+        check_nested_measures=True,
+        check_notes_on_wrong_clef=True,
+        check_out_of_range_notes=True,
+        check_overlapping_beams=True,
+        check_overlapping_glissandi=True,
+        check_overlapping_hairpins=True,
+        check_overlapping_octavation_spanners=True,
+        check_overlapping_ties=True,
+        check_overlapping_trill_spanners=True,
+        check_tied_rests=True,
+        ) -> bool:
+        """
+        Is true when client is well-formed.
+        """
+        manager = WellformednessManager()
+        for violators, total, check_name in manager(self.client):
+            if eval(check_name) is not True:
+                continue
+            if violators:
+                return False
+        return True
+
+    def leaf(self, n=0) -> typing.Optional[Leaf]:
         r"""
         Gets leaf ``n``.
 
@@ -831,7 +977,7 @@ class Inspection(AbjadObject):
             Note("c'8")
 
             >>> for n in range(8):
-            ...     leaf = abjad.inspect(first_leaf).get_leaf(n)
+            ...     leaf = abjad.inspect(first_leaf).leaf(n)
             ...     print(n, leaf)
             ...
             0 c'8
@@ -850,7 +996,7 @@ class Inspection(AbjadObject):
             Note("f'8")
 
             >>> for n in range(0, -8, -1):
-            ...     leaf = abjad.inspect(last_leaf).get_leaf(n)
+            ...     leaf = abjad.inspect(last_leaf).leaf(n)
             ...     print(n, leaf)
             ...
             0 f'8
@@ -873,7 +1019,7 @@ class Inspection(AbjadObject):
             Voice("c'8 d'8 e'8 f'8")
 
             >>> for n in range(8):
-            ...     leaf = abjad.inspect(first_voice).get_leaf(n)
+            ...     leaf = abjad.inspect(first_voice).leaf(n)
             ...     print(n, leaf)
             ...
             0 c'8
@@ -892,7 +1038,7 @@ class Inspection(AbjadObject):
             Voice("c'8 d'8 e'8 f'8")
 
             >>> for n in range(-1, -9, -1):
-            ...     leaf = abjad.inspect(first_voice).get_leaf(n)
+            ...     leaf = abjad.inspect(first_voice).leaf(n)
             ...     print(n, leaf)
             ...
             -1 f'8
@@ -904,51 +1050,51 @@ class Inspection(AbjadObject):
             -7 None
             -8 None
 
-        Returns leaf or none.
         """
-        import abjad
-        if isinstance(self.client, abjad.Leaf):
+        if isinstance(self.client, Leaf):
             return self.client._get_leaf(n)
         if 0 <= n:
             reverse = False
         else:
             reverse = True
             n = abs(n) - 1
-        leaves = abjad.iterate(self.client).leaves(reverse=reverse)
+        leaves = iterate(self.client).leaves(reverse=reverse)
         for i, leaf in enumerate(leaves):
             if i == n:
                 return leaf
+        return None
 
-    def get_lineage(self):
+    def lineage(self) -> Lineage:
         """
         Gets lineage.
-
-        Returns lineage.
         """
-        if hasattr(self.client, '_get_lineage'):
-            return self.client._get_lineage()
+        if not isinstance(self.client, Component):
+            raise Exception('can only get lineage on component.')
+        return self.client._get_lineage()
 
-    def get_logical_tie(self):
+    def logical_tie(self) -> LogicalTie:
         """
         Gets logical tie.
-
-        Returns logical tie.
         """
-        if hasattr(self.client, '_get_logical_tie'):
-            return self.client._get_logical_tie()
+        if not isinstance(self.client, Leaf):
+            raise Exception('can only get logical tie on leaf.')
+        return self.client._get_logical_tie()
 
-    def get_markup(self, direction=None):
+    def markup(self, direction=None) -> typing.List[Markup]:
         """
         Gets markup.
-
-        Returns tuple.
         """
-        if hasattr(self.client, '_get_markup'):
-            return self.client._get_markup(
-                direction=direction,
-                )
+        # TODO: extend to any non-none client
+        if not isinstance(self.client, Component):
+            raise Exception('can only get markup on component.')
+        result = self.client._get_markup(direction=direction)
+        return list(result)
 
-    def get_parentage(self, include_self=True, grace_notes=False):
+    def parentage(
+        self,
+        include_self=True,
+        grace_notes=False,
+        ) -> Parentage:
         r"""
         Gets parentage.
 
@@ -976,7 +1122,7 @@ class Inspection(AbjadObject):
                     f'4
                 }
 
-            >>> abjad.inspect(container[0]).get_parentage()
+            >>> abjad.inspect(container[0]).parentage()
             Parentage(component=Note("c'16"))
 
         .. container:: example
@@ -1004,7 +1150,7 @@ class Inspection(AbjadObject):
                 }
 
             >>> agent = abjad.inspect(container[0])
-            >>> parentage = agent.get_parentage(grace_notes=True)
+            >>> parentage = agent.parentage(grace_notes=True)
             >>> for component in parentage:
             ...     component
             ...
@@ -1013,25 +1159,127 @@ class Inspection(AbjadObject):
             Note("d'4")
             Voice("c'4 d'4 e'4 f'4")
 
-        Returns parentage.
         """
+        if not isinstance(self.client, Component):
+            raise Exception('can only get parentage on component.')
         return self.client._get_parentage(
             include_self=include_self,
             grace_notes=grace_notes,
             )
 
-    def get_pitches(self):
+    def pitches(self) -> typing.Optional[PitchSet]:
         """
         Gets pitches.
-
-        Returns pitch set.
         """
-        import abjad
         if not self.client:
-            return
-        return abjad.PitchSet.from_selection(abjad.select(self.client))
+            return None
+        selection = Selection(self.client)
+        return PitchSet.from_selection(selection)
 
-    def get_sounding_pitch(self):
+    def report_modifications(self) -> str:
+        r"""
+        Reports modifications.
+
+        ..  container:: example
+
+            Reports container modifications:
+
+            >>> container = abjad.Container("c'8 d'8 e'8 f'8")
+            >>> abjad.override(container).note_head.color = 'red'
+            >>> abjad.override(container).note_head.style = 'harmonic'
+            >>> abjad.show(container) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(container)
+                {
+                    \override NoteHead.color = #red
+                    \override NoteHead.style = #'harmonic
+                    c'8
+                    d'8
+                    e'8
+                    f'8
+                    \revert NoteHead.color
+                    \revert NoteHead.style
+                }
+
+            >>> report = abjad.inspect(container).report_modifications()
+            >>> print(report)
+            {
+                \override NoteHead.color = #red
+                \override NoteHead.style = #'harmonic
+                %%% 4 components omitted %%%
+                \revert NoteHead.color
+                \revert NoteHead.style
+            }
+
+        ..  container:: example
+
+            Reports leaf modifications:
+
+            >>> container = abjad.Container("c'8 d'8 e'8 f'8")
+            >>> abjad.attach(abjad.Clef('alto'), container[0])
+            >>> abjad.override(container[0]).note_head.color = 'red'
+            >>> abjad.override(container[0]).stem.color = 'red'
+            >>> abjad.show(container) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(container)
+                {
+                    \once \override NoteHead.color = #red
+                    \once \override Stem.color = #red
+                    \clef "alto"
+                    c'8
+                    d'8
+                    e'8
+                    f'8
+                }
+
+            >>> report = abjad.inspect(container[0]).report_modifications()
+            >>> print(report)
+            slot absolute before:
+            slot 1:
+                grob overrides:
+                    \once \override NoteHead.color = #red
+                    \once \override Stem.color = #red
+            slot 3:
+                commands:
+                    \clef "alto"
+            slot 4:
+                leaf body:
+                    c'8
+            slot 5:
+            slot 7:
+            slot absolute after:
+
+        """
+        if isinstance(self.client, Container):
+            bundle = LilyPondFormatManager.bundle_format_contributions(
+                self.client
+                )
+            result: typing.List[str] = []
+            for slot in ('before', 'open brackets', 'opening'):
+                lines = self.client._get_format_contributions_for_slot(
+                    slot,
+                    bundle,
+                    )
+                result.extend(lines)
+            line = f'    %%% {len(self.client)} components omitted %%%'
+            result.append(line)
+            for slot in ('closing', 'close brackets', 'after'):
+                lines = self.client._get_format_contributions_for_slot(
+                    slot,
+                    bundle,
+                    )
+                result.extend(lines)
+            return '\n'.join(result)
+        elif isinstance(self.client, Leaf):
+            return self.client._report_format_contributions()
+        else:
+            return f'only defined for components: {self.client}.'
+
+    def sounding_pitch(self) -> NamedPitch:
         r"""
         Gets sounding pitch.
 
@@ -1054,11 +1302,13 @@ class Inspection(AbjadObject):
                     g'8
                 }
 
-        Returns named pitch.
         """
+        if not isinstance(self.client, Note):
+            raise Exception('can only get sounding pitch of note.')
         return self.client._get_sounding_pitch()
 
-    def get_sounding_pitches(self):
+    # TODO: return PitchSet instead of list
+    def sounding_pitches(self) -> typing.List[NamedPitch]:
         r"""
         Gets sounding pitches.
 
@@ -1079,14 +1329,22 @@ class Inspection(AbjadObject):
                     <d' fs'>4
                 }
 
-            >>> abjad.inspect(staff[0]).get_sounding_pitches()
-            (NamedPitch("c'''"), NamedPitch("e'''"))
+            >>> abjad.inspect(staff[0]).sounding_pitches()
+            [NamedPitch("c'''"), NamedPitch("e'''")]
 
         Returns tuple.
         """
-        return self.client._get_sounding_pitches()
+        # TODO: extend to any non-none client
+        if not isinstance(self.client, Chord):
+            raise Exception('can only get sounding pitches of chord.')
+        result = self.client._get_sounding_pitches()
+        return list(result)
 
-    def get_spanner(self, prototype=None, default=None):
+    def spanner(
+        self,
+        prototype=None,
+        default=None,
+        ) -> typing.Any:
         """
         Gets spanner.
 
@@ -1095,9 +1353,10 @@ class Inspection(AbjadObject):
 
         Returns ``default`` when no spanner of ``prototype`` attaches to
         client.
-
-        Returns spanner or default.
         """
+        # TODO: extend to any non-none client
+        if not isinstance(self.client, (Leaf, Selection)):
+            raise Exception('can only get spanner on leaf or selection.')
         spanners = self.client._get_spanners(prototype=prototype)
         assert isinstance(spanners, list), repr(spanners)
         if not spanners:
@@ -1107,7 +1366,7 @@ class Inspection(AbjadObject):
         else:
             raise exceptions.ExtraSpannerError
 
-    def get_spanners(self, prototype=None) -> typing.List[Spanner]:
+    def spanners(self, prototype=None) -> typing.List[Spanner]:
         r"""
         Gets spanners.
 
@@ -1133,13 +1392,13 @@ class Inspection(AbjadObject):
                     ]
                 }
 
-            >>> abjad.inspect(staff).get_spanners()
+            >>> abjad.inspect(staff).spanners()
             []
 
-            >>> abjad.inspect(staff[0]).get_spanners()
+            >>> abjad.inspect(staff[0]).spanners()
             [Beam("c'8, d'8", durations=(), span_beam_count=1)]
 
-            >>> beams = abjad.inspect(staff[:]).get_spanners()
+            >>> beams = abjad.inspect(staff[:]).spanners()
             >>> beams = list(beams)
             >>> beams.sort()
             >>> beams
@@ -1148,22 +1407,62 @@ class Inspection(AbjadObject):
         """
         if isinstance(self.client, Container):
             return []
-        if hasattr(self.client, 'get_spanners'):
-            return self.client.get_spanners(prototype=prototype)
-        if hasattr(self.client, '_get_spanners'):
+        if isinstance(self.client, (Leaf, Selection)):
             return self.client._get_spanners(prototype=prototype)
         assert isinstance(self.client, collections.Iterable), repr(self.client)
         known_ids: typing.List[int] = []
         result = []
         for item in self.client:
-            for spanner in inspect(item).get_spanners(prototype=prototype):
+            for spanner in inspect(item).spanners(prototype=prototype):
                 id_ = id(spanner)
                 if id_ not in known_ids:
                     known_ids.append(id_)
                     result.append(spanner)
         return result
 
-    def get_timespan(self, in_seconds=False):
+    def tabulate_wellformedness(
+        self,
+        allow_percussion_clef=None,
+        check_beamed_long_notes=True,
+        check_discontiguous_spanners=True,
+        check_duplicate_ids=True,
+        check_empty_containers=True,
+        check_misdurated_measures=True,
+        check_misfilled_measures=True,
+        check_mismatched_enchained_hairpins=True,
+        check_mispitched_ties=True,
+        check_misrepresented_flags=True,
+        check_missing_parents=True,
+        check_nested_measures=True,
+        check_notes_on_wrong_clef=True,
+        check_out_of_range_notes=True,
+        check_overlapping_beams=True,
+        check_overlapping_glissandi=True,
+        check_overlapping_hairpins=True,
+        check_overlapping_octavation_spanners=True,
+        check_overlapping_ties=True,
+        check_overlapping_trill_spanners=True,
+        check_tied_rests=True,
+        ) -> str:
+        r"""
+        Tabulates well-formedness.
+        """
+        manager = WellformednessManager(
+            allow_percussion_clef=allow_percussion_clef,
+            )
+        triples = manager(self.client)
+        strings = []
+        for violators, total, check_name in triples:
+            if eval(check_name) is not True:
+                continue
+            violator_count = len(violators)
+            check_name = check_name.replace('check_', '')
+            check_name = check_name.replace('_', ' ')
+            string = f'{violator_count} /\t{total} {check_name}'
+            strings.append(string)
+        return '\n'.join(strings)
+
+    def timespan(self, in_seconds=False) -> Timespan:
         r"""
         Gets timespan.
 
@@ -1202,7 +1501,7 @@ class Inspection(AbjadObject):
                 }
 
             >>> for leaf in abjad.iterate(voice).leaves():
-            ...     timespan = abjad.inspect(leaf).get_timespan()
+            ...     timespan = abjad.inspect(leaf).timespan()
             ...     print(str(leaf) + ':')
             ...     abjad.f(timespan)
             ...
@@ -1287,37 +1586,33 @@ class Inspection(AbjadObject):
                     ]
                 }
 
-            >>> abjad.inspect(staff).get_timespan()
+            >>> abjad.inspect(staff).timespan()
             Timespan(start_offset=Offset(0, 1), stop_offset=Offset(1, 2))
 
-            >>> abjad.inspect(staff[0]).get_timespan()
+            >>> abjad.inspect(staff[0]).timespan()
             Timespan(start_offset=Offset(0, 1), stop_offset=Offset(1, 8))
 
-            >>> abjad.inspect(staff[:3]).get_timespan()
+            >>> abjad.inspect(staff[:3]).timespan()
             Timespan(start_offset=Offset(0, 1), stop_offset=Offset(3, 8))
 
-        Returns timespan.
         """
-        import abjad
-        if hasattr(self.client, 'get_timespan'):
-            return self.client.get_timespan(in_seconds=in_seconds)
-        if hasattr(self.client, '_get_timespan'):
+        if isinstance(self.client, Component):
             return self.client._get_timespan(in_seconds=in_seconds)
-        assert isinstance(self.client, collections.Iterable), repr(self.client)
-        timespan = abjad.inspect(self.client[0]).get_timespan(
+        assert isinstance(self.client, collections.Sequence), repr(self.client)
+        timespan = Inspection(self.client[0]).timespan(
             in_seconds=in_seconds,
             )
         start_offset = timespan.start_offset
         stop_offset = timespan.stop_offset
         for item in self.client[1:]:
-            timespan = abjad.inspect(item).get_timespan(in_seconds=in_seconds)
+            timespan = Inspection(item).timespan(in_seconds=in_seconds)
             if timespan.start_offset < start_offset:
                 start_offset = timespan.start_offset
             if stop_offset < timespan.stop_offset:
                 stop_offset = timespan.stop_offset
-        return abjad.Timespan(start_offset, stop_offset)
+        return Timespan(start_offset, stop_offset)
 
-    def get_tuplet(self, n=0):
+    def tuplet(self, n=0) -> typing.Optional[Tuplet]:
         r"""
         Gets tuplet ``n``.
 
@@ -1360,7 +1655,7 @@ class Inspection(AbjadObject):
         ..  container:: example
 
             >>> for n in range(4):
-            ...     tuplet = abjad.inspect(staff).get_tuplet(n)
+            ...     tuplet = abjad.inspect(staff).tuplet(n)
             ...     print(n, tuplet)
             ...
             0 Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
@@ -1369,7 +1664,7 @@ class Inspection(AbjadObject):
             3 Tuplet(Multiplier(2, 3), "f'8 g'8 a'8")
 
             >>> for n in range(-1, -5, -1):
-            ...     tuplet = abjad.inspect(staff).get_tuplet(n)
+            ...     tuplet = abjad.inspect(staff).tuplet(n)
             ...     print(n, tuplet)
             ...
             -1 Tuplet(Multiplier(2, 3), "f'8 g'8 a'8")
@@ -1377,23 +1672,19 @@ class Inspection(AbjadObject):
             -3 Tuplet(Multiplier(2, 3), "d'8 e'8 f'8")
             -4 Tuplet(Multiplier(2, 3), "c'8 d'8 e'8")
 
-        Returns tuplet or none.
         """
-        import abjad
         if 0 <= n:
             reverse = False
         else:
             reverse = True
             n = abs(n) - 1
-        tuplets = abjad.iterate(self.client).components(
-            abjad.Tuplet,
-            reverse=reverse,
-            )
+        tuplets = iterate(self.client).components(Tuplet, reverse=reverse)
         for i, tuplet in enumerate(tuplets):
             if i == n:
                 return tuplet
+        return None
 
-    def get_vertical_moment(self, governor=None):
+    def vertical_moment(self, governor=None) -> VerticalMoment:
         r"""
         Gets vertical moment.
 
@@ -1443,317 +1734,39 @@ class Inspection(AbjadObject):
                 >>
 
             >>> agent = abjad.inspect(staff_group[1][0])
-            >>> moment = agent.get_vertical_moment(governor=staff_group)
+            >>> moment = agent.vertical_moment(governor=staff_group)
             >>> moment.leaves
             Selection([Note("a'4"), Note("f'8")])
 
             >>> agent = abjad.inspect(staff_group[1][1])
-            >>> moment = agent.get_vertical_moment(governor=staff_group)
+            >>> moment = agent.vertical_moment(governor=staff_group)
             >>> moment.leaves
             Selection([Note("a'4"), Note("e'8")])
 
             >>> agent = abjad.inspect(staff_group[1][2])
-            >>> moment = agent.get_vertical_moment(governor=staff_group)
+            >>> moment = agent.vertical_moment(governor=staff_group)
             >>> moment.leaves
             Selection([Note("g'4"), Note("d'8")])
 
             >>> agent = abjad.inspect(staff_group[1][3])
-            >>> moment = agent.get_vertical_moment(governor=staff_group)
+            >>> moment = agent.vertical_moment(governor=staff_group)
             >>> moment.leaves
             Selection([Note("g'4"), Note("c'8")])
 
-        Returns vertical moment.
         """
+        if not isinstance(self.client, Component):
+            raise Exception('can only get vertical moment on component.')
         return self.client._get_vertical_moment(governor=governor)
 
-    def get_vertical_moment_at(self, offset):
+    def vertical_moment_at(self, offset) -> VerticalMoment:
         """
         Gets vertical moment at ``offset``.
-
-        Returns vertical moment.
         """
+        if not isinstance(self.client, Component):
+            raise Exception('can only get vertical moment on component.')
         return self.client._get_vertical_moment_at(offset)
 
-    def has_effective_indicator(self, prototype=None):
-        """
-        Is true when client has effective indicator.
-
-        Returns true or false.
-        """
-        return self.client._has_effective_indicator(prototype=prototype)
-
-    def has_indicator(self, prototype=None):
-        """
-        Is true when client has one or more indicators.
-
-        Returns true or false.
-        """
-        return self.client._has_indicator(prototype=prototype)
-
-    def has_spanner(self, prototype=None):
-        """
-        Is true when client has one or more spanners.
-
-        Returns true or false.
-        """
-        return self.client._has_spanner(prototype=prototype)
-
-    def is_bar_line_crossing(self):
-        r"""
-        Is true when client crosses bar line.
-
-        ..  container:: example
-
-            >>> staff = abjad.Staff("c'4 d'4 e'4")
-            >>> time_signature = abjad.TimeSignature((3, 8))
-            >>> abjad.attach(time_signature, staff[0])
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                {
-                    \time 3/8
-                    c'4
-                    d'4
-                    e'4
-                }
-
-            >>> for note in staff:
-            ...     result = abjad.inspect(note).is_bar_line_crossing()
-            ...     print(note, result)
-            ...
-            c'4 False
-            d'4 True
-            e'4 False
-
-        Returns true or false.
-        """
-        import abjad
-        time_signature = self.client._get_effective(abjad.TimeSignature)
-        if time_signature is None:
-            time_signature_duration = abjad.Duration(4, 4)
-        else:
-            time_signature_duration = time_signature.duration
-        partial = getattr(time_signature, 'partial', 0)
-        partial = partial or 0
-        start_offset = abjad.inspect(self.client).get_timespan().start_offset
-        shifted_start = start_offset - partial
-        shifted_start %= time_signature_duration
-        stop_offset = self.client._get_duration() + shifted_start
-        if time_signature_duration < stop_offset:
-            return True
-        return False
-
-    def is_grace_note(self):
-        """
-        Is true when client is grace note.
-
-        Returns true or false.
-        """
-        import abjad
-        if not isinstance(self.client, abjad.Leaf):
-            return False
-        prototype = (abjad.AfterGraceContainer, abjad.GraceContainer)
-        for component in abjad.inspect(self.client).get_parentage():
-            if isinstance(component, prototype):
-                return True
-        return False
-
-    def is_well_formed(
-        self,
-        check_beamed_long_notes=True,
-        check_discontiguous_spanners=True,
-        check_duplicate_ids=True,
-        check_empty_containers=True,
-        check_misdurated_measures=True,
-        check_misfilled_measures=True,
-        check_mismatched_enchained_hairpins=True,
-        check_mispitched_ties=True,
-        check_misrepresented_flags=True,
-        check_missing_parents=True,
-        check_nested_measures=True,
-        check_notes_on_wrong_clef=True,
-        check_out_of_range_notes=True,
-        check_overlapping_beams=True,
-        check_overlapping_glissandi=True,
-        check_overlapping_hairpins=True,
-        check_overlapping_octavation_spanners=True,
-        check_overlapping_ties=True,
-        check_overlapping_trill_spanners=True,
-        check_tied_rests=True,
-        ):
-        """
-        Is true when client is well-formed.
-
-        Returns true or false.
-        """
-        import abjad
-        manager = abjad.WellformednessManager()
-        for violators, total, check_name in manager(self.client):
-            if eval(check_name) is not True:
-                continue
-            if violators:
-                return False
-        return True
-
-    def report_modifications(self):
-        r"""
-        Reports modifications.
-
-        ..  container:: example
-
-            Reports container modifications:
-
-            >>> container = abjad.Container("c'8 d'8 e'8 f'8")
-            >>> abjad.override(container).note_head.color = 'red'
-            >>> abjad.override(container).note_head.style = 'harmonic'
-            >>> abjad.show(container) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(container)
-                {
-                    \override NoteHead.color = #red
-                    \override NoteHead.style = #'harmonic
-                    c'8
-                    d'8
-                    e'8
-                    f'8
-                    \revert NoteHead.color
-                    \revert NoteHead.style
-                }
-
-            >>> report = abjad.inspect(container).report_modifications()
-            >>> print(report)
-            {
-                \override NoteHead.color = #red
-                \override NoteHead.style = #'harmonic
-                %%% 4 components omitted %%%
-                \revert NoteHead.color
-                \revert NoteHead.style
-            }
-
-        ..  container:: example
-
-            Reports leaf modifications:
-
-            >>> container = abjad.Container("c'8 d'8 e'8 f'8")
-            >>> abjad.attach(abjad.Clef('alto'), container[0])
-            >>> abjad.override(container[0]).note_head.color = 'red'
-            >>> abjad.override(container[0]).stem.color = 'red'
-            >>> abjad.show(container) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(container)
-                {
-                    \once \override NoteHead.color = #red
-                    \once \override Stem.color = #red
-                    \clef "alto"
-                    c'8
-                    d'8
-                    e'8
-                    f'8
-                }
-
-            >>> report = abjad.inspect(container[0]).report_modifications()
-            >>> print(report)
-            slot absolute before:
-            slot 1:
-                grob overrides:
-                    \once \override NoteHead.color = #red
-                    \once \override Stem.color = #red
-            slot 3:
-                commands:
-                    \clef "alto"
-            slot 4:
-                leaf body:
-                    c'8
-            slot 5:
-            slot 7:
-            slot absolute after:
-
-        Returns string.
-        """
-        import abjad
-        if isinstance(self.client, abjad.Container):
-            bundle = abjad.LilyPondFormatManager.bundle_format_contributions(
-                self.client
-                )
-            result = []
-            for slot in ('before', 'open brackets', 'opening'):
-                lines = self.client._get_format_contributions_for_slot(
-                    slot,
-                    bundle,
-                    )
-                result.extend(lines)
-            line = '    %%% {} components omitted %%%'
-            line = line.format(len(self.client))
-            result.append(line)
-            for slot in ('closing', 'close brackets', 'after'):
-                lines = self.client._get_format_contributions_for_slot(
-                    slot,
-                    bundle,
-                    )
-                result.extend(lines)
-            result = '\n'.join(result)
-            return result
-        elif isinstance(self.client, abjad.Leaf):
-            return self.client._report_format_contributions()
-        else:
-            message = 'only defined for components: {}.'
-            message = message.format(self.client)
-            return message
-
-    def tabulate_wellformedness(
-        self,
-        allow_percussion_clef=None,
-        check_beamed_long_notes=True,
-        check_discontiguous_spanners=True,
-        check_duplicate_ids=True,
-        check_empty_containers=True,
-        check_misdurated_measures=True,
-        check_misfilled_measures=True,
-        check_mismatched_enchained_hairpins=True,
-        check_mispitched_ties=True,
-        check_misrepresented_flags=True,
-        check_missing_parents=True,
-        check_nested_measures=True,
-        check_notes_on_wrong_clef=True,
-        check_out_of_range_notes=True,
-        check_overlapping_beams=True,
-        check_overlapping_glissandi=True,
-        check_overlapping_hairpins=True,
-        check_overlapping_octavation_spanners=True,
-        check_overlapping_ties=True,
-        check_overlapping_trill_spanners=True,
-        check_tied_rests=True,
-        ):
-        r"""
-        Tabulates well-formedness.
-
-        Returns string.
-        """
-        import abjad
-        manager = abjad.WellformednessManager(
-            allow_percussion_clef=allow_percussion_clef,
-            )
-        triples = manager(self.client)
-        strings = []
-        for violators, total, check_name in triples:
-            if eval(check_name) is not True:
-                continue
-            violator_count = len(violators)
-            string = '{} /\t{} {}'
-            check_name = check_name.replace('check_', '')
-            check_name = check_name.replace('_', ' ')
-            string = string.format(violator_count, total, check_name)
-            strings.append(string)
-        return '\n'.join(strings)
-
-    def wrapper(self, prototype=None):
+    def wrapper(self, prototype=None) -> typing.Optional[Wrapper]:
         r"""
         Gets wrapper.
 
@@ -1789,12 +1802,12 @@ class Inspection(AbjadObject):
 
         Raises exception when more than one indicator of ``prototype`` attach
         to client.
-
-        Returns wrapper or none.
         """
-        return self.get_indicator(prototype=prototype, unwrap=False)
+        return self.indicator(prototype=prototype, unwrap=False)
 
-    def wrappers(self, prototype=None):
+    def wrappers(self, prototype=None) -> typing.Optional[
+        typing.List[Wrapper]
+        ]:
         r"""
         Gets wrappers.
 
@@ -1823,11 +1836,10 @@ class Inspection(AbjadObject):
                 }
 
             >>> abjad.inspect(staff).wrappers(abjad.Articulation)
-            ()
+            []
 
             >>> abjad.inspect(staff[0]).wrappers(abjad.Articulation)
-            (Wrapper(indicator=Articulation('^'), tag=Tag()),)
+            [Wrapper(indicator=Articulation('^'), tag=Tag())]
 
-        Returns tuple of wrappers or none.
         """
-        return self.get_indicators(prototype=prototype, unwrap=False)
+        return self.indicators(prototype=prototype, unwrap=False)

--- a/abjad/core/Iteration.py
+++ b/abjad/core/Iteration.py
@@ -674,7 +674,7 @@ class Iteration(AbjadObject):
         """
         import abjad
         prototype = prototype or abjad.Component
-        parentage = abjad.inspect(self.client).get_parentage()
+        parentage = abjad.inspect(self.client).parentage()
         logical_voice = parentage.logical_voice
         if reverse:
             direction = enums.Right
@@ -686,7 +686,7 @@ class Iteration(AbjadObject):
             ):
             if not isinstance(component, prototype):
                 continue
-            parentage = abjad.inspect(component).get_parentage()
+            parentage = abjad.inspect(component).parentage()
             if parentage.logical_voice == logical_voice:
                 yield component
 
@@ -868,8 +868,8 @@ class Iteration(AbjadObject):
         grace_container, after_grace_container = None, None
         if grace_notes is not False and isinstance(argument, abjad.Leaf):
             inspection = abjad.inspect(argument)
-            grace_container = inspection.get_grace_container()
-            after_grace_container = inspection.get_after_grace_container()
+            grace_container = inspection.grace_container()
+            after_grace_container = inspection.after_grace_container()
         if not reverse:
             if grace_notes is not False and grace_container:
                 for component in grace_container:
@@ -1597,7 +1597,7 @@ class Iteration(AbjadObject):
 
         ..  container:: example
 
-            Regression: yields logical tie even when leaves are missing in
+            REGRESSION: yields logical tie even when leaves are missing in
             input:
 
             ..  container:: example
@@ -1637,7 +1637,7 @@ class Iteration(AbjadObject):
             grace_notes=grace_notes,
             reverse=reverse,
             ):
-            logical_tie = abjad.inspect(leaf).get_logical_tie()
+            logical_tie = abjad.inspect(leaf).logical_tie()
             if leaf is not logical_tie.head:
                 continue
             if (nontrivial is None or
@@ -1678,7 +1678,7 @@ class Iteration(AbjadObject):
         """
         import abjad
         for leaf in abjad.iterate(self.client).leaves(pitched=True):
-            instrument = abjad.inspect(leaf).get_effective(abjad.Instrument)
+            instrument = abjad.inspect(leaf).effective(abjad.Instrument)
             if instrument is None:
                 message = 'no instrument found.'
                 raise ValueError(message)
@@ -2052,13 +2052,13 @@ class Iteration(AbjadObject):
         import abjad
         visited_spanners = set()
         for component in self.components(reverse=reverse):
-            spanners = abjad.inspect(component).get_spanners(
+            spanners = abjad.inspect(component).spanners(
                 prototype=prototype,
                 )
             spanners = sorted(spanners,
                 key=lambda x: (
                     type(x).__name__,
-                    abjad.inspect(x).get_timespan(),
+                    abjad.inspect(x).timespan(),
                     ),
                 )
             for spanner in spanners:
@@ -2214,11 +2214,11 @@ class Iteration(AbjadObject):
         if not reverse:
             while components:
                 current_start_offset = min(
-                    abjad.inspect(_).get_timespan().start_offset
+                    abjad.inspect(_).timespan().start_offset
                     for _ in components
                     )
                 components.sort(
-                    key=lambda x: abjad.inspect(x).get_parentage(
+                    key=lambda x: abjad.inspect(x).parentage(
                         grace_notes=True).score_index,
                     reverse=True,
                     )
@@ -2226,7 +2226,7 @@ class Iteration(AbjadObject):
                 components = []
                 while components_to_process:
                     component = components_to_process.pop()
-                    start_offset = abjad.inspect(component).get_timespan().start_offset
+                    start_offset = abjad.inspect(component).timespan().start_offset
                     #print('    COMPONENT:', component)
                     if current_start_offset < start_offset:
                         components.append(component)
@@ -2252,11 +2252,11 @@ class Iteration(AbjadObject):
                 #print('STEP')
                 #print()
                 current_stop_offset = max(
-                    abjad.inspect(_).get_timespan().stop_offset
+                    abjad.inspect(_).timespan().stop_offset
                     for _ in components
                     )
                 components.sort(
-                    key=lambda x: abjad.inspect(x).get_parentage(
+                    key=lambda x: abjad.inspect(x).parentage(
                         grace_notes=True).score_index,
                     reverse=True,
                     )
@@ -2264,7 +2264,7 @@ class Iteration(AbjadObject):
                 components = []
                 while components_to_process:
                     component = components_to_process.pop()
-                    stop_offset = abjad.inspect(component).get_timespan().stop_offset
+                    stop_offset = abjad.inspect(component).timespan().stop_offset
                     #print('\tCOMPONENT:', component)
                     if stop_offset < current_stop_offset:
                         components.insert(0, component)
@@ -2433,7 +2433,7 @@ class Iteration(AbjadObject):
         import abjad
         def _buffer_components_starting_with(component, buffer, stop_offsets):
             buffer.append(component)
-            stop_offset = abjad.inspect(component).get_timespan().stop_offset
+            stop_offset = abjad.inspect(component).timespan().stop_offset
             stop_offsets.append(stop_offset)
             if isinstance(component, abjad.Container):
                 if component.is_simultaneous:
@@ -2458,7 +2458,7 @@ class Iteration(AbjadObject):
                 offset = abjad.Offset(current_offset)
                 components = list(buffer)
                 components.sort(
-                    key=lambda _: abjad.inspect(_).get_parentage().score_index
+                    key=lambda _: abjad.inspect(_).parentage().score_index
                     )
                 vertical_moment._offset = offset
                 vertical_moment._governors = governors
@@ -2482,7 +2482,7 @@ class Iteration(AbjadObject):
                 raise StopIteration
         def _update_buffer(current_offset, buffer, stop_offsets):
             for component in buffer[:]:
-                offset = abjad.inspect(component).get_timespan().stop_offset
+                offset = abjad.inspect(component).timespan().stop_offset
                 if offset <= current_offset:
                     buffer.remove(component)
                     try:
@@ -2502,7 +2502,7 @@ class Iteration(AbjadObject):
         else:
             moments_in_governor = []
             for component in self.components():
-                offset = abjad.inspect(component).get_timespan().start_offset
+                offset = abjad.inspect(component).timespan().start_offset
                 if offset not in moments_in_governor:
                     moments_in_governor.append(offset)
             moments_in_governor.sort()

--- a/abjad/core/Label.py
+++ b/abjad/core/Label.py
@@ -2112,7 +2112,7 @@ class Label(AbjadObject):
         if self._expression:
             return self._update_expression(inspect.currentframe())
         for logical_tie in iterate(self.client).logical_ties():
-            duration = abjad_inspect(logical_tie).get_duration()
+            duration = abjad_inspect(logical_tie).duration()
             if denominator is not None:
                 duration = NonreducedFraction(duration)
                 duration = duration.with_denominator(denominator)
@@ -2904,7 +2904,7 @@ class Label(AbjadObject):
         prototype = prototype or NamedInterval
         for note in  iterate(self.client).leaves(Note):
             label = None
-            next_leaf = abjad_inspect(note).get_leaf(1)
+            next_leaf = abjad_inspect(note).leaf(1)
             if isinstance(next_leaf, Note):
                 interval = NamedInterval.from_pitch_carriers(
                     note,
@@ -4181,7 +4181,7 @@ class Label(AbjadObject):
         for logical_tie in iterate(self.client).logical_ties():
             if clock_time:
                 inspector = abjad_inspect(logical_tie.head)
-                timespan = inspector.get_timespan(in_seconds=True)
+                timespan = inspector.timespan(in_seconds=True)
                 start_offset = timespan.start_offset
                 if global_offset is not None:
                     start_offset += global_offset
@@ -4191,7 +4191,7 @@ class Label(AbjadObject):
                 else:
                     string = '"{}"'.format(string)
             else:
-                timespan = abjad_inspect(logical_tie.head).get_timespan()
+                timespan = abjad_inspect(logical_tie.head).timespan()
                 start_offset = timespan.start_offset
                 if global_offset is not None:
                     start_offset += global_offset

--- a/abjad/core/Leaf.py
+++ b/abjad/core/Leaf.py
@@ -303,7 +303,7 @@ class Leaf(Component):
     def _get_logical_tie(self):
         import abjad
         for component in [self]:
-            ties = inspect(component).get_spanners(abjad.Tie)
+            ties = inspect(component).spanners(abjad.Tie)
             if len(ties) == 1:
                 tie = ties.pop()
                 return abjad.LogicalTie(items=tie.leaves)
@@ -475,7 +475,7 @@ class Leaf(Component):
         import abjad
         durations = [Duration(_) for _ in durations]
         durations = sequence(durations)
-        leaf_duration = inspect(self).get_duration()
+        leaf_duration = inspect(self).duration()
         if cyclic:
             durations = durations.repeat_to_weight(leaf_duration)
         if sum(durations) < leaf_duration:
@@ -488,7 +488,7 @@ class Leaf(Component):
         # detach grace containers
         grace_container = self._detach_grace_container()
         after_grace_container = self._detach_after_grace_container()
-        leaf_prolation = inspect(self).get_parentage().prolation
+        leaf_prolation = inspect(self).parentage().prolation
         for duration in durations:
             new_leaf = copy.copy(self)
             preprolated_duration = duration / leaf_prolation
@@ -508,7 +508,7 @@ class Leaf(Component):
                 detach(abjad.Tie, leaf)
         # strip result leaves of indicators (other than multipliers)
         for leaf in result_leaves:
-            multiplier = inspect(leaf).get_indicator(Multiplier)
+            multiplier = inspect(leaf).indicator(Multiplier)
             detach(object, leaf)
             if multiplier is not None:
                 attach(multiplier, leaf)
@@ -523,26 +523,26 @@ class Leaf(Component):
         # fracture spanners
         if fracture_spanners:
             first_selection = result_selections[0]
-            for spanner in inspect(first_selection[-1]).get_spanners():
+            for spanner in inspect(first_selection[-1]).spanners():
                 index = spanner._index(first_selection[-1])
                 spanner._fracture(index, direction=enums.Right)
             last_selection = result_selections[-1]
-            for spanner in inspect(last_selection[0]).get_spanners():
+            for spanner in inspect(last_selection[0]).spanners():
                 index = spanner._index(last_selection[0])
                 spanner._fracture(index, direction=enums.Left)
             for middle_selection in result_selections[1:-1]:
-                spanners = inspect(middle_selection[0]).get_spanners()
+                spanners = inspect(middle_selection[0]).spanners()
                 for spanner in spanners:
                     index = spanner._index(middle_selection[0])
                     spanner._fracture(index, direction=enums.Left)
-                spanners = inspect(middle_selection[-1]).get_spanners()
+                spanners = inspect(middle_selection[-1]).spanners()
                 for spanner in spanners:
                     index = spanner._index(middle_selection[-1])
                     spanner._fracture(index, direction=enums.Right)
         # move indicators
         first_result_leaf = result_leaves[0]
         last_result_leaf = result_leaves[-1]
-        for indicator in inspect(self).get_indicators():
+        for indicator in inspect(self).indicators():
             if isinstance(indicator, Multiplier):
                 continue
             detach(indicator, self)

--- a/abjad/core/LeafMaker.py
+++ b/abjad/core/LeafMaker.py
@@ -315,7 +315,7 @@ class LeafMaker(AbjadValueObject):
         >>> leaves = maker(pitches, durations)
         >>> staff = abjad.Staff(leaves)
         >>> time_signature = abjad.TimeSignature((5, 14))
-        >>> leaf = abjad.inspect(staff).get_leaf(0)
+        >>> leaf = abjad.inspect(staff).leaf(0)
         >>> abjad.attach(time_signature, leaf)
         >>> abjad.show(staff) # doctest: +SKIP
 

--- a/abjad/core/Lineage.py
+++ b/abjad/core/Lineage.py
@@ -41,7 +41,7 @@ class Lineage(AbjadObject, collections.Sequence):
                 }
             >>
 
-        >>> for component in abjad.inspect(score).get_lineage():
+        >>> for component in abjad.inspect(score).lineage():
         ...     component
         ...
         <Score<<2>>>
@@ -53,7 +53,7 @@ class Lineage(AbjadObject, collections.Sequence):
         Note('b,4')
 
         >>> bass_voice = score['Bass Voice']
-        >>> for component in abjad.inspect(bass_voice).get_lineage():
+        >>> for component in abjad.inspect(bass_voice).lineage():
         ...     component
         ...
         <Score<<2>>>
@@ -82,10 +82,10 @@ class Lineage(AbjadObject, collections.Sequence):
         if component is not None:
             components.extend(
                 reversed(
-                abjad.inspect(component).get_parentage(include_self=False)))
+                abjad.inspect(component).parentage(include_self=False)))
             components.append(component)
             components.extend(
-                abjad.inspect(component).get_descendants(include_self=False))
+                abjad.inspect(component).descendants(include_self=False))
         self._components = components
 
     ### SPECIAL METHODS ###

--- a/abjad/core/LogicalTie.py
+++ b/abjad/core/LogicalTie.py
@@ -14,7 +14,7 @@ class LogicalTie(Selection):
         >>> staff = abjad.Staff("c' d' e' ~ e'")
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.inspect(staff[2]).get_logical_tie()
+        >>> abjad.inspect(staff[2]).logical_tie()
         LogicalTie([Note("e'4"), Note("e'4")])
 
     """
@@ -181,7 +181,7 @@ class LogicalTie(Selection):
         Returns tie spanner.
         """
         import abjad
-        return abjad.inspect(self[0]).get_spanner(abjad.Tie)
+        return abjad.inspect(self[0]).spanner(abjad.Tie)
 
     @property
     def written_duration(self):
@@ -229,7 +229,7 @@ class LogicalTie(Selection):
                     \f
                 }
 
-            >>> logical_tie = abjad.inspect(staff[1]).get_logical_tie()
+            >>> logical_tie = abjad.inspect(staff[1]).logical_tie()
             >>> logical_tie.to_tuplet([2, 1, 1, 1])
             Tuplet(Multiplier(3, 5), "c'8 c'16 c'16 c'16")
 

--- a/abjad/core/Measure.py
+++ b/abjad/core/Measure.py
@@ -559,7 +559,7 @@ class Measure(Container):
             Multiplier(2, 3)
 
             >>> for note in measure:
-            ...     note, abjad.inspect(note).get_duration()
+            ...     note, abjad.inspect(note).duration()
             (Note("c'8"), Duration(1, 12))
             (Note("d'8"), Duration(1, 12))
             (Note("e'8"), Duration(1, 12))
@@ -746,9 +746,9 @@ class Measure(Container):
         import abjad
         assert len(selections)
         if not time_signatures:
-            time_signatures = [_.get_duration() for _ in selections]
+            time_signatures = [_.duration() for _ in selections]
         assert len(selections) == len(time_signatures)
-        durations = [abjad.inspect(_).get_duration() for _ in selections]
+        durations = [abjad.inspect(_).duration() for _ in selections]
         assert durations == [abjad.Duration(_) for _ in time_signatures]
         maker = abjad.MeasureMaker()
         measures = maker(time_signatures)

--- a/abjad/core/Mutation.py
+++ b/abjad/core/Mutation.py
@@ -620,7 +620,7 @@ class Mutation(AbjadObject):
                 }
 
             >>> for leaf in staff:
-            ...     leaf, abjad.inspect(leaf).get_effective(abjad.Clef)
+            ...     leaf, abjad.inspect(leaf).effective(abjad.Clef)
             ...
             (Note("c'2"), Clef('alto'))
             (Note("f'4"), Clef('alto'))
@@ -641,7 +641,7 @@ class Mutation(AbjadObject):
                 }
 
             >>> for leaf in staff:
-            ...     leaf, abjad.inspect(leaf).get_effective(abjad.Clef)
+            ...     leaf, abjad.inspect(leaf).effective(abjad.Clef)
             ...
             (Chord("<d' e'>2"), None)
             (Note("f'4"), None)
@@ -672,7 +672,7 @@ class Mutation(AbjadObject):
                 }
 
             >>> for leaf in staff:
-            ...     leaf, abjad.inspect(leaf).get_effective(abjad.Clef)
+            ...     leaf, abjad.inspect(leaf).effective(abjad.Clef)
             ...
             (Note("c'2"), Clef('alto'))
             (Note("f'4"), Clef('alto'))
@@ -694,7 +694,7 @@ class Mutation(AbjadObject):
                 }
 
             >>> for leaf in staff:
-            ...     leaf, abjad.inspect(leaf).get_effective(abjad.Clef)
+            ...     leaf, abjad.inspect(leaf).effective(abjad.Clef)
             ...
             (Chord("<d' e'>2"), Clef('alto'))
             (Note("f'4"), Clef('alto'))
@@ -1960,7 +1960,7 @@ class Mutation(AbjadObject):
                     d'8
                 }
 
-            >>> logical_tie = abjad.inspect(staff[0]).get_logical_tie()
+            >>> logical_tie = abjad.inspect(staff[0]).logical_tie()
             >>> agent = abjad.mutate(logical_tie)
             >>> logical_tie = agent.scale(abjad.Multiplier(3, 2))
             >>> abjad.show(staff) # doctest: +SKIP
@@ -2057,7 +2057,7 @@ class Mutation(AbjadObject):
                     d'16
                 }
 
-            >>> logical_tie = abjad.inspect(staff[0]).get_logical_tie()
+            >>> logical_tie = abjad.inspect(staff[0]).logical_tie()
             >>> agent = abjad.mutate(logical_tie)
             >>> logical_tie = agent.scale(abjad.Multiplier(5, 4))
             >>> abjad.show(staff) # doctest: +SKIP
@@ -2159,7 +2159,7 @@ class Mutation(AbjadObject):
                     -\accent
                 }
 
-            >>> logical_tie = abjad.inspect(staff[0]).get_logical_tie()
+            >>> logical_tie = abjad.inspect(staff[0]).logical_tie()
             >>> agent = abjad.mutate(logical_tie)
             >>> logical_tie = agent.scale(abjad.Multiplier(4, 3))
             >>> abjad.show(staff) # doctest: +SKIP
@@ -2325,7 +2325,7 @@ class Mutation(AbjadObject):
             >>> tuplet = abjad.Tuplet((4, 5), "c'8 d'8 e'8 f'8 g'8")
             >>> staff.append(tuplet)
             >>> time_signature = abjad.TimeSignature((4, 8))
-            >>> leaf = abjad.inspect(staff).get_leaf(0)
+            >>> leaf = abjad.inspect(staff).leaf(0)
             >>> abjad.attach(time_signature, leaf)
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -3148,7 +3148,7 @@ class Mutation(AbjadObject):
             else:
                 return [], components
         # calculate total component duration
-        total_component_duration = inspect(components).get_duration()
+        total_component_duration = inspect(components).duration()
         total_split_duration = sum(durations)
         # calculate durations
         if cyclic:
@@ -3189,7 +3189,7 @@ class Mutation(AbjadObject):
             else:
                 break
             # find where current component endpoint will position us
-            duration_ = inspect(current_component).get_duration()
+            duration_ = inspect(current_component).duration()
             candidate_shard_duration = current_shard_duration + duration_
             # if current component would fill current shard exactly
             if candidate_shard_duration == next_split_point:
@@ -3204,7 +3204,7 @@ class Mutation(AbjadObject):
                 local_split_duration -= current_shard_duration
                 if isinstance(current_component, Leaf):
                     leaf_split_durations = [local_split_duration]
-                    duration_ = inspect(current_component).get_duration()
+                    duration_ = inspect(current_component).duration()
                     current_duration = duration_
                     additional_required_duration = current_duration
                     additional_required_duration -= local_split_duration
@@ -3246,7 +3246,7 @@ class Mutation(AbjadObject):
             # if current component would not fill current shard
             elif candidate_shard_duration < next_split_point:
                 shard.append(current_component)
-                duration_ = inspect(current_component).get_duration()
+                duration_ = inspect(current_component).duration()
                 current_shard_duration += duration_
                 advance_to_next_offset = False
             else:
@@ -3602,7 +3602,7 @@ class Mutation(AbjadObject):
             >>> prototype = abjad.TimeSignature
             >>> for component in abjad.iterate(staff).components():
             ...     inspection = abjad.inspect(component)
-            ...     time_signature = inspection.get_effective(prototype)
+            ...     time_signature = inspection.effective(prototype)
             ...     print(component, time_signature)
             ...
             <Staff{1}> 3/8

--- a/abjad/core/Note.py
+++ b/abjad/core/Note.py
@@ -124,7 +124,7 @@ class Note(Leaf):
 
     def _get_sounding_pitch(self):
         import abjad
-        if 'sounding pitch' in abjad.inspect(self).get_indicators(str):
+        if 'sounding pitch' in abjad.inspect(self).indicators(str):
             return self.written_pitch
         else:
             instrument = self._get_effective(abjad.Instrument)

--- a/abjad/core/Parentage.py
+++ b/abjad/core/Parentage.py
@@ -44,7 +44,7 @@ class Parentage(AbjadObject, collections.Sequence):
 
         >>> bass_voice = score['Bass Voice']
         >>> note = bass_voice[0]
-        >>> for component in abjad.inspect(note).get_parentage():
+        >>> for component in abjad.inspect(note).parentage():
         ...     component
         ...
         Note('c4')
@@ -201,7 +201,7 @@ class Parentage(AbjadObject, collections.Sequence):
                 }
 
             >>> for leaf in abjad.iterate(voice).leaves():
-            ...     parentage = abjad.inspect(leaf).get_parentage()
+            ...     parentage = abjad.inspect(leaf).parentage()
             ...     print(leaf, parentage.is_grace_note)
             ...
             c'4 False
@@ -260,7 +260,7 @@ class Parentage(AbjadObject, collections.Sequence):
                 >>
 
             >>> note = voice[0]
-            >>> parentage = abjad.inspect(note).get_parentage()
+            >>> parentage = abjad.inspect(note).parentage()
             >>> logical_voice = parentage.logical_voice
 
             >>> for key, value in logical_voice.items():
@@ -368,7 +368,7 @@ class Parentage(AbjadObject, collections.Sequence):
                 >>
 
             >>> for leaf in abjad.select(score).leaves():
-            ...     parentage = abjad.inspect(leaf).get_parentage()
+            ...     parentage = abjad.inspect(leaf).parentage()
             ...     leaf, parentage.score_index
             ...
             (Note("c''2"), (0, 0, 0))
@@ -405,7 +405,7 @@ class Parentage(AbjadObject, collections.Sequence):
 
             >>> leaves = abjad.iterate(voice).components()
             >>> for leaf in leaves:
-            ...     parentage = abjad.inspect(leaf).get_parentage()
+            ...     parentage = abjad.inspect(leaf).parentage()
             ...     leaf, parentage.score_index
             ...
             (Voice("c'8 d'8 e'8 f'8"), ())
@@ -455,13 +455,13 @@ class Parentage(AbjadObject, collections.Sequence):
                     }
                 }
 
-            >>> abjad.inspect(note).get_parentage().tuplet_depth
+            >>> abjad.inspect(note).parentage().tuplet_depth
             1
 
-            >>> abjad.inspect(tuplet).get_parentage().tuplet_depth
+            >>> abjad.inspect(tuplet).parentage().tuplet_depth
             0
 
-            >>> abjad.inspect(staff).get_parentage().tuplet_depth
+            >>> abjad.inspect(staff).parentage().tuplet_depth
             0
 
         Returns nonnegative integer.

--- a/abjad/core/Score.py
+++ b/abjad/core/Score.py
@@ -116,11 +116,11 @@ class Score(Context):
         import abjad
         bar_line = abjad.BarLine(abbreviation)
         if not to_each_voice:
-            last_leaf = abjad.inspect(self).get_leaf(-1)
+            last_leaf = abjad.inspect(self).leaf(-1)
             abjad.attach(bar_line, last_leaf, tag='SCORE1')
         else:
             for voice in abjad.iterate(self).components(abjad.Voice):
-                last_leaf = abjad.inspect(voice).get_leaf(-1)
+                last_leaf = abjad.inspect(voice).leaf(-1)
                 abjad.attach(bar_line, last_leaf, tag='SCORE1')
         return bar_line
 
@@ -368,7 +368,7 @@ class Score(Context):
         score.append(staff_group)
         for leaf in leaves:
             treble_pitches, bass_pitches = [], []
-            for pitch in abjad.inspect(leaf).get_pitches():
+            for pitch in abjad.inspect(leaf).pitches():
                 if pitch < lowest_treble_pitch:
                     bass_pitches.append(pitch)
                 else:

--- a/abjad/core/Selection.py
+++ b/abjad/core/Selection.py
@@ -562,7 +562,7 @@ class Selection(AbjadValueObject, collections.Sequence):
         # find spanners
         spanner_to_pairs = OrderedDict()
         for i, component in enumerate(iterate(self).components()):
-            for spanner in abjad_inspect(component).get_spanners():
+            for spanner in abjad_inspect(component).spanners():
                 pairs = spanner_to_pairs.setdefault(spanner, [])
                 wrappers = []
                 if wrappers:
@@ -680,8 +680,8 @@ class Selection(AbjadValueObject, collections.Sequence):
         assert isinstance(first, Tuplet)
         new_tuplet = Tuplet(first_multiplier, [])
         wrapped = False
-        if (abjad_inspect(self[0]).get_parentage().root is not
-            abjad_inspect(self[-1]).get_parentage().root):
+        if (abjad_inspect(self[0]).parentage().root is not
+            abjad_inspect(self[-1]).parentage().root):
             dummy_container = Container(self)
             wrapped = True
         mutate(self).swap(new_tuplet)
@@ -783,9 +783,9 @@ class Selection(AbjadValueObject, collections.Sequence):
         start_offsets, stop_offsets = [], []
         for component in self:
             start_offsets.append(
-                abjad_inspect(component).get_timespan().start_offset)
+                abjad_inspect(component).timespan().start_offset)
             stop_offsets.append(
-                abjad_inspect(component).get_timespan().stop_offset)
+                abjad_inspect(component).timespan().stop_offset)
         return start_offsets, stop_offsets
 
     def _get_parent_and_start_stop_indices(self):
@@ -886,7 +886,7 @@ class Selection(AbjadValueObject, collections.Sequence):
         result_ = []
         for item in result:
             if isinstance(item, Component):
-                logical_tie = abjad_inspect(item).get_logical_tie()
+                logical_tie = abjad_inspect(item).logical_tie()
                 if head == (item is logical_tie.head):
                     result_.append(item)
                 else:
@@ -896,7 +896,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                     raise NotImplementedError(item)
                 selection = []
                 for component in item:
-                    logical_tie = abjad_inspect(component).get_logical_tie()
+                    logical_tie = abjad_inspect(component).logical_tie()
                     if head == logical_tie.head:
                         selection.append(item)
                     else:
@@ -934,7 +934,7 @@ class Selection(AbjadValueObject, collections.Sequence):
         result_ = []
         for item in result:
             if isinstance(item, Component):
-                logical_tie = abjad_inspect(item).get_logical_tie()
+                logical_tie = abjad_inspect(item).logical_tie()
                 if tail == (item is logical_tie.tail):
                     result_.append(item)
                 else:
@@ -944,7 +944,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                     raise NotImplementedError(item)
                 selection = []
                 for component in item:
-                    logical_tie = abjad_inspect(component).get_logical_tie()
+                    logical_tie = abjad_inspect(component).logical_tie()
                     if tail == logical_tie.tail:
                         selection.append(item)
                     else:
@@ -1091,23 +1091,23 @@ class Selection(AbjadValueObject, collections.Sequence):
                 if not isinstance(component, prototype):
                     all_are_orphans_of_correct_type = False
                     break
-                if not abjad_inspect(component).get_parentage().is_orphan:
+                if not abjad_inspect(component).parentage().is_orphan:
                     all_are_orphans_of_correct_type = False
                     break
             if all_are_orphans_of_correct_type:
                 return True
         if not allow_orphans:
-            if any(abjad_inspect(x).get_parentage().is_orphan for x in self):
+            if any(abjad_inspect(x).parentage().is_orphan for x in self):
                 return False
         first = self[0]
         if not isinstance(first, prototype):
             return False
-        first_parentage = abjad_inspect(first).get_parentage()
+        first_parentage = abjad_inspect(first).parentage()
         first_logical_voice = first_parentage.logical_voice
         first_root = first_parentage.root
         previous = first
         for current in self[1:]:
-            current_parentage = abjad_inspect(current).get_parentage()
+            current_parentage = abjad_inspect(current).parentage()
             current_logical_voice = current_parentage.logical_voice
             # false if wrong type of component found
             if not isinstance(current, prototype):
@@ -1168,7 +1168,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 if not isinstance(component, prototype):
                     all_are_orphans_of_correct_type = False
                     break
-                if not abjad_inspect(component).get_parentage().is_orphan:
+                if not abjad_inspect(component).parentage().is_orphan:
                     all_are_orphans_of_correct_type = False
                     break
             if all_are_orphans_of_correct_type:
@@ -1177,12 +1177,12 @@ class Selection(AbjadValueObject, collections.Sequence):
         if not isinstance(first, prototype):
             return False
         orphan_components = True
-        if not abjad_inspect(first).get_parentage().is_orphan:
+        if not abjad_inspect(first).parentage().is_orphan:
             orphan_components = False
         same_logical_voice = True
-        first_signature = abjad_inspect(first).get_parentage().logical_voice
+        first_signature = abjad_inspect(first).parentage().logical_voice
         for component in self[1:]:
-            parentage = abjad_inspect(component).get_parentage()
+            parentage = abjad_inspect(component).parentage()
             if not parentage.is_orphan:
                 orphan_components = False
             if not allow_orphans and orphan_components:
@@ -1229,7 +1229,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 if not isinstance(component, prototype):
                     all_are_orphans_of_correct_type = False
                     break
-                if not abjad_inspect(component).get_parentage().is_orphan:
+                if not abjad_inspect(component).parentage().is_orphan:
                     all_are_orphans_of_correct_type = False
                     break
             if all_are_orphans_of_correct_type:
@@ -1249,7 +1249,7 @@ class Selection(AbjadValueObject, collections.Sequence):
         for current in self[1:]:
             if not isinstance(current, prototype):
                 return False
-            if not abjad_inspect(current).get_parentage().is_orphan:
+            if not abjad_inspect(current).parentage().is_orphan:
                 orphan_components = False
             if current._parent is not first_parent:
                 same_parent = False
@@ -2879,8 +2879,8 @@ class Selection(AbjadValueObject, collections.Sequence):
         result, selection = [], []
         selection.extend(self[:1])
         for item in self[1:]:
-            this_timespan = abjad_inspect(selection[-1]).get_timespan()
-            that_timespan = abjad_inspect(item).get_timespan()
+            this_timespan = abjad_inspect(selection[-1]).timespan()
+            that_timespan = abjad_inspect(item).timespan()
             if this_timespan.stop_offset == that_timespan.start_offset:
                 selection.append(item)
             else:
@@ -2974,7 +2974,7 @@ class Selection(AbjadValueObject, collections.Sequence):
         if self._expression:
             return self._update_expression(inspect.currentframe())
         def predicate(argument):
-            return abjad_inspect(argument).get_duration()
+            return abjad_inspect(argument).duration()
         return self.group_by(predicate)
 
     def group_by_length(self):
@@ -3938,7 +3938,7 @@ class Selection(AbjadValueObject, collections.Sequence):
 
         ..  container:: example
 
-            Regression: selects trimmed leaves (even when there are no rests to
+            REGRESSION: selects trimmed leaves (even when there are no rests to
             trim):
 
             ..  container:: example
@@ -6084,7 +6084,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     )
                 >>> abjad.setting(staff).auto_beaming = False
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
-                >>> leaf = abjad.inspect(staff).get_leaf(0)
+                >>> leaf = abjad.inspect(staff).leaf(0)
                 >>> abjad.attach(mark, leaf, context='Staff')
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -6170,7 +6170,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     )
                 >>> abjad.setting(staff).auto_beaming = False
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
-                >>> leaf = abjad.inspect(staff).get_leaf(0)
+                >>> leaf = abjad.inspect(staff).leaf(0)
                 >>> abjad.attach(mark, leaf, context='Staff')
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -6259,7 +6259,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     )
                 >>> abjad.setting(staff).auto_beaming = False
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
-                >>> leaf = abjad.inspect(staff).get_leaf(0)
+                >>> leaf = abjad.inspect(staff).leaf(0)
                 >>> abjad.attach(mark, leaf, context='Staff')
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -6340,7 +6340,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     )
                 >>> abjad.setting(staff).auto_beaming = False
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
-                >>> leaf = abjad.inspect(staff).get_leaf(0)
+                >>> leaf = abjad.inspect(staff).leaf(0)
                 >>> abjad.attach(mark, leaf, context='Staff')
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -6437,7 +6437,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 ...     )
                 >>> abjad.setting(staff).auto_beaming = False
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
-                >>> leaf = abjad.inspect(staff).get_leaf(0)
+                >>> leaf = abjad.inspect(staff).leaf(0)
                 >>> abjad.attach(mark, leaf, context='Staff')
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -6545,7 +6545,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                 break
             component_duration = component._get_duration()
             if in_seconds:
-                component_duration = abjad_inspect(component).get_duration(
+                component_duration = abjad_inspect(component).duration(
                     in_seconds=True)
             candidate_duration = cumulative_duration + component_duration
             if candidate_duration < target_duration:
@@ -6569,12 +6569,12 @@ class Selection(AbjadValueObject, collections.Sequence):
                     part = [component]
                     if in_seconds:
                         cumulative_duration = sum([
-                            abjad_inspect(_).get_duration(in_seconds=True)
+                            abjad_inspect(_).duration(in_seconds=True)
                             for _ in part
                             ])
                     else:
                         cumulative_duration = sum([
-                            abjad_inspect(_).get_duration() for _ in part
+                            abjad_inspect(_).duration() for _ in part
                             ])
                     current_duration_index += 1
                     try:
@@ -7240,11 +7240,11 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self._update_expression(inspect.currentframe())
         result = []
         for component in iterate(self).components(Component):
-            parentage = abjad_inspect(component).get_parentage()
+            parentage = abjad_inspect(component).parentage()
             for component_ in parentage:
                 if isinstance(component_, Context):
                     break
-                parent = abjad_inspect(component_).get_parentage().parent
+                parent = abjad_inspect(component_).parentage().parent
                 if isinstance(parent, Context) or parent is None:
                     if component_ not in result:
                         result.append(component_)

--- a/abjad/core/Tuplet.py
+++ b/abjad/core/Tuplet.py
@@ -251,7 +251,7 @@ class Tuplet(Container):
         return f'{{ {self.multiplier!s} {self._get_contents_summary()} }}'
 
     def _get_edge_height_tweak_string(self):
-        measure = inspect(self).get_parentage().get_first(Measure)
+        measure = inspect(self).parentage().get_first(Measure)
         if measure and measure.implicit_scaling:
             return
         duration = self._get_preprolated_duration()
@@ -513,7 +513,7 @@ class Tuplet(Container):
             Ignored when tuplet number text is overridden explicitly:
 
             >>> tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
-            >>> duration = abjad.inspect(tuplet).get_duration()
+            >>> duration = abjad.inspect(tuplet).duration()
             >>> markup = duration.to_score_markup()
             >>> abjad.override(tuplet).tuplet_number.text = markup
             >>> staff = abjad.Staff([tuplet])
@@ -880,13 +880,13 @@ class Tuplet(Container):
 
         """
         if preserve_duration:
-            old_duration = inspect(self).get_duration()
+            old_duration = inspect(self).duration()
         Container.append(self, component)
         if preserve_duration:
             new_duration = self._get_contents_duration()
             multiplier = old_duration / new_duration
             self.multiplier = multiplier
-            assert inspect(self).get_duration() == old_duration
+            assert inspect(self).duration() == old_duration
 
     def augmentation(self) -> bool:
         r"""
@@ -1047,13 +1047,13 @@ class Tuplet(Container):
 
         """
         if preserve_duration:
-            old_duration = inspect(self).get_duration()
+            old_duration = inspect(self).duration()
         Container.extend(self, argument)
         if preserve_duration:
             new_duration = self._get_contents_duration()
             multiplier = old_duration / new_duration
             self.multiplier = multiplier
-            assert inspect(self).get_duration() == old_duration
+            assert inspect(self).duration() == old_duration
 
     @staticmethod
     def from_duration(
@@ -1084,7 +1084,7 @@ class Tuplet(Container):
             raise Exception(f'components must be nonempty: {components!r}.')
         target_duration = Duration(duration)
         tuplet = Tuplet(1, components)
-        contents_duration = inspect(tuplet).get_duration()
+        contents_duration = inspect(tuplet).duration()
         multiplier = target_duration / contents_duration
         tuplet.multiplier = multiplier
         return tuplet
@@ -1709,7 +1709,7 @@ class Tuplet(Container):
                 for _ in proportions.numbers
                 ]
             notes = maker(0, note_durations)
-        contents_duration = inspect(notes).get_duration()
+        contents_duration = inspect(notes).duration()
         multiplier = target_duration / contents_duration
         tuplet = Tuplet(multiplier, notes)
         tuplet.normalize_multiplier()
@@ -1877,23 +1877,23 @@ class Tuplet(Container):
             if 0 < ratio.numbers[0]:
                 try:
                     note = Note(0, duration)
-                    duration = inspect(note).get_duration()
+                    duration = inspect(note).duration()
                     tuplet = Tuplet.from_duration(duration, [note])
                     return tuplet
                 except exceptions.AssignabilityError:
                     note_maker = NoteMaker()
                     notes = note_maker(0, duration)
-                    duration = inspect(notes).get_duration()
+                    duration = inspect(notes).duration()
                     return Tuplet.from_duration(duration, notes)
             elif ratio.numbers[0] < 0:
                 try:
                     rest = Rest(duration)
-                    duration = inspect(rest).get_duration()
+                    duration = inspect(rest).duration()
                     return Tuplet.from_duration(duration, [rest])
                 except exceptions.AssignabilityError:
                     leaf_maker = LeafMaker()
                     rests = leaf_maker([None], duration)
-                    duration = inspect(rests).get_duration()
+                    duration = inspect(rests).duration()
                     return Tuplet.from_duration(duration, rests)
             else:
                 raise ValueError('no divide zero values.')

--- a/abjad/core/VerticalMoment.py
+++ b/abjad/core/VerticalMoment.py
@@ -77,7 +77,7 @@ class VerticalMoment(AbjadObject):
             assert isinstance(components, collections.Iterable)
             components = list(components)
             components.sort(
-                key=lambda _: abjad.inspect(_).get_parentage().score_index)
+                key=lambda _: abjad.inspect(_).parentage().score_index)
         self._components = components
 
     ### SPECIAL METHODS ###
@@ -146,8 +146,8 @@ class VerticalMoment(AbjadObject):
         hi = len(container)
         while lo < hi:
             mid = (lo + hi) // 2
-            start_offset = abjad.inspect(container[mid]).get_timespan().start_offset
-            stop_offset = abjad.inspect(container[mid]).get_timespan().stop_offset
+            start_offset = abjad.inspect(container[mid]).timespan().start_offset
+            stop_offset = abjad.inspect(container[mid]).timespan().stop_offset
             if start_offset <= offset < stop_offset:
                 lo = mid + 1
             # if container[mid] is of nonzero duration
@@ -176,13 +176,13 @@ class VerticalMoment(AbjadObject):
         else:
             raise TypeError(message)
         governors.sort(
-            key=lambda x: abjad.inspect(x).get_parentage().score_index)
+            key=lambda x: abjad.inspect(x).parentage().score_index)
         governors = tuple(governors)
         components = []
         for governor in governors:
             components.extend(VerticalMoment._recurse(governor, offset))
         components.sort(
-            key=lambda x: abjad.inspect(x).get_parentage().score_index)
+            key=lambda x: abjad.inspect(x).parentage().score_index)
         components = tuple(components)
         return governors, components
 
@@ -194,8 +194,8 @@ class VerticalMoment(AbjadObject):
     def _recurse(component, offset):
         import abjad
         result = []
-        if (abjad.inspect(component).get_timespan().start_offset <=
-            offset < abjad.inspect(component).get_timespan().stop_offset):
+        if (abjad.inspect(component).timespan().start_offset <=
+            offset < abjad.inspect(component).timespan().stop_offset):
             result.append(component)
             if hasattr(component, 'components'):
                 if component.is_simultaneous:
@@ -273,8 +273,8 @@ class VerticalMoment(AbjadObject):
         import abjad
         candidate_shortest_leaf = self.leaves[0]
         for leaf in self.leaves[1:]:
-            if (abjad.inspect(leaf).get_timespan().stop_offset <
-                abjad.inspect(candidate_shortest_leaf).get_timespan().stop_offset):
+            if (abjad.inspect(leaf).timespan().stop_offset <
+                abjad.inspect(candidate_shortest_leaf).timespan().stop_offset):
                 candidate_shortest_leaf = leaf
         next_leaf = candidate_shortest_leaf._get_in_my_logical_voice(
             1, prototype=abjad.Leaf)
@@ -378,7 +378,7 @@ class VerticalMoment(AbjadObject):
         for leaf in self.leaves:
             #print ''
             #print leaf
-            leaf_start = abjad.inspect(leaf).get_timespan().start_offset
+            leaf_start = abjad.inspect(leaf).timespan().start_offset
             if leaf_start < self.offset:
                 #print 'found leaf starting before this moment ...'
                 if most_recent_start_offset <= leaf_start:
@@ -389,7 +389,7 @@ class VerticalMoment(AbjadObject):
                 try:
                     previous_leaf = leaf._get_in_my_logical_voice(
                         -1, prototype=abjad.Leaf)
-                    start = abjad.inspect(previous_leaf).get_timespan().start_offset
+                    start = abjad.inspect(previous_leaf).timespan().start_offset
                     #print previous_leaf, start
                     if most_recent_start_offset <= start:
                         most_recent_start_offset = start
@@ -413,7 +413,7 @@ class VerticalMoment(AbjadObject):
         result = []
         for component in self.components:
             if abjad.inspect(
-                component).get_timespan().start_offset == self.offset:
+                component).timespan().start_offset == self.offset:
                 result.append(component)
         result = tuple(result)
         return result

--- a/abjad/core/test/test_Chord___copy__.py
+++ b/abjad/core/test/test_Chord___copy__.py
@@ -107,10 +107,10 @@ def test_Chord___copy___05():
     assert format(chord_1) == format(chord_2)
     assert chord_1 is not chord_2
 
-    articulation_2 = abjad.inspect(chord_2).get_indicators(abjad.Articulation)[0]
+    articulation_2 = abjad.inspect(chord_2).indicators(abjad.Articulation)[0]
     assert articulation_1 == articulation_2
     assert articulation_1 is not articulation_2
 
-    markup_2 = abjad.inspect(chord_2).get_markup()[0]
+    markup_2 = abjad.inspect(chord_2).markup()[0]
     assert markup_1 == markup_2
     assert markup_1 is not markup_2

--- a/abjad/core/test/test_Chord___init__.py
+++ b/abjad/core/test/test_Chord___init__.py
@@ -93,7 +93,7 @@ def test_Chord___init___09():
     chord = abjad.Chord(tuplet[0])
 
     assert format(chord) == '<>8'
-    assert abjad.inspect(chord).get_parentage().parent is None
+    assert abjad.inspect(chord).parentage().parent is None
     assert abjad.inspect(chord).is_well_formed()
 
 
@@ -106,7 +106,7 @@ def test_Chord___init___10():
     chord = abjad.Chord(tuplet[0])
 
     assert format(chord) == '<>8'
-    assert abjad.inspect(chord).get_parentage().parent is None
+    assert abjad.inspect(chord).parentage().parent is None
     assert abjad.inspect(chord).is_well_formed()
 
 
@@ -120,7 +120,7 @@ def test_Chord___init___11():
     chord = abjad.Chord(staff[1])
 
     assert format(chord) == '<>8'
-    assert abjad.inspect(chord).get_parentage().parent is None
+    assert abjad.inspect(chord).parentage().parent is None
     assert abjad.inspect(chord).is_well_formed()
 
 
@@ -148,7 +148,7 @@ def test_Chord___init___13():
 
     assert format(chord) == '<>8'
     assert abjad.inspect(chord).is_well_formed()
-    assert abjad.inspect(chord).get_parentage().parent is None
+    assert abjad.inspect(chord).parentage().parent is None
 
 
 def test_Chord___init___14():
@@ -175,7 +175,7 @@ def test_Chord___init___15():
 
     assert format(chord) == "<c'>8"
     assert abjad.inspect(chord).is_well_formed()
-    assert abjad.inspect(chord).get_parentage().parent is None
+    assert abjad.inspect(chord).parentage().parent is None
 
 
 def test_Chord___init___16():
@@ -188,7 +188,7 @@ def test_Chord___init___16():
 
     assert format(chord) == "<d'>8"
     assert abjad.inspect(chord).is_well_formed()
-    assert abjad.inspect(chord).get_parentage().parent is None
+    assert abjad.inspect(chord).parentage().parent is None
 
 
 def test_Chord___init___17():

--- a/abjad/core/test/test_Component__move_indicators.py
+++ b/abjad/core/test/test_Component__move_indicators.py
@@ -19,10 +19,10 @@ def test_Component__move_indicators_01():
         """
         )
 
-    assert len(abjad.inspect(staff[0]).get_indicators()) == 2
-    assert len(abjad.inspect(staff[1]).get_indicators()) == 0
-    assert len(abjad.inspect(staff[2]).get_indicators()) == 0
-    assert len(abjad.inspect(staff[3]).get_indicators()) == 0
+    assert len(abjad.inspect(staff[0]).indicators()) == 2
+    assert len(abjad.inspect(staff[1]).indicators()) == 0
+    assert len(abjad.inspect(staff[2]).indicators()) == 0
+    assert len(abjad.inspect(staff[3]).indicators()) == 0
 
     staff[0]._move_indicators(staff[2])
 
@@ -40,7 +40,7 @@ def test_Component__move_indicators_01():
         """
         )
 
-    assert len(abjad.inspect(staff[0]).get_indicators()) == 0
-    assert len(abjad.inspect(staff[1]).get_indicators()) == 0
-    assert len(abjad.inspect(staff[2]).get_indicators()) == 2
-    assert len(abjad.inspect(staff[3]).get_indicators()) == 0
+    assert len(abjad.inspect(staff[0]).indicators()) == 0
+    assert len(abjad.inspect(staff[1]).indicators()) == 0
+    assert len(abjad.inspect(staff[2]).indicators()) == 2
+    assert len(abjad.inspect(staff[3]).indicators()) == 0

--- a/abjad/core/test/test_Container___setitem__.py
+++ b/abjad/core/test/test_Container___setitem__.py
@@ -1021,7 +1021,7 @@ def test_Container___setitem___21():
     """
 
     staff = abjad.Staff("c'8 [ { d'8 e'8 } f'8 ]")
-    beam = abjad.inspect(staff[0]).get_spanner(abjad.Beam)
+    beam = abjad.inspect(staff[0]).spanner(abjad.Beam)
 
     leaves = abjad.select(staff).leaves()
     assert beam.leaves == leaves

--- a/abjad/core/test/test_Container__get_spanners_that_dominate_component_pair.py
+++ b/abjad/core/test/test_Container__get_spanners_that_dominate_component_pair.py
@@ -31,12 +31,12 @@ def test_Container__get_spanners_that_dominate_component_pair_01():
         """
         )
 
-    parentage = abjad.inspect(container[0]).get_parentage()
-    spanners = abjad.inspect(parentage).get_spanners()
+    parentage = abjad.inspect(container[0]).parentage()
+    spanners = abjad.inspect(parentage).spanners()
     spanners == [beam, slur, trill]
     
-    parentage = abjad.inspect(container).get_parentage()
-    spanners = abjad.inspect(parentage).get_spanners()
+    parentage = abjad.inspect(container).parentage()
+    spanners = abjad.inspect(parentage).spanners()
     spanners == [trill]
 
 
@@ -70,5 +70,5 @@ def test_Container__get_spanners_that_dominate_component_pair_02():
         """
         )
 
-    parentage = abjad.inspect(container).get_parentage(include_self=False)
-    assert abjad.inspect(parentage).get_spanners() == []
+    parentage = abjad.inspect(container).parentage(include_self=False)
+    assert abjad.inspect(parentage).spanners() == []

--- a/abjad/core/test/test_GraceContainer_parentage.py
+++ b/abjad/core/test/test_GraceContainer_parentage.py
@@ -18,7 +18,7 @@ def test_GraceContainer_parentage_02():
     note = abjad.Note(1, (1, 4))
     grace_container = abjad.GraceContainer()
     abjad.attach(grace_container, note)
-    grace_container = abjad.inspect(note).get_grace_container()
+    grace_container = abjad.inspect(note).grace_container()
     assert isinstance(grace_container, abjad.GraceContainer)
     assert grace_container._carrier is note
     assert grace_container._carrier is note

--- a/abjad/core/test/test_Inspection_duration.py
+++ b/abjad/core/test/test_Inspection_duration.py
@@ -2,7 +2,7 @@ import abjad
 import pytest
 
 
-def test_Inspection_get_duration_01():
+def test_Inspection_duration_01():
     """
     Spanner duration in seconds equals sum of duration of all leaves in
     spanner, in seconds.
@@ -49,13 +49,13 @@ def test_Inspection_get_duration_01():
         """
         )
 
-    assert abjad.inspect(beam).get_duration(in_seconds=True) == abjad.Duration(100, 21)
-    assert abjad.inspect(crescendo).get_duration(in_seconds=True) == abjad.Duration(40, 21)
-    assert abjad.inspect(decrescendo).get_duration(in_seconds=True) == \
+    assert abjad.inspect(beam).duration(in_seconds=True) == abjad.Duration(100, 21)
+    assert abjad.inspect(crescendo).duration(in_seconds=True) == abjad.Duration(40, 21)
+    assert abjad.inspect(decrescendo).duration(in_seconds=True) == \
         abjad.Duration(20, 7)
 
 
-def test_Inspection_get_duration_02():
+def test_Inspection_duration_02():
 
     voice = abjad.Voice(
         [abjad.Measure((2, 12), "c'8 d'8", implicit_scaling=True),
@@ -95,12 +95,12 @@ def test_Inspection_get_duration_02():
         """
         )
 
-    assert abjad.inspect(beam).get_duration() == abjad.Duration(5, 12)
-    assert abjad.inspect(crescendo).get_duration() == abjad.Duration(2, 12)
-    assert abjad.inspect(decrescendo).get_duration() == abjad.Duration(2, 8)
+    assert abjad.inspect(beam).duration() == abjad.Duration(5, 12)
+    assert abjad.inspect(crescendo).duration() == abjad.Duration(2, 12)
+    assert abjad.inspect(decrescendo).duration() == abjad.Duration(2, 8)
 
 
-def test_Inspection_get_duration_03():
+def test_Inspection_duration_03():
     """
     Container duration in seconds equals sum of leaf durations in seconds.
     """
@@ -129,20 +129,20 @@ def test_Inspection_get_duration_03():
         """
         )
 
-    assert abjad.inspect(score).get_duration(in_seconds=True) == abjad.Duration(400, 133)
+    assert abjad.inspect(score).duration(in_seconds=True) == abjad.Duration(400, 133)
 
 
-def test_Inspection_get_duration_04():
+def test_Inspection_duration_04():
     """
     Container can not calculate duration in seconds without metronome mark.
     """
 
     container = abjad.Container("c'8 d'8 e'8 f'8")
-    statement = 'inspect(container).get_duration(in_seconds=True)'
+    statement = 'inspect(container).duration(in_seconds=True)'
     assert pytest.raises(Exception, statement)
 
 
-def test_Inspection_get_duration_05():
+def test_Inspection_duration_05():
     """
     Clock duration equals duration divide by effective tempo.
     """
@@ -168,17 +168,17 @@ def test_Inspection_get_duration_05():
         """
         )
 
-    assert abjad.inspect(staff[0]).get_duration(in_seconds=True) == abjad.Duration(15, 19)
-    assert abjad.inspect(staff[1]).get_duration(in_seconds=True) == abjad.Duration(15, 19)
-    assert abjad.inspect(staff[2]).get_duration(in_seconds=True) == abjad.Duration(5, 7)
-    assert abjad.inspect(staff[3]).get_duration(in_seconds=True) == abjad.Duration(5, 7)
+    assert abjad.inspect(staff[0]).duration(in_seconds=True) == abjad.Duration(15, 19)
+    assert abjad.inspect(staff[1]).duration(in_seconds=True) == abjad.Duration(15, 19)
+    assert abjad.inspect(staff[2]).duration(in_seconds=True) == abjad.Duration(5, 7)
+    assert abjad.inspect(staff[3]).duration(in_seconds=True) == abjad.Duration(5, 7)
 
 
-def test_Inspection_get_duration_06():
+def test_Inspection_duration_06():
     """
     Clock duration can not calculate without metronome mark.
     """
 
     note = abjad.Note("c'4")
-    statement = 'inspect(note).get_duration(in_seconds=True)'
+    statement = 'inspect(note).duration(in_seconds=True)'
     assert pytest.raises(Exception, statement)

--- a/abjad/core/test/test_Inspection_effective_staff.py
+++ b/abjad/core/test/test_Inspection_effective_staff.py
@@ -1,7 +1,7 @@
 import abjad
 
 
-def test_Inspection_get_effective_staff_01():
+def test_Inspection_effective_staff_01():
     """
     Staff changes work on the first note of a staff.
     """
@@ -39,17 +39,17 @@ def test_Inspection_get_effective_staff_01():
         )
 
     assert abjad.inspect(staff_group).is_well_formed()
-    assert abjad.inspect(staff_group[0][0]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[0][1]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[0][2]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[0][3]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[1][0]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[1][1]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[1][2]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[1][3]).get_effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[0][0]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[0][1]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[0][2]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[0][3]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[1][0]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[1][1]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[1][2]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[1][3]).effective_staff() is staff_group[1]
 
 
-def test_Inspection_get_effective_staff_02():
+def test_Inspection_effective_staff_02():
     """
     Staff changes work on middle notes of a staff.
     """
@@ -90,17 +90,17 @@ def test_Inspection_get_effective_staff_02():
         )
 
     assert abjad.inspect(staff_group).is_well_formed()
-    assert abjad.inspect(staff_group[0][0]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[0][1]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[0][2]).get_effective_staff() is staff_group[0]
-    assert abjad.inspect(staff_group[0][3]).get_effective_staff() is staff_group[0]
-    assert abjad.inspect(staff_group[1][0]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[1][1]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[1][2]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[1][3]).get_effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[0][0]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[0][1]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[0][2]).effective_staff() is staff_group[0]
+    assert abjad.inspect(staff_group[0][3]).effective_staff() is staff_group[0]
+    assert abjad.inspect(staff_group[1][0]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[1][1]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[1][2]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[1][3]).effective_staff() is staff_group[1]
 
 
-def test_Inspection_get_effective_staff_03():
+def test_Inspection_effective_staff_03():
     """
     Staff changes work on the last note of a staff.
     """
@@ -140,7 +140,7 @@ def test_Inspection_get_effective_staff_03():
     assert abjad.inspect(staff_group).is_well_formed()
 
 
-def test_Inspection_get_effective_staff_04():
+def test_Inspection_effective_staff_04():
     """
     Redudant staff changes are allowed.
     """
@@ -181,11 +181,11 @@ def test_Inspection_get_effective_staff_04():
         )
 
     assert abjad.inspect(staff_group).is_well_formed()
-    assert abjad.inspect(staff_group[0][0]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[0][1]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[0][2]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[0][3]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[1][0]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[1][1]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[1][2]).get_effective_staff() is staff_group[1]
-    assert abjad.inspect(staff_group[1][3]).get_effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[0][0]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[0][1]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[0][2]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[0][3]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[1][0]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[1][1]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[1][2]).effective_staff() is staff_group[1]
+    assert abjad.inspect(staff_group[1][3]).effective_staff() is staff_group[1]

--- a/abjad/core/test/test_Inspection_indicator.py
+++ b/abjad/core/test/test_Inspection_indicator.py
@@ -2,35 +2,35 @@ import abjad
 import pytest
 
 
-def test_Inspection_get_indicator_01():
+def test_Inspection_indicator_01():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     abjad.attach('color', staff[0])
 
-    assert abjad.inspect(staff).get_indicator('color') is None
-    assert abjad.inspect(staff[0]).get_indicator('color') == 'color'
-    assert abjad.inspect(staff[1]).get_indicator('color') is None
-    assert abjad.inspect(staff[2]).get_indicator('color') is None
-    assert abjad.inspect(staff[3]).get_indicator('color') is None
+    assert abjad.inspect(staff).indicator('color') is None
+    assert abjad.inspect(staff[0]).indicator('color') == 'color'
+    assert abjad.inspect(staff[1]).indicator('color') is None
+    assert abjad.inspect(staff[2]).indicator('color') is None
+    assert abjad.inspect(staff[3]).indicator('color') is None
 
 
-def test_Inspection_get_indicator_02():
+def test_Inspection_indicator_02():
 
     note = abjad.Note("c'8")
     articulation = abjad.Articulation('staccato')
     abjad.attach(articulation, note)
 
-    assert abjad.inspect(note).get_indicator(abjad.Articulation) is articulation
+    assert abjad.inspect(note).indicator(abjad.Articulation) is articulation
 
 
-def test_Inspection_get_indicator_03():
+def test_Inspection_indicator_03():
 
     note = abjad.Note("c'8")
 
-    assert abjad.inspect(note).get_indicator(abjad.Articulation) is None
+    assert abjad.inspect(note).indicator(abjad.Articulation) is None
 
 
-def test_Inspection_get_indicator_04():
+def test_Inspection_indicator_04():
 
     note = abjad.Note("c'8")
     articulation = abjad.Articulation('staccato')
@@ -38,28 +38,28 @@ def test_Inspection_get_indicator_04():
     articulation = abjad.Articulation('marcato')
     abjad.attach(articulation, note)
 
-    statement = 'inspect(note).get_indicator(abjad.Articulation)'
+    statement = 'inspect(note).indicator(abjad.Articulation)'
     assert pytest.raises(Exception, statement)
 
 
-def test_Inspection_get_indicator_05():
+def test_Inspection_indicator_05():
 
     note = abjad.Note("c'8")
     command = abjad.LilyPondLiteral(r'\stemUp')
     abjad.attach(command, note)
 
-    result = abjad.inspect(note).get_indicator(abjad.LilyPondLiteral)
+    result = abjad.inspect(note).indicator(abjad.LilyPondLiteral)
     assert result is command
 
 
-def test_Inspection_get_indicator_06():
+def test_Inspection_indicator_06():
 
     note = abjad.Note("c'8")
 
-    assert abjad.inspect(note).get_indicator(abjad.LilyPondLiteral) is None
+    assert abjad.inspect(note).indicator(abjad.LilyPondLiteral) is None
 
 
-def test_Inspection_get_indicator_07():
+def test_Inspection_indicator_07():
 
     note = abjad.Note("c'8")
     command = abjad.LilyPondLiteral(r'\stemUp')
@@ -67,11 +67,11 @@ def test_Inspection_get_indicator_07():
     command = abjad.LilyPondLiteral(r'\slurUp')
     abjad.attach(command, note)
 
-    statement = 'inspect(note).get_indicator(abjad.LilyPondLiteral)'
+    statement = 'inspect(note).indicator(abjad.LilyPondLiteral)'
     assert pytest.raises(Exception, statement)
 
 
-def test_Inspection_get_indicator_08():
+def test_Inspection_indicator_08():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     slur = abjad.Slur()
@@ -97,31 +97,31 @@ def test_Inspection_get_indicator_08():
         """
         )
 
-    indicators = abjad.inspect(staff[0]).get_indicators(abjad.LilyPondLiteral)
+    indicators = abjad.inspect(staff[0]).indicators(abjad.LilyPondLiteral)
 
     assert command_1 in indicators
     assert command_2 in indicators
     assert len(indicators) == 2
 
 
-def test_Inspection_get_indicator_09():
+def test_Inspection_indicator_09():
 
     note = abjad.Note("c'8")
     comment = abjad.LilyPondComment('comment')
     abjad.attach(comment, note)
 
-    indicator = abjad.inspect(note).get_indicator(abjad.LilyPondComment)
+    indicator = abjad.inspect(note).indicator(abjad.LilyPondComment)
     assert indicator is comment
 
 
-def test_Inspection_get_indicator_10():
+def test_Inspection_indicator_10():
 
     note = abjad.Note("c'8")
 
-    assert abjad.inspect(note).get_indicator(abjad.LilyPondComment) is None
+    assert abjad.inspect(note).indicator(abjad.LilyPondComment) is None
 
 
-def test_Inspection_get_indicator_11():
+def test_Inspection_indicator_11():
 
     note = abjad.Note("c'8")
     comment = abjad.LilyPondComment('comment')
@@ -129,41 +129,41 @@ def test_Inspection_get_indicator_11():
     comment = abjad.LilyPondComment('another comment')
     abjad.attach(comment, note)
 
-    statement = 'inspect(note).get_indicator(abjad.LilyPondComment)'
+    statement = 'inspect(note).indicator(abjad.LilyPondComment)'
     assert pytest.raises(Exception, statement)
 
 
-def test_Inspection_get_indicator_12():
+def test_Inspection_indicator_12():
 
     note = abjad.Note("c'8")
 
-    assert abjad.inspect(note).get_indicator() is None
+    assert abjad.inspect(note).indicator() is None
 
 
-def test_Inspection_get_indicator_13():
+def test_Inspection_indicator_13():
 
     note = abjad.Note("c'4")
     stem_tremolo = abjad.StemTremolo(16)
     abjad.attach(stem_tremolo, note)
-    stem_tremolo = abjad.inspect(note).get_indicator(abjad.StemTremolo)
+    stem_tremolo = abjad.inspect(note).indicator(abjad.StemTremolo)
 
     assert stem_tremolo is stem_tremolo
 
 
-def test_Inspection_get_indicator_14():
+def test_Inspection_indicator_14():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     violin = abjad.Violin()
     abjad.attach(violin, staff[0])
 
-    indicator = abjad.inspect(staff[0]).get_indicator(abjad.Instrument)
+    indicator = abjad.inspect(staff[0]).indicator(abjad.Instrument)
 
     assert indicator is violin
 
 
-def test_Inspection_get_indicator_15():
+def test_Inspection_indicator_15():
 
     measure = abjad.Measure((4, 8), "c'8 d'8 e'8 f'8")
-    indicator = abjad.inspect(measure).get_indicator(abjad.TimeSignature)
+    indicator = abjad.inspect(measure).indicator(abjad.TimeSignature)
 
     assert indicator == abjad.TimeSignature((4, 8))

--- a/abjad/core/test/test_Inspection_indicators.py
+++ b/abjad/core/test/test_Inspection_indicators.py
@@ -1,7 +1,7 @@
 import abjad
 
 
-def test_Inspection_get_indicators_01():
+def test_Inspection_indicators_01():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     slur = abjad.Slur()
@@ -27,13 +27,13 @@ def test_Inspection_get_indicators_01():
         """
         ), format(staff)
 
-    indicators = abjad.inspect(staff[0]).get_indicators(abjad.LilyPondLiteral)
+    indicators = abjad.inspect(staff[0]).indicators(abjad.LilyPondLiteral)
     assert command_1 in indicators
     assert command_2 in indicators
     assert len(indicators) == 2
 
 
-def test_Inspection_get_indicators_02():
+def test_Inspection_indicators_02():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     slur = abjad.Slur()
@@ -59,13 +59,13 @@ def test_Inspection_get_indicators_02():
         """
         ), format(staff)
 
-    items = abjad.inspect(staff[0]).get_indicators()
+    items = abjad.inspect(staff[0]).indicators()
     assert comment in items
     assert command in items
     assert len(items) == 2
 
 
-def test_Inspection_get_indicators_03():
+def test_Inspection_indicators_03():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     clef = abjad.Clef('treble')
@@ -87,11 +87,11 @@ def test_Inspection_get_indicators_03():
         """
         ), format(staff)
 
-    indicators = abjad.inspect(staff[0]).get_indicators()
+    indicators = abjad.inspect(staff[0]).indicators()
     assert len(indicators) == 2
 
 
-def test_Inspection_get_indicators_04():
+def test_Inspection_indicators_04():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     comment_1 = abjad.LilyPondComment('comment 1')
@@ -113,17 +113,17 @@ def test_Inspection_get_indicators_04():
         """
         ), format(staff)
 
-    indicators = abjad.inspect(staff[0]).get_indicators(abjad.LilyPondComment)
+    indicators = abjad.inspect(staff[0]).indicators(abjad.LilyPondComment)
     assert comment_1 in indicators
     assert comment_2 in indicators
     assert len(indicators) == 2
 
 
-def test_Inspection_get_indicators_05():
+def test_Inspection_indicators_05():
 
     note = abjad.Note("c'4")
     stem_tremolo = abjad.StemTremolo(16)
     abjad.attach(stem_tremolo, note)
-    stem_tremolos = abjad.inspect(note).get_indicators(abjad.StemTremolo)
+    stem_tremolos = abjad.inspect(note).indicators(abjad.StemTremolo)
 
     assert stem_tremolos[0] is stem_tremolo

--- a/abjad/core/test/test_Inspection_leaf.py
+++ b/abjad/core/test/test_Inspection_leaf.py
@@ -1,7 +1,7 @@
 import abjad
 
 
-def test_Inspection_get_leaf_01():
+def test_Inspection_leaf_01():
 
     staff = abjad.Staff([abjad.Voice("c'8 d'8 e'8 f'8"), abjad.Voice("g'8 a'8 b'8 c''8")])
 
@@ -28,34 +28,34 @@ def test_Inspection_get_leaf_01():
         )
 
     leaves = abjad.select(staff).leaves()
-    assert abjad.inspect(leaves[0]).get_leaf(0) is leaves[0]
-    assert abjad.inspect(leaves[0]).get_leaf(1) is leaves[1]
-    assert abjad.inspect(leaves[0]).get_leaf(2) is leaves[2]
-    assert abjad.inspect(leaves[0]).get_leaf(3) is leaves[3]
-    assert abjad.inspect(leaves[0]).get_leaf(4) is None
-    assert abjad.inspect(leaves[0]).get_leaf(5) is None
-    assert abjad.inspect(leaves[0]).get_leaf(6) is None
-    assert abjad.inspect(leaves[0]).get_leaf(7) is None
+    assert abjad.inspect(leaves[0]).leaf(0) is leaves[0]
+    assert abjad.inspect(leaves[0]).leaf(1) is leaves[1]
+    assert abjad.inspect(leaves[0]).leaf(2) is leaves[2]
+    assert abjad.inspect(leaves[0]).leaf(3) is leaves[3]
+    assert abjad.inspect(leaves[0]).leaf(4) is None
+    assert abjad.inspect(leaves[0]).leaf(5) is None
+    assert abjad.inspect(leaves[0]).leaf(6) is None
+    assert abjad.inspect(leaves[0]).leaf(7) is None
 
-    assert abjad.inspect(leaves[0]).get_leaf(-1) is None
+    assert abjad.inspect(leaves[0]).leaf(-1) is None
 
 
-def test_Inspection_get_leaf_02():
+def test_Inspection_leaf_02():
     """
     Voice.
     """
 
     voice = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4)])
 
-    assert abjad.inspect(voice[0]).get_leaf(1) is voice[1]
-    assert abjad.inspect(voice[1]).get_leaf(1) is voice[2]
-    assert abjad.inspect(voice[2]).get_leaf(1) is voice[3]
-    assert abjad.inspect(voice[3]).get_leaf(1) is None
+    assert abjad.inspect(voice[0]).leaf(1) is voice[1]
+    assert abjad.inspect(voice[1]).leaf(1) is voice[2]
+    assert abjad.inspect(voice[2]).leaf(1) is voice[3]
+    assert abjad.inspect(voice[3]).leaf(1) is None
 
-    assert abjad.inspect(voice[0]).get_leaf(-1) is None
-    assert abjad.inspect(voice[1]).get_leaf(-1) is voice[0]
-    assert abjad.inspect(voice[2]).get_leaf(-1) is voice[1]
-    assert abjad.inspect(voice[3]).get_leaf(-1) is voice[2]
+    assert abjad.inspect(voice[0]).leaf(-1) is None
+    assert abjad.inspect(voice[1]).leaf(-1) is voice[0]
+    assert abjad.inspect(voice[2]).leaf(-1) is voice[1]
+    assert abjad.inspect(voice[3]).leaf(-1) is voice[2]
 
     assert format(voice) == abjad.String.normalize(
         r"""
@@ -70,22 +70,22 @@ def test_Inspection_get_leaf_02():
         )
 
 
-def test_Inspection_get_leaf_03():
+def test_Inspection_leaf_03():
     """
     Staff.
     """
 
     staff = abjad.Staff([abjad.Note(i, (1, 8)) for i in range(4)])
 
-    assert abjad.inspect(staff[0]).get_leaf(1) is staff[1]
-    assert abjad.inspect(staff[1]).get_leaf(1) is staff[2]
-    assert abjad.inspect(staff[2]).get_leaf(1) is staff[3]
-    assert abjad.inspect(staff[3]).get_leaf(1) is None
+    assert abjad.inspect(staff[0]).leaf(1) is staff[1]
+    assert abjad.inspect(staff[1]).leaf(1) is staff[2]
+    assert abjad.inspect(staff[2]).leaf(1) is staff[3]
+    assert abjad.inspect(staff[3]).leaf(1) is None
 
-    assert abjad.inspect(staff[0]).get_leaf(-1) is None
-    assert abjad.inspect(staff[1]).get_leaf(-1) is staff[0]
-    assert abjad.inspect(staff[2]).get_leaf(-1) is staff[1]
-    assert abjad.inspect(staff[3]).get_leaf(-1) is staff[2]
+    assert abjad.inspect(staff[0]).leaf(-1) is None
+    assert abjad.inspect(staff[1]).leaf(-1) is staff[0]
+    assert abjad.inspect(staff[2]).leaf(-1) is staff[1]
+    assert abjad.inspect(staff[3]).leaf(-1) is staff[2]
 
     assert format(staff) == abjad.String.normalize(
         r"""
@@ -100,7 +100,7 @@ def test_Inspection_get_leaf_03():
         )
 
 
-def test_Inspection_get_leaf_04():
+def test_Inspection_leaf_04():
     """
     Container.
     """
@@ -118,18 +118,18 @@ def test_Inspection_get_leaf_04():
         """
         )
 
-    assert abjad.inspect(container[0]).get_leaf(1) is container[1]
-    assert abjad.inspect(container[1]).get_leaf(1) is container[2]
-    assert abjad.inspect(container[2]).get_leaf(1) is container[3]
-    assert abjad.inspect(container[3]).get_leaf(1) is None
+    assert abjad.inspect(container[0]).leaf(1) is container[1]
+    assert abjad.inspect(container[1]).leaf(1) is container[2]
+    assert abjad.inspect(container[2]).leaf(1) is container[3]
+    assert abjad.inspect(container[3]).leaf(1) is None
 
-    assert abjad.inspect(container[0]).get_leaf(-1) is None
-    assert abjad.inspect(container[1]).get_leaf(-1) is container[0]
-    assert abjad.inspect(container[2]).get_leaf(-1) is container[1]
-    assert abjad.inspect(container[3]).get_leaf(-1) is container[2]
+    assert abjad.inspect(container[0]).leaf(-1) is None
+    assert abjad.inspect(container[1]).leaf(-1) is container[0]
+    assert abjad.inspect(container[2]).leaf(-1) is container[1]
+    assert abjad.inspect(container[3]).leaf(-1) is container[2]
 
 
-def test_Inspection_get_leaf_05():
+def test_Inspection_leaf_05():
     """
     Tuplet.
     """
@@ -146,16 +146,16 @@ def test_Inspection_get_leaf_05():
         """
         )
 
-    assert abjad.inspect(tuplet[0]).get_leaf(1) is tuplet[1]
-    assert abjad.inspect(tuplet[1]).get_leaf(1) is tuplet[2]
-    assert abjad.inspect(tuplet[2]).get_leaf(1) is None
+    assert abjad.inspect(tuplet[0]).leaf(1) is tuplet[1]
+    assert abjad.inspect(tuplet[1]).leaf(1) is tuplet[2]
+    assert abjad.inspect(tuplet[2]).leaf(1) is None
 
-    assert abjad.inspect(tuplet[0]).get_leaf(-1) is None
-    assert abjad.inspect(tuplet[1]).get_leaf(-1) is tuplet[0]
-    assert abjad.inspect(tuplet[2]).get_leaf(-1) is tuplet[1]
+    assert abjad.inspect(tuplet[0]).leaf(-1) is None
+    assert abjad.inspect(tuplet[1]).leaf(-1) is tuplet[0]
+    assert abjad.inspect(tuplet[2]).leaf(-1) is tuplet[1]
 
 
-def test_Inspection_get_leaf_06():
+def test_Inspection_leaf_06():
     """
     Contiguous containers inside a voice.
     """
@@ -184,18 +184,18 @@ def test_Inspection_get_leaf_06():
         """
         )
 
-    assert abjad.inspect(container_1[0]).get_leaf(1) is container_1[1]
-    assert abjad.inspect(container_1[1]).get_leaf(1) is container_1[2]
-    assert abjad.inspect(container_1[2]).get_leaf(1) is container_1[3]
-    assert abjad.inspect(container_1[3]).get_leaf(1) is container_2[0]
+    assert abjad.inspect(container_1[0]).leaf(1) is container_1[1]
+    assert abjad.inspect(container_1[1]).leaf(1) is container_1[2]
+    assert abjad.inspect(container_1[2]).leaf(1) is container_1[3]
+    assert abjad.inspect(container_1[3]).leaf(1) is container_2[0]
 
-    assert abjad.inspect(container_1[1]).get_leaf(-1) is container_1[0]
-    assert abjad.inspect(container_1[2]).get_leaf(-1) is container_1[1]
-    assert abjad.inspect(container_1[3]).get_leaf(-1) is container_1[2]
-    assert abjad.inspect(container_2[0]).get_leaf(-1) is container_1[3]
+    assert abjad.inspect(container_1[1]).leaf(-1) is container_1[0]
+    assert abjad.inspect(container_1[2]).leaf(-1) is container_1[1]
+    assert abjad.inspect(container_1[3]).leaf(-1) is container_1[2]
+    assert abjad.inspect(container_2[0]).leaf(-1) is container_1[3]
 
 
-def test_Inspection_get_leaf_07():
+def test_Inspection_leaf_07():
     """
     Tuplets inside a voice.
     """
@@ -222,16 +222,16 @@ def test_Inspection_get_leaf_07():
         """
         )
 
-    assert abjad.inspect(tuplet_1[0]).get_leaf(1) is tuplet_1[1]
-    assert abjad.inspect(tuplet_1[1]).get_leaf(1) is tuplet_1[2]
-    assert abjad.inspect(tuplet_1[2]).get_leaf(1) is tuplet_2[0]
+    assert abjad.inspect(tuplet_1[0]).leaf(1) is tuplet_1[1]
+    assert abjad.inspect(tuplet_1[1]).leaf(1) is tuplet_1[2]
+    assert abjad.inspect(tuplet_1[2]).leaf(1) is tuplet_2[0]
 
-    assert abjad.inspect(tuplet_1[1]).get_leaf(-1) is tuplet_1[0]
-    assert abjad.inspect(tuplet_1[2]).get_leaf(-1) is tuplet_1[1]
-    assert abjad.inspect(tuplet_2[0]).get_leaf(-1) is tuplet_1[2]
+    assert abjad.inspect(tuplet_1[1]).leaf(-1) is tuplet_1[0]
+    assert abjad.inspect(tuplet_1[2]).leaf(-1) is tuplet_1[1]
+    assert abjad.inspect(tuplet_2[0]).leaf(-1) is tuplet_1[2]
 
 
-def test_Inspection_get_leaf_08():
+def test_Inspection_leaf_08():
     """
     Does not continue across contiguous anonymous voices inside a staff.
     """
@@ -262,11 +262,11 @@ def test_Inspection_get_leaf_08():
         """
         )
 
-    assert abjad.inspect(voice_1[3]).get_leaf(1) is None
-    assert abjad.inspect(voice_2[0]).get_leaf(-1) is None
+    assert abjad.inspect(voice_1[3]).leaf(1) is None
+    assert abjad.inspect(voice_2[0]).leaf(-1) is None
 
 
-def test_Inspection_get_leaf_09():
+def test_Inspection_leaf_09():
     """
     Does cross contiguous equally named voices inside a staff.
     """
@@ -299,18 +299,18 @@ def test_Inspection_get_leaf_09():
         """
         )
 
-    assert abjad.inspect(voice_1[0]).get_leaf(1) is voice_1[1]
-    assert abjad.inspect(voice_1[1]).get_leaf(1) is voice_1[2]
-    assert abjad.inspect(voice_1[2]).get_leaf(1) is voice_1[3]
-    assert abjad.inspect(voice_1[3]).get_leaf(1) is voice_2[0]
+    assert abjad.inspect(voice_1[0]).leaf(1) is voice_1[1]
+    assert abjad.inspect(voice_1[1]).leaf(1) is voice_1[2]
+    assert abjad.inspect(voice_1[2]).leaf(1) is voice_1[3]
+    assert abjad.inspect(voice_1[3]).leaf(1) is voice_2[0]
 
-    assert abjad.inspect(voice_1[1]).get_leaf(-1) is voice_1[0]
-    assert abjad.inspect(voice_1[2]).get_leaf(-1) is voice_1[1]
-    assert abjad.inspect(voice_1[3]).get_leaf(-1) is voice_1[2]
-    assert abjad.inspect(voice_2[0]).get_leaf(-1) is voice_1[3]
+    assert abjad.inspect(voice_1[1]).leaf(-1) is voice_1[0]
+    assert abjad.inspect(voice_1[2]).leaf(-1) is voice_1[1]
+    assert abjad.inspect(voice_1[3]).leaf(-1) is voice_1[2]
+    assert abjad.inspect(voice_2[0]).leaf(-1) is voice_1[3]
 
 
-def test_Inspection_get_leaf_10():
+def test_Inspection_leaf_10():
     """
     Does not connect through contiguous unequally named voices.
     """
@@ -343,21 +343,21 @@ def test_Inspection_get_leaf_10():
         """
         )
 
-    assert abjad.inspect(voice_1[0]).get_leaf(1) is voice_1[1]
-    assert abjad.inspect(voice_1[1]).get_leaf(1) is voice_1[2]
-    assert abjad.inspect(voice_1[2]).get_leaf(1) is voice_1[3]
-    assert abjad.inspect(voice_1[3]).get_leaf(1) is None
+    assert abjad.inspect(voice_1[0]).leaf(1) is voice_1[1]
+    assert abjad.inspect(voice_1[1]).leaf(1) is voice_1[2]
+    assert abjad.inspect(voice_1[2]).leaf(1) is voice_1[3]
+    assert abjad.inspect(voice_1[3]).leaf(1) is None
 
     voice_2.name = None
-    assert abjad.inspect(voice_1[3]).get_leaf(1) is None
+    assert abjad.inspect(voice_1[3]).leaf(1) is None
 
-    assert abjad.inspect(voice_2[1]).get_leaf(-1) is voice_2[0]
-    assert abjad.inspect(voice_2[2]).get_leaf(-1) is voice_2[1]
-    assert abjad.inspect(voice_2[3]).get_leaf(-1) is voice_2[2]
-    assert abjad.inspect(voice_2[0]).get_leaf(-1) is None
+    assert abjad.inspect(voice_2[1]).leaf(-1) is voice_2[0]
+    assert abjad.inspect(voice_2[2]).leaf(-1) is voice_2[1]
+    assert abjad.inspect(voice_2[3]).leaf(-1) is voice_2[2]
+    assert abjad.inspect(voice_2[0]).leaf(-1) is None
 
 
-def test_Inspection_get_leaf_11():
+def test_Inspection_leaf_11():
     """
     Does connect through like-named staves containing like-named voices.
     """
@@ -401,11 +401,11 @@ def test_Inspection_get_leaf_11():
         """
         )
 
-    assert abjad.inspect(voice_1[3]).get_leaf(1) is voice_2[0]
-    assert abjad.inspect(voice_2[0]).get_leaf(-1) is voice_1[3]
+    assert abjad.inspect(voice_1[3]).leaf(1) is voice_2[0]
+    assert abjad.inspect(voice_2[0]).leaf(-1) is voice_1[3]
 
 
-def test_Inspection_get_leaf_12():
+def test_Inspection_leaf_12():
     """
     Does connect through like-named staves containing like-named voices.
     """
@@ -469,14 +469,14 @@ def test_Inspection_get_leaf_12():
         """
         )
 
-    assert abjad.inspect(lower_voice_1[3]).get_leaf(1) is lower_voice_2[0]
-    assert abjad.inspect(higher_voice_1[3]).get_leaf(1) is higher_voice_2[0]
+    assert abjad.inspect(lower_voice_1[3]).leaf(1) is lower_voice_2[0]
+    assert abjad.inspect(higher_voice_1[3]).leaf(1) is higher_voice_2[0]
 
-    assert abjad.inspect(lower_voice_2[0]).get_leaf(-1) is lower_voice_1[3]
-    assert abjad.inspect(higher_voice_2[0]).get_leaf(-1) is higher_voice_1[3]
+    assert abjad.inspect(lower_voice_2[0]).leaf(-1) is lower_voice_1[3]
+    assert abjad.inspect(higher_voice_2[0]).leaf(-1) is higher_voice_1[3]
 
 
-def test_Inspection_get_leaf_13():
+def test_Inspection_leaf_13():
     """
     Does connect through symmetrical nested containers in a voice.
     """
@@ -511,18 +511,18 @@ def test_Inspection_get_leaf_13():
         """
         )
 
-    assert abjad.inspect(container_1[0][0]).get_leaf(1) is container_1[0][1]
-    assert abjad.inspect(container_1[0][1]).get_leaf(1) is container_1[0][2]
-    assert abjad.inspect(container_1[0][2]).get_leaf(1) is container_1[0][3]
-    assert abjad.inspect(container_1[0][3]).get_leaf(1) is container_2[0][0]
+    assert abjad.inspect(container_1[0][0]).leaf(1) is container_1[0][1]
+    assert abjad.inspect(container_1[0][1]).leaf(1) is container_1[0][2]
+    assert abjad.inspect(container_1[0][2]).leaf(1) is container_1[0][3]
+    assert abjad.inspect(container_1[0][3]).leaf(1) is container_2[0][0]
 
-    assert abjad.inspect(container_2[0][1]).get_leaf(-1) is container_2[0][0]
-    assert abjad.inspect(container_2[0][2]).get_leaf(-1) is container_2[0][1]
-    assert abjad.inspect(container_2[0][3]).get_leaf(-1) is container_2[0][2]
-    assert abjad.inspect(container_2[0][0]).get_leaf(-1) is container_1[0][3]
+    assert abjad.inspect(container_2[0][1]).leaf(-1) is container_2[0][0]
+    assert abjad.inspect(container_2[0][2]).leaf(-1) is container_2[0][1]
+    assert abjad.inspect(container_2[0][3]).leaf(-1) is container_2[0][2]
+    assert abjad.inspect(container_2[0][0]).leaf(-1) is container_1[0][3]
 
 
-def test_Inspection_get_leaf_14():
+def test_Inspection_leaf_14():
     """
     Tautological parentage asymmetries result in symmetric (balanced) logical
     voice parentage.
@@ -558,18 +558,18 @@ def test_Inspection_get_leaf_14():
         """
         )
 
-    assert abjad.inspect(container_1[0]).get_leaf(1) is container_1[1]
-    assert abjad.inspect(container_1[1]).get_leaf(1) is container_1[2]
-    assert abjad.inspect(container_1[2]).get_leaf(1) is container_1[3]
-    assert abjad.inspect(container_1[3]).get_leaf(1) is container_2[0][0][0]
+    assert abjad.inspect(container_1[0]).leaf(1) is container_1[1]
+    assert abjad.inspect(container_1[1]).leaf(1) is container_1[2]
+    assert abjad.inspect(container_1[2]).leaf(1) is container_1[3]
+    assert abjad.inspect(container_1[3]).leaf(1) is container_2[0][0][0]
 
-    assert abjad.inspect(container_2[0][0][1]).get_leaf(-1) is container_2[0][0][0]
-    assert abjad.inspect(container_2[0][0][2]).get_leaf(-1) is container_2[0][0][1]
-    assert abjad.inspect(container_2[0][0][3]).get_leaf(-1) is container_2[0][0][2]
-    assert abjad.inspect(container_2[0][0][0]).get_leaf(-1) is container_1[3]
+    assert abjad.inspect(container_2[0][0][1]).leaf(-1) is container_2[0][0][0]
+    assert abjad.inspect(container_2[0][0][2]).leaf(-1) is container_2[0][0][1]
+    assert abjad.inspect(container_2[0][0][3]).leaf(-1) is container_2[0][0][2]
+    assert abjad.inspect(container_2[0][0][0]).leaf(-1) is container_1[3]
 
 
-def test_Inspection_get_leaf_15():
+def test_Inspection_leaf_15():
     """
     Tautological parentage asymmetries result in symmetric (balanced) lgoical
     voice parentage.
@@ -605,18 +605,18 @@ def test_Inspection_get_leaf_15():
         """
         )
 
-    assert abjad.inspect(container_1[0][0][0]).get_leaf(1) is container_1[0][0][1]
-    assert abjad.inspect(container_1[0][0][1]).get_leaf(1) is container_1[0][0][2]
-    assert abjad.inspect(container_1[0][0][2]).get_leaf(1) is container_1[0][0][3]
-    assert abjad.inspect(container_1[0][0][3]).get_leaf(1) is container_2[0]
+    assert abjad.inspect(container_1[0][0][0]).leaf(1) is container_1[0][0][1]
+    assert abjad.inspect(container_1[0][0][1]).leaf(1) is container_1[0][0][2]
+    assert abjad.inspect(container_1[0][0][2]).leaf(1) is container_1[0][0][3]
+    assert abjad.inspect(container_1[0][0][3]).leaf(1) is container_2[0]
 
-    assert abjad.inspect(container_2[0]).get_leaf(-1) is container_1[0][0][3]
-    assert abjad.inspect(container_2[1]).get_leaf(-1) is container_2[0]
-    assert abjad.inspect(container_2[2]).get_leaf(-1) is container_2[1]
-    assert abjad.inspect(container_2[3]).get_leaf(-1) is container_2[2]
+    assert abjad.inspect(container_2[0]).leaf(-1) is container_1[0][0][3]
+    assert abjad.inspect(container_2[1]).leaf(-1) is container_2[0]
+    assert abjad.inspect(container_2[2]).leaf(-1) is container_2[1]
+    assert abjad.inspect(container_2[3]).leaf(-1) is container_2[2]
 
 
-def test_Inspection_get_leaf_16():
+def test_Inspection_leaf_16():
     """
     Does connect in sequence of alternating containers and notes.
     """
@@ -642,14 +642,14 @@ def test_Inspection_get_leaf_16():
         """
         )
 
-    assert abjad.inspect(container_1[1]).get_leaf(1) is voice[1]
-    assert abjad.inspect(voice[1]).get_leaf(1) is container_2[0]
+    assert abjad.inspect(container_1[1]).leaf(1) is voice[1]
+    assert abjad.inspect(voice[1]).leaf(1) is container_2[0]
 
-    assert abjad.inspect(voice[1]).get_leaf(-1) is container_1[1]
-    assert abjad.inspect(container_2[0]).get_leaf(-1) is voice[1]
+    assert abjad.inspect(voice[1]).leaf(-1) is container_1[1]
+    assert abjad.inspect(container_2[0]).leaf(-1) is voice[1]
 
 
-def test_Inspection_get_leaf_17():
+def test_Inspection_leaf_17():
     """
     Does connect in sequence of alternating tuplets and notes.
     """
@@ -679,14 +679,14 @@ def test_Inspection_get_leaf_17():
         """
         )
 
-    assert abjad.inspect(tuplet_1[-1]).get_leaf(1) is voice[1]
-    assert abjad.inspect(voice[1]).get_leaf(1) is tuplet_2[0]
+    assert abjad.inspect(tuplet_1[-1]).leaf(1) is voice[1]
+    assert abjad.inspect(voice[1]).leaf(1) is tuplet_2[0]
 
-    assert abjad.inspect(voice[1]).get_leaf(-1) is tuplet_1[-1]
-    assert abjad.inspect(tuplet_2[0]).get_leaf(-1) is voice[1]
+    assert abjad.inspect(voice[1]).leaf(-1) is tuplet_1[-1]
+    assert abjad.inspect(tuplet_2[0]).leaf(-1) is voice[1]
 
 
-def test_Inspection_get_leaf_18():
+def test_Inspection_leaf_18():
     """
     Does connect through asymmetrically nested tuplets.
     """
@@ -709,13 +709,13 @@ def test_Inspection_get_leaf_18():
         """
         )
 
-    assert abjad.inspect(tuplet[0]).get_leaf(1) is inner_tuplet[0]
-    assert abjad.inspect(inner_tuplet[-1]).get_leaf(1) is tuplet[-1]
-    assert abjad.inspect(tuplet[-1]).get_leaf(-1) is inner_tuplet[-1]
-    assert abjad.inspect(inner_tuplet[0]).get_leaf(-1) is tuplet[0]
+    assert abjad.inspect(tuplet[0]).leaf(1) is inner_tuplet[0]
+    assert abjad.inspect(inner_tuplet[-1]).leaf(1) is tuplet[-1]
+    assert abjad.inspect(tuplet[-1]).leaf(-1) is inner_tuplet[-1]
+    assert abjad.inspect(inner_tuplet[0]).leaf(-1) is tuplet[0]
 
 
-def test_Inspection_get_leaf_19():
+def test_Inspection_leaf_19():
     """
     Returns none in asymmetric logical voice parentage structures.
     """
@@ -747,14 +747,14 @@ def test_Inspection_get_leaf_19():
         """
         )
 
-    assert abjad.inspect(voice_1[-1]).get_leaf(1) is None
-    assert abjad.inspect(note).get_leaf(1) is None
+    assert abjad.inspect(voice_1[-1]).leaf(1) is None
+    assert abjad.inspect(note).leaf(1) is None
 
-    assert abjad.inspect(voice_2[0]).get_leaf(-1) is None
-    assert abjad.inspect(note).get_leaf(-1) is None
+    assert abjad.inspect(voice_2[0]).leaf(-1) is None
+    assert abjad.inspect(note).leaf(-1) is None
 
 
-def test_Inspection_get_leaf_20():
+def test_Inspection_leaf_20():
     """
     Noncontiguous or broken logical voices do not connect.
     """
@@ -795,19 +795,19 @@ def test_Inspection_get_leaf_20():
         """
         )
 
-    assert abjad.inspect(voice_1[-1]).get_leaf(1) is None
-    assert abjad.inspect(voice_2[-1]).get_leaf(1) is None
+    assert abjad.inspect(voice_1[-1]).leaf(1) is None
+    assert abjad.inspect(voice_2[-1]).leaf(1) is None
 
     voice_2.name = None
 
-    assert abjad.inspect(voice_1[-1]).get_leaf(1) is None
-    assert abjad.inspect(voice_2[-1]).get_leaf(1) is None
+    assert abjad.inspect(voice_1[-1]).leaf(1) is None
+    assert abjad.inspect(voice_2[-1]).leaf(1) is None
 
-    assert abjad.inspect(voice_3[0]).get_leaf(-1) is None
-    assert abjad.inspect(voice_2[0]).get_leaf(-1) is None
+    assert abjad.inspect(voice_3[0]).leaf(-1) is None
+    assert abjad.inspect(voice_2[0]).leaf(-1) is None
 
 
-def test_Inspection_get_leaf_21():
+def test_Inspection_leaf_21():
     """
     Does not connect through nested anonymous voices.
     """
@@ -830,16 +830,16 @@ def test_Inspection_get_leaf_21():
         """
         )
 
-    assert abjad.inspect(inner_voice[0]).get_leaf(1) is inner_voice[1]
-    assert abjad.inspect(inner_voice[1]).get_leaf(1) is inner_voice[2]
-    assert abjad.inspect(inner_voice[2]).get_leaf(1) is None
+    assert abjad.inspect(inner_voice[0]).leaf(1) is inner_voice[1]
+    assert abjad.inspect(inner_voice[1]).leaf(1) is inner_voice[2]
+    assert abjad.inspect(inner_voice[2]).leaf(1) is None
 
-    assert abjad.inspect(inner_voice[1]).get_leaf(-1) is inner_voice[0]
-    assert abjad.inspect(inner_voice[2]).get_leaf(-1) is inner_voice[1]
-    assert abjad.inspect(outer_voice[1]).get_leaf(-1) is None
+    assert abjad.inspect(inner_voice[1]).leaf(-1) is inner_voice[0]
+    assert abjad.inspect(inner_voice[2]).leaf(-1) is inner_voice[1]
+    assert abjad.inspect(outer_voice[1]).leaf(-1) is None
 
 
-def test_Inspection_get_leaf_22():
+def test_Inspection_leaf_22():
     """
     Does not connect through nested anonymous voices.
     """
@@ -862,17 +862,17 @@ def test_Inspection_get_leaf_22():
         """
         )
 
-    assert abjad.inspect(inner_voice[0]).get_leaf(1) is inner_voice[1]
-    assert abjad.inspect(inner_voice[1]).get_leaf(1) is inner_voice[2]
-    assert abjad.inspect(outer_voice[0]).get_leaf(1) is None
+    assert abjad.inspect(inner_voice[0]).leaf(1) is inner_voice[1]
+    assert abjad.inspect(inner_voice[1]).leaf(1) is inner_voice[2]
+    assert abjad.inspect(outer_voice[0]).leaf(1) is None
 
-    assert abjad.inspect(inner_voice[1]).get_leaf(-1) is inner_voice[0]
-    assert abjad.inspect(inner_voice[2]).get_leaf(-1) is inner_voice[1]
-    assert abjad.inspect(inner_voice[0]).get_leaf(-1) is None
+    assert abjad.inspect(inner_voice[1]).leaf(-1) is inner_voice[0]
+    assert abjad.inspect(inner_voice[2]).leaf(-1) is inner_voice[1]
+    assert abjad.inspect(inner_voice[0]).leaf(-1) is None
 
 
 
-def test_Inspection_get_leaf_23():
+def test_Inspection_leaf_23():
     """
     Does connect through nested equally named voices.
     """
@@ -897,16 +897,16 @@ def test_Inspection_get_leaf_23():
         """
         )
 
-    assert abjad.inspect(inner_voice[0]).get_leaf(1) is inner_voice[1]
-    assert abjad.inspect(inner_voice[1]).get_leaf(1) is inner_voice[2]
-    assert abjad.inspect(inner_voice[2]).get_leaf(1) is outer_voice[1]
+    assert abjad.inspect(inner_voice[0]).leaf(1) is inner_voice[1]
+    assert abjad.inspect(inner_voice[1]).leaf(1) is inner_voice[2]
+    assert abjad.inspect(inner_voice[2]).leaf(1) is outer_voice[1]
 
-    assert abjad.inspect(inner_voice[1]).get_leaf(-1) is inner_voice[0]
-    assert abjad.inspect(inner_voice[2]).get_leaf(-1) is inner_voice[1]
-    assert abjad.inspect(outer_voice[1]).get_leaf(-1) is inner_voice[-1]
+    assert abjad.inspect(inner_voice[1]).leaf(-1) is inner_voice[0]
+    assert abjad.inspect(inner_voice[2]).leaf(-1) is inner_voice[1]
+    assert abjad.inspect(outer_voice[1]).leaf(-1) is inner_voice[-1]
 
 
-def test_Inspection_get_leaf_24():
+def test_Inspection_leaf_24():
     """
     Does connect through nested equally named voices.
     """
@@ -931,16 +931,16 @@ def test_Inspection_get_leaf_24():
         """
         )
 
-    assert abjad.inspect(inner_voice[0]).get_leaf(1) is inner_voice[1]
-    assert abjad.inspect(inner_voice[1]).get_leaf(1) is inner_voice[2]
-    assert abjad.inspect(outer_voice[0]).get_leaf(1) is inner_voice[0]
+    assert abjad.inspect(inner_voice[0]).leaf(1) is inner_voice[1]
+    assert abjad.inspect(inner_voice[1]).leaf(1) is inner_voice[2]
+    assert abjad.inspect(outer_voice[0]).leaf(1) is inner_voice[0]
 
-    assert abjad.inspect(inner_voice[1]).get_leaf(-1) is inner_voice[0]
-    assert abjad.inspect(inner_voice[2]).get_leaf(-1) is inner_voice[1]
-    assert abjad.inspect(inner_voice[0]).get_leaf(-1) is outer_voice[0]
+    assert abjad.inspect(inner_voice[1]).leaf(-1) is inner_voice[0]
+    assert abjad.inspect(inner_voice[2]).leaf(-1) is inner_voice[1]
+    assert abjad.inspect(inner_voice[0]).leaf(-1) is outer_voice[0]
 
 
-def test_Inspection_get_leaf_25():
+def test_Inspection_leaf_25():
     """
     Returns none on nested differently named voices.
     """
@@ -965,16 +965,16 @@ def test_Inspection_get_leaf_25():
         """
         )
 
-    assert abjad.inspect(inner_voice[0]).get_leaf(1) is inner_voice[1]
-    assert abjad.inspect(inner_voice[1]).get_leaf(1) is inner_voice[2]
-    assert abjad.inspect(inner_voice[2]).get_leaf(1) is None
+    assert abjad.inspect(inner_voice[0]).leaf(1) is inner_voice[1]
+    assert abjad.inspect(inner_voice[1]).leaf(1) is inner_voice[2]
+    assert abjad.inspect(inner_voice[2]).leaf(1) is None
 
-    assert abjad.inspect(inner_voice[1]).get_leaf(-1) is inner_voice[0]
-    assert abjad.inspect(inner_voice[2]).get_leaf(-1) is inner_voice[1]
-    assert abjad.inspect(outer_voice[1]).get_leaf(-1) is None
+    assert abjad.inspect(inner_voice[1]).leaf(-1) is inner_voice[0]
+    assert abjad.inspect(inner_voice[2]).leaf(-1) is inner_voice[1]
+    assert abjad.inspect(outer_voice[1]).leaf(-1) is None
 
 
-def test_Inspection_get_leaf_26():
+def test_Inspection_leaf_26():
     """
     Returns none on nested differently named voices.
     """
@@ -999,10 +999,10 @@ def test_Inspection_get_leaf_26():
         """
         )
 
-    assert abjad.inspect(voice_2[0]).get_leaf(1) is voice_2[1]
-    assert abjad.inspect(voice_2[1]).get_leaf(1) is voice_2[2]
-    assert abjad.inspect(voice_1[0]).get_leaf(1) is None
+    assert abjad.inspect(voice_2[0]).leaf(1) is voice_2[1]
+    assert abjad.inspect(voice_2[1]).leaf(1) is voice_2[2]
+    assert abjad.inspect(voice_1[0]).leaf(1) is None
 
-    assert abjad.inspect(voice_2[1]).get_leaf(-1) is voice_2[0]
-    assert abjad.inspect(voice_2[2]).get_leaf(-1) is voice_2[1]
-    assert abjad.inspect(voice_1[1]).get_leaf(-1) is voice_2[-1]
+    assert abjad.inspect(voice_2[1]).leaf(-1) is voice_2[0]
+    assert abjad.inspect(voice_2[2]).leaf(-1) is voice_2[1]
+    assert abjad.inspect(voice_1[1]).leaf(-1) is voice_2[-1]

--- a/abjad/core/test/test_Inspection_markup.py
+++ b/abjad/core/test/test_Inspection_markup.py
@@ -1,23 +1,23 @@
 import abjad
 
 
-def test_Inspection_get_markup_01():
+def test_Inspection_markup_01():
 
     chord = abjad.Chord([-11, 2, 5], (1, 4))
     up_markup = abjad.Markup('UP', direction=abjad.Up)
     abjad.attach(up_markup, chord)
     down_markup = abjad.Markup('DOWN', direction=abjad.Down)
     abjad.attach(down_markup, chord)
-    found_markup = abjad.inspect(chord).get_markup(direction=abjad.Down)
-    assert found_markup == (down_markup,)
+    found_markup = abjad.inspect(chord).markup(direction=abjad.Down)
+    assert found_markup == [down_markup]
 
 
-def test_Inspection_get_markup_02():
+def test_Inspection_markup_02():
 
     chord = abjad.Chord([-11, 2, 5], (1, 4))
     up_markup = abjad.Markup('UP', direction=abjad.Up)
     abjad.attach(up_markup, chord)
     down_markup = abjad.Markup('DOWN', direction=abjad.Down)
     abjad.attach(down_markup, chord)
-    found_markup = abjad.inspect(chord).get_markup(direction=abjad.Up)
-    assert found_markup == (up_markup,)
+    found_markup = abjad.inspect(chord).markup(direction=abjad.Up)
+    assert found_markup == [up_markup]

--- a/abjad/core/test/test_Inspection_spanner.py
+++ b/abjad/core/test/test_Inspection_spanner.py
@@ -2,7 +2,7 @@ import abjad
 import pytest
 
 
-def test_Inspection_get_spanner_01():
+def test_Inspection_spanner_01():
 
     container = abjad.Container("c'8 d'8 e'8 f'8")
     beam = abjad.Beam()
@@ -25,17 +25,17 @@ def test_Inspection_get_spanner_01():
         """
         )
 
-    string = 'inspect(container[0]).get_spanner()'
+    string = 'inspect(container[0]).spanner()'
     assert pytest.raises(Exception, string)
 
-    assert abjad.inspect(container[-1]).get_spanner() is None
+    assert abjad.inspect(container[-1]).spanner() is None
 
 
-def test_Inspection_get_spanner_02():
+def test_Inspection_spanner_02():
 
     staff = abjad.Staff(r"c'4 \times 2/3 { d'8 e'8 f'8 } g'2")
     leaves = abjad.select(staff).leaves()
     slur = abjad.Slur()
     abjad.attach(slur, leaves)
     for leaf in leaves:
-        assert slur == abjad.inspect(leaf).get_spanner(abjad.Slur)
+        assert slur == abjad.inspect(leaf).spanner(abjad.Slur)

--- a/abjad/core/test/test_Inspection_timespan.py
+++ b/abjad/core/test/test_Inspection_timespan.py
@@ -2,45 +2,45 @@ import abjad
 import pytest
 
 
-def test_Inspection_get_timespan_01():
+def test_Inspection_timespan_01():
 
     voice = abjad.Voice("c'8 d'8 e'8 f'8")
     for i, x in enumerate(voice):
-        assert abjad.inspect(x).get_timespan().start_offset == i * abjad.Offset(1, 8)
+        assert abjad.inspect(x).timespan().start_offset == i * abjad.Offset(1, 8)
 
 
-def test_Inspection_get_timespan_02():
+def test_Inspection_timespan_02():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     for i, x in enumerate(staff):
-        assert abjad.inspect(x).get_timespan().start_offset == i * abjad.Offset(1, 8)
+        assert abjad.inspect(x).timespan().start_offset == i * abjad.Offset(1, 8)
 
 
-def test_Inspection_get_timespan_03():
+def test_Inspection_timespan_03():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     staff[-1] = abjad.Rest((1, 8))
     for i, x in enumerate(staff):
-        assert abjad.inspect(x).get_timespan().start_offset == i * abjad.Offset(1, 8)
+        assert abjad.inspect(x).timespan().start_offset == i * abjad.Offset(1, 8)
 
 
-def test_Inspection_get_timespan_04():
+def test_Inspection_timespan_04():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     staff[10:10] = [abjad.Rest((1, 8))]
     for i, x in enumerate(staff):
-        assert abjad.inspect(x).get_timespan().start_offset == i * abjad.Offset(1, 8)
+        assert abjad.inspect(x).timespan().start_offset == i * abjad.Offset(1, 8)
 
 
-def test_Inspection_get_timespan_05():
+def test_Inspection_timespan_05():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     staff[10:12] = [abjad.Rest((1, 8))]
     for i, x in enumerate(staff):
-        assert abjad.inspect(x).get_timespan().start_offset == i * abjad.Offset(1, 8)
+        assert abjad.inspect(x).timespan().start_offset == i * abjad.Offset(1, 8)
 
 
-def test_Inspection_get_timespan_06():
+def test_Inspection_timespan_06():
     """
     Offset works with voices.
     """
@@ -51,17 +51,17 @@ def test_Inspection_get_timespan_06():
     container = abjad.Container([voice_1, voice_2])
     leaves = abjad.select(container).leaves()
     for i, x in enumerate(leaves):
-        assert abjad.inspect(x).get_timespan().start_offset == i * abjad.Offset(1, 8)
+        assert abjad.inspect(x).timespan().start_offset == i * abjad.Offset(1, 8)
 
 
-def test_Inspection_get_timespan_07():
+def test_Inspection_timespan_07():
 
     tuplet = abjad.Tuplet((2, 3), "c'8 c'8 c'8")
     for i, x in enumerate(tuplet):
-        assert abjad.inspect(x).get_timespan().start_offset == i * abjad.Offset(1, 12)
+        assert abjad.inspect(x).timespan().start_offset == i * abjad.Offset(1, 12)
 
 
-def test_Inspection_get_timespan_08():
+def test_Inspection_timespan_08():
 
     tuplet_1 = abjad.Tuplet((2, 3), "c'8 c'8 c'8")
     voice = abjad.Voice([abjad.Note(0, (1, 8)), tuplet_1, abjad.Note(0, (1, 8))])
@@ -69,11 +69,11 @@ def test_Inspection_get_timespan_08():
     durations = [(1, 8), (1, 12), (1, 12), (1, 12), (1, 8)]
     leaves = abjad.select(voice).leaves()
     for leaf, duration in zip(leaves, durations):
-        assert abjad.inspect(leaf).get_timespan().start_offset == offset
+        assert abjad.inspect(leaf).timespan().start_offset == offset
         offset += abjad.Offset(*duration)
 
 
-def test_Inspection_get_timespan_09():
+def test_Inspection_timespan_09():
     """
     Offset works on nested tuplets.
     """
@@ -84,11 +84,11 @@ def test_Inspection_get_timespan_09():
     durations = [(1, 6), (1, 18), (1, 18), (1, 18), (1, 6)]
     leaves = abjad.select(tuplet).leaves()
     for leaf, duration in zip(leaves, durations):
-        assert abjad.inspect(leaf).get_timespan().start_offset == offset
+        assert abjad.inspect(leaf).timespan().start_offset == offset
         offset += abjad.Offset(*duration)
 
 
-def test_Inspection_get_timespan_10():
+def test_Inspection_timespan_10():
     """
     Offset works with simultaneous structures.
     """
@@ -98,14 +98,14 @@ def test_Inspection_get_timespan_10():
     staff = abjad.Staff([voice_1, voice_2])
     staff.is_simultaneous = True
     for i, leaf in enumerate(voice_1):
-        start_offset = abjad.inspect(leaf).get_timespan().start_offset
+        start_offset = abjad.inspect(leaf).timespan().start_offset
         assert start_offset == i * abjad.Offset(1, 8)
     for i, leaf in enumerate(voice_2):
-        start_offset = abjad.inspect(leaf).get_timespan().start_offset
+        start_offset = abjad.inspect(leaf).timespan().start_offset
         assert start_offset == i * abjad.Offset(1, 8)
 
 
-def test_Inspection_get_timespan_11():
+def test_Inspection_timespan_11():
     """
     Offset on leaves works in nested contexts.
     """
@@ -114,15 +114,15 @@ def test_Inspection_get_timespan_11():
     staff = abjad.Staff([abjad.Note(0, (1, 8)), voice, abjad.Note(0, (1, 8))])
     leaves = abjad.select(staff).leaves()
     for i, leaf in enumerate(leaves):
-        start_offset = abjad.inspect(leaf).get_timespan().start_offset
+        start_offset = abjad.inspect(leaf).timespan().start_offset
         assert start_offset == i * abjad.Offset(1, 8)
     leaves = abjad.select(voice).leaves()
     for i, leaf in enumerate(leaves):
-        start_offset = abjad.inspect(leaf).get_timespan().start_offset
+        start_offset = abjad.inspect(leaf).timespan().start_offset
         assert start_offset == i * abjad.Offset(1, 8) + abjad.Offset(1, 8)
 
 
-def test_Inspection_get_timespan_12():
+def test_Inspection_timespan_12():
     """
     Offset on leaves works in sequential contexts.
     """
@@ -131,14 +131,14 @@ def test_Inspection_get_timespan_12():
     voice_2 = abjad.Voice("c'8 d'8 e'8 f'8")
     staff = abjad.Staff([voice_1, voice_2])
     for i, leaf in enumerate(voice_1):
-        start_offset = abjad.inspect(leaf).get_timespan().start_offset
+        start_offset = abjad.inspect(leaf).timespan().start_offset
         assert start_offset == i * abjad.Offset(1, 8)
     for i, leaf in enumerate(voice_2):
-        start_offset = abjad.inspect(leaf).get_timespan().start_offset
+        start_offset = abjad.inspect(leaf).timespan().start_offset
         assert start_offset == i * abjad.Offset(1, 8) + abjad.Offset(1, 2)
 
 
-def test_Inspection_get_timespan_13():
+def test_Inspection_timespan_13():
     """
     Offset on leaves works in nested simultaneous contexts.
     """
@@ -148,14 +148,14 @@ def test_Inspection_get_timespan_13():
     staff = abjad.Staff([voice_1, voice_2])
     staff.is_simultaneous = True
     for i, leaf in enumerate(voice_1):
-        start_offset = abjad.inspect(leaf).get_timespan().start_offset
+        start_offset = abjad.inspect(leaf).timespan().start_offset
         assert start_offset == i * abjad.Offset(1, 8)
     for i, leaf in enumerate(voice_2):
-        start_offset = abjad.inspect(leaf).get_timespan().start_offset
+        start_offset = abjad.inspect(leaf).timespan().start_offset
         assert start_offset == i * abjad.Offset(1, 8)
 
 
-def test_Inspection_get_timespan_14():
+def test_Inspection_timespan_14():
     """
     Offset on leaves works in nested simultaneous and sequential contexts.
     """
@@ -166,11 +166,11 @@ def test_Inspection_get_timespan_14():
     staff = abjad.Staff([abjad.Container([voice_1, voice_2]), voice_3])
     staff[0].is_simultaneous = True
     for i, leaf in enumerate(voice_3):
-        start_offset = abjad.inspect(leaf).get_timespan().start_offset
+        start_offset = abjad.inspect(leaf).timespan().start_offset
         assert start_offset == i * abjad.Offset(1, 8) + abjad.Offset(1, 2)
 
 
-def test_Inspection_get_timespan_15():
+def test_Inspection_timespan_15():
     """
     Offset on leaves works in nested simultaneous and sequential contexts.
     """
@@ -181,14 +181,14 @@ def test_Inspection_get_timespan_15():
     staff = abjad.Staff([voice_3, abjad.Container([voice_1, voice_2])])
     staff[1].is_simultaneous = True
     for i, leaf in enumerate(voice_1):
-        start_offset = abjad.inspect(leaf).get_timespan().start_offset
+        start_offset = abjad.inspect(leaf).timespan().start_offset
         assert start_offset == i * abjad.Offset(1, 8) + abjad.Offset(1, 2)
     for i, leaf in enumerate(voice_2):
-        start_offset = abjad.inspect(leaf).get_timespan().start_offset
+        start_offset = abjad.inspect(leaf).timespan().start_offset
         assert start_offset == i * abjad.Offset(1, 8) + abjad.Offset(1, 2)
 
 
-def test_Inspection_get_timespan_16():
+def test_Inspection_timespan_16():
     """
     Offsets works on sequential voices.
     """
@@ -196,58 +196,58 @@ def test_Inspection_get_timespan_16():
     staff = abjad.Staff([abjad.Voice("c'8 d'8 e'8 f'8"), abjad.Voice("c'8 d'8 e'8 f'8")])
     staff[0].name = staff[1].name = 'voice'
     for i, voice in enumerate(staff):
-        start_offset = abjad.inspect(voice).get_timespan().start_offset
+        start_offset = abjad.inspect(voice).timespan().start_offset
         assert start_offset == i * abjad.Offset(4, 8)
 
 
-def test_Inspection_get_timespan_17():
+def test_Inspection_timespan_17():
     """
     Prolated offset does NOT go across sequential staves.
     """
 
     container = abjad.Container([abjad.Staff("c'8 d'8 e'8 f'8"), abjad.Staff("c'8 d'8 e'8 f'8")])
     container[0].name = container[1].name = 'staff'
-    start_offset = abjad.inspect(container[0]).get_timespan().start_offset
+    start_offset = abjad.inspect(container[0]).timespan().start_offset
     assert start_offset == abjad.Offset(0)
-    start_offset = abjad.inspect(container[1]).get_timespan().start_offset
+    start_offset = abjad.inspect(container[1]).timespan().start_offset
     assert start_offset == abjad.Offset(1, 2)
 
 
-def test_Inspection_get_timespan_18():
+def test_Inspection_timespan_18():
     """
     Offsets works with nested voices.
     """
 
     staff = abjad.Staff([abjad.Voice("c'8 d'8 e'8 f'8"), abjad.Voice("c'8 d'8 e'8 f'8")])
     for i, voice in enumerate(staff):
-        start_offset = abjad.inspect(voice).get_timespan().start_offset
+        start_offset = abjad.inspect(voice).timespan().start_offset
         assert start_offset == i * abjad.Offset(4, 8)
 
 
-def test_Inspection_get_timespan_19():
+def test_Inspection_timespan_19():
     """
     Offsets works on sequential tuplets.
     """
 
     voice = abjad.Voice(3 * abjad.Tuplet(abjad.Multiplier(2, 3), "c'8 d'8 e'8"))
-    assert abjad.inspect(voice[0]).get_timespan().start_offset == 0 * abjad.Offset(1, 4)
-    assert abjad.inspect(voice[1]).get_timespan().start_offset == 1 * abjad.Offset(1, 4)
-    assert abjad.inspect(voice[2]).get_timespan().start_offset == 2 * abjad.Offset(1, 4)
+    assert abjad.inspect(voice[0]).timespan().start_offset == 0 * abjad.Offset(1, 4)
+    assert abjad.inspect(voice[1]).timespan().start_offset == 1 * abjad.Offset(1, 4)
+    assert abjad.inspect(voice[2]).timespan().start_offset == 2 * abjad.Offset(1, 4)
 
 
-def test_Inspection_get_timespan_20():
+def test_Inspection_timespan_20():
     """
     Offsets work on tuplets between notes.
     """
 
     tuplet_1 = abjad.Tuplet((2, 3), "c'8 c'8 c'8")
     voice = abjad.Voice([abjad.Note(0, (1, 8)), tuplet_1, abjad.Note(0, (1, 8))])
-    assert abjad.inspect(voice[0]).get_timespan().start_offset == 0 * abjad.Offset(1, 8)
-    assert abjad.inspect(voice[1]).get_timespan().start_offset == 1 * abjad.Offset(1, 8)
-    assert abjad.inspect(voice[2]).get_timespan().start_offset == 3 * abjad.Offset(1, 8)
+    assert abjad.inspect(voice[0]).timespan().start_offset == 0 * abjad.Offset(1, 8)
+    assert abjad.inspect(voice[1]).timespan().start_offset == 1 * abjad.Offset(1, 8)
+    assert abjad.inspect(voice[2]).timespan().start_offset == 3 * abjad.Offset(1, 8)
 
 
-def test_Inspection_get_timespan_21():
+def test_Inspection_timespan_21():
     """
     Offsets work on nested tuplets.
     """
@@ -255,12 +255,12 @@ def test_Inspection_get_timespan_21():
     tuplet_1 = abjad.Tuplet((1, 2), "c'8 d'8 e'8 f'8")
     contents = [abjad.Note("c'4"), tuplet_1, abjad.Note("c'4")]
     tuplet = abjad.Tuplet((2, 3), contents)
-    assert abjad.inspect(tuplet[0]).get_timespan().start_offset == 0 * abjad.Offset(1, 6)
-    assert abjad.inspect(tuplet[1]).get_timespan().start_offset == 1 * abjad.Offset(1, 6)
-    assert abjad.inspect(tuplet[2]).get_timespan().start_offset == 2 * abjad.Offset(1, 6)
+    assert abjad.inspect(tuplet[0]).timespan().start_offset == 0 * abjad.Offset(1, 6)
+    assert abjad.inspect(tuplet[1]).timespan().start_offset == 1 * abjad.Offset(1, 6)
+    assert abjad.inspect(tuplet[2]).timespan().start_offset == 2 * abjad.Offset(1, 6)
 
 
-def test_Inspection_get_timespan_22():
+def test_Inspection_timespan_22():
     """
     Offsets work on nested contexts.
     """
@@ -269,11 +269,11 @@ def test_Inspection_get_timespan_22():
     outer_voice = abjad.Voice([abjad.Note(0, (1, 8)), inner_voice])
     inner_voice.name = outer_voice.name = 'voice'
     staff = abjad.Staff([abjad.Note(1, (1, 8)), outer_voice])
-    assert abjad.inspect(inner_voice).get_timespan().start_offset == abjad.Offset(2, 8)
-    assert abjad.inspect(outer_voice).get_timespan().start_offset == abjad.Offset(1, 8)
+    assert abjad.inspect(inner_voice).timespan().start_offset == abjad.Offset(2, 8)
+    assert abjad.inspect(outer_voice).timespan().start_offset == abjad.Offset(1, 8)
 
 
-def test_Inspection_get_timespan_23():
+def test_Inspection_timespan_23():
     """
     Offsets work on nested simultaneous contexts.
     """
@@ -282,11 +282,11 @@ def test_Inspection_get_timespan_23():
     voice_2 = abjad.Voice("c'8 d'8 e'8 f'8")
     staff = abjad.Staff([voice_1, voice_2])
     staff.is_simultaneous = True
-    assert abjad.inspect(staff[0]).get_timespan().start_offset == 0
-    assert abjad.inspect(staff[1]).get_timespan().start_offset == 0
+    assert abjad.inspect(staff[0]).timespan().start_offset == 0
+    assert abjad.inspect(staff[1]).timespan().start_offset == 0
 
 
-def test_Inspection_get_timespan_24():
+def test_Inspection_timespan_24():
     """
     Offsets works in nested simultaneous and sequential contexts.
     """
@@ -299,24 +299,24 @@ def test_Inspection_get_timespan_24():
     staff_1 = abjad.Staff([voice_1, voice_1b])
     staff_2 = abjad.Staff([voice_2, voice_2b])
     gs = abjad.StaffGroup([staff_1, staff_2])
-    assert abjad.inspect(voice_1).get_timespan().start_offset == 0
-    assert abjad.inspect(voice_2).get_timespan().start_offset == 0
-    assert abjad.inspect(voice_1b).get_timespan().start_offset == abjad.Offset(4, 8)
-    assert abjad.inspect(voice_2b).get_timespan().start_offset == abjad.Offset(4, 8)
+    assert abjad.inspect(voice_1).timespan().start_offset == 0
+    assert abjad.inspect(voice_2).timespan().start_offset == 0
+    assert abjad.inspect(voice_1b).timespan().start_offset == abjad.Offset(4, 8)
+    assert abjad.inspect(voice_2b).timespan().start_offset == abjad.Offset(4, 8)
 
 
-def test_Inspection_get_timespan_25():
+def test_Inspection_timespan_25():
     """
     Offset seconds can not calculate without excplit metronome mark.
     """
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
 
-    statement = 'inspect(staff[0]).get_timespan(in_seconds=True).start_offset'
+    statement = 'inspect(staff[0]).timespan(in_seconds=True).start_offset'
     assert pytest.raises(Exception, statement)
 
 
-def test_Inspection_get_timespan_26():
+def test_Inspection_timespan_26():
     """
     Offset seconds work with explicit metronome mark.
     """
@@ -338,7 +338,7 @@ def test_Inspection_get_timespan_26():
         """
         )
 
-    start_offset = abjad.inspect(staff[0]).get_timespan(in_seconds=True).start_offset
+    start_offset = abjad.inspect(staff[0]).timespan(in_seconds=True).start_offset
     assert start_offset == abjad.Offset(0)
-    start_offset = abjad.inspect(staff[1]).get_timespan(in_seconds=True).start_offset
+    start_offset = abjad.inspect(staff[1]).timespan(in_seconds=True).start_offset
     assert start_offset == abjad.Offset(5, 4)

--- a/abjad/core/test/test_Inspection_vertical_moment_at.py
+++ b/abjad/core/test/test_Inspection_vertical_moment_at.py
@@ -1,7 +1,7 @@
 import abjad
 
 
-def test_Inspection_get_vertical_moment_at_01():
+def test_Inspection_vertical_moment_at_01():
 
     score = abjad.Score([])
     tuplet = abjad.Tuplet((4, 3), "d''8 c''8 b'8")
@@ -47,23 +47,23 @@ def test_Inspection_get_vertical_moment_at_01():
         """
         )
 
-    moment = abjad.inspect(staff_group).get_vertical_moment_at((0, 8))
+    moment = abjad.inspect(staff_group).vertical_moment_at((0, 8))
     assert moment.leaves == (staff_group[0][0], staff_group[1][0])
 
-    moment = abjad.inspect(staff_group).get_vertical_moment_at((1, 8))
+    moment = abjad.inspect(staff_group).vertical_moment_at((1, 8))
     assert moment.leaves == (staff_group[0][0], staff_group[1][1])
 
-    moment = abjad.inspect(staff_group).get_vertical_moment_at((2, 8))
+    moment = abjad.inspect(staff_group).vertical_moment_at((2, 8))
     assert moment.leaves == (staff_group[0][1], staff_group[1][2])
 
-    moment = abjad.inspect(staff_group).get_vertical_moment_at((3, 8))
+    moment = abjad.inspect(staff_group).vertical_moment_at((3, 8))
     assert moment.leaves == (staff_group[0][1], staff_group[1][3])
 
-    moment = abjad.inspect(staff_group).get_vertical_moment_at((99, 8))
+    moment = abjad.inspect(staff_group).vertical_moment_at((99, 8))
     assert moment.leaves == ()
 
 
-def test_Inspection_get_vertical_moment_at_02():
+def test_Inspection_vertical_moment_at_02():
 
     score = abjad.Score([])
     tuplet = abjad.Tuplet((4, 3), "d''8 c''8 b'8")
@@ -110,35 +110,35 @@ def test_Inspection_get_vertical_moment_at_02():
         )
 
     def scorewide_vertical_moment(offset):
-        return abjad.inspect(score).get_vertical_moment_at(offset)
+        return abjad.inspect(score).vertical_moment_at(offset)
 
-    moment = abjad.inspect(score).get_vertical_moment_at((0, 8))
+    moment = abjad.inspect(score).vertical_moment_at((0, 8))
     assert moment.leaves == (
         score[0][0][0],
         staff_group[0][0],
         staff_group[1][0],
         )
 
-    moment = abjad.inspect(score).get_vertical_moment_at((1, 8))
+    moment = abjad.inspect(score).vertical_moment_at((1, 8))
     assert moment.leaves == (
         score[0][0][0],
         staff_group[0][0],
         staff_group[1][1],
         )
 
-    moment = abjad.inspect(score).get_vertical_moment_at((2, 8))
+    moment = abjad.inspect(score).vertical_moment_at((2, 8))
     assert moment.leaves == (
         score[0][0][1],
         staff_group[0][1],
         staff_group[1][2],
         )
 
-    moment = abjad.inspect(score).get_vertical_moment_at((3, 8))
+    moment = abjad.inspect(score).vertical_moment_at((3, 8))
     assert moment.leaves == (
         score[0][0][2],
         staff_group[0][1],
         staff_group[1][3],
         )
 
-    moment = abjad.inspect(score).get_vertical_moment_at((99, 8))
+    moment = abjad.inspect(score).vertical_moment_at((99, 8))
     assert moment.leaves == ()

--- a/abjad/core/test/test_Leaf__multiplied_duration.py
+++ b/abjad/core/test/test_Leaf__multiplied_duration.py
@@ -30,12 +30,12 @@ def test_Leaf__multiplied_duration_03():
     abjad.attach(abjad.Multiplier(2, 3), note)
 
     assert note.written_duration == abjad.Duration(3, 8)
-    assert abjad.inspect(note).get_indicator(abjad.Multiplier) == abjad.Multiplier(2, 3)
+    assert abjad.inspect(note).indicator(abjad.Multiplier) == abjad.Multiplier(2, 3)
     assert note._get_multiplied_duration() == abjad.Duration(1, 4)
 
     note.written_duration = abjad.Duration(1, 4)
     abjad.detach(abjad.Multiplier, note)
 
     assert note.written_duration == abjad.Duration(1, 4)
-    assert abjad.inspect(note).get_indicators(abjad.Multiplier) == ()
+    assert abjad.inspect(note).indicators(abjad.Multiplier) == []
     assert note._get_multiplied_duration() == abjad.Duration(1, 4)

--- a/abjad/core/test/test_Leaf__split_by_durations.py
+++ b/abjad/core/test/test_Leaf__split_by_durations.py
@@ -220,7 +220,7 @@ def test_Leaf__split_by_durations_06():
     """
 
     staff = abjad.Staff(r"\times 2/3 { c'8 [ d'8 e'8 ] }")
-    leaf = abjad.inspect(staff).get_leaf(0)
+    leaf = abjad.inspect(staff).leaf(0)
     halves = leaf._split_by_durations([abjad.Duration(1, 20)])
 
     assert format(staff) == abjad.String.normalize(
@@ -331,8 +331,8 @@ def test_Leaf__split_by_durations_09():
     assert isinstance(halves[1][0], abjad.Note)
     assert halves[0][0].written_duration == abjad.Duration(1, 8)
     assert halves[1][0].written_duration == abjad.Duration(1, 8)
-    assert len(abjad.inspect(halves[0][0]).get_logical_tie()) == 1
-    assert len(abjad.inspect(halves[1][0]).get_logical_tie()) == 1
+    assert len(abjad.inspect(halves[0][0]).logical_tie()) == 1
+    assert len(abjad.inspect(halves[1][0]).logical_tie()) == 1
 
 
 def test_Leaf__split_by_durations_10():
@@ -379,9 +379,9 @@ def test_Leaf__split_by_durations_11():
     assert halves[0][0].written_duration == abjad.Duration(4, 32)
     assert halves[0][1].written_duration == abjad.Duration(1, 32)
     assert halves[1][0].written_duration == abjad.Duration(3, 32)
-    assert len(abjad.inspect(halves[0][0]).get_logical_tie()) == 2
-    assert len(abjad.inspect(halves[0][1]).get_logical_tie()) == 2
-    assert len(abjad.inspect(halves[1][0]).get_logical_tie()) == 1
+    assert len(abjad.inspect(halves[0][0]).logical_tie()) == 2
+    assert len(abjad.inspect(halves[0][1]).logical_tie()) == 2
+    assert len(abjad.inspect(halves[1][0]).logical_tie()) == 1
 
 
 def test_Leaf__split_by_durations_12():
@@ -396,9 +396,9 @@ def test_Leaf__split_by_durations_12():
 
     assert len(staff) == 2
     for leaf in staff[:]:
-        assert abjad.inspect(leaf).get_spanners() == [tie]
+        assert abjad.inspect(leaf).spanners() == [tie]
         prototype = (abjad.Tie,)
-        assert abjad.inspect(leaf).get_spanner(prototype) is tie
+        assert abjad.inspect(leaf).spanner(prototype) is tie
 
     assert abjad.inspect(staff).is_well_formed()
 
@@ -419,7 +419,7 @@ def test_Leaf__split_by_durations_13():
 
     assert len(staff) == 5
     for l in staff:
-        assert abjad.inspect(l).get_spanners() == [beam]
+        assert abjad.inspect(l).spanners() == [beam]
         assert l._get_spanner(abjad.Beam) is beam
 
     assert abjad.inspect(staff).is_well_formed()
@@ -441,8 +441,8 @@ def test_Leaf__split_by_durations_14():
     assert len(halves[0]) == 2
     assert len(halves[1]) == 1
     for l in staff:
-        assert abjad.inspect(l).get_spanners() == [tie]
-        assert abjad.inspect(l).get_spanner(abjad.Tie) is tie
+        assert abjad.inspect(l).spanners() == [tie]
+        assert abjad.inspect(l).spanner(abjad.Tie) is tie
 
     assert abjad.inspect(staff).is_well_formed()
 
@@ -457,8 +457,8 @@ def test_Leaf__split_by_durations_15():
     abjad.attach(after_grace, note)
     halves = note._split_by_durations([abjad.Duration(1, 8)])
 
-    assert abjad.inspect(halves[0][0]).get_after_grace_container() is None
-    assert len(abjad.inspect(halves[1][0]).get_after_grace_container()) == 1
+    assert abjad.inspect(halves[0][0]).after_grace_container() is None
+    assert len(abjad.inspect(halves[1][0]).after_grace_container()) == 1
 
 
 def test_Leaf__split_by_durations_16():
@@ -475,7 +475,7 @@ def test_Leaf__split_by_durations_16():
     assert getattr(halves[0][0], 'after_grace', None) is None
     assert getattr(halves[0][1], 'after_grace', None) is None
     assert len(halves[1]) == 1
-    after_grace = abjad.inspect(halves[1][0]).get_after_grace_container()
+    after_grace = abjad.inspect(halves[1][0]).after_grace_container()
     assert len(after_grace) == 1
 
 
@@ -491,7 +491,7 @@ def test_Leaf__split_by_durations_17():
 
     assert len(halves[0]) == 1
     assert len(halves[1]) == 1
-    grace_container = abjad.inspect(halves[0][0]).get_grace_container()
+    grace_container = abjad.inspect(halves[0][0]).grace_container()
     assert len(grace_container) == 1
     assert not hasattr(halves[1][0], 'grace') is None
 

--- a/abjad/core/test/test_LogicalTie__add_or_remove_notes_to_achieve_written_duration.py
+++ b/abjad/core/test/test_LogicalTie__add_or_remove_notes_to_achieve_written_duration.py
@@ -7,7 +7,7 @@ def test_LogicalTie__add_or_remove_notes_to_achieve_written_duration_01():
     """
 
     staff = abjad.Staff("c'8 [ ]")
-    logical_tie = abjad.inspect(staff[0]).get_logical_tie()
+    logical_tie = abjad.inspect(staff[0]).logical_tie()
     logical_tie._add_or_remove_notes_to_achieve_written_duration(abjad.Duration(5, 32))
 
     assert abjad.inspect(staff).is_well_formed()
@@ -31,7 +31,7 @@ def test_LogicalTie__add_or_remove_notes_to_achieve_written_duration_02():
     """
 
     staff = abjad.Staff("c'8 ~ [ c'32 ]")
-    logical_tie = abjad.inspect(staff[0]).get_logical_tie()
+    logical_tie = abjad.inspect(staff[0]).logical_tie()
     logical_tie._add_or_remove_notes_to_achieve_written_duration(abjad.Duration(1, 8))
 
     assert abjad.inspect(staff).is_well_formed()

--- a/abjad/core/test/test_LogicalTie__fuse_leaves_by_immediate_parent.py
+++ b/abjad/core/test/test_LogicalTie__fuse_leaves_by_immediate_parent.py
@@ -11,7 +11,7 @@ def test_LogicalTie__fuse_leaves_by_immediate_parent_01():
     tie = abjad.Tie()
     abjad.attach(tie, leaves)
 
-    logical_tie = abjad.inspect(leaves[1]).get_logical_tie()
+    logical_tie = abjad.inspect(leaves[1]).logical_tie()
     result = logical_tie._fuse_leaves_by_immediate_parent()
 
     assert format(staff) == abjad.String.normalize(
@@ -58,7 +58,7 @@ def test_LogicalTie__fuse_leaves_by_immediate_parent_02():
         """
         )
 
-    logical_tie = abjad.inspect(staff[1]).get_logical_tie()
+    logical_tie = abjad.inspect(staff[1]).logical_tie()
     result = logical_tie._fuse_leaves_by_immediate_parent()
 
     assert format(staff) == abjad.String.normalize(
@@ -80,7 +80,7 @@ def test_LogicalTie__fuse_leaves_by_immediate_parent_03():
     """
 
     note = abjad.Note("c'4")
-    logical_tie = abjad.inspect(note).get_logical_tie()
+    logical_tie = abjad.inspect(note).logical_tie()
     result = logical_tie._fuse_leaves_by_immediate_parent()
     assert len(result) == 1
     assert abjad.inspect(note).is_well_formed()

--- a/abjad/core/test/test_LogicalTie__preprolated_duration.py
+++ b/abjad/core/test/test_LogicalTie__preprolated_duration.py
@@ -5,7 +5,7 @@ def test_LogicalTie__preprolated_duration_01():
 
     staff = abjad.Staff("c' ~ c'16")
 
-    assert abjad.inspect(staff[0]).get_logical_tie()._get_preprolated_duration() \
+    assert abjad.inspect(staff[0]).logical_tie()._get_preprolated_duration() \
         == abjad.Duration(5, 16)
 
 
@@ -13,5 +13,5 @@ def test_LogicalTie__preprolated_duration_02():
 
     staff = abjad.Staff("c'")
 
-    assert abjad.inspect(staff[0]).get_logical_tie()._get_preprolated_duration() \
+    assert abjad.inspect(staff[0]).logical_tie()._get_preprolated_duration() \
         == abjad.Duration(1, 4)

--- a/abjad/core/test/test_LogicalTie_leaves.py
+++ b/abjad/core/test/test_LogicalTie_leaves.py
@@ -5,11 +5,11 @@ def test_LogicalTie_leaves_01():
 
     staff = abjad.Staff("c' ~ c'16")
 
-    assert abjad.inspect(staff[0]).get_logical_tie().leaves == tuple(staff[:])
+    assert abjad.inspect(staff[0]).logical_tie().leaves == tuple(staff[:])
 
 
 def test_LogicalTie_leaves_02():
 
     staff = abjad.Staff("c'")
 
-    assert abjad.inspect(staff[0]).get_logical_tie().leaves == (staff[0], )
+    assert abjad.inspect(staff[0]).logical_tie().leaves == (staff[0], )

--- a/abjad/core/test/test_LogicalTie_written_duration.py
+++ b/abjad/core/test/test_LogicalTie_written_duration.py
@@ -5,11 +5,11 @@ def test_LogicalTie_written_duration_01():
 
     staff = abjad.Staff("c' ~ c'16")
 
-    assert abjad.inspect(staff[0]).get_logical_tie().written_duration == abjad.Duration(5, 16)
+    assert abjad.inspect(staff[0]).logical_tie().written_duration == abjad.Duration(5, 16)
 
 
 def test_LogicalTie_written_duration_02():
 
     staff = abjad.Staff("c'")
 
-    assert abjad.inspect(staff[0]).get_logical_tie().written_duration == abjad.Duration(1, 4)
+    assert abjad.inspect(staff[0]).logical_tie().written_duration == abjad.Duration(1, 4)

--- a/abjad/core/test/test_Measure___delitem__.py
+++ b/abjad/core/test/test_Measure___delitem__.py
@@ -183,7 +183,7 @@ def test_Measure___delitem___07():
     del(measure[:1])
 
     assert len(measure) == 3
-    assert abjad.inspect(measure).get_indicator(abjad.TimeSignature)
+    assert abjad.inspect(measure).indicator(abjad.TimeSignature)
     assert not abjad.inspect(measure).is_well_formed()
 
 
@@ -199,5 +199,5 @@ def test_Measure___delitem___08():
     del(measure[:1])
 
     assert len(measure) == 3
-    assert abjad.inspect(measure).get_indicator(abjad.TimeSignature)
+    assert abjad.inspect(measure).indicator(abjad.TimeSignature)
     assert not abjad.inspect(measure).is_well_formed()

--- a/abjad/core/test/test_Measure_duration.py
+++ b/abjad/core/test/test_Measure_duration.py
@@ -22,7 +22,7 @@ def test_Measure_duration_01():
 
     assert measure._get_contents_duration() == abjad.Duration(3, 8)
     assert measure._get_preprolated_duration() == abjad.Duration(3, 8)
-    assert abjad.inspect(measure).get_duration() == abjad.Duration(3, 8)
+    assert abjad.inspect(measure).duration() == abjad.Duration(3, 8)
 
 
 def test_Measure_duration_02():
@@ -48,7 +48,7 @@ def test_Measure_duration_02():
 
     assert measure._get_contents_duration() == abjad.Duration(3, 8)
     assert measure._get_preprolated_duration() == abjad.Duration(3, 10)
-    assert abjad.inspect(measure).get_duration() == abjad.Duration(3, 10)
+    assert abjad.inspect(measure).duration() == abjad.Duration(3, 10)
 
 
 def test_Measure_duration_03():
@@ -62,7 +62,7 @@ def test_Measure_duration_03():
 
     assert measure._get_contents_duration() == abjad.Duration(4, 8)
     assert measure._get_preprolated_duration() == abjad.Duration(4, 8)
-    assert abjad.inspect(measure).get_duration() == abjad.Duration(4, 8)
+    assert abjad.inspect(measure).duration() == abjad.Duration(4, 8)
 
 
 def test_Measure_duration_04():
@@ -77,4 +77,4 @@ def test_Measure_duration_04():
 
     assert measure._get_contents_duration() == abjad.Duration(4, 8)
     assert measure._get_preprolated_duration() == abjad.Duration(4, 10)
-    assert abjad.inspect(measure).get_duration() == abjad.Duration(4, 10)
+    assert abjad.inspect(measure).duration() == abjad.Duration(4, 10)

--- a/abjad/core/test/test_Measure_empty.py
+++ b/abjad/core/test/test_Measure_empty.py
@@ -10,7 +10,7 @@ def test_Measure_empty_01():
     assert pytest.raises(abjad.UnderfullContainerError, 'format(measure)')
     assert len(measure) == 0
     assert measure._get_preprolated_duration() == 0
-    assert abjad.inspect(measure).get_duration() == 0
+    assert abjad.inspect(measure).duration() == 0
     assert not abjad.inspect(measure).is_well_formed()
 
 
@@ -22,5 +22,5 @@ def test_Measure_empty_02():
     assert pytest.raises(abjad.UnderfullContainerError, 'format(measure)')
     assert len(measure) == 0
     assert measure._get_preprolated_duration() == 0
-    assert abjad.inspect(measure).get_duration() == 0
+    assert abjad.inspect(measure).duration() == 0
     assert not abjad.inspect(measure).is_well_formed()

--- a/abjad/core/test/test_Measure_implicit_scaling.py
+++ b/abjad/core/test/test_Measure_implicit_scaling.py
@@ -12,7 +12,7 @@ def test_Measure_implicit_scaling_01():
     measure = abjad.Measure((4, 4), abjad.Note("c'4") * 4)
 
     assert measure[0].written_duration == abjad.Duration(1, 4)
-    assert abjad.inspect(measure[0]).get_duration() == abjad.Duration(1, 4)
+    assert abjad.inspect(measure[0]).duration() == abjad.Duration(1, 4)
 
 
 def test_Measure_implicit_scaling_02():
@@ -30,9 +30,9 @@ def test_Measure_implicit_scaling_02():
     leaves = abjad.select(measure).leaves()
 
     assert leaves[0].written_duration == abjad.Duration(1, 4)
-    assert abjad.inspect(leaves[0]).get_duration() == abjad.Duration(1, 4)
+    assert abjad.inspect(leaves[0]).duration() == abjad.Duration(1, 4)
     assert leaves[1].written_duration == abjad.Duration(1, 4)
-    assert abjad.inspect(leaves[1]).get_duration() == abjad.Duration(1, 6)
+    assert abjad.inspect(leaves[1]).duration() == abjad.Duration(1, 6)
 
 
 def test_Measure_implicit_scaling_03():
@@ -50,9 +50,9 @@ def test_Measure_implicit_scaling_03():
     leaves = abjad.select(measure).leaves()
 
     assert leaves[0].written_duration == abjad.Duration(1, 4)
-    assert abjad.inspect(leaves[0]).get_duration() == abjad.Duration(1, 4)
+    assert abjad.inspect(leaves[0]).duration() == abjad.Duration(1, 4)
     assert leaves[1].written_duration == abjad.Duration(1, 4)
-    assert abjad.inspect(leaves[1]).get_duration() == abjad.Duration(1, 9)
+    assert abjad.inspect(leaves[1]).duration() == abjad.Duration(1, 9)
 
 
 def test_Measure_implicit_scaling_04():
@@ -65,7 +65,7 @@ def test_Measure_implicit_scaling_04():
     measure.implicit_scaling = True
 
     assert measure[0].written_duration == abjad.Duration(1, 4)
-    assert abjad.inspect(measure[0]).get_duration() == abjad.Duration(1, 5)
+    assert abjad.inspect(measure[0]).duration() == abjad.Duration(1, 5)
 
 
 def test_Measure_implicit_scaling_05():
@@ -84,9 +84,9 @@ def test_Measure_implicit_scaling_05():
     leaves = abjad.select(measure).leaves()
 
     assert leaves[0].written_duration == abjad.Duration(1, 4)
-    assert abjad.inspect(leaves[0]).get_duration() == abjad.Duration(1, 5)
+    assert abjad.inspect(leaves[0]).duration() == abjad.Duration(1, 5)
     assert leaves[1].written_duration == abjad.Duration(1, 4)
-    assert abjad.inspect(leaves[1]).get_duration() == abjad.Duration(2, 15)
+    assert abjad.inspect(leaves[1]).duration() == abjad.Duration(2, 15)
 
 
 def test_Measure_implicit_scaling_06():
@@ -105,6 +105,6 @@ def test_Measure_implicit_scaling_06():
     leaves = abjad.select(measure).leaves()
 
     assert leaves[0].written_duration == abjad.Duration(1, 4)
-    assert abjad.inspect(leaves[0]).get_duration() == abjad.Duration(1, 5)
+    assert abjad.inspect(leaves[0]).duration() == abjad.Duration(1, 5)
     assert leaves[1].written_duration == abjad.Duration(1, 4)
-    assert abjad.inspect(leaves[1]).get_duration() == abjad.Duration(4, 45)
+    assert abjad.inspect(leaves[1]).duration() == abjad.Duration(4, 45)

--- a/abjad/core/test/test_Mutation_fuse.py
+++ b/abjad/core/test/test_Mutation_fuse.py
@@ -48,8 +48,8 @@ def test_Mutation_fuse_04():
     assert fused[0].written_duration == abjad.Duration(1, 4)
     assert fused[1].written_duration == abjad.Duration(1, 16)
 
-    tie_1 = abjad.inspect(fused[0]).get_spanner(abjad.Tie)
-    tie_2 = abjad.inspect(fused[1]).get_spanner(abjad.Tie)
+    tie_1 = abjad.inspect(fused[0]).spanner(abjad.Tie)
+    tie_2 = abjad.inspect(fused[1]).spanner(abjad.Tie)
 
     assert tie_1 is tie_2
     assert voice[0] is fused[0]
@@ -76,7 +76,7 @@ def test_Mutation_fuse_05():
         """
         )
 
-    assert abjad.inspect(staff).get_duration() == abjad.Duration(3, 8)
+    assert abjad.inspect(staff).duration() == abjad.Duration(3, 8)
 
     abjad.mutate(staff[:]).fuse()
 
@@ -89,7 +89,7 @@ def test_Mutation_fuse_05():
         """
         )
 
-    assert abjad.inspect(staff).get_duration() == abjad.Duration(3, 8)
+    assert abjad.inspect(staff).duration() == abjad.Duration(3, 8)
     assert abjad.inspect(staff).is_well_formed()
 
 

--- a/abjad/core/test/test_Note___copy__.py
+++ b/abjad/core/test/test_Note___copy__.py
@@ -68,7 +68,7 @@ def test_Note___copy___04():
         )
 
     note_2 = copy.copy(note_1)
-    grace_container_2 = abjad.inspect(note_2).get_after_grace_container()
+    grace_container_2 = abjad.inspect(note_2).after_grace_container()
 
     assert format(note_2) == abjad.String.normalize(
         r"""
@@ -150,12 +150,12 @@ def test_Note___copy___06():
     new_note = copy.deepcopy(note)
 
     assert new_note is not note
-    assert abjad.inspect(note).get_parentage().parent is staff
-    assert abjad.inspect(new_note).get_parentage().parent is not staff
-    assert isinstance(abjad.inspect(new_note).get_parentage().parent, abjad.Staff)
+    assert abjad.inspect(note).parentage().parent is staff
+    assert abjad.inspect(new_note).parentage().parent is not staff
+    assert isinstance(abjad.inspect(new_note).parentage().parent, abjad.Staff)
     assert format(new_note) == format(note)
-    assert format(abjad.inspect(note).get_parentage().parent) == \
-        format(abjad.inspect(new_note).get_parentage().parent)
+    assert format(abjad.inspect(note).parentage().parent) == \
+        format(abjad.inspect(new_note).parentage().parent)
 
 
 def test_Note___copy___07():

--- a/abjad/core/test/test_Parentage__get_governor.py
+++ b/abjad/core/test/test_Parentage__get_governor.py
@@ -29,10 +29,10 @@ def test_Parentage__get_governor_01( ):
     """
 
     leaves = abjad.select(voice).leaves()
-    assert abjad.inspect(leaves[0]).get_parentage()._get_governor() is voice[0][0]
-    assert abjad.inspect(leaves[1]).get_parentage()._get_governor() is voice[0][0]
-    assert abjad.inspect(leaves[2]).get_parentage()._get_governor() is voice[0][1]
-    assert abjad.inspect(leaves[3]).get_parentage()._get_governor() is voice[0][1]
+    assert abjad.inspect(leaves[0]).parentage()._get_governor() is voice[0][0]
+    assert abjad.inspect(leaves[1]).parentage()._get_governor() is voice[0][0]
+    assert abjad.inspect(leaves[2]).parentage()._get_governor() is voice[0][1]
+    assert abjad.inspect(leaves[3]).parentage()._get_governor() is voice[0][1]
 
 
 def test_Parentage__get_governor_02( ):
@@ -41,7 +41,7 @@ def test_Parentage__get_governor_02( ):
     """
 
     note = abjad.Note(0, (1, 8))
-    assert abjad.inspect(note).get_parentage()._get_governor() is None
+    assert abjad.inspect(note).parentage()._get_governor() is None
 
 
 def test_Parentage__get_governor_03( ):
@@ -67,10 +67,10 @@ def test_Parentage__get_governor_03( ):
     """
 
     leaves = abjad.select(staff).leaves()
-    assert abjad.inspect(leaves[0]).get_parentage()._get_governor() is staff
-    assert abjad.inspect(leaves[1]).get_parentage()._get_governor() is staff
-    assert abjad.inspect(leaves[2]).get_parentage()._get_governor() is staff
-    assert abjad.inspect(leaves[3]).get_parentage()._get_governor() is staff
+    assert abjad.inspect(leaves[0]).parentage()._get_governor() is staff
+    assert abjad.inspect(leaves[1]).parentage()._get_governor() is staff
+    assert abjad.inspect(leaves[2]).parentage()._get_governor() is staff
+    assert abjad.inspect(leaves[3]).parentage()._get_governor() is staff
 
 
 def test_Parentage__get_governor_04( ):
@@ -95,6 +95,6 @@ def test_Parentage__get_governor_04( ):
     }
     """
 
-    assert abjad.inspect(staff[0][0]).get_parentage()._get_governor() is staff
-    assert abjad.inspect(staff[0]).get_parentage()._get_governor() is staff
-    assert abjad.inspect(staff).get_parentage()._get_governor() is staff
+    assert abjad.inspect(staff[0][0]).parentage()._get_governor() is staff
+    assert abjad.inspect(staff[0]).parentage()._get_governor() is staff
+    assert abjad.inspect(staff).parentage()._get_governor() is staff

--- a/abjad/core/test/test_Parentage__id_string.py
+++ b/abjad/core/test/test_Parentage__id_string.py
@@ -7,7 +7,7 @@ def test_Parentage__id_string_01():
     """
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    parentage = abjad.inspect(staff).get_parentage()
+    parentage = abjad.inspect(staff).parentage()
     assert parentage._id_string(staff).startswith('Staff-')
 
 
@@ -17,6 +17,6 @@ def test_Parentage__id_string_02():
     """
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    parentage = abjad.inspect(staff).get_parentage()
+    parentage = abjad.inspect(staff).parentage()
     staff.name = 'foo'
     assert parentage._id_string(staff) == "Staff-'foo'"

--- a/abjad/core/test/test_Parentage_get_first.py
+++ b/abjad/core/test/test_Parentage_get_first.py
@@ -6,7 +6,7 @@ def test_Parentage_get_first_01():
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
 
     for leaf in staff:
-        assert abjad.inspect(leaf).get_parentage().get_first(abjad.Staff) is staff
+        assert abjad.inspect(leaf).parentage().get_first(abjad.Staff) is staff
 
-    assert abjad.inspect(staff).get_parentage(include_self=True).get_first(abjad.Staff) is staff
-    assert abjad.inspect(staff).get_parentage(include_self=False).get_first(abjad.Staff) is None
+    assert abjad.inspect(staff).parentage(include_self=True).get_first(abjad.Staff) is staff
+    assert abjad.inspect(staff).parentage(include_self=False).get_first(abjad.Staff) is None

--- a/abjad/core/test/test_Parentage_is_orphan.py
+++ b/abjad/core/test/test_Parentage_is_orphan.py
@@ -5,6 +5,6 @@ def test_Parentage_is_orphan_01():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
 
-    assert abjad.inspect(staff).get_parentage().is_orphan
+    assert abjad.inspect(staff).parentage().is_orphan
     for note in staff:
-        assert not abjad.inspect(note).get_parentage().is_orphan
+        assert not abjad.inspect(note).parentage().is_orphan

--- a/abjad/core/test/test_Parentage_logical_voice.py
+++ b/abjad/core/test/test_Parentage_logical_voice.py
@@ -9,9 +9,9 @@ def test_Parentage_logical_voice_01():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
 
-    containment = abjad.inspect(staff).get_parentage().logical_voice
+    containment = abjad.inspect(staff).parentage().logical_voice
     for component in abjad.iterate(staff).components():
-        assert abjad.inspect(component).get_parentage().logical_voice == containment
+        assert abjad.inspect(component).parentage().logical_voice == containment
 
 
 def test_Parentage_logical_voice_02():
@@ -22,9 +22,9 @@ def test_Parentage_logical_voice_02():
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     staff.name = 'foo'
 
-    containment = abjad.inspect(staff).get_parentage().logical_voice
+    containment = abjad.inspect(staff).parentage().logical_voice
     for component in abjad.iterate(staff).components():
-        assert abjad.inspect(component).get_parentage().logical_voice == containment
+        assert abjad.inspect(component).parentage().logical_voice == containment
 
 def test_Parentage_logical_voice_03():
     """
@@ -36,9 +36,9 @@ def test_Parentage_logical_voice_03():
     staff[0].name = 'foo'
     staff[1].name = 'foo'
 
-    containment = abjad.inspect(staff[0][0]).get_parentage().logical_voice
+    containment = abjad.inspect(staff[0][0]).parentage().logical_voice
     for leaf in abjad.iterate(staff).leaves():
-        assert abjad.inspect(leaf).get_parentage().logical_voice == containment
+        assert abjad.inspect(leaf).parentage().logical_voice == containment
 
 
 def test_Parentage_logical_voice_04():
@@ -96,7 +96,7 @@ def test_Parentage_logical_voice_04():
         """
         )
 
-    signatures = [abjad.inspect(leaf).get_parentage().logical_voice
+    signatures = [abjad.inspect(leaf).parentage().logical_voice
         for leaf in abjad.iterate(voice).leaves()]
 
     assert signatures[0] == signatures[1]
@@ -165,7 +165,7 @@ def test_Parentage_logical_voice_05():
         )
 
     signatures = [
-        abjad.inspect(leaf).get_parentage().logical_voice
+        abjad.inspect(leaf).parentage().logical_voice
         for leaf in abjad.iterate(voice).leaves()
         ]
 
@@ -235,7 +235,7 @@ def test_Parentage_logical_voice_06():
         """
         )
 
-    signatures = [abjad.inspect(leaf).get_parentage().logical_voice
+    signatures = [abjad.inspect(leaf).parentage().logical_voice
         for leaf in leaves]
 
     signatures[0] == signatures[1]
@@ -315,7 +315,7 @@ def test_Parentage_logical_voice_07():
         )
 
     signatures = [
-        abjad.inspect(leaf).get_parentage().logical_voice
+        abjad.inspect(leaf).parentage().logical_voice
         for leaf in abjad.iterate(container).leaves()
         ]
 
@@ -346,8 +346,8 @@ def test_Parentage_logical_voice_08():
     note_1 = abjad.Note(0, (1, 8))
     note_2 = abjad.Note(0, (1, 8))
 
-    signature_1 = abjad.inspect(note_1).get_parentage().logical_voice
-    signature_2 = abjad.inspect(note_2).get_parentage().logical_voice
+    signature_1 = abjad.inspect(note_1).parentage().logical_voice
+    signature_2 = abjad.inspect(note_2).parentage().logical_voice
     assert signature_1 == signature_2
 
 
@@ -365,9 +365,9 @@ def test_Parentage_logical_voice_09():
     staff_2[0].name = 'voice'
 
     staff_1_leaf_signature = abjad.inspect(
-        staff_1[0][0]).get_parentage().logical_voice
+        staff_1[0][0]).parentage().logical_voice
     staff_2_leaf_signature = abjad.inspect(
-        staff_2[0][0]).get_parentage().logical_voice
+        staff_2[0][0]).parentage().logical_voice
     assert staff_1_leaf_signature == staff_2_leaf_signature
 
 
@@ -403,12 +403,12 @@ def test_Parentage_logical_voice_10():
         """
         )
 
-    assert abjad.inspect(staff[0]).get_parentage().logical_voice == \
-        abjad.inspect(staff[-1]).get_parentage().logical_voice
-    assert abjad.inspect(staff[0]).get_parentage().logical_voice == \
-        abjad.inspect(staff[0][0]).get_parentage().logical_voice
-    assert abjad.inspect(staff[0][0]).get_parentage().logical_voice == \
-        abjad.inspect(staff[-1]).get_parentage().logical_voice
+    assert abjad.inspect(staff[0]).parentage().logical_voice == \
+        abjad.inspect(staff[-1]).parentage().logical_voice
+    assert abjad.inspect(staff[0]).parentage().logical_voice == \
+        abjad.inspect(staff[0][0]).parentage().logical_voice
+    assert abjad.inspect(staff[0][0]).parentage().logical_voice == \
+        abjad.inspect(staff[-1]).parentage().logical_voice
 
 
 def test_Parentage_logical_voice_11():
@@ -438,11 +438,11 @@ def test_Parentage_logical_voice_11():
         )
 
     leaves = abjad.select(container).leaves()
-    assert abjad.inspect(leaves[0]).get_parentage().logical_voice == \
-        abjad.inspect(leaves[1]).get_parentage().logical_voice
-    assert abjad.inspect(leaves[0]).get_parentage().logical_voice != \
-        abjad.inspect(leaves[2]).get_parentage().logical_voice
-    assert abjad.inspect(leaves[2]).get_parentage().logical_voice == \
-        abjad.inspect(leaves[3]).get_parentage().logical_voice
-    assert abjad.inspect(leaves[2]).get_parentage().logical_voice != \
-        abjad.inspect(leaves[0]).get_parentage().logical_voice
+    assert abjad.inspect(leaves[0]).parentage().logical_voice == \
+        abjad.inspect(leaves[1]).parentage().logical_voice
+    assert abjad.inspect(leaves[0]).parentage().logical_voice != \
+        abjad.inspect(leaves[2]).parentage().logical_voice
+    assert abjad.inspect(leaves[2]).parentage().logical_voice == \
+        abjad.inspect(leaves[3]).parentage().logical_voice
+    assert abjad.inspect(leaves[2]).parentage().logical_voice != \
+        abjad.inspect(leaves[0]).parentage().logical_voice

--- a/abjad/core/test/test_Parentage_root.py
+++ b/abjad/core/test/test_Parentage_root.py
@@ -7,8 +7,8 @@ def test_Parentage_root_01():
     staff = abjad.Staff([tuplet])
     leaves = abjad.select(staff).leaves()
 
-    assert abjad.inspect(staff).get_parentage().root is staff
-    assert abjad.inspect(tuplet).get_parentage().root is staff
-    assert abjad.inspect(leaves[0]).get_parentage().root is staff
-    assert abjad.inspect(leaves[1]).get_parentage().root is staff
-    assert abjad.inspect(leaves[2]).get_parentage().root is staff
+    assert abjad.inspect(staff).parentage().root is staff
+    assert abjad.inspect(tuplet).parentage().root is staff
+    assert abjad.inspect(leaves[0]).parentage().root is staff
+    assert abjad.inspect(leaves[1]).parentage().root is staff
+    assert abjad.inspect(leaves[2]).parentage().root is staff

--- a/abjad/core/test/test_Staff_time_signature.py
+++ b/abjad/core/test/test_Staff_time_signature.py
@@ -37,7 +37,7 @@ def test_Staff_time_signature_02():
     time_signature = abjad.TimeSignature((2, 4))
     abjad.attach(time_signature, staff[0])
     for x in staff:
-        assert abjad.inspect(x).get_effective(abjad.TimeSignature) \
+        assert abjad.inspect(x).effective(abjad.TimeSignature) \
             == abjad.TimeSignature((2, 4))
 
 
@@ -51,5 +51,5 @@ def test_Staff_time_signature_03():
     abjad.attach(time_signature, staff[0])
     abjad.detach(time_signature, staff[0])
     for leaf in staff:
-        assert abjad.inspect(leaf).get_effective(
+        assert abjad.inspect(leaf).effective(
             abjad.TimeSignature) is None

--- a/abjad/core/test/test_Tuplet_get_timespan.py
+++ b/abjad/core/test/test_Tuplet_get_timespan.py
@@ -28,11 +28,11 @@ def test_Tuplet_get_timespan_01():
         """
         )
 
-    assert abjad.inspect(staff).get_timespan(in_seconds=True) == \
+    assert abjad.inspect(staff).timespan(in_seconds=True) == \
         abjad.Timespan(0, 4)
-    assert abjad.inspect(staff[0]).get_timespan(in_seconds=True) == \
+    assert abjad.inspect(staff[0]).timespan(in_seconds=True) == \
         abjad.Timespan(0, 1)
-    assert abjad.inspect(staff[1]).get_timespan(in_seconds=True) == \
+    assert abjad.inspect(staff[1]).timespan(in_seconds=True) == \
         abjad.Timespan(1, 2)
-    assert abjad.inspect(staff[-1]).get_timespan(in_seconds=True) == \
+    assert abjad.inspect(staff[-1]).timespan(in_seconds=True) == \
         abjad.Timespan(2, 4)

--- a/abjad/core/test/test_Tuplet_timespan.py
+++ b/abjad/core/test/test_Tuplet_timespan.py
@@ -20,7 +20,7 @@ def test_Tuplet_timespan_01():
         """
         )
 
-    assert abjad.inspect(staff).get_timespan() == abjad.Timespan(0, 1)
-    assert abjad.inspect(staff[0]).get_timespan() == abjad.Timespan(0, (1, 4))
-    assert abjad.inspect(staff[1]).get_timespan() == abjad.Timespan((1, 4), (1, 2))
-    assert abjad.inspect(staff[-1]).get_timespan() == abjad.Timespan((1, 2), 1)
+    assert abjad.inspect(staff).timespan() == abjad.Timespan(0, 1)
+    assert abjad.inspect(staff[0]).timespan() == abjad.Timespan(0, (1, 4))
+    assert abjad.inspect(staff[1]).timespan() == abjad.Timespan((1, 4), (1, 2))
+    assert abjad.inspect(staff[-1]).timespan() == abjad.Timespan((1, 2), 1)

--- a/abjad/core/test/test_VerticalMoment___eq__.py
+++ b/abjad/core/test/test_VerticalMoment___eq__.py
@@ -30,10 +30,10 @@ def test_VerticalMoment___eq___01():
 
     staff_group = score[1]
 
-    vertical_moment_1 = abjad.inspect(staff_group).get_vertical_moment_at(abjad.Offset(1, 8))
+    vertical_moment_1 = abjad.inspect(staff_group).vertical_moment_at(abjad.Offset(1, 8))
     "VerticalMoment(PianoStaff<<2>>, abjad.Staff{2}, a'4, abjad.Staff{4}, e'8)"
 
-    vertical_moment_2 = abjad.inspect(staff_group).get_vertical_moment_at(abjad.Offset(1, 8))
+    vertical_moment_2 = abjad.inspect(staff_group).vertical_moment_at(abjad.Offset(1, 8))
     "VerticalMoment(PianoStaff<<2>>, abjad.Staff{2}, a'4, abjad.Staff{4}, e'8)"
 
     assert vertical_moment_1 == vertical_moment_2
@@ -95,11 +95,11 @@ def test_VerticalMoment___eq___02():
         )
 
     vertical_moment_1 = abjad.inspect(
-        staff_group).get_vertical_moment_at(abjad.Offset(1, 8))
+        staff_group).vertical_moment_at(abjad.Offset(1, 8))
     "VerticalMoment(PianoStaff<<2>>, abjad.Staff{2}, a'4, abjad.Staff{4}, e'8)"
 
     vertical_moment_2 = abjad.inspect(
-        staff_group[0]).get_vertical_moment_at(abjad.Offset(1, 8))
+        staff_group[0]).vertical_moment_at(abjad.Offset(1, 8))
     "VerticalMoment(abjad.Staff{2}, a'4, abjad.Staff{4}, e'8)"
 
     assert not vertical_moment_1 == vertical_moment_2

--- a/abjad/core/test/test_VerticalMoment___len__.py
+++ b/abjad/core/test/test_VerticalMoment___len__.py
@@ -30,22 +30,22 @@ def test_VerticalMoment___len___01():
 
     staff_group = score[1]
 
-    vertical_moment = abjad.inspect(score).get_vertical_moment_at(abjad.Offset(1, 8))
+    vertical_moment = abjad.inspect(score).vertical_moment_at(abjad.Offset(1, 8))
     "VerticalMoment(abjad.Score<<2>>, abjad.Staff{1}, {@ 3:4 d''8, c''8, b'8 @}, d''8, PianoStaff<<2>>, abjad.Staff{2}, a'4, abjad.Staff{4}, e'8)"
     assert len(vertical_moment) == 9
 
-    vertical_moment = abjad.inspect(score[0]).get_vertical_moment_at(abjad.Offset(1, 8))
+    vertical_moment = abjad.inspect(score[0]).vertical_moment_at(abjad.Offset(1, 8))
     "VerticalMoment(abjad.Staff{1}, {@ 3:4 d''8, c''8, b'8 @}, d''8)"
     assert len(vertical_moment) == 3
 
-    vertical_moment = abjad.inspect(staff_group).get_vertical_moment_at(abjad.Offset(1, 8))
+    vertical_moment = abjad.inspect(staff_group).vertical_moment_at(abjad.Offset(1, 8))
     "VerticalMoment(PianoStaff<<2>>, abjad.Staff{2}, a'4, abjad.Staff{4}, e'8)"
     assert len(vertical_moment) == 5
 
-    vertical_moment = abjad.inspect(staff_group[0]).get_vertical_moment_at(abjad.Offset(1, 8))
+    vertical_moment = abjad.inspect(staff_group[0]).vertical_moment_at(abjad.Offset(1, 8))
     "VerticalMoment(abjad.Staff{2}, a'4)"
     assert len(vertical_moment) == 2
 
-    vertical_moment = abjad.inspect(staff_group[1]).get_vertical_moment_at(abjad.Offset(1, 8))
+    vertical_moment = abjad.inspect(staff_group[1]).vertical_moment_at(abjad.Offset(1, 8))
     "VerticalMoment(abjad.Staff{2}, e'8)"
     assert len(vertical_moment) == 2

--- a/abjad/core/test/test_VerticalMoment___repr__.py
+++ b/abjad/core/test/test_VerticalMoment___repr__.py
@@ -6,7 +6,7 @@ def test_VerticalMoment___repr___01():
     Vertical moment repr returns a nonempty string.
     """
 
-    vertical_moment = abjad.inspect(abjad.Note('c4')).get_vertical_moment()
+    vertical_moment = abjad.inspect(abjad.Note('c4')).vertical_moment()
     representation = repr(vertical_moment)
 
     assert isinstance(representation, str) and 0 < len(representation)

--- a/abjad/core/test/test_VerticalMoment_attack_count.py
+++ b/abjad/core/test/test_VerticalMoment_attack_count.py
@@ -28,8 +28,8 @@ def test_VerticalMoment_attack_count_01():
         """
         )
 
-    vertical_moment = abjad.inspect(score).get_vertical_moment_at(abjad.Offset(0))
+    vertical_moment = abjad.inspect(score).vertical_moment_at(abjad.Offset(0))
     assert vertical_moment.attack_count == 3
 
-    vertical_moment = abjad.inspect(score).get_vertical_moment_at(abjad.Offset(1, 8))
+    vertical_moment = abjad.inspect(score).vertical_moment_at(abjad.Offset(1, 8))
     assert vertical_moment.attack_count == 1

--- a/abjad/core/test/test_VerticalMoment_leaves.py
+++ b/abjad/core/test/test_VerticalMoment_leaves.py
@@ -30,7 +30,7 @@ def test_VerticalMoment_leaves_01():
 
     staff_group = score[1]
 
-    vertical_moment = abjad.inspect(score).get_vertical_moment_at(abjad.Offset(1, 8))
+    vertical_moment = abjad.inspect(score).vertical_moment_at(abjad.Offset(1, 8))
 
     "(abjad.Note(d'', 8), abjad.Note(a', 4), abjad.Note(e', 8))"
 

--- a/abjad/core/test/test_VerticalMoment_next_vertical_moment.py
+++ b/abjad/core/test/test_VerticalMoment_next_vertical_moment.py
@@ -28,7 +28,7 @@ def test_VerticalMoment_next_vertical_moment_01():
         """
         )
 
-    vertical_moment = abjad.inspect(score).get_vertical_moment_at(abjad.Offset(0))
+    vertical_moment = abjad.inspect(score).vertical_moment_at(abjad.Offset(0))
     assert vertical_moment.offset == abjad.Offset(0)
 
     vertical_moment = vertical_moment.next_vertical_moment

--- a/abjad/core/test/test_VerticalMoment_notes.py
+++ b/abjad/core/test/test_VerticalMoment_notes.py
@@ -30,7 +30,7 @@ def test_VerticalMoment_notes_01():
 
     staff_group = score[1]
 
-    vertical_moment = abjad.inspect(score).get_vertical_moment_at(abjad.Offset(1, 8))
+    vertical_moment = abjad.inspect(score).vertical_moment_at(abjad.Offset(1, 8))
 
     "(abjad.Note(d'', 8), abjad.Note(a', 4), abjad.Note(e', 8))"
 

--- a/abjad/core/test/test_VerticalMoment_previous_vertical_moment.py
+++ b/abjad/core/test/test_VerticalMoment_previous_vertical_moment.py
@@ -31,7 +31,7 @@ def test_VerticalMoment_previous_vertical_moment_01():
     selector = abjad.select().leaves()
     leaves = selector(score)
     last_leaf = leaves[-1]
-    vertical_moment = abjad.inspect(last_leaf).get_vertical_moment()
+    vertical_moment = abjad.inspect(last_leaf).vertical_moment()
     assert vertical_moment.offset == abjad.Offset(3, 8)
 
     vertical_moment = vertical_moment.previous_vertical_moment

--- a/abjad/demos/bartok.py
+++ b/abjad/demos/bartok.py
@@ -64,7 +64,7 @@ def make_bartok_score():
 
     # Add bass clef
     clef = abjad.Clef('bass')
-    leaf = abjad.inspect(lower_staff).get_leaf(0)
+    leaf = abjad.inspect(lower_staff).leaf(0)
     abjad.attach(clef, leaf)
 
     # Add dynamics

--- a/abjad/demos/ferneyhough.py
+++ b/abjad/demos/ferneyhough.py
@@ -786,7 +786,7 @@ class FerneyhoughDemo:
         inner_tuplet_proportions = inner_tuplet_subdivision_count * [1]
         selector = abjad.select().leaves()
         last_leaf = selector(outer_tuplet)[-1]
-        right_logical_tie = abjad.inspect(last_leaf).get_logical_tie()
+        right_logical_tie = abjad.inspect(last_leaf).logical_tie()
         right_logical_tie.to_tuplet(inner_tuplet_proportions)
         return outer_tuplet
 
@@ -846,7 +846,7 @@ class FerneyhoughDemo:
             staff = abjad.Staff(row_of_nested_tuplets)
             staff.lilypond_type = 'RhythmicStaff'
             time_signature = abjad.TimeSignature((1, 4))
-            leaf = abjad.inspect(staff).get_leaf(0)
+            leaf = abjad.inspect(staff).leaf(0)
             abjad.attach(time_signature, leaf)
             score.append(staff)
         return score

--- a/abjad/demos/ligeti.py
+++ b/abjad/demos/ligeti.py
@@ -89,7 +89,7 @@ def make_desordre_measure(pitches):
     """
     for sequence in pitches:
         container = make_desordre_cell(sequence)
-        time_signature = abjad.inspect(container).get_duration()
+        time_signature = abjad.inspect(container).duration()
         time_signature = abjad.NonreducedFraction(time_signature)
         time_signature = time_signature.with_denominator(8)
         measure = abjad.Measure(time_signature, [container])
@@ -123,7 +123,7 @@ def make_desordre_score(pitches):
         staff_group.append(staff)
 
     # set clef and key signature to left hand staff
-    leaf = abjad.inspect(staff_group[1]).get_leaf(0)
+    leaf = abjad.inspect(staff_group[1]).leaf(0)
     clef = abjad.Clef('bass')
     abjad.attach(clef, leaf)
     key_signature = abjad.KeySignature('b', 'major')

--- a/abjad/demos/mozart.py
+++ b/abjad/demos/mozart.py
@@ -310,13 +310,13 @@ def make_mozart_score():
         score['LHVoice'].append(bass)
     # abjad.attach indicators
     time_signature = abjad.TimeSignature((3, 8))
-    leaf = abjad.inspect(score['RHStaff']).get_leaf(0)
+    leaf = abjad.inspect(score['RHStaff']).leaf(0)
     abjad.attach(time_signature, leaf)
     bar_line = abjad.BarLine('|.')
-    leaf = abjad.inspect(score['RHStaff']).get_leaf(-1)
+    leaf = abjad.inspect(score['RHStaff']).leaf(-1)
     abjad.attach(bar_line, leaf)
     bar_line = abjad.BarLine('|.')
-    leaf = abjad.inspect(score['LHStaff']).get_leaf(-1)
+    leaf = abjad.inspect(score['LHStaff']).leaf(-1)
     abjad.attach(bar_line, leaf)
     # remove the default piano instrument and add a custom one:
     abjad.detach(abjad.Instrument, score['PianoStaff'])
@@ -324,7 +324,7 @@ def make_mozart_score():
         name='Katzenklavier',
         short_name='kk.',
         )
-    leaf = abjad.inspect(score['PianoStaff']).get_leaf(0)
+    leaf = abjad.inspect(score['PianoStaff']).leaf(0)
     abjad.attach(klavier, leaf)
     return score
 

--- a/abjad/demos/part.py
+++ b/abjad/demos/part.py
@@ -315,16 +315,16 @@ def edit_cello_voice(score, durated_reservoir):
     """
     voice = score['Cello Voice']
     descents = durated_reservoir['Cello']
-    logical_tie = abjad.inspect(voice[-1]).get_logical_tie()
+    logical_tie = abjad.inspect(voice[-1]).logical_tie()
     for leaf in logical_tie.leaves:
-        parent = abjad.inspect(leaf).get_parentage().parent
+        parent = abjad.inspect(leaf).parentage().parent
         index = parent.index(leaf)
         parent[index] = abjad.Chord(['e,', 'a,'], leaf.written_duration)
     selection = voice[-len(descents[-1]):]
     unison_descent = abjad.mutate(selection).copy()
     voice.extend(unison_descent)
     for chord in unison_descent:
-        index = abjad.inspect(chord).get_parentage().parent.index(chord)
+        index = abjad.inspect(chord).parentage().parent.index(chord)
         parent[index] = abjad.Note(
             chord.written_pitches[1], chord.written_duration)
         articulation = abjad.Articulation('accent')
@@ -552,7 +552,7 @@ def apply_final_bar_lines(score):
     """
     for voice in abjad.iterate(score).components(abjad.Voice):
         bar_line = abjad.BarLine('|.')
-        leaf = abjad.inspect(voice).get_leaf(-1)
+        leaf = abjad.inspect(voice).leaf(-1)
         abjad.attach(bar_line, leaf)
 
 
@@ -596,7 +596,7 @@ def configure_score(score):
     """
     # configure bell staff
     bell_staff = score['Bell Staff']
-    leaf = abjad.inspect(bell_staff).get_leaf(0)
+    leaf = abjad.inspect(bell_staff).leaf(0)
     clef = abjad.Clef('treble')
     abjad.attach(clef, leaf)
     bells = abjad.Instrument(
@@ -611,7 +611,7 @@ def configure_score(score):
     abjad.attach(time_signature, leaf)
     # configure first violin staff
     first_violin_staff = score['First Violin Staff']
-    leaf = abjad.inspect(first_violin_staff).get_leaf(0)
+    leaf = abjad.inspect(first_violin_staff).leaf(0)
     clef = abjad.Clef('treble')
     abjad.attach(clef, leaf)
     violin = abjad.Violin(
@@ -621,7 +621,7 @@ def configure_score(score):
     abjad.attach(violin, leaf)
     # configure second violin staff
     second_violin_staff = score['Second Violin Staff']
-    leaf = abjad.inspect(second_violin_staff).get_leaf(0)
+    leaf = abjad.inspect(second_violin_staff).leaf(0)
     clef = abjad.Clef('treble')
     abjad.attach(clef, leaf)
     violin = abjad.Violin(
@@ -630,19 +630,19 @@ def configure_score(score):
         )
     abjad.attach(violin, leaf)
     # configure viola staff
-    leaf = abjad.inspect(score['Viola Staff']).get_leaf(0)
+    leaf = abjad.inspect(score['Viola Staff']).leaf(0)
     clef = abjad.Clef('alto')
     abjad.attach(clef, leaf)
     viola = abjad.Viola()
     abjad.attach(viola, leaf)
     # configure cello staff
-    leaf = abjad.inspect(score['Cello Staff']).get_leaf(0)
+    leaf = abjad.inspect(score['Cello Staff']).leaf(0)
     clef = abjad.Clef('bass')
     abjad.attach(clef, leaf)
     cello = abjad.Cello()
     abjad.attach(cello, leaf)
     # configure bass staff
-    leaf = abjad.inspect(score['Bass Staff']).get_leaf(0)
+    leaf = abjad.inspect(score['Bass Staff']).leaf(0)
     clef = abjad.Clef('bass')
     abjad.attach(clef, leaf)
     contrabass = abjad.Contrabass(

--- a/abjad/indicators/BowMotionTechnique.py
+++ b/abjad/indicators/BowMotionTechnique.py
@@ -35,7 +35,7 @@ class BowMotionTechnique(AbjadValueObject):
         '_technique_name',
         )
 
-    _persistent = True
+    _parameter = True
 
     _publish_storage_format = True
 
@@ -75,17 +75,17 @@ class BowMotionTechnique(AbjadValueObject):
         return 'line'
 
     @property
-    def persistent(self) -> bool:
+    def parameter(self) -> bool:
         """
         Is true.
 
         ..  container:: example
 
-            >>> abjad.BowMotionTechnique('jete').persistent
+            >>> abjad.BowMotionTechnique('jete').parameter
             True
 
         """
-        return self._persistent
+        return self._parameter
 
     @property
     def technique_name(self) -> typing.Optional[str]:

--- a/abjad/indicators/BowPressure.py
+++ b/abjad/indicators/BowPressure.py
@@ -28,7 +28,7 @@ class BowPressure(AbjadValueObject):
         '_pressure',
         )
 
-    _persistent = True
+    _parameter = True
 
     _publish_storage_format = True
 
@@ -40,17 +40,17 @@ class BowPressure(AbjadValueObject):
     ### PUBLIC PROPERTIES ###
 
     @property
-    def persistent(self) -> bool:
+    def parameter(self) -> bool:
         """
         Is true.
 
         ..  container:: example
 
-            >>> abjad.BowPressure('overpressure').persistent
+            >>> abjad.BowPressure('overpressure').parameter
             True
 
         """
-        return self._persistent
+        return self._parameter
 
     @property
     def pressure(self) -> typing.Optional[str]:

--- a/abjad/indicators/Clef.py
+++ b/abjad/indicators/Clef.py
@@ -135,7 +135,7 @@ class Clef(AbjadValueObject):
         But Abjad components work fine:
 
         >>> for leaf in abjad.select(voice_1).leaves():
-        ...     leaf, abjad.inspect(leaf).get_effective(abjad.Clef)
+        ...     leaf, abjad.inspect(leaf).effective(abjad.Clef)
         ...
         (Note("e'8"), Clef('treble'))
         (Note("g'8"), Clef('treble'))
@@ -145,7 +145,7 @@ class Clef(AbjadValueObject):
         (Note("b'8"), Clef('treble'))
 
         >>> for leaf in abjad.select(voice_2).leaves():
-        ...     leaf, abjad.inspect(leaf).get_effective(abjad.Clef)
+        ...     leaf, abjad.inspect(leaf).effective(abjad.Clef)
         ...
         (Note("c'4."), Clef('treble'))
         (Note('c,8'), Clef('bass'))
@@ -181,7 +181,7 @@ class Clef(AbjadValueObject):
 
     _format_slot = 'opening'
 
-    _persistent = True
+    _parameter = True
 
     _redraw = True
 
@@ -386,7 +386,7 @@ class Clef(AbjadValueObject):
             }
 
             >>> for leaf in abjad.iterate(staff).leaves():
-            ...     leaf, abjad.inspect(leaf).get_effective(abjad.Clef)
+            ...     leaf, abjad.inspect(leaf).effective(abjad.Clef)
             ...
             (Note("c'4"), Clef('treble'))
             (Note("d'4"), Clef('treble'))
@@ -441,18 +441,18 @@ class Clef(AbjadValueObject):
         return self._name
 
     @property
-    def persistent(self) -> bool:
+    def parameter(self) -> bool:
         """
         Is true.
 
         ..  container:: example
 
-            >>> abjad.Clef('treble').persistent
+            >>> abjad.Clef('treble').parameter
             True
 
         Class constant.
         """
-        return self._persistent
+        return self._parameter
         
     @property
     def redraw(self) -> bool:

--- a/abjad/indicators/Dynamic.py
+++ b/abjad/indicators/Dynamic.py
@@ -99,7 +99,7 @@ class Dynamic(AbjadValueObject):
             >>
 
         >>> for leaf in abjad.select(staff).leaves():
-        ...     leaf, abjad.inspect(leaf).get_effective(abjad.Dynamic)
+        ...     leaf, abjad.inspect(leaf).effective(abjad.Dynamic)
         ...
         (Note("e'8"), Dynamic('f'))
         (Note("g'8"), Dynamic('f'))
@@ -209,7 +209,7 @@ class Dynamic(AbjadValueObject):
 
     _lilypond_dynamic_alphabet = 'fmprsz'
 
-    _persistent = True
+    _parameter = True
 
     _to_width = {
         '"f"': 2,
@@ -734,7 +734,7 @@ class Dynamic(AbjadValueObject):
             }
 
             >>> for leaf in abjad.iterate(voice).leaves():
-            ...     leaf, abjad.inspect(leaf).get_effective(abjad.Dynamic)
+            ...     leaf, abjad.inspect(leaf).effective(abjad.Dynamic)
             ...
             (Note("c'4"), Dynamic('f'))
             (Note("d'4"), Dynamic('f'))
@@ -1069,17 +1069,17 @@ class Dynamic(AbjadValueObject):
         return ordinal
 
     @property
-    def persistent(self) -> bool:
+    def parameter(self) -> bool:
         """
         Is true.
 
         ..  container:: example
 
-            >>> abjad.Dynamic('f').persistent
+            >>> abjad.Dynamic('f').parameter
             True
 
         """
-        return self._persistent
+        return self._parameter
 
     @property
     def sforzando(self) -> typing.Optional[bool]:

--- a/abjad/indicators/DynamicTrend.py
+++ b/abjad/indicators/DynamicTrend.py
@@ -50,6 +50,8 @@ class DynamicTrend(AbjadValueObject):
         '_tweaks',
         )
 
+    _context = 'Voice'
+
     _crescendo_start = r'\<'
 
     _decrescendo_start = r'\>'
@@ -161,6 +163,52 @@ class DynamicTrend(AbjadValueObject):
             )
 
     ### PUBLIC PROPERTIES ###
+
+    @property
+    def context(self) -> str:
+        r"""
+        Returns (historically conventional) context ``'Voice'``.
+
+        ..  container:: example
+
+            >>> abjad.DynamicTrend('<').context
+            'Voice'
+
+        ..  container:: example
+
+            >>> voice = abjad.Voice("c'4 d' e' f'")
+            >>> abjad.attach(abjad.Dynamic('p'), voice[0])
+            >>> abjad.attach(abjad.DynamicTrend('<'), voice[0])
+            >>> abjad.attach(abjad.Dynamic('f'), voice[-1])
+            >>> abjad.show(voice) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(voice)
+                \new Voice
+                {
+                    c'4
+                    \p
+                    \<
+                    d'4
+                    e'4
+                    f'4
+                    \f
+                }
+
+
+            >>> for leaf in voice:
+            ...     print(leaf, abjad.inspect(leaf).effective(abjad.DynamicTrend))
+            c'4 DynamicTrend(shape='<')
+            d'4 DynamicTrend(shape='<')
+            e'4 DynamicTrend(shape='<')
+            f'4 DynamicTrend(shape='<')
+
+        Class constant.
+
+        Override with ``abjad.attach(..., context='...')``.
+        """
+        return self._context
 
     @property
     def known_shapes(self) -> typing.Tuple[str, ...]:

--- a/abjad/indicators/KeySignature.py
+++ b/abjad/indicators/KeySignature.py
@@ -63,7 +63,7 @@ class KeySignature(AbjadValueObject):
 
     _format_slot = 'opening'
 
-    _persistent = True
+    _parameter = True
     
     _redraw = True
 
@@ -208,18 +208,18 @@ class KeySignature(AbjadValueObject):
         return f'{tonic!s} {self.mode.mode_name!s}'
 
     @property
-    def persistent(self) -> bool:
+    def parameter(self) -> bool:
         """
         Is true.
 
         ..  container:: example
 
-            >>> abjad.KeySignature('e', 'major').persistent
+            >>> abjad.KeySignature('e', 'major').parameter
             True
 
         Class constant.
         """
-        return self._persistent
+        return self._parameter
 
     @property
     def redraw(self) -> bool:

--- a/abjad/indicators/MarginMarkup.py
+++ b/abjad/indicators/MarginMarkup.py
@@ -45,7 +45,7 @@ class MarginMarkup(AbjadValueObject):
 
     _latent = True
 
-    _persistent = True
+    _parameter = True
 
     _publish_storage_format = True
 
@@ -225,7 +225,7 @@ class MarginMarkup(AbjadValueObject):
         return self._markup
 
     @property
-    def persistent(self) -> bool:
+    def parameter(self) -> bool:
         """
         Is true.
 
@@ -234,12 +234,12 @@ class MarginMarkup(AbjadValueObject):
             >>> margin_markup = abjad.MarginMarkup(
             ...     markup=abjad.Markup('Vc.'),
             ...     )
-            >>> margin_markup.persistent
+            >>> margin_markup.parameter
             True
 
         Class constant.
         """
-        return self._persistent
+        return self._parameter
 
     @property
     def redraw(self) -> bool:

--- a/abjad/indicators/MetricModulation.py
+++ b/abjad/indicators/MetricModulation.py
@@ -698,10 +698,6 @@ class MetricModulation(AbjadValueObject):
         '_right_rhythm',
         )
 
-    _context = 'Score'
-
-    _persistent = 'abjad.MetronomeMark'
-
     _publish_storage_format = True
 
     ### INITIALIZER ###
@@ -1077,24 +1073,6 @@ class MetricModulation(AbjadValueObject):
     ### PUBLIC PROPERTIES ###
 
     @property
-    def context(self) -> str:
-        """
-        Gets (historically conventional) context.
-
-        ..  container:: example
-
-            >>> metric_modulation = abjad.MetricModulation(
-            ...     left_rhythm=abjad.Note("c'4"),
-            ...     right_rhythm=abjad.Note("c'4."),
-            ...     )
-            >>> metric_modulation.context
-            'Score'
-
-        Override with ``abjad.attach(..., context='...')``.
-        """
-        return self._context
-
-    @property
     def hide(self) -> typing.Optional[bool]:
         """
         Is true when metric modulation generates no LilyPond output.
@@ -1136,23 +1114,6 @@ class MetricModulation(AbjadValueObject):
         return self._left_rhythm
 
     @property
-    def persistent(self) -> str:
-        """
-        Is ``'abjad.MetronomeMark'``.
-
-        ..  container:: example
-
-            >>> metric_modulation = abjad.MetricModulation(
-            ...     left_rhythm=abjad.Note("c'4"),
-            ...     right_rhythm=abjad.Note("c'4."),
-            ...     )
-            >>> metric_modulation.persistent
-            'abjad.MetronomeMark'
-
-        """
-        return self._persistent
-
-    @property
     def ratio(self) -> Ratio:
         """
         Gets ratio of metric modulation.
@@ -1167,8 +1128,8 @@ class MetricModulation(AbjadValueObject):
             Ratio((2, 3))
 
         """
-        left_duration = inspect(self.left_rhythm).get_duration()
-        right_duration = inspect(self.right_rhythm).get_duration()
+        left_duration = inspect(self.left_rhythm).duration()
+        right_duration = inspect(self.right_rhythm).duration()
         duration = left_duration / right_duration
         ratio = Ratio(duration.pair)
         return ratio

--- a/abjad/indicators/MetronomeMark.py
+++ b/abjad/indicators/MetronomeMark.py
@@ -254,7 +254,7 @@ class MetronomeMark(AbjadValueObject):
 
     _format_slot = 'opening'
 
-    _persistent = 'abjad.MetronomeMark'
+    _parameter = 'METRONOME_MARK'
 
     ### INITIALIZER ###
 
@@ -1013,7 +1013,7 @@ class MetronomeMark(AbjadValueObject):
 
             >>> for leaf in abjad.iterate(staff).leaves():
             ...     prototype = abjad.MetronomeMark
-            ...     leaf, abjad.inspect(leaf).get_effective(prototype)
+            ...     leaf, abjad.inspect(leaf).effective(prototype)
             ...
             (Note("c'4"), MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=72))
             (Note("d'4"), MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=72))
@@ -1059,17 +1059,17 @@ class MetronomeMark(AbjadValueObject):
         return True
 
     @property
-    def persistent(self) -> str:
+    def parameter(self) -> str:
         """
-        Is ``'abjad.MetronomeMark'``.
+        Is ``'METRONOME_MARK'``.
 
         ..  container:: example
 
-            >>> abjad.MetronomeMark((1, 8), 52).persistent
-            'abjad.MetronomeMark'
+            >>> abjad.MetronomeMark((1, 8), 52).parameter
+            'METRONOME_MARK'
 
         """
-        return self._persistent
+        return self._parameter
 
     @property
     def quarters_per_minute(self) -> typing.Union[tuple, None, Fraction]:

--- a/abjad/indicators/StringContactPoint.py
+++ b/abjad/indicators/StringContactPoint.py
@@ -56,7 +56,7 @@ class StringContactPoint(AbjadValueObject):
         'sul tasto',
         )
 
-    _persistent = True
+    _parameter = True
 
     _publish_storage_format = True
 
@@ -140,17 +140,17 @@ class StringContactPoint(AbjadValueObject):
         return markup
 
     @property
-    def persistent(self) -> bool:
+    def parameter(self) -> bool:
         """
         Is true.
 
         ..  container:: example
 
-            >>> abjad.StringContactPoint('sul tasto').persistent
+            >>> abjad.StringContactPoint('sul tasto').parameter
             True
 
         """
-        return self._persistent
+        return self._parameter
 
     @property
     def tweaks(self) -> None:

--- a/abjad/indicators/TimeSignature.py
+++ b/abjad/indicators/TimeSignature.py
@@ -120,7 +120,7 @@ class TimeSignature(AbjadValueObject):
 
     _format_slot = 'opening'
 
-    _persistent = True
+    _parameter = True
 
     ### INITIALIZER ###
 
@@ -428,7 +428,7 @@ class TimeSignature(AbjadValueObject):
 
             >>> for leaf in abjad.iterate(staff).leaves():
             ...     prototype = abjad.TimeSignature 
-            ...     leaf, abjad.inspect(leaf).get_effective(prototype)
+            ...     leaf, abjad.inspect(leaf).effective(prototype)
             ...
             (Note("c'4"), TimeSignature((4, 4)))
             (Note("d'4"), TimeSignature((4, 4)))
@@ -502,17 +502,17 @@ class TimeSignature(AbjadValueObject):
         return self._partial
 
     @property
-    def persistent(self) -> bool:
+    def parameter(self) -> bool:
         """
         Is true.
 
         ..  container:: example
 
-            >>> abjad.TimeSignature((3, 8)).persistent
+            >>> abjad.TimeSignature((3, 8)).parameter
             True
 
         """
-        return self._persistent
+        return self._parameter
 
     @property
     def tweaks(self) -> None:

--- a/abjad/instruments.py
+++ b/abjad/instruments.py
@@ -54,7 +54,7 @@ class Instrument(AbjadValueObject):
             >>
 
         >>> for leaf in abjad.select(voice_1).leaves():
-        ...     leaf, abjad.inspect(leaf).get_effective(abjad.Instrument)
+        ...     leaf, abjad.inspect(leaf).effective(abjad.Instrument)
         ...
         (Note("e'8"), Flute())
         (Note("g'8"), Flute())
@@ -62,7 +62,7 @@ class Instrument(AbjadValueObject):
         (Note("a'8"), Flute())
 
         >>> for leaf in abjad.select(voice_2).leaves():
-        ...     leaf, abjad.inspect(leaf).get_effective(abjad.Instrument)
+        ...     leaf, abjad.inspect(leaf).effective(abjad.Instrument)
         ...
         (Note("c'2"), Viola())
 
@@ -89,7 +89,7 @@ class Instrument(AbjadValueObject):
 
     _latent = True
 
-    _persistent = 'abjad.Instrument'
+    _parameter = 'INSTRUMENT'
 
     _publish_storage_format = True
 
@@ -269,15 +269,13 @@ class Instrument(AbjadValueObject):
         return self._name
 
     @property
-    def persistent(self):
+    def parameter(self) -> str:
         """
-        Is set to ``'abjad.Instrument'`` for all instruments.
+        Is set to ``'INSTRUMENT'`` for all instruments.
 
         Class constant.
-
-        Returns true.
         """
-        return self._persistent
+        return self._parameter
 
     @property
     def pitch_range(self):
@@ -377,7 +375,7 @@ class Instrument(AbjadValueObject):
         """
         import abjad
         for leaf in abjad.iterate(argument).leaves(pitched=True):
-            instrument = abjad.inspect(leaf).get_effective(abjad.Instrument)
+            instrument = abjad.inspect(leaf).effective(abjad.Instrument)
             if not instrument:
                 continue
             sounding_pitch = instrument.middle_c_sounding_pitch
@@ -436,7 +434,7 @@ class Instrument(AbjadValueObject):
         """
         import abjad
         for leaf in abjad.iterate(argument).leaves(pitched=True):
-            instrument = abjad.inspect(leaf).get_effective(abjad.Instrument)
+            instrument = abjad.inspect(leaf).effective(abjad.Instrument)
             if not instrument:
                 continue
             sounding_pitch = instrument.middle_c_sounding_pitch
@@ -2240,7 +2238,7 @@ class Flute(Instrument):
         }
 
         >>> for leaf in abjad.select(staff).leaves():
-        ...     leaf, abjad.inspect(leaf).get_effective(abjad.Instrument)
+        ...     leaf, abjad.inspect(leaf).effective(abjad.Instrument)
         ...
         (Note("c'4"), Flute())
         (Note("d'4"), Flute())

--- a/abjad/lilypondfile/LilyPondFile.py
+++ b/abjad/lilypondfile/LilyPondFile.py
@@ -1406,7 +1406,7 @@ class LilyPondFile(AbjadObject):
                     break
         if isinstance(selections, list):
             if divisions is None:
-                duration = abjad_inspect(selections).get_duration()
+                duration = abjad_inspect(selections).duration()
                 divisions = [duration]
             time_signatures = time_signatures or divisions
             maker = MeasureMaker(implicit_scaling=implicit_scaling)
@@ -1451,7 +1451,7 @@ class LilyPondFile(AbjadObject):
                 voices.append(voice)
             staff = Staff(voices, is_simultaneous=True)
             if divisions is None:
-                duration = abjad_inspect(staff).get_duration()
+                duration = abjad_inspect(staff).duration()
                 divisions = [duration]
         else:
             message = 'must be list or dictionary of selections:'

--- a/abjad/meter.py
+++ b/abjad/meter.py
@@ -836,7 +836,7 @@ class Meter(AbjadValueObject):
                 )
             #print('DEPTH:', depth)
             logical_tie_duration = logical_tie._get_preprolated_duration()
-            logical_tie_timespan = abjad.inspect(logical_tie).get_timespan()
+            logical_tie_timespan = abjad.inspect(logical_tie).timespan()
             logical_tie_start_offset = logical_tie_timespan.start_offset
             logical_tie_stop_offset = logical_tie_timespan.stop_offset
             logical_tie_starts_in_offsets = logical_tie_start_offset in offsets
@@ -941,15 +941,15 @@ class Meter(AbjadValueObject):
             initial_offset = abjad.Offset(0)
         initial_offset = abjad.Offset(initial_offset)
         first_start_offset = abjad.inspect(
-            components[0]).get_timespan().start_offset
+            components[0]).timespan().start_offset
         last_start_offset = abjad.inspect(
-            components[-1]).get_timespan().start_offset
+            components[-1]).timespan().start_offset
         difference = last_start_offset - first_start_offset + initial_offset
         assert difference < meter.implied_time_signature.duration
         # Build offset inventory, adjusted for initial offset and prolation.
-        first_offset = abjad.inspect(components[0]).get_timespan().start_offset
+        first_offset = abjad.inspect(components[0]).timespan().start_offset
         first_offset -= initial_offset
-        prolation = abjad.inspect(components[0]).get_parentage(
+        prolation = abjad.inspect(components[0]).parentage(
             include_self=False).prolation
         offset_inventory = []
         for offsets in meter.depthwise_offset_inventory:
@@ -2113,8 +2113,8 @@ class OffsetCounter(TypedCounter):
                     self[item.stop_offset] += 1
                 except Exception:
                     if hasattr(item, '_get_timespan'):
-                        self[abjad.inspect(item).get_timespan().start_offset] += 1
-                        self[abjad.inspect(item).get_timespan().stop_offset] += 1
+                        self[abjad.inspect(item).timespan().start_offset] += 1
+                        self[abjad.inspect(item).timespan().stop_offset] += 1
                     else:
                         offset = abjad.Offset(item)
                         self[offset] += 1

--- a/abjad/parser/LilyPondParser.py
+++ b/abjad/parser/LilyPondParser.py
@@ -777,10 +777,10 @@ class LilyPondParser(Parser):
 
     def _get_span_events(self, leaf):
         import abjad
-        annotation = abjad.inspect(leaf).get_annotation('spanners', [])
+        annotation = abjad.inspect(leaf).annotation('spanners', [])
         abjad.detach(annotation, leaf)
         assert isinstance(annotation, list), repr(annotation)
-        assert abjad.inspect(leaf).get_annotation('spanners') is None
+        assert abjad.inspect(leaf).annotation('spanners') is None
         return annotation
 
     def _pop_variable_scope(self):
@@ -807,7 +807,7 @@ class LilyPondParser(Parser):
             elif isinstance(post_event, nonspanner_post_event_types):
                 attach(post_event, leaf)
             else:
-                annotation = abjad.inspect(leaf).get_annotation('spanners')
+                annotation = abjad.inspect(leaf).annotation('spanners')
                 if annotation is None:
                     annotation = []
                     abjad.annotate(leaf, 'spanners', annotation)

--- a/abjad/parser/test/test_LilyPondParser__indicators__Articulation.py
+++ b/abjad/parser/test/test_LilyPondParser__indicators__Articulation.py
@@ -50,7 +50,7 @@ def test_LilyPondParser__indicators__Articulation_01():
     assert format(target) == format(result) and \
         target is not result
     for x in result:
-        assert 1 == len(abjad.inspect(x).get_indicators(abjad.Articulation))
+        assert 1 == len(abjad.inspect(x).indicators(abjad.Articulation))
 
 
 def test_LilyPondParser__indicators__Articulation_02():
@@ -84,7 +84,7 @@ def test_LilyPondParser__indicators__Articulation_02():
     result = parser(string)
     assert format(target) == format(result) and \
         target is not result
-    assert 7 == len(abjad.inspect(result[0]).get_indicators(abjad.Articulation))
+    assert 7 == len(abjad.inspect(result[0]).indicators(abjad.Articulation))
 
 
 def test_LilyPondParser__indicators__Articulation_03():
@@ -126,4 +126,4 @@ def test_LilyPondParser__indicators__Articulation_03():
     assert format(target) == format(result) and \
         target is not result
     for x in result:
-        assert 1 == len(abjad.inspect(x).get_indicators(abjad.Articulation))
+        assert 1 == len(abjad.inspect(x).indicators(abjad.Articulation))

--- a/abjad/parser/test/test_LilyPondParser__indicators__BarLine.py
+++ b/abjad/parser/test/test_LilyPondParser__indicators__BarLine.py
@@ -24,5 +24,5 @@ def test_LilyPondParser__indicators__BarLine_01():
     parser = abjad.parser.LilyPondParser()
     result = parser(format(target))
     assert format(target) == format(result) and target is not result
-    items = abjad.inspect(result[2]).get_indicators()
+    items = abjad.inspect(result[2]).indicators()
     assert 1 == len(items) and isinstance(items[0], abjad.BarLine)

--- a/abjad/parser/test/test_LilyPondParser__indicators__Clef.py
+++ b/abjad/parser/test/test_LilyPondParser__indicators__Clef.py
@@ -20,5 +20,5 @@ def test_LilyPondParser__indicators__Clef_01():
     parser = abjad.parser.LilyPondParser()
     result = parser(format(target))
     assert format(target) == format(result) and target is not result
-    clefs = abjad.inspect(result[0]).get_indicators(abjad.Clef)
+    clefs = abjad.inspect(result[0]).indicators(abjad.Clef)
     assert len(clefs) == 1

--- a/abjad/parser/test/test_LilyPondParser__indicators__Dynamic.py
+++ b/abjad/parser/test/test_LilyPondParser__indicators__Dynamic.py
@@ -24,5 +24,5 @@ def test_LilyPondParser__indicators__Dynamic_01():
     result = parser(string)
     assert format(target) == format(result) and target is not result
     for x in result:
-        dynamics = abjad.inspect(x).get_indicators(abjad.Dynamic)
+        dynamics = abjad.inspect(x).indicators(abjad.Dynamic)
         assert len(dynamics) == 1

--- a/abjad/parser/test/test_LilyPondParser__indicators__KeySignature.py
+++ b/abjad/parser/test/test_LilyPondParser__indicators__KeySignature.py
@@ -20,5 +20,5 @@ def test_LilyPondParser__indicators__KeySignature_01():
     parser = abjad.parser.LilyPondParser()
     result = parser(format(target))
     assert format(target) == format(result) and target is not result
-    key_signatures = abjad.inspect(result[0]).get_indicators(abjad.KeySignature)
+    key_signatures = abjad.inspect(result[0]).indicators(abjad.KeySignature)
     assert len(key_signatures) == 1

--- a/abjad/parser/test/test_LilyPondParser__indicators__Markup.py
+++ b/abjad/parser/test/test_LilyPondParser__indicators__Markup.py
@@ -23,7 +23,7 @@ def test_LilyPondParser__indicators__Markup_01():
     result = parser(string)
     assert format(target, 'lilypond') == format(result, 'lilypond') and \
         target is not result
-    assert 1 == len(abjad.inspect(result[0]).get_markup())
+    assert 1 == len(abjad.inspect(result[0]).markup())
 
 
 def test_LilyPondParser__indicators__Markup_02():
@@ -53,7 +53,7 @@ def test_LilyPondParser__indicators__Markup_02():
     result = parser(string)
     assert format(target, 'lilypond') == format(result, 'lilypond') and \
         target is not result
-    assert 1 == len(abjad.inspect(result[0]).get_markup())
+    assert 1 == len(abjad.inspect(result[0]).markup())
 
 
 def test_LilyPondParser__indicators__Markup_03():
@@ -86,7 +86,7 @@ def test_LilyPondParser__indicators__Markup_03():
     result = parser(string)
     assert format(target, 'lilypond') == format(result, 'lilypond') and \
         target is not result
-    assert 1 == len(abjad.inspect(result[0]).get_markup())
+    assert 1 == len(abjad.inspect(result[0]).markup())
 
 
 def test_LilyPondParser__indicators__Markup_04():

--- a/abjad/parser/test/test_LilyPondParser__indicators__MetronomeMark.py
+++ b/abjad/parser/test/test_LilyPondParser__indicators__MetronomeMark.py
@@ -26,7 +26,7 @@ def test_LilyPondParser__indicators__MetronomeMark_01():
     assert format(target) == format(result) and target is not result
     leaves = abjad.select(result).leaves()
     leaf = leaves[0]
-    marks = abjad.inspect(leaf).get_indicators(abjad.MetronomeMark)
+    marks = abjad.inspect(leaf).indicators(abjad.MetronomeMark)
     assert len(marks) == 1
 
 
@@ -55,7 +55,7 @@ def test_LilyPondParser__indicators__MetronomeMark_02():
     assert format(target) == format(result) and target is not result
     leaves = abjad.select(result).leaves()
     leaf = leaves[0]
-    marks = abjad.inspect(leaf).get_indicators(abjad.MetronomeMark)
+    marks = abjad.inspect(leaf).indicators(abjad.MetronomeMark)
     assert len(marks) == 1
 
 
@@ -84,7 +84,7 @@ def test_LilyPondParser__indicators__MetronomeMark_03():
     assert format(target) == format(result) and target is not result
     leaves = abjad.select(result).leaves()
     leaf = leaves[0]
-    marks = abjad.inspect(leaf).get_indicators(abjad.MetronomeMark)
+    marks = abjad.inspect(leaf).indicators(abjad.MetronomeMark)
     assert len(marks) == 1
 
 
@@ -117,7 +117,7 @@ def test_LilyPondParser__indicators__MetronomeMark_04():
     assert format(target) == format(result) and target is not result
     leaves = abjad.select(result).leaves()
     leaf = leaves[0]
-    marks = abjad.inspect(leaf).get_indicators(abjad.MetronomeMark)
+    marks = abjad.inspect(leaf).indicators(abjad.MetronomeMark)
     assert len(marks) == 1
 
 
@@ -150,5 +150,5 @@ def test_LilyPondParser__indicators__MetronomeMark_05():
     assert format(target) == format(result) and target is not result
     leaves = abjad.select(result).leaves()
     leaf = leaves[0]
-    marksn = abjad.inspect(leaf).get_indicators(abjad.MetronomeMark)
+    marksn = abjad.inspect(leaf).indicators(abjad.MetronomeMark)
     assert len(marksn) == 1

--- a/abjad/parser/test/test_LilyPondParser__indicators__StemTremolo.py
+++ b/abjad/parser/test/test_LilyPondParser__indicators__StemTremolo.py
@@ -20,5 +20,5 @@ def test_LilyPondParser__indicators__StemTremolo_01():
     parser = abjad.parser.LilyPondParser()
     result = parser(format(target))
     assert format(target) == format(result) and target is not result
-    stem_tremolos = abjad.inspect(result[0]).get_indicators(abjad.StemTremolo)
+    stem_tremolos = abjad.inspect(result[0]).indicators(abjad.StemTremolo)
     assert 1 == len(stem_tremolos)

--- a/abjad/parser/test/test_LilyPondParser__indicators__TimeSignature.py
+++ b/abjad/parser/test/test_LilyPondParser__indicators__TimeSignature.py
@@ -25,5 +25,5 @@ def test_LilyPondParser__indicators__TimeSignature_01():
     assert format(target) == format(result) and target is not result
     leaves = abjad.select(result).leaves()
     leaf = leaves[0]
-    time_signatures = abjad.inspect(leaf).get_indicators(abjad.TimeSignature)
+    time_signatures = abjad.inspect(leaf).indicators(abjad.TimeSignature)
     assert len(time_signatures) == 1

--- a/abjad/parser/test/test_LilyPondParser__spanners__Beam.py
+++ b/abjad/parser/test/test_LilyPondParser__spanners__Beam.py
@@ -128,7 +128,7 @@ def test_LilyPondParser__spanners__Beam_06():
 
     string = "{ c'8 c'8 c'8 c'8 ] }"
     result = abjad.parser.LilyPondParser()(string)
-    assert not abjad.inspect(result[-1]).get_spanners()
+    assert not abjad.inspect(result[-1]).spanners()
 
 
 def test_LilyPondParser__spanners__Beam_07():

--- a/abjad/pitch/PitchRange.py
+++ b/abjad/pitch/PitchRange.py
@@ -228,7 +228,7 @@ class PitchRange(AbjadValueObject):
         import abjad
         if (
             hasattr(argument, '_has_effective_indicator') and
-            'unpitched' in abjad.inspect(argument).get_indicators(str)
+            'unpitched' in abjad.inspect(argument).indicators(str)
             ):
             return True
         elif isinstance(argument, (int, float)):
@@ -237,10 +237,10 @@ class PitchRange(AbjadValueObject):
         elif isinstance(argument, abjad.NamedPitch):
             return self._contains_pitch(argument)
         elif isinstance(argument, abjad.Note):
-            sounding_pitch = abjad.inspect(argument).get_sounding_pitch()
+            sounding_pitch = abjad.inspect(argument).sounding_pitch()
             return self._contains_pitch(sounding_pitch)
         elif isinstance(argument, abjad.Chord):
-            sounding_pitches = abjad.inspect(argument).get_sounding_pitches()
+            sounding_pitches = abjad.inspect(argument).sounding_pitches()
             return all(self._contains_pitch(x) for x in sounding_pitches)
         elif isinstance(argument, (abjad.Rest, abjad.Skip)):
             return True

--- a/abjad/rhythmtrees.py
+++ b/abjad/rhythmtrees.py
@@ -618,7 +618,7 @@ class RhythmTreeContainer(RhythmTreeMixin, uqbar.containers.UniqueTreeContainer)
                         tie = abjad.Tie()
                         abjad.attach(tie, leaves)
             assert tuplet.multiplier == 1, repr(tuplet.multiplier)
-            contents_duration = abjad.inspect(tuplet).get_duration()
+            contents_duration = abjad.inspect(tuplet).duration()
             target_duration = tuplet_duration
             multiplier = target_duration / contents_duration
             tuplet.multiplier = multiplier

--- a/abjad/scheme.py
+++ b/abjad/scheme.py
@@ -648,7 +648,7 @@ class SchemePair(Scheme):
 
     ..  container:: example
 
-        Regression tests:
+        REGRESSION:
 
         Right-hand side string forces quotes:
 

--- a/abjad/segments/Momento.py
+++ b/abjad/segments/Momento.py
@@ -11,9 +11,9 @@ class Momento(AbjadObject):
     ### CLASS VARIABLES ###
 
     __slots__ = (
-        '_absent',
         '_context',
         '_edition',
+        '_manifest',
         '_prototype',
         '_value',
         )
@@ -22,15 +22,12 @@ class Momento(AbjadObject):
 
     def __init__(
         self, 
-        absent: bool = None,
         context: str = None,
         edition: typing.Union[str, Tag] = None,
+        manifest: str = None,
         prototype: str = None,
         value: typing.Any = None,
         ) -> None:
-        if absent is not None:
-            absent = bool(absent)
-        self._absent = absent
         if context is not None:
             assert isinstance(context, str), repr(context)
         self._context = context
@@ -38,22 +35,20 @@ class Momento(AbjadObject):
         if edition is not None:
             edition_ = Tag(edition)
         self._edition = edition_
+        if manifest is not None:
+            assert isinstance(manifest, str), repr(manifest)
+            assert prototype is None
+        self._manifest = manifest
         if prototype is not None:
             assert isinstance(prototype, str), repr(prototype)
+            assert manifest is None
         self._prototype = prototype
         if value is not None:
-            if not isinstance(value, (int, str)):
-                assert type(value).__name__ == 'PersistentOverride'
+            if not isinstance(value, (int, str, dict)):
+                assert type(value).__name__ == 'PersistentOverride', repr(value)
         self._value = value
 
     ### PUBLIC PROPERTIES ###
-
-    @property
-    def absent(self) -> typing.Optional[bool]:
-        """
-        Is true when context is absent in this segment.
-        """
-        return self._absent
 
     @property
     def context(self) -> typing.Optional[str]:
@@ -68,6 +63,13 @@ class Momento(AbjadObject):
         Gets edition.
         """
         return self._edition
+
+    @property
+    def manifest(self) -> typing.Optional[str]:
+        """
+        Gets manifest.
+        """
+        return self._manifest
 
     @property
     def prototype(self) -> typing.Optional[str]:

--- a/abjad/segments/PersistentOverride.py
+++ b/abjad/segments/PersistentOverride.py
@@ -39,7 +39,7 @@ class PersistentOverride(AbjadObject):
         '_value',
         )
 
-    _persistent = True
+    _parameter = True
     
     _publish_storage_format = True
 
@@ -159,7 +159,7 @@ class PersistentOverride(AbjadObject):
         bundle = LilyPondFormatBundle()
         if self.hide:
             return bundle
-        #staff = abjad.inspect(component).get_parentage().get_first(abjad.Staff)
+        #staff = abjad.inspect(component).parentage().get_first(abjad.Staff)
         #strings = self._get_lilypond_format(context=staff)
         strings = self._get_lilypond_format()
         bundle.before.commands.extend(strings)
@@ -268,9 +268,9 @@ class PersistentOverride(AbjadObject):
         return self._hide
 
     @property
-    def persistent(self) -> bool:
+    def parameter(self) -> bool:
         """
-        Is class constant true.
+        Is true.
 
         ..  container:: example
 
@@ -281,11 +281,12 @@ class PersistentOverride(AbjadObject):
             ...     value=(-2, 0),
             ...     )
 
-            >>> override.persistent
+            >>> override.parameter
             True
 
+        Class constant.
         """
-        return self._persistent
+        return self._parameter
 
     @property
     def value(self) -> typing.Optional[str]:

--- a/abjad/segments/ScoreTemplate.py
+++ b/abjad/segments/ScoreTemplate.py
@@ -187,34 +187,34 @@ class ScoreTemplate(AbjadValueObject):
             for voice in voices:
                 leaves = select(voice).leaves()
                 if not all(isinstance(_, empty_prototype) for _ in leaves):
-                    leaf = inspect(voice).get_leaf(0)
+                    leaf = inspect(voice).leaf(0)
             # otherwise, find first leaf in voice in non-removable staff
             if leaf is None:
                 for voice in voices:
                     voice_might_vanish = False
-                    for component in inspect(voice).get_parentage():
-                        if inspect(component).get_annotation(tag) is True:
+                    for component in inspect(voice).parentage():
+                        if inspect(component).annotation(tag) is True:
                             voice_might_vanish = True
                     if not voice_might_vanish:
-                        leaf = inspect(voice).get_leaf(0)
+                        leaf = inspect(voice).leaf(0)
                         if leaf is not None:    
                             break
             # otherwise, as last resort find first leaf in first voice
             if leaf is None:
-                leaf = inspect(voices[0]).get_leaf(0)
+                leaf = inspect(voices[0]).leaf(0)
             if leaf is None:
                 continue
-            instrument = inspect(leaf).get_indicator(instruments.Instrument)
+            instrument = inspect(leaf).indicator(instruments.Instrument)
             if instrument is None:
                 string = 'default_instrument'
-                instrument = inspect(staff__group).get_annotation(string)
+                instrument = inspect(staff__group).annotation(string)
                 if instrument is not None:
                     wrapper = attach(instrument, leaf, tag='ST1', wrapper=True)
                     wrappers.append(wrapper)
-            margin_markup = inspect(leaf).get_indicator(MarginMarkup)
+            margin_markup = inspect(leaf).indicator(MarginMarkup)
             if margin_markup is None:
                 string = 'default_margin_markup'
-                margin_markup = inspect(staff__group).get_annotation(string)
+                margin_markup = inspect(staff__group).annotation(string)
                 if margin_markup is not None:
                     wrapper = attach(
                         margin_markup,
@@ -224,11 +224,11 @@ class ScoreTemplate(AbjadValueObject):
                         )
                     wrappers.append(wrapper)
         for staff in staves:
-            leaf = inspect(staff).get_leaf(0)
-            clef = inspect(leaf).get_indicator(Clef)
+            leaf = inspect(staff).leaf(0)
+            clef = inspect(leaf).indicator(Clef)
             if clef is not None:
                 continue
-            clef = inspect(staff).get_annotation('default_clef')
+            clef = inspect(staff).annotation('default_clef')
             if clef is not None:
                 wrapper = attach(clef, leaf, tag='ST3', wrapper=True)
                 wrappers.append(wrapper)

--- a/abjad/segments/SegmentMaker.py
+++ b/abjad/segments/SegmentMaker.py
@@ -113,7 +113,7 @@ class SegmentMaker(AbjadObject):
                     assert container_identifier.is_lilypond_identifier()
                     assert container_identifier not in \
                         container_to_part_assignment
-                    timespan = inspect(container).get_timespan()
+                    timespan = inspect(container).timespan()
                     pair = (part, timespan)
                     container_to_part_assignment[container_identifier] = pair
                     container.identifier = f'%*% {container_identifier}'

--- a/abjad/spanners/Beam.py
+++ b/abjad/spanners/Beam.py
@@ -209,7 +209,7 @@ class Beam(Spanner):
             left, right = self._get_left_right_for_exterior_leaf(leaf)
         elif self._is_just_left_of_gap(leaf):
             left = leaf.written_duration.flag_count
-            next_leaf = inspect(leaf).get_leaf(1)
+            next_leaf = inspect(leaf).leaf(1)
             if self._is_beamable(
                 next_leaf,
                 beam_rests=self.beam_rests,
@@ -218,7 +218,7 @@ class Beam(Spanner):
             else:
                 right = 0
         elif self._is_just_right_of_gap(leaf):
-            previous_leaf = inspect(leaf).get_leaf(-1)
+            previous_leaf = inspect(leaf).leaf(-1)
             if self._is_beamable(
                 previous_leaf,
                 beam_rests=self.beam_rests,
@@ -265,14 +265,14 @@ class Beam(Spanner):
         if self.stemlet_length is None:
             return
         if leaf is self[0]:
-            parentage = inspect(leaf).get_parentage()
+            parentage = inspect(leaf).parentage()
             staff = parentage.get_first(Staff)
             lilypond_type = staff.lilypond_type
             string = r'\override {}.Stem.stemlet-length = {}'
             string = string.format(lilypond_type, self.stemlet_length)
             bundle.before.commands.append(string)
         if leaf is self[-1]:
-            parentage = inspect(leaf).get_parentage()
+            parentage = inspect(leaf).parentage()
             staff = parentage.get_first(Staff)
             lilypond_type = staff.lilypond_type
             string = r'\revert {}.Stem.stemlet-length'
@@ -300,8 +300,8 @@ class Beam(Spanner):
         self, left, right = Spanner._fracture_left(self, i)
         if self.durations:
             weights = [
-                inspect(left).get_duration(),
-                inspect(right).get_duration(),
+                inspect(left).duration(),
+                inspect(right).duration(),
                 ]
             assert sum(self.durations) == sum(weights)
             split_durations = sequence(self.durations)
@@ -319,8 +319,8 @@ class Beam(Spanner):
         self, left, right = Spanner._fracture_right(self, i)
         if self.durations:
             weights = [
-                inspect(left).get_duration(),
-                inspect(right).get_duration(),
+                inspect(left).duration(),
+                inspect(right).duration(),
                 ]
             assert sum(self.durations) == sum(weights)
             split_durations = sequence(self.durations)

--- a/abjad/spanners/BowContactSpanner.py
+++ b/abjad/spanners/BowContactSpanner.py
@@ -229,11 +229,11 @@ class BowContactSpanner(Spanner):
         bow_contact_point = None
         prototype = BowContactPoint
         if inspector.has_indicator(prototype):
-            bow_contact_point = inspector.get_indicator(prototype)
+            bow_contact_point = inspector.indicator(prototype)
         bow_motion_technique = None
         prototype = BowMotionTechnique
         if inspector.has_indicator(prototype):
-            bow_motion_technique = inspector.get_indicator(prototype)
+            bow_motion_technique = inspector.indicator(prototype)
         return (
             bow_contact_point,
             bow_motion_technique,
@@ -314,18 +314,18 @@ class BowContactSpanner(Spanner):
         ):
         cautionary_change = False
         direction_change = None
-        next_leaf = inspect(leaf).get_leaf(1)
+        next_leaf = inspect(leaf).leaf(1)
         this_contact_point = bow_contact_point
         if this_contact_point is None:
             return
-        next_contact_point = inspect(next_leaf).get_indicator(BowContactPoint)
+        next_contact_point = inspect(next_leaf).indicator(BowContactPoint)
         if next_contact_point is None:
             return
-        previous_leaf = inspect(leaf).get_leaf(-1)
+        previous_leaf = inspect(leaf).leaf(-1)
         previous_contact_point = None
         if previous_leaf is not None:
             previous_contact_points = inspect(previous_leaf
-                ).get_indicators(BowContactPoint)
+                ).indicators(BowContactPoint)
             if previous_contact_points:
                 previous_contact_point = previous_contact_points[0]
         if (leaf is self[0] or
@@ -337,8 +337,8 @@ class BowContactSpanner(Spanner):
             elif next_contact_point < this_contact_point:
                 direction_change = enums.Up
         else:
-            previous_leaf = inspect(leaf).get_leaf(-1)
-            previous_contact_point = inspect(previous_leaf).get_indicator(
+            previous_leaf = inspect(leaf).leaf(-1)
+            previous_contact_point = inspect(previous_leaf).indicator(
                 BowContactPoint)
             if (previous_contact_point < this_contact_point and
                 next_contact_point < this_contact_point):
@@ -406,10 +406,10 @@ class BowContactSpanner(Spanner):
             Rest,
             Skip,
             )
-        next_leaf = inspect(leaf).get_leaf(1)
+        next_leaf = inspect(leaf).leaf(1)
         if next_leaf is None or isinstance(next_leaf, prototype):
             return False
-        next_contact_point = inspect(next_leaf).get_indicator(BowContactPoint)
+        next_contact_point = inspect(next_leaf).indicator(BowContactPoint)
         if next_contact_point is None:
             return False
         elif next_contact_point.contact_point is None:

--- a/abjad/spanners/Glissando.py
+++ b/abjad/spanners/Glissando.py
@@ -183,12 +183,12 @@ class Glissando(Spanner):
 
     @staticmethod
     def _is_last_in_tie_chain(leaf):
-        logical_tie = inspect(leaf).get_logical_tie()
+        logical_tie = inspect(leaf).logical_tie()
         return leaf is logical_tie[-1]
 
     @staticmethod
     def _next_leaf_changes_current_pitch(leaf):
-        next_leaf = inspect(leaf).get_leaf(n=1)
+        next_leaf = inspect(leaf).leaf(n=1)
         if (isinstance(leaf, Note) and
             isinstance(next_leaf, Note) and
             leaf.written_pitch == next_leaf.written_pitch):
@@ -209,7 +209,7 @@ class Glissando(Spanner):
 
     @staticmethod
     def _previous_leaf_changes_current_pitch(leaf):
-        previous_leaf = inspect(leaf).get_leaf(n=-1)
+        previous_leaf = inspect(leaf).leaf(n=-1)
         if (isinstance(leaf, Note) and
             isinstance(previous_leaf, Note) and
             leaf.written_pitch == previous_leaf.written_pitch):

--- a/abjad/spanners/Hairpin.py
+++ b/abjad/spanners/Hairpin.py
@@ -56,7 +56,7 @@ class Hairpin(Spanner):
             }
 
         >>> for leaf in abjad.select(voice).leaves():
-        ...     leaf, abjad.inspect(leaf).get_effective(abjad.Dynamic)
+        ...     leaf, abjad.inspect(leaf).effective(abjad.Dynamic)
         ...
         (Rest('r8'), None)
         (Note("d'8"), None)
@@ -95,7 +95,7 @@ class Hairpin(Spanner):
             }
 
         >>> for leaf in abjad.select(voice).leaves():
-        ...     leaf, abjad.inspect(leaf).get_effective(abjad.Dynamic)
+        ...     leaf, abjad.inspect(leaf).effective(abjad.Dynamic)
         ...
         (Rest('r8'), None)
         (Note("d'8"), None)
@@ -129,7 +129,7 @@ class Hairpin(Spanner):
             }
 
         >>> for leaf in abjad.select(voice).leaves():
-        ...     leaf, abjad.inspect(leaf).get_effective(abjad.Dynamic)
+        ...     leaf, abjad.inspect(leaf).effective(abjad.Dynamic)
         ...
         (Note("c'2."), None)
         (Rest('r4'), None)
@@ -176,7 +176,7 @@ class Hairpin(Spanner):
             }
 
         >>> for leaf in abjad.select(voice).leaves():
-        ...     leaf, abjad.inspect(leaf).get_effective(abjad.Dynamic)
+        ...     leaf, abjad.inspect(leaf).effective(abjad.Dynamic)
         ...
         (Note("c'8"), Dynamic('p'))
         (Note("d'8"), Dynamic('p'))
@@ -427,13 +427,13 @@ class Hairpin(Spanner):
         if self._has_sounding_stop_dynamic():
             string = self._get_directed_stop_dynamic()
             return string
-        effective_dynamic = inspect(leaf).get_effective(Dynamic)
+        effective_dynamic = inspect(leaf).effective(Dynamic)
         if effective_dynamic is None or effective_dynamic.name == 'niente':
             string = self._stop_command
             return string
         if effective_dynamic not in inspect(leaf).wrappers():
             found_match = False
-            for indicator in inspect(leaf).get_indicators(Dynamic):
+            for indicator in inspect(leaf).indicators(Dynamic):
                 if indicator == effective_dynamic:
                     found_match = True
             if not found_match:

--- a/abjad/spanners/Spanner.py
+++ b/abjad/spanners/Spanner.py
@@ -490,4 +490,4 @@ class Spanner(AbjadObject):
         return self._tweaks
 
 
-collections.Sequence.register(Spanner)
+collections.Sequence.register(Spanner) # noqa

--- a/abjad/spanners/Spanner.py
+++ b/abjad/spanners/Spanner.py
@@ -1,3 +1,4 @@
+import collections
 import copy
 import typing
 from abjad import enums
@@ -412,8 +413,8 @@ class Spanner(AbjadObject):
         self._remove_leaf(leaf)
 
     def _start_offset_in_me(self, leaf):
-        leaf_start_offset = inspect(leaf).get_timespan().start_offset
-        self_start_offset = inspect(self).get_timespan().start_offset
+        leaf_start_offset = inspect(leaf).timespan().start_offset
+        self_start_offset = inspect(self).timespan().start_offset
         return leaf_start_offset - self_start_offset
 
     def _stop_command_string(self):
@@ -487,3 +488,6 @@ class Spanner(AbjadObject):
         Gets tweaks.
         """
         return self._tweaks
+
+
+collections.Sequence.register(Spanner)

--- a/abjad/spanners/Spanner.py
+++ b/abjad/spanners/Spanner.py
@@ -1,4 +1,3 @@
-import collections
 import copy
 import typing
 from abjad import enums
@@ -488,6 +487,3 @@ class Spanner(AbjadObject):
         Gets tweaks.
         """
         return self._tweaks
-
-
-collections.Sequence.register(Spanner) # noqa

--- a/abjad/spanners/test/test_Spanner_start_offset.py
+++ b/abjad/spanners/test/test_Spanner_start_offset.py
@@ -28,5 +28,5 @@ def test_Spanner_start_offset_01():
         """
         )
 
-    assert abjad.inspect(beam).get_timespan().start_offset == abjad.Duration(1, 8)
-    assert abjad.inspect(glissando).get_timespan().start_offset == abjad.Duration(0)
+    assert abjad.inspect(beam).timespan().start_offset == abjad.Duration(1, 8)
+    assert abjad.inspect(glissando).timespan().start_offset == abjad.Duration(0)

--- a/abjad/spanners/test/test_Spanner_stop_offset.py
+++ b/abjad/spanners/test/test_Spanner_stop_offset.py
@@ -28,5 +28,5 @@ def test_Spanner_stop_offset_01():
         """
         )
 
-    assert abjad.inspect(beam).get_timespan().stop_offset == abjad.Duration(3, 8)
-    assert abjad.inspect(glissando).get_timespan().stop_offset == abjad.Duration(4, 8)
+    assert abjad.inspect(beam).timespan().stop_offset == abjad.Duration(3, 8)
+    assert abjad.inspect(glissando).timespan().stop_offset == abjad.Duration(4, 8)

--- a/abjad/system/LilyPondFormatManager.py
+++ b/abjad/system/LilyPondFormatManager.py
@@ -26,7 +26,7 @@ class LilyPondFormatManager(AbjadObject):
     def _collect_indicators(component):
         import abjad
         wrappers = []
-        parentage = abjad.inspect(component).get_parentage(include_self=True)
+        parentage = abjad.inspect(component).parentage(include_self=True)
         for parent in parentage:
             wrappers_ = abjad.inspect(parent).wrappers()
             wrappers.extend(wrappers_)
@@ -230,7 +230,7 @@ class LilyPondFormatManager(AbjadObject):
         if not hasattr(component, '_spanners'):
             return
         pairs = []
-        for spanner in abjad.inspect(component).get_spanners():
+        for spanner in abjad.inspect(component).spanners():
             spanner_bundle = spanner._get_lilypond_format_bundle(component)
             spanner_bundle.tag_format_contributions(
                 spanner._tag,

--- a/abjad/system/Tags.py
+++ b/abjad/system/Tags.py
@@ -170,8 +170,6 @@ class Tags(AbjadValueObject):
 
         ### METRONOME MARKS ###
 
-        'METRONOME_MARK_SPANNER',
-
         'EXPLICIT_METRONOME_MARK',
         'EXPLICIT_METRONOME_MARK_WITH_COLOR',
 
@@ -256,7 +254,7 @@ class Tags(AbjadValueObject):
         Raises attribute error when ``tag`` is unknown.
         """
         if tag not in self._known_tags:
-            raise AttributeError('unknown tag: {!r}.'.format(tag))
+            raise AttributeError('unknown tag {!r}.'.format(tag))
         return tag
 
     ### PUBLIC METHODS ###
@@ -439,7 +437,6 @@ class Tags(AbjadValueObject):
             'LOCAL_MEASURE_NUMBER_MARKUP'
             'MEASURE_INDEX_MARKUP'
             'MEASURE_NUMBER_MARKUP'
-            'METRONOME_MARK_SPANNER'
             'REDUNDANT_TIME_SIGNATURE_COLOR'
             'STAGE_NUMBER_MARKUP'
 
@@ -450,7 +447,6 @@ class Tags(AbjadValueObject):
             self.LOCAL_MEASURE_NUMBER_MARKUP,
             self.MEASURE_INDEX_MARKUP,
             self.MEASURE_NUMBER_MARKUP,
-            self.METRONOME_MARK_SPANNER,
             self.REDUNDANT_TIME_SIGNATURE_COLOR,
             self.STAGE_NUMBER_MARKUP,
             ]

--- a/abjad/system/UpdateManager.py
+++ b/abjad/system/UpdateManager.py
@@ -218,7 +218,7 @@ class UpdateManager(AbjadObject):
         assert offsets or offsets_in_seconds or indicators
         if component._is_forbidden_to_update:
             return
-        parentage = abjad.inspect(component).get_parentage(
+        parentage = abjad.inspect(component).parentage(
             include_self=True,
             grace_notes=True,
             )
@@ -290,7 +290,7 @@ class UpdateManager(AbjadObject):
         import abjad
         wrappers = []
         prototype = abjad.TimeSignature
-        score_root = abjad.inspect(component).get_parentage(
+        score_root = abjad.inspect(component).parentage(
             include_self=True).root
         for component in self._iterate_entire_score(score_root):
             wrappers_ = abjad.inspect(component).wrappers(prototype)
@@ -298,7 +298,7 @@ class UpdateManager(AbjadObject):
         pairs = []
         for wrapper in wrappers:
             inspector = abjad.inspect(wrapper.component)
-            start_offset = inspector.get_timespan().start_offset
+            start_offset = inspector.timespan().start_offset
             time_signature = wrapper.indicator
             pair = start_offset, time_signature
             pairs.append(pair)
@@ -310,10 +310,10 @@ class UpdateManager(AbjadObject):
         elif not pairs:
             pairs = [default_pair]
         pairs.sort(key=lambda x: x[0])
-        parentage = abjad.inspect(component).get_parentage()
+        parentage = abjad.inspect(component).parentage()
         score_root = parentage.root
         inspector = abjad.inspect(score_root)
-        score_stop_offset = inspector.get_timespan().stop_offset
+        score_stop_offset = inspector.timespan().stop_offset
         dummy_last_pair = (score_stop_offset, None)
         pairs.append(dummy_last_pair)
         measure_start_offsets = []
@@ -334,7 +334,7 @@ class UpdateManager(AbjadObject):
         ):
         import abjad
         inspector = abjad.inspect(component)
-        component_start_offset = inspector.get_timespan().start_offset
+        component_start_offset = inspector.timespan().start_offset
         measure_number_start_offsets = measure_number_start_offsets[:]
         measure_number_start_offsets.append(abjad.mathtools.Infinity())
         pairs = abjad.sequence(measure_number_start_offsets)
@@ -351,7 +351,7 @@ class UpdateManager(AbjadObject):
         import abjad
         measure_start_offsets = self._get_measure_start_offsets(component)
         assert measure_start_offsets, repr(measure_start_offsets)
-        score_root = abjad.inspect(component).get_parentage(
+        score_root = abjad.inspect(component).parentage(
             include_self=True).root
         for component in self._iterate_entire_score(score_root):
             measure_number = self._to_measure_number(

--- a/abjad/system/WellformednessManager.py
+++ b/abjad/system/WellformednessManager.py
@@ -52,7 +52,7 @@ class WellformednessManager(AbjadObject):
         import abjad
         violators, spanners = set(), set()
         for leaf in abjad.iterate(argument).leaves():
-            spanners_ = list(abjad.inspect(leaf).get_spanners(prototype))
+            spanners_ = list(abjad.inspect(leaf).spanners(prototype))
             spanners.update(spanners_)
             if 1 < len(spanners_):
                 if len(spanners_) == 2:
@@ -95,8 +95,8 @@ class WellformednessManager(AbjadObject):
         """
         import abjad
         violators = []
-        descendants = abjad.inspect(argument).get_descendants()
-        spanners = abjad.inspect(descendants).get_spanners()
+        descendants = abjad.inspect(argument).descendants()
+        spanners = abjad.inspect(descendants).spanners()
         for spanner in spanners:
             if spanner._contiguity_constraint == 'logical voice':
                 if not spanner[:].are_contiguous_logical_voice():
@@ -229,7 +229,7 @@ class WellformednessManager(AbjadObject):
         import abjad
         violators, total = [], set()
         for leaf in abjad.iterate(argument).leaves():
-            hairpins = abjad.inspect(leaf).get_spanners(abjad.Hairpin)
+            hairpins = abjad.inspect(leaf).spanners(abjad.Hairpin)
             hairpins = list(hairpins)
             total.update(hairpins)
             if len(hairpins) <= 1:
@@ -324,13 +324,13 @@ class WellformednessManager(AbjadObject):
         import abjad
         violators, ties = [], set()
         for leaf in abjad.iterate(argument).leaves(pitched=True):
-            ties_ = abjad.inspect(leaf).get_spanners(abjad.Tie)
+            ties_ = abjad.inspect(leaf).spanners(abjad.Tie)
             ties.update(ties_)
         for tie in ties:
             for first_leaf, second_leaf in abjad.sequence(tie).nwise():
-                first_pitches = abjad.inspect(first_leaf).get_pitches()
+                first_pitches = abjad.inspect(first_leaf).pitches()
                 first_pitches = set([_.number for _ in first_pitches])
-                second_pitches = abjad.inspect(second_leaf).get_pitches()
+                second_pitches = abjad.inspect(second_leaf).pitches()
                 second_pitches = set([_.number for _ in second_pitches])
                 if not (first_pitches & second_pitches):
                     violators.append(tie)
@@ -374,7 +374,7 @@ class WellformednessManager(AbjadObject):
         for i, component in enumerate(components):
             total.add(component)
             if 0 < i:
-                if abjad.inspect(component).get_parentage().parent is None:
+                if abjad.inspect(component).parentage().parent is None:
                     violators.append(component)
         return violators, len(total)
 
@@ -388,7 +388,7 @@ class WellformednessManager(AbjadObject):
         violators, total = [], set()
         for measure in abjad.iterate(argument).components(abjad.Measure):
             total.add(measure)
-            parentage = abjad.inspect(measure).get_parentage(
+            parentage = abjad.inspect(measure).parentage(
                 include_self=False,
                 )
             if parentage.get_first(abjad.Measure):
@@ -523,10 +523,10 @@ class WellformednessManager(AbjadObject):
         violators, total = [], set()
         for leaf in abjad.iterate(argument).leaves():
             total.add(leaf)
-            instrument = abjad.inspect(leaf).get_effective(abjad.Instrument)
+            instrument = abjad.inspect(leaf).effective(abjad.Instrument)
             if instrument is None:
                 continue
-            clef = abjad.inspect(leaf).get_effective(abjad.Clef)
+            clef = abjad.inspect(leaf).effective(abjad.Clef)
             if clef is None:
                 continue
             allowable_clefs = [
@@ -590,7 +590,7 @@ class WellformednessManager(AbjadObject):
         violators, total = [], set()
         for leaf in abjad.iterate(argument).leaves(pitched=True):
             total.add(leaf)
-            instrument = abjad.inspect(leaf).get_effective(abjad.Instrument)
+            instrument = abjad.inspect(leaf).effective(abjad.Instrument)
             if instrument is None:
                 continue
             if leaf not in instrument.pitch_range:
@@ -638,7 +638,7 @@ class WellformednessManager(AbjadObject):
         import abjad
         violators, total = [], set()
         for leaf in abjad.iterate(argument).leaves():
-            beams = abjad.inspect(leaf).get_spanners(abjad.Beam)
+            beams = abjad.inspect(leaf).spanners(abjad.Beam)
             total.update(beams)
             if 1 < len(beams):
                 for beam in beams:
@@ -706,7 +706,7 @@ class WellformednessManager(AbjadObject):
         violators, total = [], set()
         prototype = abjad.OctavationSpanner
         for leaf in abjad.iterate(argument).leaves():
-            spanners = abjad.inspect(leaf).get_spanners(prototype)
+            spanners = abjad.inspect(leaf).spanners(prototype)
             total.update(spanners)
             if 1 < len(spanners):
                 for spanner in spanners:
@@ -756,7 +756,7 @@ class WellformednessManager(AbjadObject):
         import abjad
         violators, total = [], set()
         for leaf in abjad.iterate(argument).leaves():
-            spanners = abjad.inspect(leaf).get_spanners(abjad.Tie)
+            spanners = abjad.inspect(leaf).spanners(abjad.Tie)
             total.update(spanners)
             if 1 < len(spanners):
                 for spanner in spanners:

--- a/abjad/system/Wrapper.py
+++ b/abjad/system/Wrapper.py
@@ -182,7 +182,7 @@ class Wrapper(AbjadValueObject):
             }
 
             >>> leaf = old_staff[0]
-            >>> abjad.inspect(leaf).get_annotation('bow_direction')
+            >>> abjad.inspect(leaf).annotation('bow_direction')
             Down
 
             >>> new_staff = abjad.mutate(old_staff).copy()
@@ -195,7 +195,7 @@ class Wrapper(AbjadValueObject):
             }
 
             >>> leaf = new_staff[0]
-            >>> abjad.inspect(leaf).get_annotation('bow_direction')
+            >>> abjad.inspect(leaf).annotation('bow_direction')
             Down
 
         ..  container:: example
@@ -343,13 +343,13 @@ class Wrapper(AbjadValueObject):
             return None
         context = getattr(abjad, self.context, self.context)
         if isinstance(context, type):
-            for component in abjad.inspect(self.component).get_parentage():
+            for component in abjad.inspect(self.component).parentage():
                 if not isinstance(component, abjad.Context):
                     continue
                 if isinstance(component, context):
                     return component
         elif isinstance(context, str):
-            for component in abjad.inspect(self.component).get_parentage():
+            for component in abjad.inspect(self.component).parentage():
                 if not isinstance(component, abjad.Context):
                     continue
                 if (component.name == context or
@@ -480,7 +480,7 @@ class Wrapper(AbjadValueObject):
             wrapper.deactivate is not True and
             wrapper.indicator != self.indicator):
             if wrapper.start_offset == self.start_offset:
-                parentage = abjad.inspect(component).get_parentage()
+                parentage = abjad.inspect(component).parentage()
                 context = parentage.get_first(abjad.Context)
                 message = f'\n\nCan not attach ...\n\n{self.indicator}\n\n...'
                 message += f' to {repr(component)}'
@@ -491,7 +491,7 @@ class Wrapper(AbjadValueObject):
                     message += ' to the same leaf.'
                 else:
                     inspection = abjad.inspect(wrapper.component)
-                    parentage = inspection.get_parentage()
+                    parentage = inspection.parentage()
                     context = parentage.get_first(abjad.Context)
                     message += f' to {repr(wrapper.component)}'
                     message += f' in {context.name}.'
@@ -537,7 +537,7 @@ class Wrapper(AbjadValueObject):
             >>> note = abjad.Note("c'4")
             >>> articulation = abjad.Articulation('accent', direction=abjad.Up)
             >>> abjad.annotate(note, 'foo', articulation)
-            >>> abjad.inspect(note).get_annotation('foo')
+            >>> abjad.inspect(note).annotation('foo')
             Articulation('accent', Up)
 
         """
@@ -598,7 +598,7 @@ class Wrapper(AbjadValueObject):
         from abjad.top.inspect import inspect
         if self._synthetic_offset is not None:
             return self._synthetic_offset
-        return inspect(self._component).get_timespan().start_offset
+        return inspect(self._component).timespan().start_offset
 
     @property
     def synthetic_offset(self):

--- a/abjad/timespans/Timespan.py
+++ b/abjad/timespans/Timespan.py
@@ -715,8 +715,8 @@ class Timespan(AbjadValueObject):
         elif hasattr(argument, '_get_timespan'):
             start_offset, stop_offset = argument._get_timespan().offsets
         # TODO: remove this branch in favor of the _get_timespan above
-        #elif hasattr(argument, 'get_timespan'):
-        #    start_offset, stop_offset = argument.get_timespan().offsets
+        #elif hasattr(argument, 'timespan'):
+        #    start_offset, stop_offset = argument.timespan().offsets
         else:
             raise ValueError(argument)
         return abjad.new(
@@ -735,7 +735,7 @@ class Timespan(AbjadValueObject):
         if hasattr(timespan, '_get_timespan'):
             return True
         # TODO: remove this branch in favor of the _get_timespan above
-        if hasattr(timespan, 'get_timespan'):
+        if hasattr(timespan, 'timespan'):
             return True
         if getattr(timespan, 'timespan', 'foo') != 'foo':
             return True

--- a/abjad/timespans/TimespanTimespanTimeRelation.py
+++ b/abjad/timespans/TimespanTimespanTimeRelation.py
@@ -283,7 +283,7 @@ class TimespanTimespanTimeRelation(TimeRelation):
             Note("d''4")
             Note("ef''4")
 
-            >>> abjad.inspect(result).get_timespan()
+            >>> abjad.inspect(result).timespan()
             Timespan(start_offset=Offset(20, 1), stop_offset=Offset(22, 1))
 
         ``counttime_components`` must belong to a single voice.
@@ -302,7 +302,7 @@ class TimespanTimespanTimeRelation(TimeRelation):
         # iterate counttime components
         result = []
         for counttime_component in counttime_components:
-            if self(timespan_2=abjad.inspect(counttime_component).get_timespan()):
+            if self(timespan_2=abjad.inspect(counttime_component).timespan()):
                 result.append(counttime_component)
         # return result
         return abjad.select(result)
@@ -319,11 +319,11 @@ class TimespanTimespanTimeRelation(TimeRelation):
 
             >>> staff = abjad.Staff("c'8 d'8 e'8 f'8 g'8 a'8 b'8 c''8")
             >>> start_offsets = [
-            ...     abjad.inspect(note).get_timespan().start_offset
+            ...     abjad.inspect(note).timespan().start_offset
             ...     for note in staff
             ...     ]
             >>> stop_offsets = [
-            ...     abjad.inspect(note).get_timespan().stop_offset
+            ...     abjad.inspect(note).timespan().stop_offset
             ...     for note in staff
             ...     ]
 

--- a/abjad/timespans/timespan_2_starts_during_timespan_1.py
+++ b/abjad/timespans/timespan_2_starts_during_timespan_1.py
@@ -29,11 +29,11 @@ def timespan_2_starts_during_timespan_1(
         >>> abjad.show(score) # doctest: +SKIP
 
         >>> start_offsets = [
-        ...     abjad.inspect(note).get_timespan().start_offset
+        ...     abjad.inspect(note).timespan().start_offset
         ...     for note in staff_1
         ...     ]
         >>> stop_offsets = [
-        ...     abjad.inspect(note).get_timespan().stop_offset
+        ...     abjad.inspect(note).timespan().stop_offset
         ...     for note in staff_1
         ...     ]
 

--- a/abjad/top/annotate.py
+++ b/abjad/top/annotate.py
@@ -21,13 +21,13 @@ def annotate(component, annotation, indicator):
                 f'4
             }
 
-        >>> abjad.inspect(staff[0]).get_annotation('bow_direction')
+        >>> abjad.inspect(staff[0]).annotation('bow_direction')
         Down
 
-        >>> abjad.inspect(staff[0]).get_annotation('bow_fraction') is None
+        >>> abjad.inspect(staff[0]).annotation('bow_fraction') is None
         True
 
-        >>> abjad.inspect(staff[0]).get_annotation('bow_fraction', 99)
+        >>> abjad.inspect(staff[0]).annotation('bow_fraction', 99)
         99
 
     Returns none.

--- a/abjad/top/attach.py
+++ b/abjad/top/attach.py
@@ -85,7 +85,7 @@ def attach(
             }
 
         >>> for leaf in abjad.select(staff).leaves():
-        ...     leaf, abjad.inspect(leaf).get_effective(abjad.Clef)
+        ...     leaf, abjad.inspect(leaf).effective(abjad.Clef)
         ...
         (Note("c'4"), Clef('alto'))
         (Note("d'4"), Clef('alto'))
@@ -144,7 +144,7 @@ def attach(
         are present:
 
         >>> for note in staff:
-        ...     clef = abjad.inspect(staff[0]).get_effective(abjad.Clef)
+        ...     clef = abjad.inspect(staff[0]).effective(abjad.Clef)
         ...     note, clef
         ...
         (Note("c'4"), Clef('treble'))
@@ -177,7 +177,7 @@ def attach(
             }
 
         >>> for note in staff:
-        ...     clef = abjad.inspect(staff[0]).get_effective(abjad.Clef)
+        ...     clef = abjad.inspect(staff[0]).effective(abjad.Clef)
         ...     note, clef
         ...
         (Note("c'4"), Clef('alto'))

--- a/abjad/top/detach.py
+++ b/abjad/top/detach.py
@@ -228,11 +228,11 @@ def detach(argument, target=None, by_id=False):
     inspector = abjad.inspect(target)
     if isinstance(argument, type):
         if issubclass(argument, abjad.Spanner):
-            spanners = inspector.get_spanners(argument)
+            spanners = inspector.spanners(argument)
         elif issubclass(argument, abjad.AfterGraceContainer):
-            after_grace_container = inspector.get_after_grace_container()
+            after_grace_container = inspector.after_grace_container()
         elif issubclass(argument, abjad.GraceContainer):
-            grace_container = inspector.get_grace_container()
+            grace_container = inspector.grace_container()
         else:
             assert hasattr(target, '_wrappers')
             result = []
@@ -247,11 +247,11 @@ def detach(argument, target=None, by_id=False):
             return result
     else:
         if isinstance(argument, abjad.Spanner):
-            spanners = inspector.get_spanners(argument)
+            spanners = inspector.spanners(argument)
         elif isinstance(argument, abjad.AfterGraceContainer):
-            after_grace_container = inspector.get_after_grace_container()
+            after_grace_container = inspector.after_grace_container()
         elif isinstance(argument, abjad.GraceContainer):
-            grace_container = inspector.get_grace_container()
+            grace_container = inspector.grace_container()
         else:
             assert hasattr(target, '_wrappers')
             result = []

--- a/abjad/top/inspect.py
+++ b/abjad/top/inspect.py
@@ -24,7 +24,7 @@ def inspect(client):
 
         Gets duration of first note in staff:
 
-        >>> abjad.inspect(staff[0]).get_duration()
+        >>> abjad.inspect(staff[0]).duration()
         Duration(1, 4)
 
     ..  container:: example

--- a/abjad/utilities/Duration.py
+++ b/abjad/utilities/Duration.py
@@ -1261,7 +1261,7 @@ class Duration(AbjadObject, Fraction):
             >>> tuplet = abjad.Tuplet((5, 7), "c'16 c' c' c' c' c' c'")
             >>> abjad.attach(abjad.Beam(), tuplet[:])
             >>> staff = abjad.Staff([tuplet], lilypond_type='RhythmicStaff')
-            >>> duration = abjad.inspect(tuplet).get_duration()
+            >>> duration = abjad.inspect(tuplet).duration()
             >>> markup = duration.to_score_markup()
             >>> markup = markup.scale((0.75, 0.75))
             >>> abjad.override(tuplet).tuplet_number.text = markup

--- a/abjad/utilities/DurationInequality.py
+++ b/abjad/utilities/DurationInequality.py
@@ -71,12 +71,12 @@ class DurationInequality(Inequality):
             if self.preprolated:
                 duration = argument._get_preprolated_duration()
             else:
-                duration = abjad.inspect(argument).get_duration()
+                duration = abjad.inspect(argument).duration()
         elif isinstance(argument, abjad.Selection):
             if self.preprolated:
                 duration = argument._get_preprolated_duration()
             else:
-                duration = abjad.inspect(argument).get_duration()
+                duration = abjad.inspect(argument).duration()
         else:
             duration = abjad.Duration(argument)
         return self._operator_function(duration, self.duration)

--- a/abjad/utilities/Sequence.py
+++ b/abjad/utilities/Sequence.py
@@ -3197,7 +3197,7 @@ class Sequence(AbjadValueObject, collections.Sequence):
 
         ..  container:: example
 
-            Regression: partitions sequence cyclically into enchained parts by
+            REGRESSION: partitions sequence cyclically into enchained parts by
             counts; does not return false 1-element part at end:
 
             ..  container:: example

--- a/abjad/utilities/String.py
+++ b/abjad/utilities/String.py
@@ -978,7 +978,7 @@ class String(str):
 
         ..  container:: example
 
-            Regressions:
+            REGRESSION:
 
             >>> abjad.String.match_strings(strings, '||')
             []
@@ -1090,7 +1090,7 @@ class String(str):
 
         ..  container:: example
 
-            Regressions:
+            REGRESSION:
 
             >>> string = abjad.String('IOManager')
             >>> string.match_word_starts(['I', 'O'])
@@ -1569,9 +1569,9 @@ class String(str):
             'METRONOME_MARK'
 
         """
-        persistent = getattr(indicator, 'persistent', None)
-        if isinstance(persistent, str):
-            stem = persistent.lstrip('abjad.')
+        parameter = getattr(indicator, 'parameter', None)
+        if isinstance(parameter, str):
+            stem = parameter.lstrip('abjad.')
         else:
             stem = type(indicator).__name__
         return String(stem).to_shout_case()


### PR DESCRIPTION
OLD:

    * abjad.inspect().get_after_grace_container()
    * abjad.inspect().get_annotation()
    * abjad.inspect().get_badly_formed_components()
    * abjad.inspect().get_contents()
    * abjad.inspect().get_descendants()
    * abjad.inspect().get_duration()
    * abjad.inspect().get_effective()
    * abjad.inspect().get_effective_staff()
    * abjad.inspect().get_effective_wrapper()
    * abjad.inspect().get_grace_container()
    * abjad.inspect().get_indicator()
    * abjad.inspect().get_indicators()
    * abjad.inspect().get_leaf()
    * abjad.inspect().get_lineage()
    * abjad.inspect().get_logical_tie()
    * abjad.inspect().get_markup()
    * abjad.inspect().get_parentage()
    * abjad.inspect().get_pitches()
    * abjad.inspect().get_sounding_pitch()
    * abjad.inspect().get_sounding_pitches()
    * abjad.inspect().get_spanner()
    * abjad.inspect().get_spanners()
    * abjad.inspect().get_tuplet()
    * abjad.inspect().get_vertical_moment()
    * abjad.inspect().get_vertical_moment_at()

NEW:

    * abjad.inspect().after_grace_container()
    * abjad.inspect().annotation()
    * abjad.inspect().badly_formed_components()
    * abjad.inspect().contents()
    * abjad.inspect().descendants()
    * abjad.inspect().duration()
    * abjad.inspect().effective()
    * abjad.inspect().effective_staff()
    * abjad.inspect().effective_wrapper()
    * abjad.inspect().grace_container()
    * abjad.inspect().indicator()
    * abjad.inspect().indicators()
    * abjad.inspect().leaf()
    * abjad.inspect().lineage()
    * abjad.inspect().logical_tie()
    * abjad.inspect().markup()
    * abjad.inspect().parentage()
    * abjad.inspect().pitches()
    * abjad.inspect().sounding_pitch()
    * abjad.inspect().sounding_pitches()
    * abjad.inspect().spanner()
    * abjad.inspect().spanners()
    * abjad.inspect().tuplet()
    * abjad.inspect().vertical_moment()
    * abjad.inspect().vertical_moment_at()

LILYPOND FIX: abjad.Tie now corrects for down-positioned midstaff repeat ties.

abjad.Tie automatically tweaks repeat tie direction up when repeat tie connects
to long-duration note at staff position zero:

    >>> tie = abjad.Tie(repeat=True)
    >>> staff = abjad.Staff(r"b'4 b'4 b'2 b'1 b'\breve")
    >>> abjad.attach(abjad.TimeSignature((8, 4)), staff[-1])
    >>> abjad.attach(tie, staff[:])

    >>> abjad.f(staff)
    \new Staff
    {
        b'4
        b'4
        \repeatTie
        b'2
        \repeatTie
        b'1
        - \tweak direction #up
        \repeatTie
        \time 8/4
        b'\breve
        - \tweak direction #up
        \repeatTie
    }