### PR TITLE
Restored duplicate noncontexted literals. Closes #1012.

### DIFF
--- a/abjad/core/Inspection.py
+++ b/abjad/core/Inspection.py
@@ -1322,7 +1322,9 @@ class Inspection(AbjadObject):
 
         """
         if not isinstance(self.client, Component):
-            raise Exception('can only get parentage on component.')
+            message = 'can only get parentage on component'
+            message += f' (not {self.client}).'
+            raise Exception(message)
         return self.client._get_parentage(
             include_self=include_self,
             grace_notes=grace_notes,

--- a/abjad/core/Mutation.py
+++ b/abjad/core/Mutation.py
@@ -702,7 +702,7 @@ class Mutation(AbjadObject):
         if not wrappers:
             return
         for wrapper in wrappers:
-            # bypass Wrapper._bind_to_component()
+            # bypass Wrapper._bind_component()
             # to avoid full-score update / traversal;
             # this works because one-to-one leaf replacement
             # including all (persistent) indicators

--- a/abjad/core/Tuplet.py
+++ b/abjad/core/Tuplet.py
@@ -3,6 +3,7 @@ import typing
 from abjad import Fraction
 from abjad import exceptions
 from abjad import mathtools
+from abjad import typings
 from abjad.lilypondnames.LilyPondTweakManager import LilyPondTweakManager
 from abjad.mathtools.NonreducedFraction import NonreducedFraction
 from abjad.mathtools.NonreducedRatio import NonreducedRatio
@@ -1084,7 +1085,7 @@ class Tuplet(Container):
 
     @staticmethod
     def from_duration(
-        duration: typing.Union[typing.Tuple[int, int], Duration],
+        duration: typings.DurationTyping,
         components,
         *,
         tag: str = None,

--- a/abjad/indicators/BowContactPoint.py
+++ b/abjad/indicators/BowContactPoint.py
@@ -1,5 +1,6 @@
 import functools
 import typing
+from abjad import typings
 from abjad.system.AbjadValueObject import AbjadValueObject
 from abjad.markups import Markup
 from abjad.utilities.Multiplier import Multiplier
@@ -46,7 +47,7 @@ class BowContactPoint(AbjadValueObject):
 
     def __init__(
         self,
-        contact_point: typing.Tuple[int, int] = None
+        contact_point: typings.IntegerPair = None,
         ) -> None:
         contact_point_ = None
         if contact_point is not None:

--- a/abjad/indicators/MetronomeMark.py
+++ b/abjad/indicators/MetronomeMark.py
@@ -254,6 +254,8 @@ class MetronomeMark(AbjadValueObject):
 
     _format_slot = 'opening'
 
+    _mutates_offsets_in_seconds = True
+
     _parameter = 'METRONOME_MARK'
 
     _persistent = True
@@ -262,8 +264,7 @@ class MetronomeMark(AbjadValueObject):
 
     def __init__(
         self,
-        reference_duration: typing.Union[
-            Duration, typing.Tuple[int, int]] = None,
+        reference_duration: typings.DurationTyping = None,
         units_per_minute: typings.Number = None,
         textual_indication: Markup = None,
         *,

--- a/abjad/indicators/TimeSignature.py
+++ b/abjad/indicators/TimeSignature.py
@@ -1,6 +1,7 @@
 import collections
 import typing
 from abjad import mathtools
+from abjad import typings
 from abjad.system.AbjadValueObject import AbjadValueObject
 from abjad.mathtools.NonreducedFraction import NonreducedFraction
 from abjad.system.FormatSpecification import FormatSpecification
@@ -126,7 +127,7 @@ class TimeSignature(AbjadValueObject):
 
     def __init__(
         self,
-        pair: typing.Tuple[int, int] = (4, 4),
+        pair: typings.IntegerPair = (4, 4),
         *,
         partial: Duration = None,
         hide: bool = None,
@@ -503,7 +504,7 @@ class TimeSignature(AbjadValueObject):
         return self._numerator
 
     @property
-    def pair(self) -> typing.Tuple[int, int]:
+    def pair(self) -> typings.IntegerPair:
         """
         Gets numerator / denominator pair corresponding to time siganture.
 

--- a/abjad/scheme.py
+++ b/abjad/scheme.py
@@ -550,7 +550,7 @@ class SchemeMoment(Scheme):
 
     def __init__(
         self,
-        duration: typing.Union[typing.Tuple[int, int]] = (0, 1),
+        duration: typings.IntegerPair = (0, 1),
         ) -> None:
         pair = NonreducedFraction(duration).pair
         Scheme.__init__(self, pair)

--- a/abjad/segments/PartAssignment.py
+++ b/abjad/segments/PartAssignment.py
@@ -1,4 +1,5 @@
 import typing
