### PR TITLE
Added 'varC', 'tenorvarC', 'halfopen', and 'snappizzicato'

### DIFF
--- a/abjad/indicators/Articulation.py
+++ b/abjad/indicators/Articulation.py
@@ -79,24 +79,26 @@ class Articulation(object):
         'staccatissimo',
         'espressivo'
         'staccato',
-        'tenuto'
-        'portato'
+        'tenuto',
+        'portato',
         'upbow',
-        'downbow'
-        'flageolet'
+        'downbow',
+        'flageolet',
         'thumb',
-        'lheel'
-        'rheel'
-        'ltoe',
-        'rtoe'
-        'open'
+        'lheel',
+        'rheel',
+        'ltoe',,
+        'rtoe',
+        'open',
+        'halfopen',
+        'snappizzicato',
         'stopped',
-        'turn'
-        'reverseturn'
+        'turn',
+        'reverseturn',
         'trill',
-        'prall'
-        'mordent'
-        'prallprall'
+        'prall',
+        'mordent',
+        'prallprall',
         'prallmordent',
         'upprall',
         'downprall',

--- a/abjad/indicators/Articulation.py
+++ b/abjad/indicators/Articulation.py
@@ -87,7 +87,7 @@ class Articulation(object):
         'thumb',
         'lheel',
         'rheel',
-        'ltoe',,
+        'ltoe',
         'rtoe',
         'open',
         'halfopen',

--- a/abjad/indicators/Clef.py
+++ b/abjad/indicators/Clef.py
@@ -165,8 +165,9 @@ class Clef(object):
     _clef_name_to_middle_c_position = {
         'treble': -6,
         'alto': 0,
-        'tenor': 2,
         'varC': 0,
+        'tenor': 2,
+        'tenorvarC': 2,
         'bass': 6,
         'french': -8,
         'soprano': -4,
@@ -192,6 +193,7 @@ class Clef(object):
         'bass': 2.75,
         'percussion': 2.5,
         'tenor': 2.75,
+        'tenorvarC': 2.75,
         'treble': 2.5,
         }
 
@@ -299,6 +301,7 @@ class Clef(object):
             'alto': NamedPitch('C4'),
             'varC': NamedPitch('C4'),
             'tenor': NamedPitch('A3'),
+            'tenorvarC': NamedPitch('A3'),
             'bass': NamedPitch('D3'),
             'french': NamedPitch('D5'),
             'soprano': NamedPitch('G4'),

--- a/abjad/indicators/Clef.py
+++ b/abjad/indicators/Clef.py
@@ -166,6 +166,7 @@ class Clef(object):
         'treble': -6,
         'alto': 0,
         'tenor': 2,
+        'varC': 0,
         'bass': 6,
         'french': -8,
         'soprano': -4,
@@ -187,6 +188,7 @@ class Clef(object):
 
     _to_width = {
         'alto': 2.75,
+        'varC': 2.75,
         'bass': 2.75,
         'percussion': 2.5,
         'tenor': 2.75,
@@ -295,6 +297,7 @@ class Clef(object):
         return {
             'treble': NamedPitch('B4'),
             'alto': NamedPitch('C4'),
+            'varC': NamedPitch('C4'),
             'tenor': NamedPitch('A3'),
             'bass': NamedPitch('D3'),
             'french': NamedPitch('D5'),
@@ -394,8 +397,8 @@ class Clef(object):
         ..  container:: example
 
             >>> staff = abjad.Staff("c'4 d' e' f'")
-            >>> abjad.attach(abjad.Clef('treble'), staff[0]) 
-            >>> abjad.attach(abjad.Clef('alto', hide=True), staff[2]) 
+            >>> abjad.attach(abjad.Clef('treble'), staff[0])
+            >>> abjad.attach(abjad.Clef('alto', hide=True), staff[2])
             >>> abjad.show(staff) # doctest: +SKIP
 
             >>> abjad.f(staff)
@@ -476,7 +479,7 @@ class Clef(object):
         Class constant.
         """
         return self._persistent
-        
+
     @property
     def redraw(self) -> bool:
         """
@@ -495,7 +498,7 @@ class Clef(object):
     def tweaks(self) -> None:
         r"""
         Are not implemented on clef.
-        
+
         The LilyPond ``\clef`` command refuses tweaks.
 
         Override the LilyPond ``Clef`` grob instead.


### PR DESCRIPTION
@trevorbaca, I added two alternate clefs and two articulations that are present in Lilypond 2.19 but not in the current Abjad.