### PR TITLE
NEW. Added abjad.bow_contact_spanner(..., omit_bow_changes=None)

### DIFF
--- a/abjad/indicators/GlissandoIndicator.py
+++ b/abjad/indicators/GlissandoIndicator.py
@@ -129,12 +129,12 @@ class GlissandoIndicator(object):
 
     def _get_lilypond_format_bundle(self, component=None):
         bundle = LilyPondFormatBundle()
-        if self.tweaks:
-            tweaks = self.tweaks._list_format_contributions()
-            bundle.after.spanner_starts.extend(tweaks)
         strings = []
         if self.zero_padding:
             strings.append(r'- \abjad-zero-padding-glissando')
+        if self.tweaks:
+            tweaks = self.tweaks._list_format_contributions()
+            strings.extend(tweaks)
         strings.append(r'\glissando')
         bundle.after.spanner_starts.extend(strings)
         return bundle

--- a/abjad/top/attach.py
+++ b/abjad/top/attach.py
@@ -209,7 +209,8 @@ def attach(
     import abjad
 
     if isinstance(attachable, abjad.Multiplier):
-        raise Exception(attachable, 'AAA')
+        message = 'use the Leaf.multiplier property to multiply leaf duration.'
+        raise Exception(message)
 
     assert attachable is not None, repr(attachable)
     assert target is not None, repr(target)


### PR DESCRIPTION
Set omit_bow_changes=True to suppress up-bown and down-bow indicators.

Closes #1050.