### PR TITLE
NEW 3.1 TAG FEATURE SET 1: component tags; tweak tags; template tags.

### DIFF
--- a/abjad/boilerplate/__make_segment_pdf__.py
+++ b/abjad/boilerplate/__make_segment_pdf__.py
@@ -153,7 +153,7 @@ if __name__ == '__main__':
 
     try:
         if getattr(maker, 'do_not_externalize', False) is not True:
-            illustration_ly.extern()
+            illustration_ly.extern(realign=99)
             illustration_ily = illustration_ly.with_suffix('.ily')
             assert illustration_ily.is_file()
         with abjad.Timer() as timer:

--- a/abjad/core/AfterGraceContainer.py
+++ b/abjad/core/AfterGraceContainer.py
@@ -64,9 +64,17 @@ class AfterGraceContainer(Container):
 
     ### INITIALIZER ###
 
-    def __init__(self, components=None):
+    def __init__(
+        self,
+        components=None,
+        tag: str = None,
+        ) -> None:
         self._carrier = None
-        Container.__init__(self, components)
+        Container.__init__(
+            self,
+            components,
+            tag=tag,
+            )
 
     ### SPECIAL METHODS ###
 

--- a/abjad/core/DrumNoteHead.py
+++ b/abjad/core/DrumNoteHead.py
@@ -23,13 +23,13 @@ class DrumNoteHead(NoteHead):
 
     def __init__(
         self,
-        written_pitch='snare',
+        written_pitch: str = 'snare',
         client=None,
-        is_cautionary=None,
-        is_forced=None,
-        is_parenthesized=None,
+        is_cautionary: bool = None,
+        is_forced: bool = None,
+        is_parenthesized: bool = None,
         tweaks=(),
-        ):
+        ) -> None:
         from abjad.ly import drums
         NoteHead.__init__(
             self,

--- a/abjad/core/GraceContainer.py
+++ b/abjad/core/GraceContainer.py
@@ -148,9 +148,9 @@ class GraceContainer(Container):
 
     ### INITIALIZER ###
 
-    def __init__(self, components=None):
+    def __init__(self, components=None, tag: str = None) -> None:
         self._carrier = None
-        Container.__init__(self, components)
+        Container.__init__(self, components, tag=tag)
 
     ### SPECIAL METHODS ###
 

--- a/abjad/core/Leaf.py
+++ b/abjad/core/Leaf.py
@@ -1,5 +1,6 @@
 import abc
 import copy
+import typing
 import uqbar.graphs
 from abjad import enums
 from abjad import exceptions
@@ -8,6 +9,7 @@ from abjad.mathtools.NonreducedFraction import NonreducedFraction
 from abjad.mathtools.Ratio import Ratio
 from abjad.system.FormatSpecification import FormatSpecification
 from abjad.system.LilyPondFormatManager import LilyPondFormatManager
+from abjad.system.Tag import Tag
 from abjad.top.attach import attach
 from abjad.top.detach import detach
 from abjad.top.inspect import inspect
@@ -40,12 +42,17 @@ class Leaf(Component):
     ### INITIALIZER ###
 
     @abc.abstractmethod
-    def __init__(self, written_duration):
-        Component.__init__(self)
+    def __init__(
+        self,
+        written_duration,
+        tag: str = None,
+        ) -> None:
+        from abjad.spanners.Spanner import Spanner
+        Component.__init__(self, tag=tag)
         self._after_grace_container = None
         self._grace_container = None
         self._leaf_index = None
-        self._spanners = []
+        self._spanners: typing.List[Spanner] = []
         self.written_duration = Duration(written_duration)
 
     ### SPECIAL METHODS ###
@@ -227,7 +234,15 @@ class Leaf(Component):
         return ['self body', result]
 
     def _format_leaf_nucleus(self):
-        return ['nucleus', self._get_body()]
+        strings = self._get_body()
+        if self.tag:
+            tag = Tag(self.tag)
+            strings = LilyPondFormatManager.tag(
+                strings,
+                tag=tag,
+                )
+        #return ['nucleus', self._get_body()]
+        return ['nucleus', strings]
 
     def _format_open_brackets_slot(self, bundle):
         return []

--- a/abjad/core/MultimeasureRest.py
+++ b/abjad/core/MultimeasureRest.py
@@ -1,4 +1,7 @@
+import typing
+from abjad.system.LilyPondFormatManager import LilyPondFormatManager
 from .Leaf import Leaf
+from .Rest import Rest
 
 
 class MultimeasureRest(Leaf):
@@ -10,6 +13,12 @@ class MultimeasureRest(Leaf):
         >>> rest = abjad.MultimeasureRest((1, 4))
         >>> abjad.show(rest) # doctest: +SKIP
 
+    ..  container:: example
+
+        >>> rest = abjad.MultimeasureRest('R1', tag='GLOBAL_MULTIMEASURE_REST')
+        >>> abjad.f(rest)
+        R1 %! GLOBAL_MULTIMEASURE_REST
+
     """
 
     ### CLASS VARIABLES ###
@@ -20,12 +29,11 @@ class MultimeasureRest(Leaf):
 
     ### INITIALIZER ###
 
-    def __init__(self, *arguments):
-        import abjad
+    def __init__(self, *arguments, tag: str = None) -> None:
         if len(arguments) == 0:
             arguments = ((1, 4),)
-        rest = abjad.Rest(*arguments)
-        Leaf.__init__(self, rest.written_duration)
+        rest = Rest(*arguments)
+        Leaf.__init__(self, rest.written_duration, tag=tag)
 
     ### PRIVATE METHODS ###
 
@@ -39,3 +47,22 @@ class MultimeasureRest(Leaf):
 
     def _get_compact_representation(self):
         return f'R{self._get_formatted_duration()}'
+
+    ### PUBLIC PROPERTIES ###
+
+    @property
+    def tag(self) -> typing.Optional[str]:
+        r"""
+        Gets tag.
+
+        ..  container:: example
+
+            >>> rest = abjad.MultimeasureRest(1, tag='MULTIMEASURE_REST')
+            >>> multiplier = abjad.Multiplier(3, 8)
+            >>> abjad.attach(multiplier, rest)
+
+            >>> abjad.f(rest)
+            R1 * 3/8 %! MULTIMEASURE_REST
+
+        """
+        return super().tag

--- a/abjad/core/Mutation.py
+++ b/abjad/core/Mutation.py
@@ -1954,7 +1954,7 @@ class Mutation(AbjadObject):
                 {
                     \time 3/8
                     c'8
-                    -\accent
+                    - \accent
                     ~
                     c'8
                     d'8
@@ -1972,7 +1972,7 @@ class Mutation(AbjadObject):
                 {
                     \time 3/8
                     c'4.
-                    -\accent
+                    - \accent
                     d'8
                 }
 
@@ -2051,7 +2051,7 @@ class Mutation(AbjadObject):
                 {
                     \time 5/16
                     c'8
-                    -\accent
+                    - \accent
                     ~
                     c'8
                     d'16
@@ -2069,7 +2069,7 @@ class Mutation(AbjadObject):
                 {
                     \time 5/16
                     c'4
-                    -\accent
+                    - \accent
                     ~
                     c'16
                     d'16
@@ -2156,7 +2156,7 @@ class Mutation(AbjadObject):
                 \new Staff
                 {
                     c'8
-                    -\accent
+                    - \accent
                 }
 
             >>> logical_tie = abjad.inspect(staff[0]).logical_tie()
@@ -2172,7 +2172,7 @@ class Mutation(AbjadObject):
                     \tweak edge-height #'(0.7 . 0)
                     \times 2/3 {
                         c'4
-                        -\accent
+                        - \accent
                     }
                 }
 
@@ -3088,11 +3088,11 @@ class Mutation(AbjadObject):
                 \new Staff
                 {
                     c'4
-                    -\marcato
+                    - \marcato
                     d'4
                     \laissezVibrer
                     e'4
-                    -\marcato
+                    - \marcato
                     f'4
                     \laissezVibrer
                 }
@@ -3112,7 +3112,7 @@ class Mutation(AbjadObject):
                 \new Staff
                 {
                     c'8
-                    -\marcato
+                    - \marcato
                     ~
                     c'8
                     d'8
@@ -3120,7 +3120,7 @@ class Mutation(AbjadObject):
                     d'8
                     \laissezVibrer
                     e'8
-                    -\marcato
+                    - \marcato
                     ~
                     e'8
                     f'8

--- a/abjad/core/NoteHead.py
+++ b/abjad/core/NoteHead.py
@@ -1,10 +1,12 @@
 import copy
 import functools
 import typing
+from abjad.pitch import NamedPitch
 from abjad.system.AbjadObject import AbjadObject
 from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.pitch.NamedPitch import NamedPitch
 from abjad.system.FormatSpecification import FormatSpecification
+from abjad.system.LilyPondFormatManager import LilyPondFormatManager
 from abjad.system.StorageFormatManager import StorageFormatManager
 from abjad.top.tweak import tweak
 
@@ -207,7 +209,6 @@ class NoteHead(AbjadObject):
             )
 
     def _get_format_pieces(self):
-        import abjad
         assert self.written_pitch
         result = []
         if self.is_parenthesized:
@@ -215,7 +216,7 @@ class NoteHead(AbjadObject):
         strings = self.tweaks._list_format_contributions(directed=False)
         result.extend(strings)
         written_pitch = self.written_pitch
-        if isinstance(written_pitch, abjad.NamedPitch):
+        if isinstance(written_pitch, NamedPitch):
             written_pitch = written_pitch.simplify()
         kernel = format(written_pitch)
         if self.is_forced:
@@ -226,19 +227,18 @@ class NoteHead(AbjadObject):
         return result
 
     def _get_lilypond_format(self, formatted_duration=None):
-        import abjad
         pieces = self._get_format_pieces()
         if formatted_duration is not None:
             pieces[-1] = pieces[-1] + formatted_duration
         if self.alternative:
-            pieces = abjad.LilyPondFormatManager.tag(
+            pieces = LilyPondFormatManager.tag(
                 pieces,
                 tag=self.alternative[2],
                 )
             pieces_ = self.alternative[0]._get_format_pieces()
             if formatted_duration is not None:
                 pieces_[-1] = pieces_[-1] + formatted_duration
-            pieces_ = abjad.LilyPondFormatManager.tag(
+            pieces_ = LilyPondFormatManager.tag(
                 pieces_,
                 deactivate=True,
                 tag=self.alternative[1],

--- a/abjad/core/Rest.py
+++ b/abjad/core/Rest.py
@@ -1,3 +1,5 @@
+from abjad.top.parse import parse
+from abjad.utilities.Duration import Duration
 from .Leaf import Leaf
 
 
@@ -29,21 +31,20 @@ class Rest(Leaf):
 
     ### INITIALIZER ###
 
-    def __init__(self, written_duration=None):
-        import abjad
+    def __init__(self, written_duration=None, tag: str = None) -> None:
         original_input = written_duration
         if isinstance(written_duration, str):
             string = f'{{ {written_duration} }}'
-            parsed = abjad.parse(string)
+            parsed = parse(string)
             assert len(parsed) == 1 and isinstance(parsed[0], Leaf)
             written_duration = parsed[0]
         if isinstance(written_duration, Leaf):
             written_duration = written_duration.written_duration
         elif written_duration is None:
-            written_duration = abjad.Duration(1, 4)
+            written_duration = Duration(1, 4)
         else:
-            written_duration = abjad.Duration(written_duration)
-        Leaf.__init__(self, written_duration)
+            written_duration = Duration(written_duration)
+        Leaf.__init__(self, written_duration, tag=tag)
         if isinstance(original_input, Leaf):
             self._copy_override_and_set_from_leaf(original_input)
 

--- a/abjad/core/Score.py
+++ b/abjad/core/Score.py
@@ -1,6 +1,6 @@
 import copy
-from .Context import Context
-
+import typing
+from .Context import Context 
 
 class Score(Context):
     r"""
@@ -49,17 +49,51 @@ class Score(Context):
     def __init__(
         self,
         components=None,
-        lilypond_type='Score',
-        is_simultaneous=True,
-        name=None,
-        ):
+        lilypond_type: str = 'Score',
+        is_simultaneous: bool = True,
+        name: str = None,
+        tag: str = None,
+        ) -> None:
         Context.__init__(
             self,
             components=components,
             lilypond_type=lilypond_type,
             is_simultaneous=is_simultaneous,
             name=name,
+            tag=tag,
             )
+
+    ### PUBLIC PROPERTIES ###
+
+    @property
+    def tag(self) -> typing.Optional[str]:
+        r"""
+        Gets tag.
+
+        ..  container:: example
+
+            >>> voice = abjad.Voice("c'4 d' e' f'", tag='RED')
+            >>> staff = abjad.Staff([voice], tag='BLUE')
+            >>> score = abjad.Score([staff], tag='GREEN')
+            >>> abjad.show(score) # doctest: +SKIP
+
+            >>> abjad.f(score, strict=20)
+            \new Score          %! GREEN
+            <<                  %! GREEN
+                \new Staff      %! BLUE
+                {               %! BLUE
+                    \new Voice  %! RED
+                    {           %! RED
+                        c'4
+                        d'4
+                        e'4
+                        f'4
+                    }           %! RED
+                }               %! BLUE
+            >>                  %! GREEN
+
+        """
+        return super().tag
 
     ### PUBLIC METHODS ###
 
@@ -105,7 +139,7 @@ class Score(Context):
                     d'4
                     e'4
                     f'4
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                 }
             >>
 
@@ -117,11 +151,11 @@ class Score(Context):
         bar_line = abjad.BarLine(abbreviation)
         if not to_each_voice:
             last_leaf = abjad.inspect(self).leaf(-1)
-            abjad.attach(bar_line, last_leaf, tag='SCORE1')
+            abjad.attach(bar_line, last_leaf, tag='SCORE_1')
         else:
             for voice in abjad.iterate(self).components(abjad.Voice):
                 last_leaf = abjad.inspect(voice).leaf(-1)
-                abjad.attach(bar_line, last_leaf, tag='SCORE1')
+                abjad.attach(bar_line, last_leaf, tag='SCORE_1')
         return bar_line
 
     def add_final_markup(self, markup, extra_offset=None):
@@ -156,14 +190,14 @@ class Score(Context):
                         e'4
                         \once \override TextScript.extra-offset = #'(0.5 . -2)
                         f'4
-                        _ \markup { %! SCORE2
-                            \italic %! SCORE2
-                                \right-column %! SCORE2
-                                    { %! SCORE2
-                                        "Bremen - Boston - LA." %! SCORE2
-                                        "July 2010 - May 2011." %! SCORE2
-                                    } %! SCORE2
-                            } %! SCORE2
+                        _ \markup {                             %! SCORE_2
+                            \italic                             %! SCORE_2
+                                \right-column                   %! SCORE_2
+                                    {                           %! SCORE_2
+                                        "Bremen - Boston - LA." %! SCORE_2
+                                        "July 2010 - May 2011." %! SCORE_2
+                                    }                           %! SCORE_2
+                            }                                   %! SCORE_2
                     }
                 >>
 
@@ -203,14 +237,14 @@ class Score(Context):
                         f'4
                         \once \override MultiMeasureRestText.extra-offset = #'(14.5 . -2)
                         R1
-                        _ \markup { %! SCORE2
-                            \italic %! SCORE2
-                                \right-column %! SCORE2
-                                    { %! SCORE2
-                                        "Bremen - Boston - LA." %! SCORE2
-                                        "July 2010 - May 2011." %! SCORE2
-                                    } %! SCORE2
-                            } %! SCORE2
+                        _ \markup {                             %! SCORE_2
+                            \italic                             %! SCORE_2
+                                \right-column                   %! SCORE_2
+                                    {                           %! SCORE_2
+                                        "Bremen - Boston - LA." %! SCORE_2
+                                        "July 2010 - May 2011." %! SCORE_2
+                                    }                           %! SCORE_2
+                            }                                   %! SCORE_2
                     }
                 >>
 
@@ -220,7 +254,7 @@ class Score(Context):
         selection = abjad.select(self)
         last_leaf = selection._get_component(abjad.Leaf, -1)
         markup = copy.copy(markup)
-        abjad.attach(markup, last_leaf, tag='SCORE2')
+        abjad.attach(markup, last_leaf, tag='SCORE_2')
         if extra_offset is not None:
             if isinstance(last_leaf, abjad.MultimeasureRest):
                 grob_proxy = abjad.override(last_leaf).multi_measure_rest_text

--- a/abjad/core/Selection.py
+++ b/abjad/core/Selection.py
@@ -123,30 +123,24 @@ class Selection(AbjadValueObject, collections.Sequence):
 
     ### SPECIAL METHODS ###
 
-    def __add__(self, argument):
+    def __add__(self, argument) -> typing.Union['Selection', Expression]:
         """
         Cocatenates ``argument`` to selection.
-
-        Returns new selection.
         """
         assert isinstance(argument, collections.Iterable)
         items = self.items + tuple(argument)
         return type(self)(items=items)
 
-    def __contains__(self, argument):
+    def __contains__(self, argument) -> bool:
         """
         Is true when ``argument`` is in selection.
-
-        Returns true or false.
         """
         return argument in self.items
 
-    def __eq__(self, argument):
+    def __eq__(self, argument) -> bool:
         """
         Is true when selection and ``argument`` are of the same type
         and when items in selection equal item in ``argument``.
-
-        Returns true or false.
         """
         if isinstance(argument, type(self)):
             return self.items == argument.items
@@ -154,17 +148,18 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self.items == tuple(argument)
         return False
 
-    def __format__(self, format_specification=''):
+    def __format__(self, format_specification='') -> str:
         """
-        Formats duration.
-
-        Returns string.
+        Formats selection.
         """
         if format_specification in ('', 'storage'):
             return StorageFormatManager(self).get_storage_format()
         raise ValueError(repr(format_specification))
 