+from abjad import typings
 from abjad.system.AbjadValueObject import AbjadValueObject
 from abjad.utilities.String import String
 from abjad.system.FormatSpecification import FormatSpecification
@@ -52,7 +53,7 @@ class PartAssignment(AbjadValueObject):
     token_type = typing.Union[
         None,
         int,
-        typing.Tuple[int, int],
+        typings.IntegerPair,
         typing.List[int],
         ]
 

--- a/abjad/segments/Path.py
+++ b/abjad/segments/Path.py
@@ -3,9 +3,7 @@ import os
 import pathlib
 import shutil
 import typing
-from .Line import Line
-from .Part import Part
-from .PartManifest import PartManifest
+from abjad import typings
 from abjad.core.MultimeasureRest import MultimeasureRest
 from abjad.core.Container import Container
 from abjad.core.Score import Score
@@ -25,6 +23,9 @@ from abjad.top.iterate import iterate
 from abjad.utilities.CyclicTuple import CyclicTuple
 from abjad.utilities.OrderedDict import OrderedDict
 from abjad.utilities.String import String
+from .Line import Line
+from .Part import Part
+from .PartManifest import PartManifest
 
 
 class Path(pathlib.PosixPath):
@@ -1090,7 +1091,7 @@ class Path(pathlib.PosixPath):
     def count(
         self,
         tag: typing.Union[str, typing.Callable],
-        ) -> typing.Tuple[typing.Tuple[int, int], typing.Tuple[int, int]]:
+        ) -> typing.Tuple[typings.IntegerPair, typings.IntegerPair]:
         """
         Counts ``tag`` in path.
 

--- a/abjad/system/LilyPondFormatManager.py
+++ b/abjad/system/LilyPondFormatManager.py
@@ -61,7 +61,8 @@ class LilyPondFormatManager(AbjadObject):
                     neutral_markup_wrappers.append(wrapper)
             # store context wrappers
             elif wrapper.context is not None:
-                if wrapper._is_formattable_for_component(component):
+                if (wrapper.annotation is None and
+                    wrapper.component is component):
                     context_wrappers.append(wrapper)
             # store noncontext wrappers
             else:

--- a/abjad/top/annotate.py
+++ b/abjad/top/annotate.py
@@ -1,4 +1,4 @@
-def annotate(component, annotation, indicator):
+def annotate(component, annotation, indicator) -> None:
     r"""
     Annotates ``component`` with ``indicator``.
 
@@ -32,11 +32,10 @@ def annotate(component, annotation, indicator):
 
     Returns none.
     """
-    import abjad
+    from abjad.system.Wrapper import Wrapper
     assert isinstance(annotation, str), repr(annotation)
-    wrapper = abjad.Wrapper(
+    wrapper = Wrapper(
         annotation=annotation,
         component=component,
         indicator=indicator,
         )
-    wrapper._bind_to_component(component)

--- a/abjad/top/attach.py
+++ b/abjad/top/attach.py
@@ -16,9 +16,7 @@ def attach(
 
     Third for attaches grace container ``attachable`` to leaf ``target``.
 
-    Fourth form attaches time signature ``attachable`` to measure ``target``.
-
-    Fifth form attaches wrapper ``attachable`` to unknown (?) ``target``.
+    Fourth form attaches wrapper ``attachable`` to unknown (?) ``target``.
 
     ..  container:: example
 
@@ -222,8 +220,7 @@ def attach(
         )
 
     if context is not None and isinstance(attachable, nonindicator_prototype):
-        message = 'set context only for indicators, not {!r}.'
-        message = message.format(attachable)
+        message = f'set context only for indicators, not {attachable!r}.'
         raise Exception(message)
 
     if deactivate is True and tag is None:
@@ -302,7 +299,6 @@ def attach(
         synthetic_offset=synthetic_offset,
         tag=tag,
         )
-    wrapper_._bind_to_component(component)
 
     if wrapper is True:
         return wrapper_


### PR DESCRIPTION
EXAMPLE:

    staff = abjad.Staff("c'4 d'4 e'4 f'4")
    for leaf in (staff[0], staff[0], staff[2]):
        start_group = abjad.LilyPondLiteral(r'\startGroup', format_slot='after')
        abjad.attach(start_group, leaf)

    for leaf in (staff[1], staff[3], staff[3]):
        stop_group = abjad.LilyPondLiteral(r'\stopGroup', format_slot='after')
        abjad.attach(stop_group, leaf)

    abjad.f(staff)
    \new Staff
    {
        c'4
        \startGroup
        \startGroup
        d'4
        \stopGroup
        e'4
        \startGroup
        f'4
        \stopGroup
        \stopGroup
    }