-    def __getitem__(self, argument):
+    def __getitem__(
+        self,
+        argument,
+        ):
         r"""
         Gets item, slice or pattern ``argument`` in selection.
 
@@ -375,11 +370,9 @@ class Selection(AbjadValueObject, collections.Sequence):
                 result = type(self)(result)
         return result
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict:
         """
         Gets state of selection.
-
-        Returns dictionary.
         """
         if hasattr(self, '__dict__'):
             state = vars(self).copy()
@@ -393,7 +386,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                     pass
         return state
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """
         Hashes selection.
 
@@ -432,37 +425,29 @@ class Selection(AbjadValueObject, collections.Sequence):
         lilypond_file = abjad.LilyPondFile.new(score)
         return lilypond_file
 
-    def __len__(self):
+    def __len__(self) -> int:
         """
         Gets number of items in selection.
-
-        Returns nonnegative integer.
         """
         return len(self.items)
 
-    def __radd__(self, argument):
+    def __radd__(self, argument) -> typing.Union['Selection', Expression]:
         """
         Concatenates selection to ``argument``.
-
-        Returns newly created selection.
         """
         assert isinstance(argument, collections.Iterable)
         items = tuple(argument) + self.items
         return type(self)(items=items)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Gets interpreter representation of selection.
-
-        Returns string.
         """
         return super().__repr__()
 
-    def __setstate__(self, state):
+    def __setstate__(self, state) -> None:
         """
         Sets state of selection.
-
-        Returns none.
         """
         for key, value in state.items():
             setattr(self, key, value)
@@ -1043,7 +1028,7 @@ class Selection(AbjadValueObject, collections.Sequence):
     ### PUBLIC PROPERTIES ###
 
     @property
-    def items(self):
+    def items(self) -> typing.Tuple:
         """
         Gets items.
 
@@ -1052,13 +1037,16 @@ class Selection(AbjadValueObject, collections.Sequence):
             >>> abjad.Staff("c'4 d'4 e'4 f'4")[:].items
             (Note("c'4"), Note("d'4"), Note("e'4"), Note("f'4"))
 
-        Returns tuple.
         """
         return self._items
 
     ### PUBLIC METHODS ###
 
-    def are_contiguous_logical_voice(self, prototype=None, allow_orphans=True):
+    def are_contiguous_logical_voice(
+        self,
+        prototype=None,
+        allow_orphans=True,
+        ) -> typing.Union[bool, Expression]:
         """
         Is true when items in selection are contiguous components in the
         same logical voice.
@@ -1073,7 +1061,6 @@ class Selection(AbjadValueObject, collections.Sequence):
             >>> selection.are_contiguous_logical_voice()
             False
 
-        Returns true or false.
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
@@ -1122,7 +1109,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             previous = current
         return True
 
-    def are_leaves(self):
+    def are_leaves(self) -> typing.Union[bool, Expression]:
         """
         Is true when items in selection are all leaves.
 
@@ -1131,13 +1118,16 @@ class Selection(AbjadValueObject, collections.Sequence):
             >>> abjad.Staff("c'4 d'4 e'4 f'4")[:].are_leaves()
             True
 
-        Returns true or false.
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
         return all(isinstance(_, Leaf) for _ in self)
 
-    def are_logical_voice(self, prototype=None, allow_orphans=True):
+    def are_logical_voice(
+        self,
+        prototype=None,
+        allow_orphans=True,
+        ) -> typing.Union[bool, Expression]:
         """
         Is true when items in selection are all components in the same
         logical voice.
@@ -1152,7 +1142,6 @@ class Selection(AbjadValueObject, collections.Sequence):
             >>> selection.are_logical_voice()
             True
 
-        Returns true or false.
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
@@ -1198,7 +1187,11 @@ class Selection(AbjadValueObject, collections.Sequence):
                 return False
         return True
 
-    def are_contiguous_same_parent(self, prototype=None, allow_orphans=True):
+    def are_contiguous_same_parent(
+        self,
+        prototype=None,
+        allow_orphans=True,
+        ) -> typing.Union[bool, Expression]:
         """
         Is true when items in selection are all contiguous components in
         the same parent.
@@ -1213,7 +1206,6 @@ class Selection(AbjadValueObject, collections.Sequence):
             >>> selection.are_contiguous_same_parent()
             False
 
-        Returns true or false.
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
@@ -1262,7 +1254,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             previous = current
         return True
 
-    def chord(self, n):
+    def chord(self, n) -> typing.Union[Chord, Expression]:
         r"""
         Selects chord ``n``.
 
@@ -1354,7 +1346,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self._update_expression(inspect.currentframe(), lone=True)
         return self.chords()[n]
 
-    def chords(self):
+    def chords(self) -> typing.Union['Selection', Expression]:
         r"""
         Selects chords.
 
@@ -1472,7 +1464,12 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self._update_expression(inspect.currentframe())
         return self.components(Chord)
 
-    def components(self, prototype=None, grace_notes=None, reverse=False):
+    def components(
+        self,
+        prototype=None,
+        grace_notes=None,
+        reverse=False,
+        ) -> typing.Union['Selection', Expression]:
         r"""
         Selects components.
 
@@ -1540,7 +1537,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                     g'8
                 }
 
-        Returns new selection (or expression).
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
@@ -1551,7 +1547,10 @@ class Selection(AbjadValueObject, collections.Sequence):
             )
         return type(self)(generator)
 
-    def filter(self, predicate=None):
+    def filter(
+        self,
+        predicate=None,
+        ) -> typing.Union['Selection', Expression]:
         r"""
         Filters selection by ``predicate``.
 
@@ -1605,7 +1604,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                     a'8
                 }
 
-        Returns new selection (or expression).
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
@@ -1613,7 +1611,11 @@ class Selection(AbjadValueObject, collections.Sequence):
             return type(self)(self)
         return type(self)([_ for _ in self if predicate(_)])
 
-    def filter_duration(self, operator, duration):
+    def filter_duration(
+        self,
+        operator,
+        duration,
+        ) -> typing.Union['Selection', Expression]:
         r"""
         Filters selection by ``operator`` and ``duration``.
 
@@ -1722,13 +1724,16 @@ class Selection(AbjadValueObject, collections.Sequence):
                     a'8
                 }
 
-        Returns new selection (or expression).
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
         return self.filter(DurationInequality(operator, duration))
 
-    def filter_length(self, operator, length):
+    def filter_length(
+        self,
+        operator,
+        length,
+        ) -> typing.Union['Selection', Expression]:
         r"""
         Filters selection by ``operator`` and ``length``.
 
@@ -1843,7 +1848,11 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self._update_expression(inspect.currentframe())
         return self.filter(LengthInequality(operator, length))
 
-    def filter_pitches(self, operator, pitches):
+    def filter_pitches(
+        self,
+        operator,
+        pitches,
+        ) -> typing.Union['Selection', Expression]:
         r"""
         Filters selection by ``operator`` and ``pitches``.
 
@@ -2022,13 +2031,16 @@ class Selection(AbjadValueObject, collections.Sequence):
                     <c' e' g'>4
                 }
 
-        Returns new selection (or expression).
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
         return self.filter(PitchInequality(operator, pitches))
 
-    def filter_preprolated(self, operator, duration):
+    def filter_preprolated(
+        self,
+        operator,
+        duration,
+        ) -> typing.Union['Selection', Expression]:
         r"""
         Filters selection by ``operator`` and preprolated ``duration``.
 
@@ -2148,7 +2160,10 @@ class Selection(AbjadValueObject, collections.Sequence):
             )
         return self.filter(inequality)
 
-    def flatten(self, depth=1):
+    def flatten(
+        self,
+        depth: int = 1,
+        ) -> typing.Union['Selection', Expression]:
         r"""
         Flattens selection to ``depth``.
 
@@ -2347,13 +2362,12 @@ class Selection(AbjadValueObject, collections.Sequence):
                     }   % measure
                 }
 
-        Returns new selection (or expression).
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
         return type(self)(Sequence(self).flatten(depth=depth))
 
-    def group(self):
+    def group(self) -> typing.Union['Selection', Expression]:
         r"""
         Groups selection.
 
@@ -2421,13 +2435,15 @@ class Selection(AbjadValueObject, collections.Sequence):
                     d'16
                 }
 
-        Returns nested selection (or expression).
         """
         if self._expression:
             return self._update_expression(inspect.currentframe(), lone=True)
         return self.group_by()
 
-    def group_by(self, predicate=None):
+    def group_by(
+        self,
+        predicate=None,
+        ) -> typing.Union['Selection', Expression]:
         r'''
         Groups items in selection by ``predicate``.
 
@@ -2498,7 +2514,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                     d'16
                 }
 
-        Returns nested selection (or expression).
         '''
         if self._expression:
             return self._update_expression(
@@ -2516,7 +2531,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             items.append(item)
         return type(self)(items)
 
-    def group_by_contiguity(self):
+    def group_by_contiguity(self) -> typing.Union['Selection', Expression]:
         r'''
         Groups items in selection by contiguity.
 
@@ -2872,11 +2887,11 @@ class Selection(AbjadValueObject, collections.Sequence):
                     d'16
                 }
 
-        Returns new selection (or expression).
         '''
         if self._expression:
             return self._update_expression(inspect.currentframe())
-        result, selection = [], []
+        result = []
+        selection: typing.List[typing.Union[Component, Selection]] = []
         selection.extend(self[:1])
         for item in self[1:]:
             this_timespan = abjad_inspect(selection[-1]).timespan()
@@ -2890,7 +2905,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             result.append(type(self)(selection))
         return type(self)(result)
 
-    def group_by_duration(self):
+    def group_by_duration(self) -> typing.Union['Selection', Expression]:
         r"""
         Groups items in selection by duration.
 
@@ -2969,7 +2984,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                     f'16
                 }
 
-        Returns nested selection (or expression).
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
@@ -2977,7 +2991,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return abjad_inspect(argument).duration()
         return self.group_by(predicate)
 
-    def group_by_length(self):
+    def group_by_length(self) -> typing.Union['Selection', Expression]:
         r"""
         Groups items in selection by length.
 
@@ -3051,7 +3065,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                     f'16
                 }
 
-        Returns nested selection (or expression).
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
@@ -3061,7 +3074,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return len(argument)
         return self.group_by(predicate)
 
-    def group_by_measure(self):
+    def group_by_measure(self) -> typing.Union['Selection', Expression]:
         r"""
         Groups items in selection by measure.
 
@@ -3399,7 +3412,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                     c''4
                 }
 
-        Returns new selection (or expression).
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
@@ -3423,7 +3435,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             selections.append(selection)
         return type(self)(selections)
 
-    def group_by_pitch(self):
+    def group_by_pitch(self) -> typing.Union['Selection', Expression]:
         r"""
         Groups items in selection by pitches.
 
@@ -3497,7 +3509,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                     f'16
                 }
 
-        Returns nested selection (or expression).
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
@@ -3505,7 +3516,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return PitchSet.from_selection(argument)
         return self.group_by(predicate)
 
-    def leaf(self, n):
+    def leaf(self, n) -> typing.Union[Leaf, Expression]:
         r"""
         Selects leaf ``n``.
 
@@ -3606,7 +3617,7 @@ class Selection(AbjadValueObject, collections.Sequence):
         reverse: bool = False,
         tail: bool = None,
         trim: typing.Union[bool, enums.HorizontalAlignment] = None,
-        ):
+        ) -> typing.Union['Selection', Expression]:
         r'''
         Selects leaves (without grace notes).
 
@@ -4374,7 +4385,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                     }
                 }
 
-        Returns new selection (or expression).
         '''
         assert trim in (True, False, enums.Left, None)
         if self._expression:
@@ -4398,7 +4408,7 @@ class Selection(AbjadValueObject, collections.Sequence):
         nontrivial=None,
         pitched=None,
         reverse=False,
-        ):
+        ) -> typing.Union['Selection', Expression]:
         r'''
         Selects logical ties (without grace notes).
 
@@ -4755,7 +4765,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                     }
                 }
 
-        Returns new selection (or expression).
         '''
         if self._expression:
             return self._update_expression(inspect.currentframe())
@@ -4767,7 +4776,10 @@ class Selection(AbjadValueObject, collections.Sequence):
             )
         return type(self)(generator)
 
-    def map(self, expression=None):
+    def map(
+        self,
+        expression=None,
+        ) -> typing.Union['Selection', Expression]:
         r'''
         Maps ``expression`` to items in selection.
 
@@ -4984,7 +4996,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return type(self)(self)
         return type(self)([expression(_) for _ in self])
 
-    def note(self, n):
+    def note(self, n) -> typing.Union[Note, Expression]:
         r"""
         Selects note ``n``.
 
@@ -5076,7 +5088,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self._update_expression(inspect.currentframe(), lone=True)
         return self.notes()[n]
 
-    def notes(self):
+    def notes(self) -> typing.Union['Selection', Expression]:
         r"""
         Selects notes.
 
@@ -5185,7 +5197,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self._update_expression(inspect.currentframe())
         return self.components(Note)
 
-    def nontrivial(self):
+    def nontrivial(self) -> typing.Union['Selection', Expression]:
         r"""
         Filters selection by length greater than 1.
 
@@ -5251,12 +5263,13 @@ class Selection(AbjadValueObject, collections.Sequence):
     def partition_by_counts(
         self,
         counts,
+        *,
         cyclic=False,
         enchain=False,
         fuse_overhang=False,
         nonempty=False,
         overhang=False,
-        ):
+        ) -> typing.Union['Selection', Expression]:
         r"""
         Partitions selection by ``counts``.
 
@@ -5602,10 +5615,211 @@ class Selection(AbjadValueObject, collections.Sequence):
                     c''8
                 }
 
-        Returns nested selection (or expression):
+        ..  container:: example
 
-            >>> type(result).__name__
-            'Selection'
+            With negative ``counts``.
+
+            Partitions leaves alternately into parts 2 and -3 (without
+            overhang):
+
+            ..  container:: example
+
+                >>> string = "c'8 r8 d'8 e'8 r8 f'8 g'8 a'8 b'8 r8 c''8"
+                >>> staff = abjad.Staff(string)
+                >>> abjad.setting(staff).auto_beaming = False
+                >>> abjad.show(staff) # doctest: +SKIP
+
+                >>> result = abjad.select(staff).leaves().partition_by_counts(
+                ...     [2, -3],
+                ...     cyclic=True,
+                ...     )
+
+                >>> for item in result:
+                ...     item
+                ...
+                Selection([Note("c'8"), Rest('r8')])
+                Selection([Note("f'8"), Note("g'8")])
+
+            ..  container:: example expression
+
+                >>> selector = abjad.select().leaves().partition_by_counts(
+                ...     [2, -3],
+                ...     cyclic=True,
+                ...     )
+                >>> result = selector(staff)
+
+                >>> selector.print(result)
+                Selection([Note("c'8"), Rest('r8')])
+                Selection([Note("f'8"), Note("g'8")])
+
+                >>> selector.color(result)
+                >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                \with
+                {
+                    autoBeaming = ##f
+                }
+                {
+                    \abjad_color_music "red"
+                    c'8
+                    \abjad_color_music "red"
+                    r8
+                    d'8
+                    e'8
+                    r8
+                    \abjad_color_music "blue"
+                    f'8
+                    \abjad_color_music "blue"
+                    g'8
+                    a'8
+                    b'8
+                    r8
+                    c''8
+                }
+
+        ..  container:: example
+
+            With negative ``counts``.
+
+            Partitions leaves alternately into parts 2 and -3 (with overhang):
+
+            ..  container:: example
+
+                >>> string = "c'8 r8 d'8 e'8 r8 f'8 g'8 a'8 b'8 r8 c''8"
+                >>> staff = abjad.Staff(string)
+                >>> abjad.setting(staff).auto_beaming = False
+                >>> abjad.show(staff) # doctest: +SKIP
+
+                >>> result = abjad.select(staff).leaves().partition_by_counts(
+                ...     [2, -3],
+                ...     cyclic=True,
+                ...     overhang=True,
+                ...     )
+
+                >>> for item in result:
+                ...     item
+                ...
+                Selection([Note("c'8"), Rest('r8')])
+                Selection([Note("f'8"), Note("g'8")])
+                Selection([Note("c''8")])
+
+            ..  container:: example expression
+
+                >>> selector = abjad.select().leaves().partition_by_counts(
+                ...     [2, -3],
+                ...     cyclic=True,
+                ...     overhang=True,
+                ...     )
+                >>> result = selector(staff)
+
+                >>> selector.print(result)
+                Selection([Note("c'8"), Rest('r8')])
+                Selection([Note("f'8"), Note("g'8")])
+                Selection([Note("c''8")])
+
+                >>> selector.color(result)
+                >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                \with
+                {
+                    autoBeaming = ##f
+                }
+                {
+                    \abjad_color_music "red"
+                    c'8
+                    \abjad_color_music "red"
+                    r8
+                    d'8
+                    e'8
+                    r8
+                    \abjad_color_music "blue"
+                    f'8
+                    \abjad_color_music "blue"
+                    g'8
+                    a'8
+                    b'8
+                    r8
+                    \abjad_color_music "red"
+                    c''8
+                }
+
+        ..  container:: example
+
+            REGRESSION. Noncyclic counts work when ``overhang`` is true:
+
+            ..  container:: example
+
+                >>> string = "c'8 r8 d'8 e'8 r8 f'8 g'8 a'8 b'8 r8 c''8"
+                >>> staff = abjad.Staff(string)
+                >>> abjad.setting(staff).auto_beaming = False
+                >>> abjad.show(staff) # doctest: +SKIP
+
+                >>> result = abjad.select(staff).leaves().partition_by_counts(
+                ...     [3],
+                ...     overhang=True,
+                ...     )
+
+                >>> for item in result:
+                ...     item
+                ...
+                Selection([Note("c'8"), Rest('r8'), Note("d'8")])
+                Selection([Note("e'8"), Rest('r8'), Note("f'8"), Note("g'8"), Note("a'8"), Note("b'8"), Rest('r8'), Note("c''8")])
+
+            ..  container:: example expression
+
+                >>> selector = abjad.select().leaves().partition_by_counts(
+                ...     [3],
+                ...     overhang=True,
+                ...     )
+                >>> result = selector(staff)
+
+                >>> selector.print(result)
+                Selection([Note("c'8"), Rest('r8'), Note("d'8")])
+                Selection([Note("e'8"), Rest('r8'), Note("f'8"), Note("g'8"), Note("a'8"), Note("b'8"), Rest('r8'), Note("c''8")])
+
+                >>> selector.color(result)
+                >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                \with
+                {
+                    autoBeaming = ##f
+                }
+                {
+                    \abjad_color_music "red"
+                    c'8
+                    \abjad_color_music "red"
+                    r8
+                    \abjad_color_music "red"
+                    d'8
+                    \abjad_color_music "blue"
+                    e'8
+                    \abjad_color_music "blue"
+                    r8
+                    \abjad_color_music "blue"
+                    f'8
+                    \abjad_color_music "blue"
+                    g'8
+                    \abjad_color_music "blue"
+                    a'8
+                    \abjad_color_music "blue"
+                    b'8
+                    \abjad_color_music "blue"
+                    r8
+                    \abjad_color_music "blue"
+                    c''8
+                }
 
         """
         if self._expression:
@@ -5618,6 +5832,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             overhang=overhang,
             )
         groups = list(groups)
+        total = len(groups)
         if overhang and fuse_overhang and 1 < len(groups):
             last_count = counts[(len(groups) - 1) % len(counts)]
             if len(groups[-1]) != last_count:
@@ -5627,12 +5842,15 @@ class Selection(AbjadValueObject, collections.Sequence):
         if cyclic:
             counts = CyclicTuple(counts)
         for i, group in enumerate(groups):
-            try:
-                count = counts[i]
-            except:
-                raise Exception(counts, i)
-            if count < 0:
-                continue
+            if overhang and i == total - 1:
+                pass
+            else:
+                try:
+                    count = counts[i]
+                except:
+                    raise Exception(counts, i)
+                if count < 0:
+                    continue
             items = type(self)(group)
             subresult.append(items)
         if nonempty and not subresult:
@@ -5644,11 +5862,12 @@ class Selection(AbjadValueObject, collections.Sequence):
     def partition_by_durations(
         self,
         durations,
+        *,
         cyclic=False,
         fill=None,
         in_seconds=False,
         overhang=False,
-        ):
+        ) -> typing.Union['Selection', Expression]:
         r"""
         Partitions selection by ``durations``.
 
@@ -6568,14 +6787,16 @@ class Selection(AbjadValueObject, collections.Sequence):
                     result.append(part)
                     part = [component]
                     if in_seconds:
-                        cumulative_duration = sum([
+                        sum_ = sum([
                             abjad_inspect(_).duration(in_seconds=True)
                             for _ in part
                             ])
+                        cumulative_duration = Duration(sum_)
                     else:
-                        cumulative_duration = sum([
+                        sum_ = sum([
                             abjad_inspect(_).duration() for _ in part
                             ])
+                        cumulative_duration = Duration(sum_)
                     current_duration_index += 1
                     try:
                         target_duration = durations[current_duration_index]
@@ -6605,10 +6826,13 @@ class Selection(AbjadValueObject, collections.Sequence):
         if len(components_copy):
             if overhang:
                 result.append(components_copy)
-        result = [type(self)(_) for _ in result]
-        return type(self)(result)
+        selections = [type(self)(_) for _ in result]
+        return type(self)(selections)
 
-    def partition_by_ratio(self, ratio):
+    def partition_by_ratio(
+        self,
+        ratio,
+        ) -> typing.Union['Selection', Expression]:
         r"""
         Partitions selection by ``ratio``.
 
@@ -6742,11 +6966,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                     r8
                 }
 
-        Returns nested selection (or expression):
-
-            >>> type(result).__name__
-            'Selection'
-
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())
@@ -6756,7 +6975,7 @@ class Selection(AbjadValueObject, collections.Sequence):
         selections = [type(self)(_) for _ in parts]
         return type(self)(selections)
 
-    def rest(self, n):
+    def rest(self, n) -> typing.Union[Rest, Expression]:
         r"""
         Selects rest ``n``.
 
@@ -6848,7 +7067,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self._update_expression(inspect.currentframe(), lone=True)
         return  self.rests()[n]
 
-    def rests(self):
+    def rests(self) -> typing.Union['Selection', Expression]:
         r"""
         Selects rests.
 
@@ -6948,7 +7167,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self._update_expression(inspect.currentframe())
         return self.components((MultimeasureRest, Rest))
 
-    def run(self, n):
+    def run(self, n) -> typing.Union['Selection', Expression]:
         r"""
         Selects run ``n``.
 
@@ -7044,7 +7263,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self._update_expression(inspect.currentframe(), lone=True)
         return self.runs()[n]
 
-    def runs(self):
+    def runs(self) -> typing.Union['Selection', Expression]:
         r"""
         Selects runs.
 
@@ -7158,7 +7377,7 @@ class Selection(AbjadValueObject, collections.Sequence):
         result = result.group_by_contiguity().map(Selection)
         return result
 
-    def top(self):
+    def top(self) -> typing.Union['Selection', Expression]:
         r"""
         Selects top components.
 
@@ -7238,7 +7457,7 @@ class Selection(AbjadValueObject, collections.Sequence):
         from .Context import Context
         if self._expression:
             return self._update_expression(inspect.currentframe())
-        result = []
+        result: typing.List[typing.Union[Component, Selection]] = []
         for component in iterate(self).components(Component):
             parentage = abjad_inspect(component).parentage()
             for component_ in parentage:
@@ -7251,7 +7470,7 @@ class Selection(AbjadValueObject, collections.Sequence):
                     break
         return type(self)(result)
 
-    def tuplet(self, n):
+    def tuplet(self, n) -> typing.Union[Component, Expression]:
         r"""
         Selects tuplet ``n``.
 
@@ -7348,7 +7567,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self._update_expression(inspect.currentframe(), lone=True)
         return self.tuplets()[n]
 
-    def tuplets(self):
+    def tuplets(self) -> typing.Union['Selection', Expression]:
         r"""
         Selects tuplets.
 
@@ -7464,7 +7683,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             return self._update_expression(inspect.currentframe())
         return self.components(Tuplet)
 
-    def with_next_leaf(self):
+    def with_next_leaf(self) -> typing.Union['Selection', Expression]:
         r"""
         Extends selection with next leaf.
 
@@ -7692,7 +7911,7 @@ class Selection(AbjadValueObject, collections.Sequence):
             leaves.append(next_leaf)
         return type(self)(leaves)
 
-    def with_previous_leaf(self):
+    def with_previous_leaf(self) -> typing.Union['Selection', Expression]:
         r"""
         Extends selection with previous leaf.
 
@@ -7821,7 +8040,6 @@ class Selection(AbjadValueObject, collections.Sequence):
                     f'8
                 }
 
-        Returns new selection (or expression).
         """
         if self._expression:
             return self._update_expression(inspect.currentframe())

--- a/abjad/core/Skip.py
+++ b/abjad/core/Skip.py
@@ -1,3 +1,5 @@
+from abjad.top.parse import parse
+from abjad.utilities.Duration import Duration
 from .Leaf import Leaf
 
 
@@ -16,6 +18,14 @@ class Skip(Leaf):
             >>> abjad.f(skip)
             s8.
 
+    ..  container:: example
+
+        Skips can be tagged:
+
+        >>> skip = abjad.Skip('s8.', tag='GLOBAL_SKIP')
+        >>> abjad.f(skip)
+        s8. %! GLOBAL_SKIP
+
     """
 
     ### CLASS VARIABLES ###
@@ -26,13 +36,12 @@ class Skip(Leaf):
 
     ### INITIALIZER ###
 
-    def __init__(self, *arguments):
-        import abjad
+    def __init__(self, *arguments, tag: str = None) -> None:
         input_leaf = None
         written_duration = None
         if len(arguments) == 1 and isinstance(arguments[0], str):
             string = f'{{ {arguments[0]} }}'
-            parsed = abjad.parse(string)
+            parsed = parse(string)
             assert len(parsed) == 1 and isinstance(parsed[0], Leaf)
             input_leaf = parsed[0]
             written_duration = input_leaf.written_duration
@@ -42,11 +51,11 @@ class Skip(Leaf):
         elif len(arguments) == 1 and not isinstance(arguments[0], str):
             written_duration = arguments[0]
         elif len(arguments) == 0:
-            written_duration = abjad.Duration(1, 4)
+            written_duration = Duration(1, 4)
         else:
             message = f'can not initialize skip from {arguments!r}.'
             raise ValueError(message)
-        Leaf.__init__(self, written_duration)
+        Leaf.__init__(self, written_duration, tag=tag)
         if input_leaf is not None:
             self._copy_override_and_set_from_leaf(input_leaf)
 

--- a/abjad/core/Staff.py
+++ b/abjad/core/Staff.py
@@ -85,14 +85,16 @@ class Staff(Context):
     def __init__(
         self,
         components=None,
-        lilypond_type='Staff',
-        is_simultaneous=None,
-        name=None,
-        ):
+        lilypond_type: str = 'Staff',
+        is_simultaneous: bool = None,
+        name: str = None,
+        tag: str = None,
+        ) -> None:
         Context.__init__(
             self,
             components=components,
             lilypond_type=lilypond_type,
             is_simultaneous=is_simultaneous,
             name=name,
+            tag=tag,
             )

--- a/abjad/core/StaffGroup.py
+++ b/abjad/core/StaffGroup.py
@@ -48,14 +48,16 @@ class StaffGroup(Context):
     def __init__(
         self,
         components=None,
-        lilypond_type='StaffGroup',
-        is_simultaneous=True,
-        name=None,
-        ):
+        lilypond_type: str = 'StaffGroup',
+        is_simultaneous: bool = True,
+        name: str = None,
+        tag: str = None,
+        ) -> None:
         Context.__init__(
             self,
             components=components,
             lilypond_type=lilypond_type,
             is_simultaneous=is_simultaneous,
             name=name,
+            tag=tag,
             )

--- a/abjad/core/Voice.py
+++ b/abjad/core/Voice.py
@@ -1,3 +1,4 @@
+import typing
 from .Context import Context
 
 
@@ -36,14 +37,40 @@ class Voice(Context):
     def __init__(
         self,
         components=None,
-        lilypond_type='Voice',
-        is_simultaneous=None,
-        name=None,
-        ):
+        lilypond_type: str = 'Voice',
+        is_simultaneous: bool = None,
+        name: str = None,
+        tag: str = None,
+        ) -> None:
         Context.__init__(
             self,
             components=components,
             lilypond_type=lilypond_type,
             is_simultaneous=is_simultaneous,
             name=name,
+            tag=tag,
             )
+
+    ### PUBLIC PROPERTIES ###
+
+    @property
+    def tag(self) -> typing.Optional[str]:
+        r"""
+        Gets tag.
+
+        ..  container:: example
+
+            >>> voice = abjad.Voice("c'4 d' e' f'", tag='RED')
+            >>> abjad.show(voice) # doctest: +SKIP
+
+            >>> abjad.f(voice, strict=20)
+            \new Voice          %! RED
+            {                   %! RED
+                c'4
+                d'4
+                e'4
+                f'4
+            }                   %! RED
+
+        """
+        return super().tag

--- a/abjad/core/Wellformedness.py
+++ b/abjad/core/Wellformedness.py
@@ -831,14 +831,17 @@ class Wellformedness(AbjadObject):
             for wrapper in wrappers:
                 if isinstance(wrapper.indicator, StartTextSpan):
                     total += 1
-                    string = wrapper.indicator.command
-                    string = string.strip(r'\start')
-                    open_spanners[string] = wrapper.component
+                    command = wrapper.indicator.command
+                    command = command.strip(r'\start')
+                    if command not in open_spanners:
+                        open_spanners[command] = []
+                    open_spanners[command].append(wrapper.component)
                 elif isinstance(wrapper.indicator, StopTextSpan):
-                    string = wrapper.indicator.command
-                    string = string.strip(r'\stop')
-                    assert string in open_spanners, repr(string)
-                    del(open_spanners[string])
-            for string, component in open_spanners.items():
-                violators.append(component)
+                    command = wrapper.indicator.command
+                    command = command.strip(r'\stop')
+                    assert command in open_spanners, repr(command)
+                    open_spanners[command].pop()
+            for command, list_ in open_spanners.items():
+                for component in list_:
+                    violators.append(component)
         return violators, total

--- a/abjad/indicators/Articulation.py
+++ b/abjad/indicators/Articulation.py
@@ -204,7 +204,7 @@ class Articulation(AbjadValueObject):
                     self.direction)
                 assert isinstance(direction_, String), repr(direction)
                 direction = direction_
-            return f'{direction}\{string}'
+            return f'{direction} \{string}'
         else:
             return ''
 
@@ -299,7 +299,7 @@ class Articulation(AbjadValueObject):
                 >>> abjad.f(note)
                 c'4
                 - \tweak color #blue
-                -\marcato
+                - \marcato
 
         ..  container:: example
 
@@ -316,7 +316,7 @@ class Articulation(AbjadValueObject):
                 >>> abjad.f(note)
                 c'4
                 - \tweak color #blue
-                -\marcato
+                - \marcato
 
         """
         return self._tweaks

--- a/abjad/indicators/Dynamic.py
+++ b/abjad/indicators/Dynamic.py
@@ -8,7 +8,9 @@ from abjad.system.AbjadValueObject import AbjadValueObject
 from abjad.system.FormatSpecification import FormatSpecification
 from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 from abjad.system.LilyPondFormatManager import LilyPondFormatManager
+from abjad.system.Tags import Tags
 from abjad.utilities.String import String
+abjad_tags = Tags()
 
 
 class Dynamic(AbjadValueObject):
@@ -474,8 +476,6 @@ class Dynamic(AbjadValueObject):
 
     @staticmethod
     def _tag_hide(strings):
-        import abjad
-        abjad_tags = abjad.Tags()
         return LilyPondFormatManager.tag(
             strings,
             deactivate=False,

--- a/abjad/lilypondfile/Block.py
+++ b/abjad/lilypondfile/Block.py
@@ -173,7 +173,7 @@ class Block(AbjadObject):
             result.extend(pieces)
         return result
 
-    def _get_format_pieces(self):
+    def _get_format_pieces(self, tag=None):
         import abjad
         indent = LilyPondFormatManager.indent
         result = []
@@ -187,6 +187,12 @@ class Block(AbjadObject):
             result.append(string)
             return result
         string = '{} {{'.format(self._escaped_name)
+        if tag is not None:
+            strings = LilyPondFormatManager.tag(
+                [string],
+                tag=tag,
+                )
+            string = strings[0]
         result.append(string)
         for item in self.items:
             if isinstance(item, abjad.ContextBlock):
@@ -202,7 +208,15 @@ class Block(AbjadObject):
         formatted_context_blocks = [
             indent + _ for _ in formatted_context_blocks]
         result.extend(formatted_context_blocks)
-        result.append('}')
+        string = '}'
+        if tag is not None:
+            strings = LilyPondFormatManager.tag(
+                [string],
+                tag=tag,
+                )
+            string = strings[0]
+        result.append(string)
+
         return result
 
     def _get_format_specification(self):
@@ -216,7 +230,6 @@ class Block(AbjadObject):
     def _get_formatted_user_attributes(self):
         import abjad
         result = []
-        #prototype = (abjad.Scheme, abjad.LilyPondLiteral)
         prototype = abjad.Scheme
         for value in self.items:
             if isinstance(value, prototype):
@@ -224,7 +237,6 @@ class Block(AbjadObject):
         prototype = (
             abjad.Scheme,
             abjad.LilyPondDimension,
-            #abjad.LilyPondLiteral,
             )
         for key in self._public_attribute_names:
             assert not key.startswith('_'), repr(key)
@@ -246,17 +258,13 @@ class Block(AbjadObject):
                 formatted_value = abjad.Scheme(value)
                 formatted_value = format(formatted_value, 'lilypond')
                 formatted_value = [formatted_value]
-            setting = '{!s} = {!s}'
-            setting = setting.format(
-                formatted_key,
-                formatted_value[0],
-                )
+            setting = f'{formatted_key!s} = {formatted_value[0]!s}'
             result.append(setting)
             result.extend(formatted_value[1:])
         return result
 
-    def _get_lilypond_format(self):
-        return '\n'.join(self._get_format_pieces())
+    def _get_lilypond_format(self, tag=None):
+        return '\n'.join(self._get_format_pieces(tag=tag))
 
     ### PUBLIC PROPERTIES ###
 

--- a/abjad/lilypondfile/ContextBlock.py
+++ b/abjad/lilypondfile/ContextBlock.py
@@ -64,7 +64,7 @@ class ContextBlock(Block):
 
     ### PRIVATE METHODS ###
 
-    def _get_format_pieces(self):
+    def _get_format_pieces(self, tag=None):
         import abjad
         indent = abjad.LilyPondFormatManager.indent
         result = []

--- a/abjad/lilypondfile/LilyPondDimension.py
+++ b/abjad/lilypondfile/LilyPondDimension.py
@@ -52,7 +52,7 @@ class LilyPondDimension(system.AbjadObject):
 
     ### PRIVATE METHODS ###
 
-    def _get_format_pieces(self):
+    def _get_format_pieces(self, tag=None):
         return [r'{}\{}'.format(self.value, self.unit)]
 
     def _get_lilypond_format(self):

--- a/abjad/parser/LilyPondParser.py
+++ b/abjad/parser/LilyPondParser.py
@@ -40,7 +40,7 @@ class LilyPondParser(Parser):
             d'8
             e'8
             fs'2
-            -\fermata
+            - \fermata
             )
         }
 
@@ -74,10 +74,10 @@ class LilyPondParser(Parser):
                 \>
                 (
                 d'8
-                -\portato
+                - \portato
                 [
                 e'8
-                ^\accent
+                ^ \accent
                 f'8
                 \ppp
                 \<
@@ -91,7 +91,7 @@ class LilyPondParser(Parser):
                 \stopTrillSpan
                 c''8
                 \sfz
-                -\accent
+                - \accent
                 )
             }
 

--- a/abjad/pitch/Inversion.py
+++ b/abjad/pitch/Inversion.py
@@ -73,7 +73,7 @@ class Inversion(AbjadValueObject):
                     g'8
                     f'8
                     e'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -98,7 +98,7 @@ class Inversion(AbjadValueObject):
                     cs'8
                     b'8
                     bf'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 

--- a/abjad/pitch/Multiplication.py
+++ b/abjad/pitch/Multiplication.py
@@ -71,7 +71,7 @@ class Multiplication(AbjadValueObject):
                     cs'8
                     b'8
                     e'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -96,7 +96,7 @@ class Multiplication(AbjadValueObject):
                     cs'8
                     b'8
                     e'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 

--- a/abjad/pitch/PitchClassSegment.py
+++ b/abjad/pitch/PitchClassSegment.py
@@ -31,7 +31,7 @@ class PitchClassSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -55,7 +55,7 @@ class PitchClassSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -82,7 +82,7 @@ class PitchClassSegment(Segment):
                     ef'8
                     bqs'8
                     d'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -106,7 +106,7 @@ class PitchClassSegment(Segment):
                     ef'8
                     bqs'8
                     d'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -183,7 +183,7 @@ class PitchClassSegment(Segment):
                         ef'8
                         bqs'8
                         d'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -233,7 +233,7 @@ class PitchClassSegment(Segment):
                         ef'8
                         bqs'8
                         d'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -265,7 +265,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -315,7 +315,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -356,7 +356,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -419,7 +419,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -451,7 +451,7 @@ class PitchClassSegment(Segment):
                         d'8
                         c'8
                         ef'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -515,7 +515,7 @@ class PitchClassSegment(Segment):
                         d'8
                         c'8
                         ef'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -548,7 +548,7 @@ class PitchClassSegment(Segment):
                         bqf'8
                         bf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -622,7 +622,7 @@ class PitchClassSegment(Segment):
                         bqf'8
                         bf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -695,7 +695,7 @@ class PitchClassSegment(Segment):
                     d'8
                     c'8
                     ef'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -743,7 +743,7 @@ class PitchClassSegment(Segment):
                     ef'8
                     cs'8
                     e'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -828,7 +828,7 @@ class PitchClassSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -865,7 +865,7 @@ class PitchClassSegment(Segment):
                     ef'8
                     bqs'8
                     d'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -988,7 +988,7 @@ class PitchClassSegment(Segment):
                         bqf'8
                         fs'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -1029,7 +1029,7 @@ class PitchClassSegment(Segment):
                         bqf'8
                         fs'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -1055,7 +1055,7 @@ class PitchClassSegment(Segment):
                         fs'8
                         bqf'8
                         bf'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -1101,7 +1101,7 @@ class PitchClassSegment(Segment):
                         fs'8
                         bqf'8
                         bf'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -1127,7 +1127,7 @@ class PitchClassSegment(Segment):
                         bqf'8
                         g'8
                         fs'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -1178,7 +1178,7 @@ class PitchClassSegment(Segment):
                         bqf'8
                         g'8
                         fs'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -1221,7 +1221,7 @@ class PitchClassSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1246,7 +1246,7 @@ class PitchClassSegment(Segment):
                     ef'8
                     bqs'8
                     d'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1710,7 +1710,7 @@ class PitchClassSegment(Segment):
                         f'8
                         dqf'8
                         f'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -1752,7 +1752,7 @@ class PitchClassSegment(Segment):
                         f'8
                         dqf'8
                         f'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -1780,7 +1780,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -1830,7 +1830,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -1979,7 +1979,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2023,7 +2023,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2051,7 +2051,7 @@ class PitchClassSegment(Segment):
                         b'8
                         eqs'8
                         b'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2095,7 +2095,7 @@ class PitchClassSegment(Segment):
                         b'8
                         eqs'8
                         b'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2123,7 +2123,7 @@ class PitchClassSegment(Segment):
                         cs'8
                         dqf'8
                         cs'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2167,7 +2167,7 @@ class PitchClassSegment(Segment):
                         cs'8
                         dqf'8
                         cs'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2195,7 +2195,7 @@ class PitchClassSegment(Segment):
                         f'8
                         gqs'8
                         f'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2239,7 +2239,7 @@ class PitchClassSegment(Segment):
                         f'8
                         gqs'8
                         f'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2283,7 +2283,7 @@ class PitchClassSegment(Segment):
                     g'8
                     b'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -2305,7 +2305,7 @@ class PitchClassSegment(Segment):
                     ef'8
                     b'8
                     ef'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -2349,7 +2349,7 @@ class PitchClassSegment(Segment):
                     ef'8
                     b'8
                     ef'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -2402,7 +2402,7 @@ class PitchClassSegment(Segment):
                         fs'8
                         bqf'8
                         bf'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2444,7 +2444,7 @@ class PitchClassSegment(Segment):
                         fs'8
                         bqf'8
                         bf'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2472,7 +2472,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2522,7 +2522,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2585,7 +2585,7 @@ class PitchClassSegment(Segment):
                         fs'8
                         g'8
                         bqf'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2629,7 +2629,7 @@ class PitchClassSegment(Segment):
                         fs'8
                         g'8
                         bqf'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2657,7 +2657,7 @@ class PitchClassSegment(Segment):
                         bqf'8
                         g'8
                         bf'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2701,7 +2701,7 @@ class PitchClassSegment(Segment):
                         bqf'8
                         g'8
                         bf'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2729,7 +2729,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2776,7 +2776,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2808,7 +2808,7 @@ class PitchClassSegment(Segment):
                         b'8
                         c'8
                         eqf'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2852,7 +2852,7 @@ class PitchClassSegment(Segment):
                         b'8
                         c'8
                         eqf'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -2902,7 +2902,7 @@ class PitchClassSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -2924,7 +2924,7 @@ class PitchClassSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -2954,7 +2954,7 @@ class PitchClassSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -2976,7 +2976,7 @@ class PitchClassSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -3011,7 +3011,7 @@ class PitchClassSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -3075,7 +3075,7 @@ class PitchClassSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -3164,7 +3164,7 @@ class PitchClassSegment(Segment):
                         af'8
                         bqs'8
                         af'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -3208,7 +3208,7 @@ class PitchClassSegment(Segment):
                         af'8
                         bqs'8
                         af'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -3236,7 +3236,7 @@ class PitchClassSegment(Segment):
                         fs'8
                         aqs'8
                         fs'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -3280,7 +3280,7 @@ class PitchClassSegment(Segment):
                         fs'8
                         aqs'8
                         fs'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -3308,7 +3308,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 
@@ -3355,7 +3355,7 @@ class PitchClassSegment(Segment):
                         g'8
                         bqf'8
                         g'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 

--- a/abjad/pitch/PitchSegment.py
+++ b/abjad/pitch/PitchSegment.py
@@ -985,7 +985,7 @@ class PitchSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1044,7 +1044,7 @@ class PitchSegment(Segment):
                     g'8
                     bqf'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 

--- a/abjad/pitch/Retrograde.py
+++ b/abjad/pitch/Retrograde.py
@@ -68,7 +68,7 @@ class Retrograde(AbjadValueObject):
                     g'8
                     f'8
                     ef'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -93,7 +93,7 @@ class Retrograde(AbjadValueObject):
                     g'8
                     f'8
                     ef'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 

--- a/abjad/pitch/Rotation.py
+++ b/abjad/pitch/Rotation.py
@@ -78,7 +78,7 @@ class Rotation(AbjadValueObject):
                     g'8
                     af'8
                     ef'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -103,7 +103,7 @@ class Rotation(AbjadValueObject):
                     g'8
                     af'8
                     ef'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 

--- a/abjad/pitch/Transposition.py
+++ b/abjad/pitch/Transposition.py
@@ -71,7 +71,7 @@ class Transposition(AbjadValueObject):
                     fs'8
                     af'8
                     a'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -96,7 +96,7 @@ class Transposition(AbjadValueObject):
                     fs'8
                     af'8
                     a'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 

--- a/abjad/pitch/TwelveToneRow.py
+++ b/abjad/pitch/TwelveToneRow.py
@@ -96,7 +96,7 @@ class TwelveToneRow(PitchClassSegment):
                     e'8
                     c'8
                     e'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -126,7 +126,7 @@ class TwelveToneRow(PitchClassSegment):
                     a'8
                     bf'8
                     b'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -151,7 +151,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     af'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -181,7 +181,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     cs'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -206,7 +206,7 @@ class TwelveToneRow(PitchClassSegment):
                     a'8
                     b'8
                     cs'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -236,7 +236,7 @@ class TwelveToneRow(PitchClassSegment):
                     a'8
                     e'8
                     b'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -261,7 +261,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     fs'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -308,7 +308,7 @@ class TwelveToneRow(PitchClassSegment):
                     ef'8
                     fs'8
                     g'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -330,7 +330,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     af'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -381,7 +381,7 @@ class TwelveToneRow(PitchClassSegment):
                     a'8
                     bf'8
                     b'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -412,7 +412,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     af'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -470,7 +470,7 @@ class TwelveToneRow(PitchClassSegment):
                     a'8
                     bf'8
                     b'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -516,7 +516,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     af'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -575,7 +575,7 @@ class TwelveToneRow(PitchClassSegment):
                     a'8
                     bf'8
                     b'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -620,7 +620,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     af'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -916,7 +916,7 @@ class TwelveToneRow(PitchClassSegment):
                     c'8
                     fs'8
                     d'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -951,7 +951,7 @@ class TwelveToneRow(PitchClassSegment):
                     c'8
                     fs'8
                     d'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -982,7 +982,7 @@ class TwelveToneRow(PitchClassSegment):
                     bf'8
                     e'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1011,7 +1011,7 @@ class TwelveToneRow(PitchClassSegment):
                     af'8
                     d'8
                     bf'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1065,7 +1065,7 @@ class TwelveToneRow(PitchClassSegment):
                     bf'8
                     e'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1094,7 +1094,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     af'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1123,7 +1123,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     af'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1174,7 +1174,7 @@ class TwelveToneRow(PitchClassSegment):
                     a'8
                     b'8
                     cs'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1203,7 +1203,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     af'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1257,7 +1257,7 @@ class TwelveToneRow(PitchClassSegment):
                     bf'8
                     d'8
                     af'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1286,7 +1286,7 @@ class TwelveToneRow(PitchClassSegment):
                     af'8
                     c'8
                     cs'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1315,7 +1315,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     af'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1347,7 +1347,7 @@ class TwelveToneRow(PitchClassSegment):
                     a'8
                     cs'8
                     d'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1398,7 +1398,7 @@ class TwelveToneRow(PitchClassSegment):
                     ef'8
                     a'8
                     cs'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1427,7 +1427,7 @@ class TwelveToneRow(PitchClassSegment):
                     cs'8
                     g'8
                     b'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 
@@ -1456,7 +1456,7 @@ class TwelveToneRow(PitchClassSegment):
                     d'8
                     af'8
                     c'8
-                    \bar "|." %! SCORE1
+                    \bar "|." %! SCORE_1
                     \override Score.BarLine.transparent = ##f
                 }
 

--- a/abjad/segments/GroupedRhythmicStavesScoreTemplate.py
+++ b/abjad/segments/GroupedRhythmicStavesScoreTemplate.py
@@ -17,80 +17,80 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
 
         ..  docs::
 
-            >>> abjad.f(template_1.__illustrate__()[abjad.Score])
-            \context Score = "Grouped Rhythmic Staves Score"
-            <<
-                \context StaffGroup = "Grouped Rhythmic Staves Staff Group"
-                <<
-                    \context RhythmicStaff = "Staff 1"
-                    {
-                        \context Voice = "Voice 1"
-                        {
-                            \clef "percussion" %! ST3
-                            s1
-                        }
-                    }
-                    \context RhythmicStaff = "Staff 2"
-                    {
-                        \context Voice = "Voice 2"
-                        {
-                            \clef "percussion" %! ST3
-                            s1
-                        }
-                    }
-                    \context RhythmicStaff = "Staff 3"
-                    {
-                        \context Voice = "Voice 3"
-                        {
-                            \clef "percussion" %! ST3
-                            s1
-                        }
-                    }
-                    \context RhythmicStaff = "Staff 4"
-                    {
-                        \context Voice = "Voice 4"
-                        {
-                            \clef "percussion" %! ST3
-                            s1
-                        }
-                    }
-                >>
-            >>
+            >>> abjad.f(template_1.__illustrate__()[abjad.Score], strict=60)
+            \context Score = "Grouped Rhythmic Staves Score"            %! GroupedRhythmicStavesScoreTemplate
+            <<                                                          %! GroupedRhythmicStavesScoreTemplate
+                \context StaffGroup = "Grouped Rhythmic Staves Staff Group" %! GroupedRhythmicStavesScoreTemplate
+                <<                                                      %! GroupedRhythmicStavesScoreTemplate
+                    \context RhythmicStaff = "Staff 1"                  %! GroupedRhythmicStavesScoreTemplate
+                    {                                                   %! GroupedRhythmicStavesScoreTemplate
+                        \context Voice = "Voice 1"                      %! GroupedRhythmicStavesScoreTemplate
+                        {                                               %! GroupedRhythmicStavesScoreTemplate
+                            \clef "percussion"                          %! attach_defaults
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                                   %! GroupedRhythmicStavesScoreTemplate
+                    \context RhythmicStaff = "Staff 2"                  %! GroupedRhythmicStavesScoreTemplate
+                    {                                                   %! GroupedRhythmicStavesScoreTemplate
+                        \context Voice = "Voice 2"                      %! GroupedRhythmicStavesScoreTemplate
+                        {                                               %! GroupedRhythmicStavesScoreTemplate
+                            \clef "percussion"                          %! attach_defaults
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                                   %! GroupedRhythmicStavesScoreTemplate
+                    \context RhythmicStaff = "Staff 3"                  %! GroupedRhythmicStavesScoreTemplate
+                    {                                                   %! GroupedRhythmicStavesScoreTemplate
+                        \context Voice = "Voice 3"                      %! GroupedRhythmicStavesScoreTemplate
+                        {                                               %! GroupedRhythmicStavesScoreTemplate
+                            \clef "percussion"                          %! attach_defaults
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                                   %! GroupedRhythmicStavesScoreTemplate
+                    \context RhythmicStaff = "Staff 4"                  %! GroupedRhythmicStavesScoreTemplate
+                    {                                                   %! GroupedRhythmicStavesScoreTemplate
+                        \context Voice = "Voice 4"                      %! GroupedRhythmicStavesScoreTemplate
+                        {                                               %! GroupedRhythmicStavesScoreTemplate
+                            \clef "percussion"                          %! attach_defaults
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                                   %! GroupedRhythmicStavesScoreTemplate
+                >>                                                      %! GroupedRhythmicStavesScoreTemplate
+            >>                                                          %! GroupedRhythmicStavesScoreTemplate
 
         >>> score = template_1()
         >>> abjad.show(score) # doctest: +SKIP
 
-        >>> abjad.f(score)
-        \context Score = "Grouped Rhythmic Staves Score"
-        <<
-            \context StaffGroup = "Grouped Rhythmic Staves Staff Group"
-            <<
-                \context RhythmicStaff = "Staff 1"
-                {
-                    \context Voice = "Voice 1"
-                    {
-                    }
-                }
-                \context RhythmicStaff = "Staff 2"
-                {
-                    \context Voice = "Voice 2"
-                    {
-                    }
-                }
-                \context RhythmicStaff = "Staff 3"
-                {
-                    \context Voice = "Voice 3"
-                    {
-                    }
-                }
-                \context RhythmicStaff = "Staff 4"
-                {
-                    \context Voice = "Voice 4"
-                    {
-                    }
-                }
-            >>
-        >>
+        >>> abjad.f(score, strict=60)
+        \context Score = "Grouped Rhythmic Staves Score"            %! GroupedRhythmicStavesScoreTemplate
+        <<                                                          %! GroupedRhythmicStavesScoreTemplate
+            \context StaffGroup = "Grouped Rhythmic Staves Staff Group" %! GroupedRhythmicStavesScoreTemplate
+            <<                                                      %! GroupedRhythmicStavesScoreTemplate
+                \context RhythmicStaff = "Staff 1"                  %! GroupedRhythmicStavesScoreTemplate
+                {                                                   %! GroupedRhythmicStavesScoreTemplate
+                    \context Voice = "Voice 1"                      %! GroupedRhythmicStavesScoreTemplate
+                    {                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                               %! GroupedRhythmicStavesScoreTemplate
+                }                                                   %! GroupedRhythmicStavesScoreTemplate
+                \context RhythmicStaff = "Staff 2"                  %! GroupedRhythmicStavesScoreTemplate
+                {                                                   %! GroupedRhythmicStavesScoreTemplate
+                    \context Voice = "Voice 2"                      %! GroupedRhythmicStavesScoreTemplate
+                    {                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                               %! GroupedRhythmicStavesScoreTemplate
+                }                                                   %! GroupedRhythmicStavesScoreTemplate
+                \context RhythmicStaff = "Staff 3"                  %! GroupedRhythmicStavesScoreTemplate
+                {                                                   %! GroupedRhythmicStavesScoreTemplate
+                    \context Voice = "Voice 3"                      %! GroupedRhythmicStavesScoreTemplate
+                    {                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                               %! GroupedRhythmicStavesScoreTemplate
+                }                                                   %! GroupedRhythmicStavesScoreTemplate
+                \context RhythmicStaff = "Staff 4"                  %! GroupedRhythmicStavesScoreTemplate
+                {                                                   %! GroupedRhythmicStavesScoreTemplate
+                    \context Voice = "Voice 4"                      %! GroupedRhythmicStavesScoreTemplate
+                    {                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                               %! GroupedRhythmicStavesScoreTemplate
+                }                                                   %! GroupedRhythmicStavesScoreTemplate
+            >>                                                      %! GroupedRhythmicStavesScoreTemplate
+        >>                                                          %! GroupedRhythmicStavesScoreTemplate
 
     ..  container:: example
 
@@ -101,77 +101,77 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
 
         ..  docs::
 
-            >>> abjad.f(template_2.__illustrate__()[abjad.Score])
-            \context Score = "Grouped Rhythmic Staves Score"
-            <<
-                \context StaffGroup = "Grouped Rhythmic Staves Staff Group"
-                <<
-                    \context RhythmicStaff = "Staff 1"
-                    <<
-                        \context Voice = "Voice 1-1"
-                        {
-                            s1
-                        }
-                        \context Voice = "Voice 1-2"
-                        {
-                            s1
-                        }
-                    >>
-                    \context RhythmicStaff = "Staff 2"
-                    {
-                        \context Voice = "Voice 2"
-                        {
-                            s1
-                        }
-                    }
-                    \context RhythmicStaff = "Staff 3"
-                    <<
-                        \context Voice = "Voice 3-1"
-                        {
-                            s1
-                        }
-                        \context Voice = "Voice 3-2"
-                        {
-                            s1
-                        }
-                    >>
-                >>
-            >>
+            >>> abjad.f(template_2.__illustrate__()[abjad.Score], strict=60)
+            \context Score = "Grouped Rhythmic Staves Score"            %! GroupedRhythmicStavesScoreTemplate
+            <<                                                          %! GroupedRhythmicStavesScoreTemplate
+                \context StaffGroup = "Grouped Rhythmic Staves Staff Group" %! GroupedRhythmicStavesScoreTemplate
+                <<                                                      %! GroupedRhythmicStavesScoreTemplate
+                    \context RhythmicStaff = "Staff 1"                  %! GroupedRhythmicStavesScoreTemplate
+                    <<                                                  %! GroupedRhythmicStavesScoreTemplate
+                        \context Voice = "Voice 1-1"                    %! GroupedRhythmicStavesScoreTemplate
+                        {                                               %! GroupedRhythmicStavesScoreTemplate
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedRhythmicStavesScoreTemplate
+                        \context Voice = "Voice 1-2"                    %! GroupedRhythmicStavesScoreTemplate
+                        {                                               %! GroupedRhythmicStavesScoreTemplate
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedRhythmicStavesScoreTemplate
+                    >>                                                  %! GroupedRhythmicStavesScoreTemplate
+                    \context RhythmicStaff = "Staff 2"                  %! GroupedRhythmicStavesScoreTemplate
+                    {                                                   %! GroupedRhythmicStavesScoreTemplate
+                        \context Voice = "Voice 2"                      %! GroupedRhythmicStavesScoreTemplate
+                        {                                               %! GroupedRhythmicStavesScoreTemplate
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                                   %! GroupedRhythmicStavesScoreTemplate
+                    \context RhythmicStaff = "Staff 3"                  %! GroupedRhythmicStavesScoreTemplate
+                    <<                                                  %! GroupedRhythmicStavesScoreTemplate
+                        \context Voice = "Voice 3-1"                    %! GroupedRhythmicStavesScoreTemplate
+                        {                                               %! GroupedRhythmicStavesScoreTemplate
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedRhythmicStavesScoreTemplate
+                        \context Voice = "Voice 3-2"                    %! GroupedRhythmicStavesScoreTemplate
+                        {                                               %! GroupedRhythmicStavesScoreTemplate
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedRhythmicStavesScoreTemplate
+                    >>                                                  %! GroupedRhythmicStavesScoreTemplate
+                >>                                                      %! GroupedRhythmicStavesScoreTemplate
+            >>                                                          %! GroupedRhythmicStavesScoreTemplate
 
         >>> score = template_2()
         >>> abjad.show(score) # doctest: +SKIP
 
-        >>> abjad.f(score)
-        \context Score = "Grouped Rhythmic Staves Score"
-        <<
-            \context StaffGroup = "Grouped Rhythmic Staves Staff Group"
-            <<
-                \context RhythmicStaff = "Staff 1"
-                <<
-                    \context Voice = "Voice 1-1"
-                    {
-                    }
-                    \context Voice = "Voice 1-2"
-                    {
-                    }
-                >>
-                \context RhythmicStaff = "Staff 2"
-                {
-                    \context Voice = "Voice 2"
-                    {
-                    }
-                }
-                \context RhythmicStaff = "Staff 3"
-                <<
-                    \context Voice = "Voice 3-1"
-                    {
-                    }
-                    \context Voice = "Voice 3-2"
-                    {
-                    }
-                >>
-            >>
-        >>
+        >>> abjad.f(score, strict=60)
+        \context Score = "Grouped Rhythmic Staves Score"            %! GroupedRhythmicStavesScoreTemplate
+        <<                                                          %! GroupedRhythmicStavesScoreTemplate
+            \context StaffGroup = "Grouped Rhythmic Staves Staff Group" %! GroupedRhythmicStavesScoreTemplate
+            <<                                                      %! GroupedRhythmicStavesScoreTemplate
+                \context RhythmicStaff = "Staff 1"                  %! GroupedRhythmicStavesScoreTemplate
+                <<                                                  %! GroupedRhythmicStavesScoreTemplate
+                    \context Voice = "Voice 1-1"                    %! GroupedRhythmicStavesScoreTemplate
+                    {                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                               %! GroupedRhythmicStavesScoreTemplate
+                    \context Voice = "Voice 1-2"                    %! GroupedRhythmicStavesScoreTemplate
+                    {                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                               %! GroupedRhythmicStavesScoreTemplate
+                >>                                                  %! GroupedRhythmicStavesScoreTemplate
+                \context RhythmicStaff = "Staff 2"                  %! GroupedRhythmicStavesScoreTemplate
+                {                                                   %! GroupedRhythmicStavesScoreTemplate
+                    \context Voice = "Voice 2"                      %! GroupedRhythmicStavesScoreTemplate
+                    {                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                               %! GroupedRhythmicStavesScoreTemplate
+                }                                                   %! GroupedRhythmicStavesScoreTemplate
+                \context RhythmicStaff = "Staff 3"                  %! GroupedRhythmicStavesScoreTemplate
+                <<                                                  %! GroupedRhythmicStavesScoreTemplate
+                    \context Voice = "Voice 3-1"                    %! GroupedRhythmicStavesScoreTemplate
+                    {                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                               %! GroupedRhythmicStavesScoreTemplate
+                    \context Voice = "Voice 3-2"                    %! GroupedRhythmicStavesScoreTemplate
+                    {                                               %! GroupedRhythmicStavesScoreTemplate
+                    }                                               %! GroupedRhythmicStavesScoreTemplate
+                >>                                                  %! GroupedRhythmicStavesScoreTemplate
+            >>                                                      %! GroupedRhythmicStavesScoreTemplate
+        >>                                                          %! GroupedRhythmicStavesScoreTemplate
 
     """
 
@@ -200,13 +200,14 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
         """
         import abjad
         staves = []
+        tag = 'GroupedRhythmicStavesScoreTemplate'
         if isinstance(self.staff_count, int):
             for index in range(self.staff_count):
                 number = index + 1
                 name = 'Voice {}'.format(number)
-                voice = abjad.Voice([], name=name)
+                voice = abjad.Voice([], name=name, tag=tag)
                 name = 'Staff {}'.format(number)
-                staff = abjad.Staff([voice], name=name)
+                staff = abjad.Staff([voice], name=name, tag=tag)
                 staff.lilypond_type = 'RhythmicStaff'
                 abjad.annotate(staff, 'default_clef', abjad.Clef('percussion'))
                 staves.append(staff)
@@ -216,7 +217,7 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
             for staff_index, voice_count in enumerate(self.staff_count):
                 staff_number = staff_index + 1
                 name = 'Staff {}'.format(staff_number)
-                staff = abjad.Staff(name=name)
+                staff = abjad.Staff(name=name, tag=tag)
                 staff.lilypond_type = 'RhythmicStaff'
                 assert 1 <= voice_count
                 for voice_index in range(voice_count):
@@ -228,7 +229,7 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
                             staff_number, voice_number)
                         staff.is_simultaneous = True
                     name = 'Voice {}'.format(voice_identifier)
-                    voice = abjad.Voice([], name=name)
+                    voice = abjad.Voice([], name=name, tag=tag)
                     staff.append(voice)
                     key = 'v{}'.format(voice_identifier)
                     self.voice_abbreviations[key] = voice.name
@@ -236,10 +237,12 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
         grouped_rhythmic_staves_staff_group = abjad.StaffGroup(
             staves,
             name='Grouped Rhythmic Staves Staff Group',
+            tag=tag,
             )
         grouped_rhythmic_staves_score = abjad.Score(
             [grouped_rhythmic_staves_staff_group],
             name='Grouped Rhythmic Staves Score',
+            tag=tag,
             )
         return grouped_rhythmic_staves_score
 

--- a/abjad/segments/GroupedStavesScoreTemplate.py
+++ b/abjad/segments/GroupedStavesScoreTemplate.py
@@ -14,74 +14,74 @@ class GroupedStavesScoreTemplate(ScoreTemplate):
 
         ..  docs::
 
-            >>> abjad.f(template.__illustrate__()[abjad.Score])
-            \context Score = "Grouped Staves Score"
-            <<
-                \context StaffGroup = "Grouped Staves Staff Group"
-                <<
-                    \context Staff = "Staff 1"
-                    {
-                        \context Voice = "Voice 1"
-                        {
-                            s1
-                        }
-                    }
-                    \context Staff = "Staff 2"
-                    {
-                        \context Voice = "Voice 2"
-                        {
-                            s1
-                        }
-                    }
-                    \context Staff = "Staff 3"
-                    {
-                        \context Voice = "Voice 3"
-                        {
-                            s1
-                        }
-                    }
-                    \context Staff = "Staff 4"
-                    {
-                        \context Voice = "Voice 4"
-                        {
-                            s1
-                        }
-                    }
-                >>
-            >>
+            >>> abjad.f(template.__illustrate__()[abjad.Score], strict=60)
+            \context Score = "Grouped Staves Score"                     %! GroupedStavesScoreTemplate
+            <<                                                          %! GroupedStavesScoreTemplate
+                \context StaffGroup = "Grouped Staves Staff Group"      %! GroupedStavesScoreTemplate
+                <<                                                      %! GroupedStavesScoreTemplate
+                    \context Staff = "Staff 1"                          %! GroupedStavesScoreTemplate
+                    {                                                   %! GroupedStavesScoreTemplate
+                        \context Voice = "Voice 1"                      %! GroupedStavesScoreTemplate
+                        {                                               %! GroupedStavesScoreTemplate
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedStavesScoreTemplate
+                    }                                                   %! GroupedStavesScoreTemplate
+                    \context Staff = "Staff 2"                          %! GroupedStavesScoreTemplate
+                    {                                                   %! GroupedStavesScoreTemplate
+                        \context Voice = "Voice 2"                      %! GroupedStavesScoreTemplate
+                        {                                               %! GroupedStavesScoreTemplate
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedStavesScoreTemplate
+                    }                                                   %! GroupedStavesScoreTemplate
+                    \context Staff = "Staff 3"                          %! GroupedStavesScoreTemplate
+                    {                                                   %! GroupedStavesScoreTemplate
+                        \context Voice = "Voice 3"                      %! GroupedStavesScoreTemplate
+                        {                                               %! GroupedStavesScoreTemplate
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedStavesScoreTemplate
+                    }                                                   %! GroupedStavesScoreTemplate
+                    \context Staff = "Staff 4"                          %! GroupedStavesScoreTemplate
+                    {                                                   %! GroupedStavesScoreTemplate
+                        \context Voice = "Voice 4"                      %! GroupedStavesScoreTemplate
+                        {                                               %! GroupedStavesScoreTemplate
+                            s1                                          %! ScoreTemplate.__illustrate__
+                        }                                               %! GroupedStavesScoreTemplate
+                    }                                                   %! GroupedStavesScoreTemplate
+                >>                                                      %! GroupedStavesScoreTemplate
+            >>                                                          %! GroupedStavesScoreTemplate
 
         >>> score = template()
-        >>> abjad.f(score)
-        \context Score = "Grouped Staves Score"
-        <<
-            \context StaffGroup = "Grouped Staves Staff Group"
-            <<
-                \context Staff = "Staff 1"
-                {
-                    \context Voice = "Voice 1"
-                    {
-                    }
-                }
-                \context Staff = "Staff 2"
-                {
-                    \context Voice = "Voice 2"
-                    {
-                    }
-                }
-                \context Staff = "Staff 3"
-                {
-                    \context Voice = "Voice 3"
-                    {
-                    }
-                }
-                \context Staff = "Staff 4"
-                {
-                    \context Voice = "Voice 4"
-                    {
-                    }
-                }
-            >>
-        >>
+        >>> abjad.f(score, strict=60)
+        \context Score = "Grouped Staves Score"                     %! GroupedStavesScoreTemplate
+        <<                                                          %! GroupedStavesScoreTemplate
+            \context StaffGroup = "Grouped Staves Staff Group"      %! GroupedStavesScoreTemplate
+            <<                                                      %! GroupedStavesScoreTemplate
+                \context Staff = "Staff 1"                          %! GroupedStavesScoreTemplate
+                {                                                   %! GroupedStavesScoreTemplate
+                    \context Voice = "Voice 1"                      %! GroupedStavesScoreTemplate
+                    {                                               %! GroupedStavesScoreTemplate
+                    }                                               %! GroupedStavesScoreTemplate
+                }                                                   %! GroupedStavesScoreTemplate
+                \context Staff = "Staff 2"                          %! GroupedStavesScoreTemplate
+                {                                                   %! GroupedStavesScoreTemplate
+                    \context Voice = "Voice 2"                      %! GroupedStavesScoreTemplate
+                    {                                               %! GroupedStavesScoreTemplate
+                    }                                               %! GroupedStavesScoreTemplate
+                }                                                   %! GroupedStavesScoreTemplate
+                \context Staff = "Staff 3"                          %! GroupedStavesScoreTemplate
+                {                                                   %! GroupedStavesScoreTemplate
+                    \context Voice = "Voice 3"                      %! GroupedStavesScoreTemplate
+                    {                                               %! GroupedStavesScoreTemplate
+                    }                                               %! GroupedStavesScoreTemplate
+                }                                                   %! GroupedStavesScoreTemplate
+                \context Staff = "Staff 4"                          %! GroupedStavesScoreTemplate
+                {                                                   %! GroupedStavesScoreTemplate
+                    \context Voice = "Voice 4"                      %! GroupedStavesScoreTemplate
+                    {                                               %! GroupedStavesScoreTemplate
+                    }                                               %! GroupedStavesScoreTemplate
+                }                                                   %! GroupedStavesScoreTemplate
+            >>                                                      %! GroupedStavesScoreTemplate
+        >>                                                          %! GroupedStavesScoreTemplate
 
     """
 
@@ -107,25 +107,30 @@ class GroupedStavesScoreTemplate(ScoreTemplate):
         """
         import abjad
         staves = []
+        tag = 'GroupedStavesScoreTemplate'
         for index in range(self.staff_count):
             number = index + 1
             voice = abjad.Voice(
                 [],
                 name='Voice {}'.format(number),
+                tag=tag,
                 )
             staff = abjad.Staff(
                 [voice],
                 name='Staff {}'.format(number),
+                tag=tag,
                 )
             staves.append(staff)
             self.voice_abbreviations['v{}'.format(number)] = voice.name
         staff_group = abjad.StaffGroup(
             staves,
             name='Grouped Staves Staff Group',
+            tag=tag,
             )
         score = abjad.Score(
             [staff_group],
             name='Grouped Staves Score',
+            tag=tag,
             )
         return score
 

--- a/abjad/segments/Line.py
+++ b/abjad/segments/Line.py
@@ -72,14 +72,22 @@ class Line(AbjadObject):
             >>> abjad.Line(string).get_tags()
             ['MEASURE_NUMBER_MARKUP', 'SM31']
 
+        ..  container:: example
+
+            REGRESSION. Works with multiple ``%!`` prefixes:
+
+            >>> string = '    %@%  \with-color %! SM31 %! SM32'
+            >>> line = abjad.Line(string)
+            >>> line.get_tags()
+            ['SM31', 'SM32']
+
         Returns list of zero or more strings.
         """
         tags = []
         if ' %! ' in self.string:
-            index = self.string.find('%! ')
-            string = self.string[index+2:].strip()
-            parts = string.split()
-            tags.extend(parts[0].split(':'))
+            for chunk in self.string.split(' %! ')[1:]:
+                parts = chunk.split()
+                tags.extend(parts[0].split(':'))
         return tags
 
     def is_active(self):
@@ -196,6 +204,19 @@ class Line(AbjadObject):
 
             >>> line.match(predicate)
             False
+
+        ..  container:: example
+
+            REGRESSION. Works with multiple ``%!`` prefixes:
+
+            >>> string = '    %@%  \with-color %! SM31 %! SM32'
+            >>> line = abjad.Line(string)
+
+            >>> line.match('SM31')
+            True
+
+            >>> line.match('SM32')
+            True
 
         Returns true or false.
         """

--- a/abjad/segments/ScoreTemplate.py
+++ b/abjad/segments/ScoreTemplate.py
@@ -71,7 +71,8 @@ class ScoreTemplate(AbjadValueObject):
         """
         score: Score = self()
         for voice in iterate(score).components(Voice):
-            voice.append(Skip(1))
+            skip = Skip(1, tag='ScoreTemplate.__illustrate__')
+            voice.append(skip)
         self.attach_defaults(score)
         lilypond_file: LilyPondFile = score.__illustrate__()
         lilypond_file = new(
@@ -88,16 +89,19 @@ class ScoreTemplate(AbjadValueObject):
         global_rests = Context(
             lilypond_type='GlobalRests',
             name='GlobalRests',
+            tag='_make_global_context',
             )
         global_skips = Context(
             lilypond_type='GlobalSkips',
             name='GlobalSkips',
+            tag='_make_global_context',
             )
         global_context = Context(
             [global_rests, global_skips],
             lilypond_type='GlobalContext',
             is_simultaneous=True,
             name='GlobalContext',
+            tag='_make_global_context',
             )
         return global_context
 
@@ -209,7 +213,12 @@ class ScoreTemplate(AbjadValueObject):
                 string = 'default_instrument'
                 instrument = inspect(staff__group).annotation(string)
                 if instrument is not None:
-                    wrapper = attach(instrument, leaf, tag='ST1', wrapper=True)
+                    wrapper = attach(
+                        instrument,
+                        leaf,
+                        tag='attach_defaults',
+                        wrapper=True,
+                        )
                     wrappers.append(wrapper)
             margin_markup = inspect(leaf).indicator(MarginMarkup)
             if margin_markup is None:
@@ -219,7 +228,7 @@ class ScoreTemplate(AbjadValueObject):
                     wrapper = attach(
                         margin_markup,
                         leaf,
-                        tag=Tag('-PARTS').prepend('ST2'),
+                        tag=Tag('-PARTS').prepend('attach_defaults'),
                         wrapper=True,
                         )
                     wrappers.append(wrapper)
@@ -230,7 +239,12 @@ class ScoreTemplate(AbjadValueObject):
                 continue
             clef = inspect(staff).annotation('default_clef')
             if clef is not None:
-                wrapper = attach(clef, leaf, tag='ST3', wrapper=True)
+                wrapper = attach(
+                    clef,
+                    leaf,
+                    tag='attach_defaults',
+                    wrapper=True,
+                    )
                 wrappers.append(wrapper)
         return wrappers
 

--- a/abjad/segments/StringOrchestraScoreTemplate.py
+++ b/abjad/segments/StringOrchestraScoreTemplate.py
@@ -11,314 +11,314 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         >>> template = abjad.StringOrchestraScoreTemplate()
         >>> abjad.show(template) # doctest: +SKIP
 
-        >>> abjad.f(template.__illustrate__()[abjad.Score])
-        \context Score = "Score"
-        <<
-            \tag #'(Violin1 Violin2 Violin3 Violin4 Violin5 Violin6 Viola1 Viola2 Viola3 Viola4 Cello1 Cello2 Cello3 Contrabass1 Contrabass2)
-            \context GlobalContext = "GlobalContext"
-            {
-            }
-            \context StaffGroup = "Outer Staff Group"
-            <<
-                \context ViolinStaffGroup = "Violin Staff Group"
-                <<
-                    \tag #'Violin1
-                    \context StringPerformerStaffGroup = "Violin 1 Staff Group"
-                    <<
-                        \context BowingStaff = "Violin 1 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Violin 1 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Violin 1 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Violin 1 Fingering Voice"
-                            {
-                                \clef "treble" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Violin2
-                    \context StringPerformerStaffGroup = "Violin 2 Staff Group"
-                    <<
-                        \context BowingStaff = "Violin 2 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Violin 2 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Violin 2 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Violin 2 Fingering Voice"
-                            {
-                                \clef "treble" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Violin3
-                    \context StringPerformerStaffGroup = "Violin 3 Staff Group"
-                    <<
-                        \context BowingStaff = "Violin 3 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Violin 3 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Violin 3 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Violin 3 Fingering Voice"
-                            {
-                                \clef "treble" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Violin4
-                    \context StringPerformerStaffGroup = "Violin 4 Staff Group"
-                    <<
-                        \context BowingStaff = "Violin 4 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Violin 4 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Violin 4 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Violin 4 Fingering Voice"
-                            {
-                                \clef "treble" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Violin5
-                    \context StringPerformerStaffGroup = "Violin 5 Staff Group"
-                    <<
-                        \context BowingStaff = "Violin 5 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Violin 5 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Violin 5 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Violin 5 Fingering Voice"
-                            {
-                                \clef "treble" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Violin6
-                    \context StringPerformerStaffGroup = "Violin 6 Staff Group"
-                    <<
-                        \context BowingStaff = "Violin 6 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Violin 6 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Violin 6 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Violin 6 Fingering Voice"
-                            {
-                                \clef "treble" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                >>
-                \context ViolaStaffGroup = "Viola Staff Group"
-                <<
-                    \tag #'Viola1
-                    \context StringPerformerStaffGroup = "Viola 1 Staff Group"
-                    <<
-                        \context BowingStaff = "Viola 1 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Viola 1 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Viola 1 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Viola 1 Fingering Voice"
-                            {
-                                \clef "alto" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Viola2
-                    \context StringPerformerStaffGroup = "Viola 2 Staff Group"
-                    <<
-                        \context BowingStaff = "Viola 2 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Viola 2 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Viola 2 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Viola 2 Fingering Voice"
-                            {
-                                \clef "alto" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Viola3
-                    \context StringPerformerStaffGroup = "Viola 3 Staff Group"
-                    <<
-                        \context BowingStaff = "Viola 3 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Viola 3 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Viola 3 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Viola 3 Fingering Voice"
-                            {
-                                \clef "alto" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Viola4
-                    \context StringPerformerStaffGroup = "Viola 4 Staff Group"
-                    <<
-                        \context BowingStaff = "Viola 4 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Viola 4 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Viola 4 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Viola 4 Fingering Voice"
-                            {
-                                \clef "alto" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                >>
-                \context CelloStaffGroup = "Cello Staff Group"
-                <<
-                    \tag #'Cello1
-                    \context StringPerformerStaffGroup = "Cello 1 Staff Group"
-                    <<
-                        \context BowingStaff = "Cello 1 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Cello 1 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Cello 1 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Cello 1 Fingering Voice"
-                            {
-                                \clef "bass" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Cello2
-                    \context StringPerformerStaffGroup = "Cello 2 Staff Group"
-                    <<
-                        \context BowingStaff = "Cello 2 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Cello 2 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Cello 2 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Cello 2 Fingering Voice"
-                            {
-                                \clef "bass" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Cello3
-                    \context StringPerformerStaffGroup = "Cello 3 Staff Group"
-                    <<
-                        \context BowingStaff = "Cello 3 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Cello 3 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Cello 3 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Cello 3 Fingering Voice"
-                            {
-                                \clef "bass" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                >>
-                \context ContrabassStaffGroup = "Contrabass Staff Group"
-                <<
-                    \tag #'Contrabass1
-                    \context StringPerformerStaffGroup = "Contrabass 1 Staff Group"
-                    <<
-                        \context BowingStaff = "Contrabass 1 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Contrabass 1 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Contrabass 1 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Contrabass 1 Fingering Voice"
-                            {
-                                \clef "bass_8" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Contrabass2
-                    \context StringPerformerStaffGroup = "Contrabass 2 Staff Group"
-                    <<
-                        \context BowingStaff = "Contrabass 2 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Contrabass 2 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Contrabass 2 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Contrabass 2 Fingering Voice"
-                            {
-                                \clef "bass_8" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                >>
-            >>
-        >>
+        >>> abjad.f(template.__illustrate__()[abjad.Score], strict=89)
+        \context Score = "Score"                                                                 %! StringOrchestraScoreTemplate
+        <<                                                                                       %! StringOrchestraScoreTemplate
+            \tag #'(Violin1 Violin2 Violin3 Violin4 Violin5 Violin6 Viola1 Viola2 Viola3 Viola4 Cello1 Cello2 Cello3 Contrabass1 Contrabass2) %! StringOrchestraScoreTemplate
+            \context GlobalContext = "GlobalContext"                                             %! StringOrchestraScoreTemplate
+            {                                                                                    %! StringOrchestraScoreTemplate
+            }                                                                                    %! StringOrchestraScoreTemplate
+            \context StaffGroup = "Outer Staff Group"                                            %! StringOrchestraScoreTemplate
+            <<                                                                                   %! StringOrchestraScoreTemplate
+                \context ViolinStaffGroup = "Violin Staff Group"                                 %! StringOrchestraScoreTemplate
+                <<                                                                               %! StringOrchestraScoreTemplate
+                    \tag #'Violin1                                                               %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Violin 1 Staff Group"                  %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Violin 1 Bowing Staff"                           %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Violin 1 Bowing Voice"                       %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Violin 1 Fingering Staff"                     %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Violin 1 Fingering Voice"                 %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "treble"                                                   %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Violin2                                                               %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Violin 2 Staff Group"                  %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Violin 2 Bowing Staff"                           %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Violin 2 Bowing Voice"                       %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Violin 2 Fingering Staff"                     %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Violin 2 Fingering Voice"                 %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "treble"                                                   %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Violin3                                                               %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Violin 3 Staff Group"                  %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Violin 3 Bowing Staff"                           %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Violin 3 Bowing Voice"                       %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Violin 3 Fingering Staff"                     %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Violin 3 Fingering Voice"                 %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "treble"                                                   %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Violin4                                                               %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Violin 4 Staff Group"                  %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Violin 4 Bowing Staff"                           %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Violin 4 Bowing Voice"                       %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Violin 4 Fingering Staff"                     %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Violin 4 Fingering Voice"                 %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "treble"                                                   %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Violin5                                                               %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Violin 5 Staff Group"                  %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Violin 5 Bowing Staff"                           %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Violin 5 Bowing Voice"                       %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Violin 5 Fingering Staff"                     %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Violin 5 Fingering Voice"                 %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "treble"                                                   %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Violin6                                                               %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Violin 6 Staff Group"                  %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Violin 6 Bowing Staff"                           %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Violin 6 Bowing Voice"                       %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Violin 6 Fingering Staff"                     %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Violin 6 Fingering Voice"                 %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "treble"                                                   %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                >>                                                                               %! StringOrchestraScoreTemplate
+                \context ViolaStaffGroup = "Viola Staff Group"                                   %! StringOrchestraScoreTemplate
+                <<                                                                               %! StringOrchestraScoreTemplate
+                    \tag #'Viola1                                                                %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Viola 1 Staff Group"                   %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Viola 1 Bowing Staff"                            %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Viola 1 Bowing Voice"                        %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Viola 1 Fingering Staff"                      %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Viola 1 Fingering Voice"                  %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "alto"                                                     %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Viola2                                                                %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Viola 2 Staff Group"                   %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Viola 2 Bowing Staff"                            %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Viola 2 Bowing Voice"                        %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Viola 2 Fingering Staff"                      %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Viola 2 Fingering Voice"                  %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "alto"                                                     %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Viola3                                                                %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Viola 3 Staff Group"                   %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Viola 3 Bowing Staff"                            %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Viola 3 Bowing Voice"                        %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Viola 3 Fingering Staff"                      %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Viola 3 Fingering Voice"                  %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "alto"                                                     %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Viola4                                                                %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Viola 4 Staff Group"                   %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Viola 4 Bowing Staff"                            %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Viola 4 Bowing Voice"                        %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Viola 4 Fingering Staff"                      %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Viola 4 Fingering Voice"                  %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "alto"                                                     %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                >>                                                                               %! StringOrchestraScoreTemplate
+                \context CelloStaffGroup = "Cello Staff Group"                                   %! StringOrchestraScoreTemplate
+                <<                                                                               %! StringOrchestraScoreTemplate
+                    \tag #'Cello1                                                                %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Cello 1 Staff Group"                   %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Cello 1 Bowing Staff"                            %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Cello 1 Bowing Voice"                        %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Cello 1 Fingering Staff"                      %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Cello 1 Fingering Voice"                  %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "bass"                                                     %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Cello2                                                                %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Cello 2 Staff Group"                   %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Cello 2 Bowing Staff"                            %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Cello 2 Bowing Voice"                        %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Cello 2 Fingering Staff"                      %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Cello 2 Fingering Voice"                  %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "bass"                                                     %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Cello3                                                                %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Cello 3 Staff Group"                   %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Cello 3 Bowing Staff"                            %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Cello 3 Bowing Voice"                        %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Cello 3 Fingering Staff"                      %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Cello 3 Fingering Voice"                  %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "bass"                                                     %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                >>                                                                               %! StringOrchestraScoreTemplate
+                \context ContrabassStaffGroup = "Contrabass Staff Group"                         %! StringOrchestraScoreTemplate
+                <<                                                                               %! StringOrchestraScoreTemplate
+                    \tag #'Contrabass1                                                           %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Contrabass 1 Staff Group"              %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Contrabass 1 Bowing Staff"                       %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Contrabass 1 Bowing Voice"                   %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Contrabass 1 Fingering Staff"                 %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Contrabass 1 Fingering Voice"             %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "bass_8"                                                   %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Contrabass2                                                           %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Contrabass 2 Staff Group"              %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Contrabass 2 Bowing Staff"                       %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Contrabass 2 Bowing Voice"                   %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Contrabass 2 Fingering Staff"                 %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Contrabass 2 Fingering Voice"             %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "bass_8"                                                   %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                >>                                                                               %! StringOrchestraScoreTemplate
+            >>                                                                                   %! StringOrchestraScoreTemplate
+        >>                                                                                       %! StringOrchestraScoreTemplate
 
     ..  container:: example
 
@@ -332,102 +332,102 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         ...     )
         >>> abjad.show(template) # doctest: +SKIP
 
-        >>> abjad.f(template.__illustrate__()[abjad.Score])
-        \context Score = "Score"
-        <<
-            \tag #'(Violin1 Violin2 Viola Cello)
-            \context GlobalContext = "GlobalContext"
-            {
-            }
-            \context StaffGroup = "Outer Staff Group"
-            <<
-                \context ViolinStaffGroup = "Violin Staff Group"
-                <<
-                    \tag #'Violin1
-                    \context StringPerformerStaffGroup = "Violin 1 Staff Group"
-                    <<
-                        \context BowingStaff = "Violin 1 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Violin 1 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Violin 1 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Violin 1 Fingering Voice"
-                            {
-                                \clef "treble" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                    \tag #'Violin2
-                    \context StringPerformerStaffGroup = "Violin 2 Staff Group"
-                    <<
-                        \context BowingStaff = "Violin 2 Bowing Staff"
-                        <<
-                            \context BowingVoice = "Violin 2 Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Violin 2 Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Violin 2 Fingering Voice"
-                            {
-                                \clef "treble" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                >>
-                \context ViolaStaffGroup = "Viola Staff Group"
-                <<
-                    \tag #'Viola
-                    \context StringPerformerStaffGroup = "Viola Staff Group"
-                    <<
-                        \context BowingStaff = "Viola Bowing Staff"
-                        <<
-                            \context BowingVoice = "Viola Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Viola Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Viola Fingering Voice"
-                            {
-                                \clef "alto" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                >>
-                \context CelloStaffGroup = "Cello Staff Group"
-                <<
-                    \tag #'Cello
-                    \context StringPerformerStaffGroup = "Cello Staff Group"
-                    <<
-                        \context BowingStaff = "Cello Bowing Staff"
-                        <<
-                            \context BowingVoice = "Cello Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Cello Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Cello Fingering Voice"
-                            {
-                                \clef "bass" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                >>
-            >>
-        >>
+        >>> abjad.f(template.__illustrate__()[abjad.Score], strict=89)
+        \context Score = "Score"                                                                 %! StringOrchestraScoreTemplate
+        <<                                                                                       %! StringOrchestraScoreTemplate
+            \tag #'(Violin1 Violin2 Viola Cello)                                                 %! StringOrchestraScoreTemplate
+            \context GlobalContext = "GlobalContext"                                             %! StringOrchestraScoreTemplate
+            {                                                                                    %! StringOrchestraScoreTemplate
+            }                                                                                    %! StringOrchestraScoreTemplate
+            \context StaffGroup = "Outer Staff Group"                                            %! StringOrchestraScoreTemplate
+            <<                                                                                   %! StringOrchestraScoreTemplate
+                \context ViolinStaffGroup = "Violin Staff Group"                                 %! StringOrchestraScoreTemplate
+                <<                                                                               %! StringOrchestraScoreTemplate
+                    \tag #'Violin1                                                               %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Violin 1 Staff Group"                  %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Violin 1 Bowing Staff"                           %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Violin 1 Bowing Voice"                       %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Violin 1 Fingering Staff"                     %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Violin 1 Fingering Voice"                 %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "treble"                                                   %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                    \tag #'Violin2                                                               %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Violin 2 Staff Group"                  %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Violin 2 Bowing Staff"                           %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Violin 2 Bowing Voice"                       %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Violin 2 Fingering Staff"                     %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Violin 2 Fingering Voice"                 %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "treble"                                                   %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                >>                                                                               %! StringOrchestraScoreTemplate
+                \context ViolaStaffGroup = "Viola Staff Group"                                   %! StringOrchestraScoreTemplate
+                <<                                                                               %! StringOrchestraScoreTemplate
+                    \tag #'Viola                                                                 %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Viola Staff Group"                     %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Viola Bowing Staff"                              %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Viola Bowing Voice"                          %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Viola Fingering Staff"                        %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Viola Fingering Voice"                    %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "alto"                                                     %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                >>                                                                               %! StringOrchestraScoreTemplate
+                \context CelloStaffGroup = "Cello Staff Group"                                   %! StringOrchestraScoreTemplate
+                <<                                                                               %! StringOrchestraScoreTemplate
+                    \tag #'Cello                                                                 %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Cello Staff Group"                     %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Cello Bowing Staff"                              %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Cello Bowing Voice"                          %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Cello Fingering Staff"                        %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Cello Fingering Voice"                    %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "bass"                                                     %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                >>                                                                               %! StringOrchestraScoreTemplate
+            >>                                                                                   %! StringOrchestraScoreTemplate
+        >>                                                                                       %! StringOrchestraScoreTemplate
 
     ..  container:: example
 
@@ -441,39 +441,39 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         ...     )
         >>> abjad.show(template) # doctest: +SKIP
 
-        >>> abjad.f(template.__illustrate__()[abjad.Score])
-        \context Score = "Score"
-        <<
-            \tag #'(Cello)
-            \context GlobalContext = "GlobalContext"
-            {
-            }
-            \context StaffGroup = "Outer Staff Group"
-            <<
-                \context CelloStaffGroup = "Cello Staff Group"
-                <<
-                    \tag #'Cello
-                    \context StringPerformerStaffGroup = "Cello Staff Group"
-                    <<
-                        \context BowingStaff = "Cello Bowing Staff"
-                        <<
-                            \context BowingVoice = "Cello Bowing Voice"
-                            {
-                                s1
-                            }
-                        >>
-                        \context FingeringStaff = "Cello Fingering Staff"
-                        <<
-                            \context FingeringVoice = "Cello Fingering Voice"
-                            {
-                                \clef "bass" %! ST3
-                                s1
-                            }
-                        >>
-                    >>
-                >>
-            >>
-        >>
+        >>> abjad.f(template.__illustrate__()[abjad.Score], strict=89)
+        \context Score = "Score"                                                                 %! StringOrchestraScoreTemplate
+        <<                                                                                       %! StringOrchestraScoreTemplate
+            \tag #'(Cello)                                                                       %! StringOrchestraScoreTemplate
+            \context GlobalContext = "GlobalContext"                                             %! StringOrchestraScoreTemplate
+            {                                                                                    %! StringOrchestraScoreTemplate
+            }                                                                                    %! StringOrchestraScoreTemplate
+            \context StaffGroup = "Outer Staff Group"                                            %! StringOrchestraScoreTemplate
+            <<                                                                                   %! StringOrchestraScoreTemplate
+                \context CelloStaffGroup = "Cello Staff Group"                                   %! StringOrchestraScoreTemplate
+                <<                                                                               %! StringOrchestraScoreTemplate
+                    \tag #'Cello                                                                 %! StringOrchestraScoreTemplate
+                    \context StringPerformerStaffGroup = "Cello Staff Group"                     %! StringOrchestraScoreTemplate
+                    <<                                                                           %! StringOrchestraScoreTemplate
+                        \context BowingStaff = "Cello Bowing Staff"                              %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context BowingVoice = "Cello Bowing Voice"                          %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                        \context FingeringStaff = "Cello Fingering Staff"                        %! StringOrchestraScoreTemplate
+                        <<                                                                       %! StringOrchestraScoreTemplate
+                            \context FingeringVoice = "Cello Fingering Voice"                    %! StringOrchestraScoreTemplate
+                            {                                                                    %! StringOrchestraScoreTemplate
+                                \clef "bass"                                                     %! attach_defaults
+                                s1                                                               %! ScoreTemplate.__illustrate__
+                            }                                                                    %! StringOrchestraScoreTemplate
+                        >>                                                                       %! StringOrchestraScoreTemplate
+                    >>                                                                           %! StringOrchestraScoreTemplate
+                >>                                                                               %! StringOrchestraScoreTemplate
+            >>                                                                                   %! StringOrchestraScoreTemplate
+        >>                                                                                       %! StringOrchestraScoreTemplate
 
     """
 
@@ -521,6 +521,8 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         """
         import abjad
 
+        tag = 'StringOrchestraScoreTemplate'
+
         ### TAGS ###
 
         tag_names = []
@@ -529,11 +531,13 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
 
         staff_group = abjad.StaffGroup(
             name='Outer Staff Group',
+            tag=tag,
             )
 
         score = abjad.Score(
             [staff_group],
             name='Score',
+            tag=tag,
             )
 
         ### VIOLINS ###
@@ -609,11 +613,12 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         global_context = abjad.Context(
             name='GlobalContext',
             lilypond_type='GlobalContext',
+            tag=tag,
             )
         instrument_tags = ' '.join(tag_names)
         tag_string = r"\tag #'({})".format(instrument_tags)
-        tag_command = abjad.LilyPondLiteral(tag_string, 'before')
-        abjad.attach(tag_command, global_context)
+        literal = abjad.LilyPondLiteral(tag_string, 'before')
+        abjad.attach(literal, global_context, tag=tag)
         score.insert(0, global_context)
         return score
 
@@ -626,10 +631,12 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         instrument=None,
         ):
         import abjad
+        tag = 'StringOrchestraScoreTemplate'
         name = instrument.name.title()
         instrument_staff_group = abjad.StaffGroup(
             lilypond_type='{}StaffGroup'.format(name),
             name='{} Staff Group'.format(name),
+            tag=tag,
             )
         tag_names = []
         if count == 1:
@@ -660,6 +667,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         number=None,
         ):
         import abjad
+        tag = 'StringOrchestraScoreTemplate'
         if number is not None:
             name = '{} {}'.format(
                 instrument.name.title(),
@@ -671,16 +679,18 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         staff_group = abjad.StaffGroup(
             lilypond_type='StringPerformerStaffGroup',
             name='{} Staff Group'.format(name),
+            tag=tag,
             )
         tag_name = name.replace(' ', '')
         tag_string = r"\tag #'{}".format(tag_name)
         tag_command = abjad.LilyPondLiteral(tag_string, 'before')
-        abjad.attach(tag_command, staff_group)
+        abjad.attach(tag_command, staff_group, tag=tag)
         if self.split_hands:
             lh_voice = abjad.Voice(
                 [],
                 lilypond_type='FingeringVoice',
                 name='{} Fingering Voice'.format(name),
+                tag=tag,
                 )
             abbreviation = lh_voice.name.lower().replace(' ', '_')
             self.voice_abbreviations[abbreviation] = lh_voice.name
@@ -690,6 +700,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
                     ],
                 lilypond_type='FingeringStaff',
                 name='{} Fingering Staff'.format(name),
+                tag=tag,
                 )
             lh_staff.is_simultaneous = True
             abjad.annotate(lh_staff, 'pitch_range', pitch_range)
@@ -698,6 +709,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
                 [],
                 lilypond_type='BowingVoice',
                 name='{} Bowing Voice'.format(name),
+                tag=tag,
                 )
             abbreviation = rh_voice.name.lower().replace(' ', '_')
             self.voice_abbreviations[abbreviation] = rh_voice.name
@@ -707,6 +719,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
                     ],
                 lilypond_type='BowingStaff',
                 name='{} Bowing Staff'.format(name),
+                tag=tag,
                 )
             rh_staff.is_simultaneous = True
             staff_group.extend([rh_staff, lh_staff])
@@ -715,6 +728,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
                 [],
                 lilypond_type='FingeringVoice',
                 name='{} Voice'.format(name),
+                tag=tag,
                 )
             lh_staff = abjad.Staff(
                 [
@@ -722,6 +736,7 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
                     ],
                 lilypond_type='FingeringStaff',
                 name='{} Staff'.format(name),
+                tag=tag,
                 )
             lh_staff.is_simultaneous = True
             abjad.annotate(lh_staff, 'pitch_range', pitch_range)

--- a/abjad/segments/StringQuartetScoreTemplate.py
+++ b/abjad/segments/StringQuartetScoreTemplate.py
@@ -13,49 +13,49 @@ class StringQuartetScoreTemplate(ScoreTemplate):
         >>> template = abjad.StringQuartetScoreTemplate()
         >>> abjad.show(template) # doctest: +SKIP
 
-        >>> abjad.f(template.__illustrate__()[abjad.Score])
-        \context Score = "String Quartet Score"
-        <<
-            \context StaffGroup = "String Quartet Staff Group"
-            <<
+        >>> abjad.f(template.__illustrate__()[abjad.Score], strict=60)
+        \context Score = "String Quartet Score"                     %! StringQuartetScoreTemplate
+        <<                                                          %! StringQuartetScoreTemplate
+            \context StaffGroup = "String Quartet Staff Group"      %! StringQuartetScoreTemplate
+            <<                                                      %! StringQuartetScoreTemplate
                 \tag #'first-violin
-                \context Staff = "First Violin Staff"
-                {
-                    \context Voice = "First Violin Voice"
-                    {
-                        \clef "treble" %! ST3
-                        s1
-                    }
-                }
+                \context Staff = "First Violin Staff"               %! StringQuartetScoreTemplate
+                {                                                   %! StringQuartetScoreTemplate
+                    \context Voice = "First Violin Voice"           %! StringQuartetScoreTemplate
+                    {                                               %! StringQuartetScoreTemplate
+                        \clef "treble"                              %! attach_defaults
+                        s1                                          %! ScoreTemplate.__illustrate__
+                    }                                               %! StringQuartetScoreTemplate
+                }                                                   %! StringQuartetScoreTemplate
                 \tag #'second-violin
-                \context Staff = "Second Violin Staff"
-                {
-                    \context Voice = "Second Violin Voice"
-                    {
-                        \clef "treble" %! ST3
-                        s1
-                    }
-                }
+                \context Staff = "Second Violin Staff"              %! StringQuartetScoreTemplate
+                {                                                   %! StringQuartetScoreTemplate
+                    \context Voice = "Second Violin Voice"          %! StringQuartetScoreTemplate
+                    {                                               %! StringQuartetScoreTemplate
+                        \clef "treble"                              %! attach_defaults
+                        s1                                          %! ScoreTemplate.__illustrate__
+                    }                                               %! StringQuartetScoreTemplate
+                }                                                   %! StringQuartetScoreTemplate
                 \tag #'viola
-                \context Staff = "Viola Staff"
-                {
-                    \context Voice = "Viola Voice"
-                    {
-                        \clef "alto" %! ST3
-                        s1
-                    }
-                }
+                \context Staff = "Viola Staff"                      %! StringQuartetScoreTemplate
+                {                                                   %! StringQuartetScoreTemplate
+                    \context Voice = "Viola Voice"                  %! StringQuartetScoreTemplate
+                    {                                               %! StringQuartetScoreTemplate
+                        \clef "alto"                                %! attach_defaults
+                        s1                                          %! ScoreTemplate.__illustrate__
+                    }                                               %! StringQuartetScoreTemplate
+                }                                                   %! StringQuartetScoreTemplate
                 \tag #'cello
-                \context Staff = "Cello Staff"
-                {
-                    \context Voice = "Cello Voice"
-                    {
-                        \clef "bass" %! ST3
-                        s1
-                    }
-                }
-            >>
-        >>
+                \context Staff = "Cello Staff"                      %! StringQuartetScoreTemplate
+                {                                                   %! StringQuartetScoreTemplate
+                    \context Voice = "Cello Voice"                  %! StringQuartetScoreTemplate
+                    {                                               %! StringQuartetScoreTemplate
+                        \clef "bass"                                %! attach_defaults
+                        s1                                          %! ScoreTemplate.__illustrate__
+                    }                                               %! StringQuartetScoreTemplate
+                }                                                   %! StringQuartetScoreTemplate
+            >>                                                      %! StringQuartetScoreTemplate
+        >>                                                          %! StringQuartetScoreTemplate
 
     Returns score template.
     """
@@ -93,14 +93,18 @@ class StringQuartetScoreTemplate(ScoreTemplate):
         """
         import abjad
 
+        class_name = 'StringQuartetScoreTemplate'
+
         # make first violin voice and staff
         first_violin_voice = abjad.Voice(
             [],
             name='First Violin Voice',
+            tag=class_name,
             )
         first_violin_staff = abjad.Staff(
             [first_violin_voice],
             name='First Violin Staff',
+            tag=class_name,
             )
         clef = abjad.Clef('treble')
         abjad.annotate(first_violin_staff, 'default_clef', clef)
@@ -113,10 +117,12 @@ class StringQuartetScoreTemplate(ScoreTemplate):
         second_violin_voice = abjad.Voice(
             [],
             name='Second Violin Voice',
+            tag=class_name,
             )
         second_violin_staff = abjad.Staff(
             [second_violin_voice],
             name='Second Violin Staff',
+            tag=class_name,
             )
         clef = abjad.Clef('treble')
         abjad.annotate(second_violin_staff, 'default_clef', clef)
@@ -129,10 +135,12 @@ class StringQuartetScoreTemplate(ScoreTemplate):
         viola_voice = abjad.Voice(
             [],
             name='Viola Voice',
+            tag=class_name,
             )
         viola_staff = abjad.Staff(
             [viola_voice],
             name='Viola Staff',
+            tag=class_name,
             )
         clef = abjad.Clef('alto')
         abjad.annotate(viola_staff, 'default_clef', clef)
@@ -145,10 +153,12 @@ class StringQuartetScoreTemplate(ScoreTemplate):
         cello_voice = abjad.Voice(
             [],
             name='Cello Voice',
+            tag=class_name,
             )
         cello_staff = abjad.Staff(
             [cello_voice],
             name='Cello Staff',
+            tag=class_name,
             )
         clef = abjad.Clef('bass')
         abjad.annotate(cello_staff, 'default_clef', clef)
@@ -165,12 +175,14 @@ class StringQuartetScoreTemplate(ScoreTemplate):
             cello_staff,
             ],
             name='String Quartet Staff Group',
+            tag=class_name,
             )
 
         # make string quartet score
         string_quartet_score = abjad.Score(
             [string_quartet_staff_group],
             name='String Quartet Score',
+            tag=class_name,
             )
 
         # return string quartet score

--- a/abjad/segments/TwoStaffPianoScoreTemplate.py
+++ b/abjad/segments/TwoStaffPianoScoreTemplate.py
@@ -11,37 +11,37 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
         >>> template = abjad.TwoStaffPianoScoreTemplate()
         >>> abjad.show(template) # doctest: +SKIP
 
-        >>> abjad.f(template.__illustrate__()[abjad.Score])
-        \context Score = "TwoStaffPianoScore"
-        <<
-            \context GlobalContext = "GlobalContext"
-            <<
-                \context GlobalRests = "GlobalRests"
-                {
-                }
-                \context GlobalSkips = "GlobalSkips"
-                {
-                }
-            >>
-            \context PianoStaff = "PianoStaff"
-            <<
-                \context Staff = "RHStaff"
-                {
-                    \context Voice = "RHVoice"
-                    {
-                        s1
-                    }
-                }
-                \context Staff = "LHStaff"
-                {
-                    \context Voice = "LHVoice"
-                    {
-                        \clef "bass" %! ST3
-                        s1
-                    }
-                }
-            >>
-        >>
+        >>> abjad.f(template.__illustrate__()[abjad.Score], strict=60)
+        \context Score = "TwoStaffPianoScore"                       %! TwoStaffPianoScoreTemplate
+        <<                                                          %! TwoStaffPianoScoreTemplate
+            \context GlobalContext = "GlobalContext"                %! _make_global_context
+            <<                                                      %! _make_global_context
+                \context GlobalRests = "GlobalRests"                %! _make_global_context
+                {                                                   %! _make_global_context
+                }                                                   %! _make_global_context
+                \context GlobalSkips = "GlobalSkips"                %! _make_global_context
+                {                                                   %! _make_global_context
+                }                                                   %! _make_global_context
+            >>                                                      %! _make_global_context
+            \context PianoStaff = "PianoStaff"                      %! TwoStaffPianoScoreTemplate
+            <<                                                      %! TwoStaffPianoScoreTemplate
+                \context Staff = "RHStaff"                          %! TwoStaffPianoScoreTemplate
+                {                                                   %! TwoStaffPianoScoreTemplate
+                    \context Voice = "RHVoice"                      %! TwoStaffPianoScoreTemplate
+                    {                                               %! TwoStaffPianoScoreTemplate
+                        s1                                          %! ScoreTemplate.__illustrate__
+                    }                                               %! TwoStaffPianoScoreTemplate
+                }                                                   %! TwoStaffPianoScoreTemplate
+                \context Staff = "LHStaff"                          %! TwoStaffPianoScoreTemplate
+                {                                                   %! TwoStaffPianoScoreTemplate
+                    \context Voice = "LHVoice"                      %! TwoStaffPianoScoreTemplate
+                    {                                               %! TwoStaffPianoScoreTemplate
+                        \clef "bass"                                %! attach_defaults
+                        s1                                          %! ScoreTemplate.__illustrate__
+                    }                                               %! TwoStaffPianoScoreTemplate
+                }                                                   %! TwoStaffPianoScoreTemplate
+            >>                                                      %! TwoStaffPianoScoreTemplate
+        >>                                                          %! TwoStaffPianoScoreTemplate
 
     Returns score template.
     """
@@ -69,21 +69,30 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
         Returns score.
         """
         import abjad
+        tag = 'TwoStaffPianoScoreTemplate'
         # GLOBAL CONTEXT
         global_context = self._make_global_context()
 
         # RH STAFF
-        rh_voice = abjad.Voice(name='RHVoice')
+        rh_voice = abjad.Voice(
+            name='RHVoice',
+            tag=tag,
+            )
         rh_staff = abjad.Staff(
             [rh_voice],
             name='RHStaff',
+            tag=tag,
             )
 
         # LH STAFF
-        lh_voice = abjad.Voice(name='LHVoice')
+        lh_voice = abjad.Voice(
+            name='LHVoice',
+            tag=tag,
+            )
         lh_staff = abjad.Staff(
             [lh_voice],
             name='LHStaff',
+            tag=tag,
             )
         abjad.annotate(
             lh_staff,
@@ -96,6 +105,7 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
             [rh_staff, lh_staff],
             lilypond_type='PianoStaff',
             name='PianoStaff',
+            tag=tag,
             )
         abjad.annotate(
             staff_group,
@@ -107,5 +117,6 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
         score = abjad.Score(
             [global_context, staff_group],
             name='TwoStaffPianoScore',
+            tag=tag,
             )
         return score

--- a/abjad/spanners/BowContactSpanner.py
+++ b/abjad/spanners/BowContactSpanner.py
@@ -83,7 +83,7 @@ class BowContactSpanner(Spanner):
                     }
                 \clef "percussion"
                 c'4.
-                ^\downbow
+                ^ \downbow
                 \glissando
                 \once \override NoteHead.Y-offset = 1.0
                 \once \override NoteHead.stencil = #ly:text-interface::print
@@ -95,7 +95,7 @@ class BowContactSpanner(Spanner):
                                 4
                     }
                 c'8
-                ^\upbow
+                ^ \upbow
                 \glissando
                 \times 2/3 {
                     \once \override NoteHead.Y-offset = 0.0
@@ -108,7 +108,7 @@ class BowContactSpanner(Spanner):
                                     2
                         }
                     c'4
-                    ^\downbow
+                    ^ \downbow
                     \glissando
                     \once \override Glissando.style = #'zigzag
                     \once \override NoteHead.Y-offset = 2.0
@@ -121,7 +121,7 @@ class BowContactSpanner(Spanner):
                                     1
                         }
                     c'4
-                    ^\upbow
+                    ^ \upbow
                     \glissando
                     \once \override NoteHead.Y-offset = -2.0
                     \once \override NoteHead.stencil = #ly:text-interface::print
@@ -199,7 +199,7 @@ class BowContactSpanner(Spanner):
                                 4
                     }
                 c'4
-                ^\upbow
+                ^ \upbow
                 \glissando
                 \once \override NoteHead.Y-offset = 0.0
                 \once \override NoteHead.stencil = #ly:text-interface::print

--- a/abjad/spanners/PhrasingSlur.py
+++ b/abjad/spanners/PhrasingSlur.py
@@ -38,10 +38,15 @@ class PhrasingSlur(Spanner):
         >>> phrasing_slur = abjad.PhrasingSlur()
         >>> abjad.attach(phrasing_slur, staff[:1])
         Traceback (most recent call last):
-            ...
+          File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/doctest.py", line 1330, in __run
+            compileflags, 1), test.globs)
+          File "<doctest PhrasingSlur.py[7]>", line 1, in <module>
+            abjad.attach(phrasing_slur, staff[:1])
+          File "/Users/trevorbaca/abjad/abjad/top/attach.py", line 243, in attach
+            raise Exception(message)
         Exception: PhrasingSlur()._attachment_test_all():
           Requires at least two leaves.
-          Not just Note("c'8").
+          Not just Selection([Note("c'8")]).
 
     """
 

--- a/abjad/spanners/Slur.py
+++ b/abjad/spanners/Slur.py
@@ -60,10 +60,15 @@ class Slur(Spanner):
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> abjad.attach(abjad.Slur(), staff[:1])
         Traceback (most recent call last):
-            ...
+          File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/doctest.py", line 1330, in __run
+            compileflags, 1), test.globs)
+          File "<doctest Slur.py[11]>", line 1, in <module>
+            abjad.attach(abjad.Slur(), staff[:1])
+          File "/Users/trevorbaca/abjad/abjad/top/attach.py", line 243, in attach
+            raise Exception(message)
         Exception: Slur()._attachment_test_all():
           Requires at least two leaves.
-          Not just Note("c'4").
+          Not just Selection([Note("c'4")]).
 
     """
 

--- a/abjad/spanners/Spanner.py
+++ b/abjad/spanners/Spanner.py
@@ -161,7 +161,7 @@ class Spanner(AbjadObject):
             return True
         return [
             'Requires at least two leaves.',
-            f'Not just {leaves[0]!r}.',
+            f'Not just {leaves!r}.',
             ]
 
     def _attach(

--- a/abjad/spanners/TextSpanner.py
+++ b/abjad/spanners/TextSpanner.py
@@ -59,10 +59,15 @@ class TextSpanner(Spanner):
         >>> spanner = abjad.TextSpanner()
         >>> abjad.attach(spanner, staff[:1])
         Traceback (most recent call last):
-            ...
+          File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/doctest.py", line 1330, in __run
+            compileflags, 1), test.globs)
+          File "<doctest TextSpanner.py[8]>", line 1, in <module>
+            abjad.attach(spanner, staff[:1])
+          File "/Users/trevorbaca/abjad/abjad/top/attach.py", line 243, in attach
+            raise Exception(message)
         Exception: TextSpanner()._attachment_test_all():
           Requires at least two leaves.
-          Not just Note("c'4").
+          Not just Selection([Note("c'4")]).
 
     ..  container:: example
 

--- a/abjad/system/Wrapper.py
+++ b/abjad/system/Wrapper.py
@@ -477,7 +477,7 @@ class Wrapper(AbjadValueObject):
         command = getattr(self.indicator, 'command', None)
         wrapper = abjad.inspect(component).effective_wrapper(
             prototype,
-            command=command,
+            attributes={'command': command},
             )
         if (wrapper is not None and
             wrapper.context is not None and

--- a/abjad/top/attach.py
+++ b/abjad/top/attach.py
@@ -57,7 +57,7 @@ def attach(
                 d'4
                 e'4
                 f'4
-                -\accent
+                - \accent
             }
 
     ..  container:: example

--- a/abjad/top/detach.py
+++ b/abjad/top/detach.py
@@ -22,7 +22,7 @@ def detach(argument, target=None, by_id=False):
             \new Staff
             {
                 c'4
-                -\accent
+                - \accent
                 d'4
                 e'4
                 f'4

--- a/abjad/top/f.py
+++ b/abjad/top/f.py
@@ -15,18 +15,18 @@ def f(argument, strict=None):
         \new Staff
         {
             c'4
-            -\staccato
+            - \staccato
             ^ \markup {
                 \with-color
                     #blue
                     Allegro
                 }
             d'4
-            -\staccato
+            - \staccato
             e'4
-            -\staccato
+            - \staccato
             f'4
-            -\staccato
+            - \staccato
         }
 
         >>> abjad.show(staff) # doctest: +SKIP

--- a/abjad/top/tweak.py
+++ b/abjad/top/tweak.py
@@ -1,7 +1,11 @@
 from abjad import enums
 
 
-def tweak(argument):
+def tweak(
+    argument,
+    deactivate=None,
+    tag=None,
+    ):
     r"""
     Makes LilyPond tweak manager.
 
@@ -172,6 +176,29 @@ def tweak(argument):
 
     ..  container:: example
 
+        Tweaks can be tagged:
+
+        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> markup = abjad.Markup('Allegro assai', direction=abjad.Up)
+        >>> abjad.tweak(markup, tag='+PARTS').color = 'red'
+        >>> abjad.attach(markup, staff[0])
+        >>> abjad.show(staff) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> abjad.f(staff)
+            \new Staff
+            {
+                c'4
+                - \tweak color #red %! +PARTS
+                ^ \markup { "Allegro assai" }
+                d'4
+                e'4
+                f'4
+            }
+
+    ..  container:: example
+
         Returns LilyPond tweak manager:
 
         >>> abjad.tweak(markup_1)
@@ -195,12 +222,15 @@ def tweak(argument):
     constants = (enums.Down, enums.Left, enums.Right, enums.Up)
     prototype = (bool, int, float, str, tuple, abjad.Scheme)
     if argument in constants or isinstance(argument, prototype):
-        manager = abjad.LilyPondTweakManager()
+        manager = abjad.LilyPondTweakManager(deactivate=deactivate, tag=tag)
         manager._pending_value = argument
         return manager
     if not hasattr(argument, '_tweaks'):
         name = type(argument).__name__
         raise NotImplementedError(f'{name} does not allow tweaks (yet).')
     if argument._tweaks is None:
-        argument._tweaks = abjad.LilyPondTweakManager()
+        argument._tweaks = abjad.LilyPondTweakManager(
+            deactivate=deactivate,
+            tag=tag,
+            )
     return argument._tweaks

--- a/abjad/typings.py
+++ b/abjad/typings.py
@@ -12,4 +12,6 @@ Number = typing.Union[int, float]
 
 NumberPair = typing.Tuple[Number, Number]
 
+Prototype = typing.Union[typing.Type, typing.Tuple[typing.Type, ...]]
+
 Selector = typing.Union[str, Expression]

--- a/abjad/utilities/Duration.py
+++ b/abjad/utilities/Duration.py
@@ -156,9 +156,7 @@ class Duration(AbjadObject, Fraction):
                     class_,
                     *[int(x) for x in arguments]
                     )
-        message = 'can not construct duration: {!r}.'
-        message = message.format(arguments)
-        raise ValueError(message)
+        raise ValueError(f'can not construct duration: {arguments!r}.')
 
     ### SPECIAL METHODS ###
 

--- a/abjad/utilities/Expression.py
+++ b/abjad/utilities/Expression.py
@@ -2067,7 +2067,7 @@ class Expression(AbjadValueObject):
                         af'8
                         bqs'8
                         af'8
-                        \bar "|." %! SCORE1
+                        \bar "|." %! SCORE_1
                         \override Score.BarLine.transparent = ##f
                     }
 

--- a/abjad/utilities/String.py
+++ b/abjad/utilities/String.py
@@ -1558,6 +1558,9 @@ class String(str):
             >>> abjad.String.to_indicator_stem(abjad.Dynamic('f'))
             'DYNAMIC'
 
+            >>> abjad.String.to_indicator_stem(abjad.DynamicTrend('<'))
+            'DYNAMIC'
+
             >>> abjad.String.to_indicator_stem(abjad.Cello())
             'INSTRUMENT'
 
@@ -1581,6 +1584,8 @@ class String(str):
         assert getattr(indicator, 'persistent', False), repr(indicator)
         if isinstance(indicator, Instrument):
             stem = 'INSTRUMENT'
+        elif getattr(indicator, 'parameter', None) == 'TEMPO':
+            stem = 'METRONOME_MARK'
         elif hasattr(indicator, 'parameter'):
             stem = indicator.parameter
         else:

--- a/tests/test_Component__move_indicators.py
+++ b/tests/test_Component__move_indicators.py
@@ -11,7 +11,7 @@ def test_Component__move_indicators_01():
         {
             \clef "bass"
             c4
-            -\staccato
+            - \staccato
             d4
             e4
             f4
@@ -34,7 +34,7 @@ def test_Component__move_indicators_01():
             d4
             \clef "bass"
             e4
-            -\staccato
+            - \staccato
             f4
         }
         """

--- a/tests/test_LilyPondGrobNameManager___setattr__.py
+++ b/tests/test_LilyPondGrobNameManager___setattr__.py
@@ -699,7 +699,7 @@ def test_LilyPondGrobNameManager___setattr___28():
         r"""
         \once \override Script.color = #red
         c'4
-        -\staccato
+        - \staccato
         """
         )
 

--- a/tests/test_LilyPondParser__indicators__Articulation.py
+++ b/tests/test_LilyPondParser__indicators__Articulation.py
@@ -26,19 +26,19 @@ def test_LilyPondParser__indicators__Articulation_01():
         \new Staff
         {
             c''4
-            ^\marcato
+            ^ \marcato
             c''4
-            _\stopped
+            _ \stopped
             c''4
-            -\tenuto
+            - \tenuto
             c''4
-            -\staccatissimo
+            - \staccatissimo
             c''4
-            -\accent
+            - \accent
             c''4
-            -\staccato
+            - \staccato
             c''2
-            -\portato
+            - \portato
         }
         """
         )
@@ -71,14 +71,7 @@ def test_LilyPondParser__indicators__Articulation_02():
     articulation = abjad.Articulation('portato')
     abjad.attach(articulation, target[0])
 
-    r"""
-    \new Staff {
-        c'4 ^\marcato _\stopped -\tenuto -\staccatissimo -\accent -\staccato -\portato
-    }
-    """
-
     string = r"""\new Staff { c'4 ^^ _+ -- -| -> -. -_ }"""
-
 
     parser = abjad.parser.LilyPondParser()
     result = parser(string)
@@ -108,13 +101,13 @@ def test_LilyPondParser__indicators__Articulation_03():
         r"""
         {
             c''4
-            -\staccato
+            - \staccato
             c''4
-            -\mordent
+            - \mordent
             b'2
-            -\turn
+            - \turn
             c''1
-            -\fermata
+            - \fermata
         }
         """
         )

--- a/tests/test_LilyPondParser__indicators__Markup.py
+++ b/tests/test_LilyPondParser__indicators__Markup.py
@@ -73,7 +73,7 @@ def test_LilyPondParser__indicators__Markup_03():
         \new Staff
         {
             c'4
-            -\staccato
+            - \staccato
             ^ \markup { hello }
             d'4
         }

--- a/tests/test_LilyPondParser__misc__chord_repetition.py
+++ b/tests/test_LilyPondParser__misc__chord_repetition.py
@@ -49,21 +49,21 @@ def test_LilyPondParser__misc__chord_repetition_02():
     abjad.attach(articulation, target[-1])
 
     assert format(target) == abjad.String.normalize(
-        r'''
+        r"""
         \new Staff
         {
             <c' e' g'>8
             \p
             <c' e' g'>8
             <c' e' g'>4
-            -\staccatissimo
+            - \staccatissimo
             <c' e' g'>8.
             ^ \markup { text }
             <c' e' g'>16
             <c' e' g'>4
-            -\staccatissimo
+            - \staccatissimo
         }
-        '''
+        """
         )
 
     string = r'''\new Staff { <c' e' g'>8\p q q4-| q8.^"text" q16 q4-| }'''

--- a/tests/test_Note___copy__.py
+++ b/tests/test_Note___copy__.py
@@ -105,7 +105,7 @@ def test_Note___copy___05():
         }
         \once \override NoteHead.color = #red
         c'4
-        -\staccato
+        - \staccato
         """
         )
 
@@ -137,7 +137,7 @@ def test_Note___copy___06():
             }
             \once \override NoteHead.color = #red
             c'8
-            -\staccato
+            - \staccato
             [
             c'8
             e'8


### PR DESCRIPTION
NEW COMPONENT TAGS:

    Components may be tagged:

    Tags notes:

        >>> maker = abjad.NoteMaker(tag='NoteMaker')
        >>> notes = maker([0], [(1, 16), (1, 8), (1, 8)])
        >>> staff = abjad.Staff(notes)
        >>> abjad.f(staff, strict=20)
        \new Staff
        {
            c'16        %! NoteMaker
            c'8         %! NoteMaker
            c'8         %! NoteMaker
        }

    Tags tuplet:

        >>> tuplet = abjad.Tuplet((2, 3), "c'4 d' e'", tag='Tuplet')
        >>> abjad.f(tuplet, strict=20)
        \times 2/3 {        %! Tuplet
            c'4
            d'4
            e'4
        }                   %! Tuplet

    Tags contexts:

        >>> voice = abjad.Voice("c'4 d' e' f'", tag='Voice')
        >>> staff = abjad.Staff([voice], tag='Staff')
        >>> score = abjad.Score([staff], tag='Score')
        >>> abjad.f(score, strict=20)
        \new Score          %! Score
        <<                  %! Score
            \new Staff      %! Staff
            {               %! Staff
                \new Voice  %! Voice
                {           %! Voice
                    c'4
                    d'4
                    e'4
                    f'4
                }           %! Voice
            }               %! Staff
        >>                  %! Score

    * abjad.LeafMaker output may also be tagged

    * abjad.NoteMaker output may also be tagged

    * score templates may also be tagged

    * all rmakers may also be tagged

NEW TWEAK TAGS:

    Tweaks may be tagged:

    >>> staff = abjad.Staff("c'4 d' e' f'")
    >>> markup = abjad.Markup('Allegro', direction=abjad.Up).italic()
    >>> abjad.tweak(markup, tag='+PARTS').color = 'red'
    >>> abjad.attach(markup, staff[0])

    >>> abjad.f(staff)
    \new Staff
    {
        c'4
        - \tweak color #red %! +PARTS
        ^ \markup {
            \italic
                Allegro
            }
        d'4
        e'4
        f'4
    }

    * Added abjad.tweak(..., tag=None) keyword.

    * Added abjad.tweak(..., deactivate=None) keyword.

NEW ATTRIBUTE INSPECTION FUNCTIONALITY:

    * Added abjad.inspect().indicator(..., attributes=None) keyword.

    Integrated in the following:

        * abjad.inspect().effective(..., attributes=None)
        * abjad.inspect().effective_wrapper(..., attributes=None)
        * abjad.inspect().has_effective_indicator(..., attributes=None)
        * abjad.inspect().has_indicator(..., attributes=None)
        * abjad.inspect().indicator(..., attributes=None)
        * abjad.inspect().indicators(..., attributes=None)
        * abjad.inspect().wrapper(..., attributes=None)
        * abjad.inspect().wrappers(..., attributes=None)

    EXAMPLE:

        >>> voice = abjad.Voice("c'4 d' e' f'")
        >>> start_text_span = abjad.StartTextSpan()
        >>> abjad.attach(start_text_span, voice[0])
        >>> stop_text_span = abjad.StopTextSpan()
        >>> abjad.attach(stop_text_span, voice[2])

        >>> abjad.f(voice)
        \new Voice
        {
            c'4
            \startTextSpan
            d'4
            e'4
            \stopTextSpan
            f'4
        }

        >>> for note in voice:
        ...     note, abjad.inspect(note).effective(abjad.StartTextSpan)
        ...
        (Note("c'4"), StartTextSpan(command='\\startTextSpan', concat_hspace_left=0.5))
        (Note("d'4"), StartTextSpan(command='\\startTextSpan', concat_hspace_left=0.5))
        (Note("e'4"), StartTextSpan(command='\\startTextSpan', concat_hspace_left=0.5))
        (Note("f'4"), StartTextSpan(command='\\startTextSpan', concat_hspace_left=0.5))

        >>> for note in voice:
        ...     note, abjad.inspect(note).effective(abjad.StopTextSpan)
        ...
        (Note("c'4"), None)
        (Note("d'4"), None)
        (Note("e'4"), StopTextSpan(command='\\stopTextSpan'))
        (Note("f'4"), StopTextSpan(command='\\stopTextSpan'))

        >>> attributes = {'parameter': 'TEXT_SPANNER'}
        >>> for note in voice:
        ...     indicator = abjad.inspect(note).effective(
        ...         object,
        ...         attributes=attributes,
        ...         )
        ...     note, indicator
        ...
        (Note("c'4"), StartTextSpan(command='\\startTextSpan', concat_hspace_left=0.5))
        (Note("d'4"), StartTextSpan(command='\\startTextSpan', concat_hspace_left=0.5))
        (Note("e'4"), StopTextSpan(command='\\stopTextSpan'))
        (Note("f'4"), StopTextSpan(command='\\stopTextSpan'))