### PR TITLE
Fixed abjad.mutate().split(..., repeat_ties=True) bug. Closes #1092.

### DIFF
--- a/abjad/core/Container.py
+++ b/abjad/core/Container.py
@@ -881,14 +881,10 @@ class Container(Component):
         # return new left and right containers
         return halves
 
-    def _split_by_duration(
-        self, duration, tie_split_notes=True, repeat_ties=False
-    ):
+    def _split_by_duration(self, duration, repeat_ties=False):
         if self.is_simultaneous:
             return self._split_simultaneous_by_duration(
-                duration=duration,
-                tie_split_notes=tie_split_notes,
-                repeat_ties=repeat_ties,
+                duration=duration, repeat_ties=repeat_ties
             )
         duration = Duration(duration)
         assert 0 <= duration, repr(duration)
@@ -917,9 +913,7 @@ class Container(Component):
             start_offset = timespan.start_offset
             split_point_in_bottom = global_split_point - start_offset
             new_leaves = bottom._split_by_durations(
-                [split_point_in_bottom],
-                tie_split_notes=tie_split_notes,
-                repeat_ties=repeat_ties,
+                [split_point_in_bottom], repeat_ties=repeat_ties
             )
             for leaf in new_leaves:
                 timespan = inspect(leaf).timespan()
@@ -963,7 +957,7 @@ class Container(Component):
             previous = right
         # reapply tie here if crawl above killed tie applied to leaves
         if did_split_leaf:
-            if tie_split_notes and isinstance(leaf_left_of_split, Note):
+            if isinstance(leaf_left_of_split, Note):
                 if (
                     inspect(leaf_left_of_split).parentage().root
                     is inspect(leaf_right_of_split).parentage().root
@@ -977,16 +971,12 @@ class Container(Component):
         # return list-wrapped halves of container
         return [left], [right]
 
-    def _split_simultaneous_by_duration(
-        self, duration, tie_split_notes=True, repeat_ties=False
-    ):
+    def _split_simultaneous_by_duration(self, duration, repeat_ties=False):
         assert self.is_simultaneous
         left_components, right_components = [], []
         for component in self[:]:
             halves = component._split_by_duration(
-                duration=duration,
-                tie_split_notes=tie_split_notes,
-                repeat_ties=repeat_ties,
+                duration=duration, repeat_ties=repeat_ties
             )
             left_components_, right_components_ = halves
             left_components.extend(left_components_)

--- a/abjad/core/Mutation.py
+++ b/abjad/core/Mutation.py
@@ -2376,140 +2376,9 @@ class Mutation(object):
     # TODO: add tests of tupletted notes and rests.
     # TODO: add examples that show indicator handling.
     # TODO: add example showing grace and after grace handling.
-    def split(
-        self, durations, cyclic=False, tie_split_notes=True, repeat_ties=False
-    ):
+    def split(self, durations, cyclic=False, repeat_ties=False):
         r"""
         Splits mutation client by ``durations``.
-
-        ..  container:: example
-
-            Splits leaves:
-
-            >>> staff = abjad.Staff("c'8 e' d' f' c' e' d' f'")
-            >>> leaves = staff[:]
-            >>> abjad.hairpin('p < f', leaves)
-            >>> abjad.override(staff).dynamic_line_spanner.staff_padding = 3
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                \with
-                {
-                    \override DynamicLineSpanner.staff-padding = #3
-                }
-                {
-                    c'8
-                    \p
-                    \<
-                    e'8
-                    d'8
-                    f'8
-                    c'8
-                    e'8
-                    d'8
-                    f'8
-                    \f
-                }
-
-            >>> durations = [(3, 16), (7, 32)]
-            >>> result = abjad.mutate(leaves).split(
-            ...     durations,
-            ...     tie_split_notes=False,
-            ...     )
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                \with
-                {
-                    \override DynamicLineSpanner.staff-padding = #3
-                }
-                {
-                    c'8
-                    \p
-                    \<
-                    e'16
-                    e'16
-                    d'8
-                    f'32
-                    f'16.
-                    c'8
-                    e'8
-                    d'8
-                    f'8
-                    \f
-                }
-
-        ..  container:: example
-
-            Splits leaves cyclically:
-
-            >>> staff = abjad.Staff("c'8 e' d' f' c' e' d' f'")
-            >>> leaves = staff[:]
-            >>> abjad.hairpin('p < f', leaves)
-            >>> abjad.override(staff).dynamic_line_spanner.staff_padding = 3
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                \with
-                {
-                    \override DynamicLineSpanner.staff-padding = #3
-                }
-                {
-                    c'8
-                    \p
-                    \<
-                    e'8
-                    d'8
-                    f'8
-                    c'8
-                    e'8
-                    d'8
-                    f'8
-                    \f
-                }
-
-            >>> durations = [(3, 16), (7, 32)]
-            >>> result = abjad.mutate(leaves).split(
-            ...     durations,
-            ...     cyclic=True,
-            ...     tie_split_notes=False,
-            ...     )
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> abjad.f(staff)
-                \new Staff
-                \with
-                {
-                    \override DynamicLineSpanner.staff-padding = #3
-                }
-                {
-                    c'8
-                    \p
-                    \<
-                    e'16
-                    e'16
-                    d'8
-                    f'32
-                    f'16.
-                    c'16.
-                    c'32
-                    e'8
-                    d'16
-                    d'16
-                    f'8
-                    \f
-                }
 
         ..  container:: example
 
@@ -2540,7 +2409,6 @@ class Mutation(object):
             >>> result = abjad.mutate(staff[:]).split(
             ...     durations,
             ...     cyclic=True,
-            ...     tie_split_notes=True,
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2574,7 +2442,6 @@ class Mutation(object):
             >>> result = abjad.mutate(staff[:]).split(
             ...     durations,
             ...     cyclic=True,
-            ...     tie_split_notes=True,
             ...     repeat_ties=True,
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
@@ -2638,7 +2505,6 @@ class Mutation(object):
             >>> result = abjad.mutate(staff[:]).split(
             ...     durations,
             ...     cyclic=True,
-            ...     tie_split_notes=True,
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2767,7 +2633,6 @@ class Mutation(object):
             >>> result = abjad.mutate(container).split(
             ...     durations,
             ...     cyclic=False,
-            ...     tie_split_notes=True,
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2857,7 +2722,6 @@ class Mutation(object):
             >>> result = abjad.mutate(staff[:]).split(
             ...     durations,
             ...     cyclic=True,
-            ...     tie_split_notes=True,
             ...     )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2914,6 +2778,41 @@ class Mutation(object):
                     d'4...
                     ~
                     d'2
+                }
+
+        ..  container:: example
+
+            REGRESSION #1092. Preserves conventional tie when creating repeat
+            ties:
+
+            >>> staff = abjad.Staff("d'1 ~ d'")
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    d'1
+                    ~
+                    d'1
+                }
+
+            >>> result = abjad.mutate(staff[1]).split(
+            ...     [(1, 2)], repeat_ties=True
+            ... )
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    d'1
+                    ~
+                    d'2
+                    d'2
+                    \repeatTie
                 }
 
         Returns list of selections.
@@ -3002,7 +2901,6 @@ class Mutation(object):
                     leaf_shards = current_component._split_by_durations(
                         leaf_split_durations,
                         cyclic=False,
-                        tie_split_notes=tie_split_notes,
                         repeat_ties=repeat_ties,
                     )
                     shard.extend(leaf_shards)
@@ -3011,9 +2909,7 @@ class Mutation(object):
                 else:
                     assert isinstance(current_component, Container)
                     pair = current_component._split_by_duration(
-                        local_split_duration,
-                        tie_split_notes=tie_split_notes,
-                        repeat_ties=repeat_ties,
+                        local_split_duration, repeat_ties=repeat_ties
                     )
                     left_list, right_list = pair
                     shard.extend(left_list)

--- a/abjad/core/Selection.py
+++ b/abjad/core/Selection.py
@@ -7,8 +7,8 @@ from abjad import enums
 from abjad import exceptions
 from abjad import mathtools
 from abjad import typings
-from abjad.indicators.TieIndicator import TieIndicator
 from abjad.indicators.RepeatTie import RepeatTie
+from abjad.indicators.TieIndicator import TieIndicator
 from abjad.mathtools import Ratio
 from abjad.pitch.PitchSet import PitchSet
 from abjad.system.FormatSpecification import FormatSpecification
@@ -526,19 +526,14 @@ class Selection(collections.abc.Sequence):
     ### PRIVATE METHODS ###
 
     def _attach_tie_to_leaves(self, repeat_ties=False):
-        from abjad.spanners import tie as abjad_tie
-
-        leaves = []
-        for leaf in self:
-            assert isinstance(leaf, Leaf), repr(leaf)
-            for leaf_ in abjad_inspect(leaf).logical_tie().leaves:
-                if leaf_ not in leaves:
-                    leaves.append(leaf_)
-        leaves = Selection(leaves)
-        for leaf in leaves:
-            detach(TieIndicator, leaf)
-            detach(RepeatTie, leaf)
-        abjad_tie(leaves, repeat=repeat_ties)
+        if not repeat_ties:
+            for leaf in self[:-1]:
+                detach(TieIndicator, leaf)
+                attach(TieIndicator(), leaf)
+        else:
+            for leaf in self[1:]:
+                detach(RepeatTie, leaf)
+                attach(RepeatTie(), leaf)
 
     @staticmethod
     def _check(items):

--- a/abjad/indicators/Dynamic.py
+++ b/abjad/indicators/Dynamic.py
@@ -355,7 +355,8 @@ class Dynamic(object):
         import abjad
 
         if not isinstance(component_expression, abjad.Leaf):
-            return False
+            strings = ["Must be leaf (not {component_expression})."]
+            return strings
         return True
 
     def _format_effort_dynamic(self):

--- a/abjad/indicators/RepeatTie.py
+++ b/abjad/indicators/RepeatTie.py
@@ -104,6 +104,20 @@ class RepeatTie(object):
 
     ### PRIVATE METHODS ###
 
+    def _attachment_test_all(self, argument):
+        from abjad.core.Chord import Chord
+        from abjad.core.Note import Note
+
+        if not isinstance(argument, (Chord, Note)):
+            string = f"Must be note or chord (not {argument})."
+            return [string]
+        previous_leaf = inspect(argument).leaf(-1)
+        if not isinstance(previous_leaf, (Chord, Note, type(None))):
+            string = f"Can not attach repeat-tie to {argument}"
+            string += f" when previous leaf is {previous_leaf}."
+            return [string]
+        return True
+
     def _get_lilypond_format_bundle(self, component=None):
         bundle = LilyPondFormatBundle()
         if self.tweaks:

--- a/abjad/indicators/TieIndicator.py
+++ b/abjad/indicators/TieIndicator.py
@@ -5,6 +5,7 @@ from abjad.system.LilyPondFormatBundle import LilyPondFormatBundle
 from abjad.system.LilyPondFormatManager import LilyPondFormatManager
 from abjad.system.StorageFormatManager import StorageFormatManager
 from abjad.system.Tags import Tags
+from abjad.top.inspect import inspect
 from abjad.utilities.String import String
 
 abjad_tags = Tags()
@@ -111,7 +112,13 @@ class TieIndicator(object):
         from abjad.core.Note import Note
 
         if not isinstance(argument, (Chord, Note)):
-            return False
+            string = f"Must be note or chord (not {argument})."
+            return [string]
+        next_leaf = inspect(argument).leaf(1)
+        if not isinstance(next_leaf, (Chord, Note, type(None))):
+            string = f"Can not attach tie to {argument}"
+            string += f" when next leaf is {next_leaf}."
+            return [string]
         return True
 
     def _get_lilypond_format_bundle(self, component=None):

--- a/abjad/instruments.py
+++ b/abjad/instruments.py
@@ -206,7 +206,8 @@ class Instrument(object):
         import abjad
 
         if abjad.inspect(component_expression).has_indicator(Instrument):
-            return False
+            string = f"Already has instrument: {component_expression}."
+            return string
         return True
 
     def _get_format_specification(self):

--- a/abjad/meter.py
+++ b/abjad/meter.py
@@ -751,7 +751,6 @@ class Meter(object):
             offsets = _MeterManager.get_offsets_at_depth(
                 depth, offset_inventory
             )
-            # print('DEPTH:', depth)
             logical_tie_duration = logical_tie._get_preprolated_duration()
             logical_tie_timespan = inspect(logical_tie).timespan()
             logical_tie_start_offset = logical_tie_timespan.start_offset
@@ -764,12 +763,12 @@ class Meter(object):
                 logical_tie_stops_in_offsets=logical_tie_stops_in_offsets,
                 maximum_dot_count=maximum_dot_count,
             ):
-                # print('UNACCEPTABLE:', logical_tie, logical_tie_start_offset, logical_tie_stop_offset)
                 split_offset = None
                 offsets = _MeterManager.get_offsets_at_depth(
                     depth, offset_inventory
                 )
-                # If the logical tie's start aligns, take the latest possible offset.
+                # If the logical tie's start aligns,
+                # take the latest possible offset.
                 if logical_tie_starts_in_offsets:
                     offsets = reversed(offsets)
                 for offset in offsets:
@@ -780,26 +779,11 @@ class Meter(object):
                     ):
                         split_offset = offset
                         break
-                # print('\tABS:', split_offset)
                 if split_offset is not None:
                     split_offset -= logical_tie_start_offset
-                    # print('\tREL:', split_offset)
-                    # print()
-
-                    #                    print('LT796', logical_tie)
-                    #                    for leaf in logical_tie:
-                    #                        print(leaf, inspect(leaf).indicators(), 'III')
-
                     shards = mutate(logical_tie[:]).split(
                         [split_offset], repeat_ties=repeat_ties
                     )
-
-                    #                    for shard in shards:
-                    #                        print('SH', shard)
-                    #                        for leaf in select(shards).leaves():
-                    #                            print(leaf, inspect(leaf).indicators(), 'PPP')
-                    #                    print()
-
                     logical_ties = [LogicalTie(_) for _ in shards]
                     for logical_tie in logical_ties:
                         recurse(
@@ -809,7 +793,6 @@ class Meter(object):
                             logical_tie=logical_tie,
                         )
                 else:
-                    # print()
                     recurse(
                         boundary_depth=boundary_depth,
                         boundary_offsets=boundary_offsets,
@@ -822,7 +805,6 @@ class Meter(object):
                 logical_tie_start_offset=logical_tie_start_offset,
                 logical_tie_stop_offset=logical_tie_stop_offset,
             ):
-                # print('BOUNDARY CROSSING', logical_tie, logical_tie_start_offset, logical_tie_stop_offset)
                 offsets = boundary_offsets
                 if logical_tie_start_offset in boundary_offsets:
                     offsets = reversed(boundary_offsets)
@@ -836,11 +818,7 @@ class Meter(object):
                         split_offset = offset
                         break
                 assert split_offset is not None
-                # print('\tABS:', split_offset)
                 split_offset -= logical_tie_start_offset
-                # print('\tREL:', split_offset)
-                # print()
-                # print('LT836', logical_tie)
                 shards = mutate(logical_tie[:]).split(
                     [split_offset], repeat_ties=repeat_ties
                 )
@@ -853,8 +831,6 @@ class Meter(object):
                         logical_tie=logical_tie,
                     )
             else:
-                # print('ACCEPTABLE:', logical_tie, logical_tie_start_offset, logical_tie_stop_offset)
-                # print()
                 logical_tie[:]._fuse()
 
         assert isinstance(components, Selection), repr(components)
@@ -894,12 +870,12 @@ class Meter(object):
             boundary_offsets = offset_inventory[boundary_depth]
         else:
             boundary_offsets = None
-        # Cache results of iterator, as we'll be mutating the underlying collection
+        # Cache results of iterator;
+        # we'll be mutating the underlying collection
         iterator = _MeterManager.iterate_rewrite_inputs(components)
         items = tuple(iterator)
         for item in items:
             if isinstance(item, LogicalTie):
-                # print('RECURSING:', item)
                 recurse(
                     boundary_depth=boundary_depth,
                     boundary_offsets=boundary_offsets,
@@ -909,7 +885,6 @@ class Meter(object):
             elif isinstance(item, Tuplet) and not rewrite_tuplets:
                 pass
             else:
-                # print('DESCENDING:', item)
                 preprolated_duration = sum(
                     [_._get_preprolated_duration() for _ in item]
                 )

--- a/abjad/top/attach.py
+++ b/abjad/top/attach.py
@@ -3,6 +3,7 @@ def attach(
     target,
     context=None,
     deactivate=None,
+    do_not_test=None,
     synthetic_offset=None,
     tag=None,
     wrapper=None,
@@ -227,7 +228,7 @@ def attach(
     if hasattr(attachable, "_before_attach"):
         attachable._before_attach(target)
 
-    if hasattr(attachable, "_attachment_test_all"):
+    if hasattr(attachable, "_attachment_test_all") and not do_not_test:
         result = attachable._attachment_test_all(target)
         if result is not True:
             assert isinstance(result, list), repr(result)

--- a/tests/test_Container__split_by_duration.py
+++ b/tests/test_Container__split_by_duration.py
@@ -3,70 +3,6 @@ import pytest
 
 
 def test_Container__split_by_duration_01():
-
-    staff = abjad.Staff()
-    staff.append(abjad.Container("c'8 d'8"))
-    staff.append(abjad.Container("e'8 f'8"))
-    leaves = abjad.select(staff).leaves()
-    abjad.beam(leaves[:2])
-    abjad.beam(leaves[-2:])
-    abjad.slur(leaves)
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    halves = staff[0]._split_by_duration(
-        abjad.Duration(1, 32), tie_split_notes=False
-    )
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                c'32
-                [
-                (
-            }
-            {
-                c'16.
-                d'8
-                ]
-            }
-            {
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    assert abjad.inspect(staff).wellformed()
-
-
-def test_Container__split_by_duration_02():
     """
     Split one container in score.
     Adds tie after split.
@@ -102,9 +38,7 @@ def test_Container__split_by_duration_02():
         """
     ), print(format(staff))
 
-    halves = staff[0]._split_by_duration(
-        abjad.Duration(1, 32), tie_split_notes=True
-    )
+    halves = staff[0]._split_by_duration(abjad.Duration(1, 32))
 
     assert format(staff) == abjad.String.normalize(
         r"""
@@ -135,77 +69,7 @@ def test_Container__split_by_duration_02():
     assert abjad.inspect(staff).wellformed()
 
 
-def test_Container__split_by_duration_03():
-    """
-    Split in-score at split offset with non-power-of-two denominator.
-    Does not tie leaves after split.
-    """
-
-    staff = abjad.Staff()
-    staff.append(abjad.Container("c'8 d'8"))
-    staff.append(abjad.Container("e'8 f'8"))
-    leaves = abjad.select(staff).leaves()
-    abjad.beam(leaves[:2])
-    abjad.beam(leaves[-2:])
-    abjad.slur(leaves)
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    halves = staff[0]._split_by_duration(
-        abjad.Duration(1, 5), tie_split_notes=False
-    )
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                c'8
-                [
-                (
-            }
-            {
-                \times 4/5 {
-                    d'16.
-                    d'16
-                    ]
-                }
-            }
-            {
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    assert abjad.inspect(staff).wellformed()
-
-
-def test_Container__split_by_duration_04():
+def test_Container__split_by_duration_02():
     """
     Split in-score container at split offset with non-power-of-two denominator.
     Does not tie leaves after split.
@@ -241,9 +105,7 @@ def test_Container__split_by_duration_04():
         """
     ), print(format(staff))
 
-    halves = staff[0]._split_by_duration(
-        abjad.Duration(1, 5), tie_split_notes=True
-    )
+    halves = staff[0]._split_by_duration(abjad.Duration(1, 5))
 
     assert format(staff) == abjad.String.normalize(
         r"""

--- a/tests/test_Leaf__split_by_durations.py
+++ b/tests/test_Leaf__split_by_durations.py
@@ -6,49 +6,6 @@ def test_Leaf__split_by_durations_01():
     """
     Splits note into assignable notes.
 
-    Does not tie split notes.
-    """
-
-    staff = abjad.Staff("c'8 [ d'8 e'8 ]")
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            c'8
-            [
-            d'8
-            e'8
-            ]
-        }
-        """
-    ), print(format(staff))
-
-    new_leaves = staff[1]._split_by_durations(
-        [abjad.Duration(1, 32)], tie_split_notes=False
-    )
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            c'8
-            [
-            d'32
-            d'16.
-            e'8
-            ]
-        }
-        """
-    ), print(format(staff))
-
-    assert abjad.inspect(staff).wellformed()
-
-
-def test_Leaf__split_by_durations_02():
-    """
-    Splits note into assignable notes.
-
     Does tie split notes.
     """
 
@@ -67,9 +24,7 @@ def test_Leaf__split_by_durations_02():
         """
     ), print(format(staff))
 
-    new_leaves = staff[1]._split_by_durations(
-        [abjad.Duration(1, 32)], tie_split_notes=True
-    )
+    new_leaves = staff[1]._split_by_durations([abjad.Duration(1, 32)])
 
     assert format(staff) == abjad.String.normalize(
         r"""
@@ -89,39 +44,7 @@ def test_Leaf__split_by_durations_02():
     assert abjad.inspect(staff).wellformed()
 
 
-def test_Leaf__split_by_durations_03():
-    """
-    Adds tuplet.
-
-    Does not tie split notes.
-    """
-
-    staff = abjad.Staff("c'8 [ d'8 e'8 ]")
-
-    new_leaves = staff[1]._split_by_durations(
-        [abjad.Duration(1, 24)], tie_split_notes=False
-    )
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            c'8
-            [
-            \times 2/3 {
-                d'16
-                d'8
-            }
-            e'8
-            ]
-        }
-        """
-    ), print(format(staff))
-
-    assert abjad.inspect(staff).wellformed()
-
-
-def test_Leaf__split_by_durations_04():
+def test_Leaf__split_by_durations_02():
     """
     REGRESSION.
     
@@ -158,56 +81,7 @@ def test_Leaf__split_by_durations_04():
     assert abjad.inspect(staff).wellformed()
 
 
-def test_Leaf__split_by_durations_05():
-    """
-    Assignable duration produces two notes.
-    """
-
-    voice = abjad.Voice(r"c'8 \times 2/3 { d'8 e'8 f'8 }")
-    leaves = abjad.select(voice).leaves()
-    abjad.beam(leaves)
-
-    assert format(voice) == abjad.String.normalize(
-        r"""
-        \new Voice
-        {
-            c'8
-            [
-            \times 2/3 {
-                d'8
-                e'8
-                f'8
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    new_leaves = leaves[1]._split_by_durations(
-        [abjad.Duration(1, 24)], tie_split_notes=False
-    )
-
-    assert format(voice) == abjad.String.normalize(
-        r"""
-        \new Voice
-        {
-            c'8
-            [
-            \times 2/3 {
-                d'16
-                d'16
-                e'8
-                f'8
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    assert abjad.inspect(voice).wellformed()
-
-
-def test_Leaf__split_by_durations_06():
+def test_Leaf__split_by_durations_03():
     """
     Leaf duration less than split duration produces no change.
     """
@@ -220,22 +94,7 @@ def test_Leaf__split_by_durations_06():
     assert staff[0].written_duration == abjad.Duration(1, 4)
 
 
-def test_Leaf__split_by_durations_07():
-    """
-    Returns selection of new leaves.
-    """
-
-    note = abjad.Note("c'4")
-
-    new_leaves = note._split_by_durations(
-        [abjad.Duration(1, 8)], tie_split_notes=False
-    )
-
-    assert isinstance(new_leaves, abjad.Selection)
-    assert all(isinstance(_, abjad.Note) for _ in new_leaves)
-
-
-def test_Leaf__split_by_durations_08():
+def test_Leaf__split_by_durations_04():
     """
     Returns selection of new leaves.
     """
@@ -247,22 +106,7 @@ def test_Leaf__split_by_durations_08():
     assert all(isinstance(_, abjad.Note) for _ in new_leaves)
 
 
-def test_Leaf__split_by_durations_09():
-    """
-    Nonassignable power-of-two duration returns selection of new leaves.
-    """
-
-    note = abjad.Note("c'4")
-
-    new_leaves = note._split_by_durations(
-        [abjad.Duration(5, 32)], tie_split_notes=False
-    )
-
-    assert isinstance(new_leaves, abjad.Selection)
-    assert all(isinstance(_, abjad.Note) for _ in new_leaves)
-
-
-def test_Leaf__split_by_durations_10():
+def test_Leaf__split_by_durations_05():
     """
     Lone spanned leaf results in two spanned leaves.
     """
@@ -274,20 +118,7 @@ def test_Leaf__split_by_durations_10():
     assert abjad.inspect(staff).wellformed()
 
 
-def test_Leaf__split_by_durations_11():
-
-    staff = abjad.Staff("c'8 c'8 c'8 c'8")
-    abjad.beam(staff[:])
-
-    new_leaves = staff[0]._split_by_durations(
-        [abjad.Duration(1, 16)], tie_split_notes=False
-    )
-
-    assert len(staff) == 5
-    assert abjad.inspect(staff).wellformed()
-
-
-def test_Leaf__split_by_durations_12():
+def test_Leaf__split_by_durations_06():
     """
     Returns three leaves with two tied.
     """
@@ -314,7 +145,7 @@ def test_Leaf__split_by_durations_12():
     assert abjad.inspect(staff).wellformed()
 
 
-def test_Leaf__split_by_durations_13():
+def test_Leaf__split_by_durations_07():
     """
     After grace notes are removed from first split leaf.
     """
@@ -346,7 +177,7 @@ def test_Leaf__split_by_durations_13():
     abjad.inspect(staff).wellformed()
 
 
-def test_Leaf__split_by_durations_14():
+def test_Leaf__split_by_durations_08():
     """
     After grace notes are removed from first split leaf.
     """
@@ -378,7 +209,7 @@ def test_Leaf__split_by_durations_14():
     abjad.inspect(staff).wellformed()
 
 
-def test_Leaf__split_by_durations_15():
+def test_Leaf__split_by_durations_09():
     """
     Grace notes are removed from second split leaf.
     """
@@ -407,69 +238,7 @@ def test_Leaf__split_by_durations_15():
     abjad.inspect(staff).wellformed()
 
 
-def test_Leaf__split_by_durations_16():
-
-    staff = abjad.Staff()
-    staff.append(abjad.Container("c'8 d'8"))
-    staff.append(abjad.Container("e'8 f'8"))
-    leaves = abjad.select(staff).leaves()
-    abjad.beam(leaves[:2])
-    abjad.beam(leaves[-2:])
-    abjad.slur(leaves)
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    new_leaves = leaves[0]._split_by_durations(
-        [abjad.Duration(1, 32)], tie_split_notes=False
-    )
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                c'32
-                [
-                (
-                c'16.
-                d'8
-                ]
-            }
-            {
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    assert abjad.inspect(staff).wellformed()
-
-
-def test_Leaf__split_by_durations_17():
+def test_Leaf__split_by_durations_10():
     """
     Split one leaf in score.
     Ties after split.
@@ -505,9 +274,7 @@ def test_Leaf__split_by_durations_17():
         """
     ), print(format(staff))
 
-    new_leaves = leaves[0]._split_by_durations(
-        [abjad.Duration(1, 32)], tie_split_notes=True
-    )
+    new_leaves = leaves[0]._split_by_durations([abjad.Duration(1, 32)])
 
     assert format(staff) == abjad.String.normalize(
         r"""

--- a/tests/test_LilyPondParser__spanners__Hairpin.py
+++ b/tests/test_LilyPondParser__spanners__Hairpin.py
@@ -62,7 +62,7 @@ def test_LilyPondParser__spanners__Hairpin_01():
 #    assert format(target) == format(result) and target is not result
 
 
-def test_LilyPondParser__spanners__Hairpin_03():
+def test_LilyPondParser__spanners__Hairpin_02():
     """
     Dynamics can terminate hairpins.
     """
@@ -93,7 +93,7 @@ def test_LilyPondParser__spanners__Hairpin_03():
     assert format(target) == format(result) and target is not result
 
 
-def test_LilyPondParser__spanners__Hairpin_04():
+def test_LilyPondParser__spanners__Hairpin_03():
     """
     Unterminated.
     """
@@ -103,7 +103,7 @@ def test_LilyPondParser__spanners__Hairpin_04():
         abjad.LilyPondParser()(string)
 
 
-def test_LilyPondParser__spanners__Hairpin_05():
+def test_LilyPondParser__spanners__Hairpin_04():
     """
     Unbegun is okay.
     """
@@ -112,7 +112,7 @@ def test_LilyPondParser__spanners__Hairpin_05():
     result = abjad.parser.LilyPondParser()(string)
 
 
-def test_LilyPondParser__spanners__Hairpin_06():
+def test_LilyPondParser__spanners__Hairpin_05():
     """
     No double dynamic spans permitted.
     """
@@ -122,7 +122,7 @@ def test_LilyPondParser__spanners__Hairpin_06():
         abjad.LilyPondParser()(string)
 
 
-def test_LilyPondParser__spanners__Hairpin_07():
+def test_LilyPondParser__spanners__Hairpin_06():
     """
     With direction.
     """
@@ -160,7 +160,7 @@ def test_LilyPondParser__spanners__Hairpin_07():
     assert format(target) == format(result) and target is not result
 
 
-def test_LilyPondParser__spanners__Hairpin_08():
+def test_LilyPondParser__spanners__Hairpin_07():
 
     string = r"\new Staff { c'4 ( \p \< d'4 e'4 f'4 ) \! }"
     parser = abjad.parser.LilyPondParser()

--- a/tests/test_Mutation_split.py
+++ b/tests/test_Mutation_split.py
@@ -145,215 +145,6 @@ def test_Mutation_split_02():
 
 def test_Mutation_split_03():
     """
-    Cyclically splits containers in score.
-    """
-
-    staff = abjad.Staff(r"abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |")
-    leaves = abjad.select(staff).leaves()
-    abjad.beam(leaves[:2])
-    abjad.beam(leaves[-2:])
-    abjad.slur(leaves)
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                \time 2/8
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    measures = staff[:1]
-    result = abjad.mutate(measures).split(
-        [abjad.Duration(3, 32)], cyclic=True, tie_split_notes=False
-    )
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                \time 2/8
-                c'16.
-                [
-                (
-            }
-            {
-                c'32
-                d'16
-            }
-            {
-                d'16
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    assert abjad.inspect(staff).wellformed()
-
-
-def test_Mutation_split_04():
-    """
-    Cyclically splits consecutive measures in score.
-    """
-
-    staff = abjad.Staff(r"abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |")
-    leaves = abjad.select(staff).leaves()
-    abjad.beam(leaves[:2])
-    abjad.beam(leaves[-2:])
-    abjad.slur(leaves)
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                \time 2/8
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    measures = staff[:]
-    result = abjad.mutate(measures).split(
-        [abjad.Duration(3, 32)], cyclic=True, tie_split_notes=False
-    )
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                \time 2/8
-                c'16.
-                [
-                (
-            }
-            {
-                c'32
-                d'16
-            }
-            {
-                d'16
-                ]
-            }
-            {
-                \time 2/8
-                e'32
-                [
-            }
-            {
-                e'16.
-            }
-            {
-                f'16.
-            }
-            {
-                f'32
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    assert abjad.inspect(staff).wellformed()
-
-
-def test_Mutation_split_05():
-    """
-    Cyclically splits orphan measures.
-    """
-
-    measures = [abjad.Container("c'8 d'8"), abjad.Container("e'8 f'8")]
-    leaves = abjad.select(measures).leaves()
-    abjad.beam(leaves[:2])
-    abjad.beam(leaves[-2:])
-
-    result = abjad.mutate(measures).split(
-        [abjad.Duration(3, 32)], cyclic=True, tie_split_notes=False
-    )
-
-    components = abjad.sequence(result).flatten(depth=-1)
-    staff = abjad.Staff(components)
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                c'16.
-                [
-            }
-            {
-                c'32
-                d'16
-            }
-            {
-                d'16
-                ]
-            }
-            {
-                e'32
-                [
-            }
-            {
-                e'16.
-            }
-            {
-                f'16.
-            }
-            {
-                f'32
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    assert abjad.inspect(staff).wellformed()
-    assert len(result) == 6
-
-
-def test_Mutation_split_06():
-    """
     Cyclically splits note in score.
     """
 
@@ -388,9 +179,7 @@ def test_Mutation_split_06():
     ), print(format(staff))
 
     notes = staff[0][1:]
-    result = abjad.mutate(notes).split(
-        [abjad.Duration(1, 32)], cyclic=True, tie_split_notes=True
-    )
+    result = abjad.mutate(notes).split([abjad.Duration(1, 32)], cyclic=True)
 
     assert format(staff) == abjad.String.normalize(
         r"""
@@ -426,7 +215,7 @@ def test_Mutation_split_06():
     assert len(result) == 4
 
 
-def test_Mutation_split_07():
+def test_Mutation_split_04():
     """
     Cyclically splits consecutive notes in score.
     """
@@ -461,9 +250,7 @@ def test_Mutation_split_07():
         """
     ), print(format(staff))
 
-    result = abjad.mutate(leaves).split(
-        [abjad.Duration(1, 16)], cyclic=True, tie_split_notes=True
-    )
+    result = abjad.mutate(leaves).split([abjad.Duration(1, 16)], cyclic=True)
 
     assert format(staff) == abjad.String.normalize(
         r"""
@@ -501,7 +288,7 @@ def test_Mutation_split_07():
     assert len(result) == 8
 
 
-def test_Mutation_split_08():
+def test_Mutation_split_05():
     """
     Cyclically splits measure in score.
     """
@@ -537,9 +324,7 @@ def test_Mutation_split_08():
     ), print(format(staff))
 
     measures = staff[:1]
-    result = abjad.mutate(measures).split(
-        [abjad.Duration(1, 16)], cyclic=True, tie_split_notes=True
-    )
+    result = abjad.mutate(measures).split([abjad.Duration(1, 16)], cyclic=True)
 
     assert format(staff) == abjad.String.normalize(
         r"""
@@ -579,7 +364,7 @@ def test_Mutation_split_08():
     assert len(result) == 4
 
 
-def test_Mutation_split_09():
+def test_Mutation_split_06():
     """
     Cyclically splits consecutive measures in score.
     """
@@ -615,9 +400,7 @@ def test_Mutation_split_09():
     ), print(format(staff))
 
     measures = staff[:]
-    result = abjad.mutate(measures).split(
-        [abjad.Duration(3, 32)], cyclic=True, tie_split_notes=True
-    )
+    result = abjad.mutate(measures).split([abjad.Duration(3, 32)], cyclic=True)
 
     assert format(staff) == abjad.String.normalize(
         r"""
@@ -665,160 +448,7 @@ def test_Mutation_split_09():
     assert len(result) == 6
 
 
-def test_Mutation_split_10():
-    """
-    Force-splits measure in score.
-    """
-
-    staff = abjad.Staff(r"abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |")
-    leaves = abjad.select(staff).leaves()
-    abjad.beam(leaves[:2])
-    abjad.beam(leaves[-2:])
-    abjad.slur(leaves)
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                \time 2/8
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    measures = staff[:1]
-    result = abjad.mutate(measures).split(
-        [abjad.Duration(1, 32), abjad.Duration(3, 32), abjad.Duration(5, 32)],
-        cyclic=False,
-        tie_split_notes=False,
-    )
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                \time 2/8
-                c'32
-                [
-                (
-            }
-            {
-                c'16.
-            }
-            {
-                d'8
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    assert abjad.inspect(staff).wellformed()
-    assert len(result) == 3
-
-
-def test_Mutation_split_11():
-    """
-    Force-splits consecutive measures in score.
-    """
-
-    staff = abjad.Staff(r"abj: | 2/8 c'8 d'8 || 2/8 e'8 f'8 |")
-    leaves = abjad.select(staff).leaves()
-    abjad.beam(leaves[:2])
-    abjad.beam(leaves[-2:])
-    abjad.slur(leaves)
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                \time 2/8
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    measures = staff[:]
-    result = abjad.mutate(measures).split(
-        [abjad.Duration(1, 32), abjad.Duration(3, 32), abjad.Duration(5, 32)],
-        cyclic=False,
-        tie_split_notes=False,
-    )
-
-    assert format(staff) == abjad.String.normalize(
-        r"""
-        \new Staff
-        {
-            {
-                \time 2/8
-                c'32
-                [
-                (
-            }
-            {
-                c'16.
-            }
-            {
-                d'8
-                ]
-            }
-            {
-                \time 2/8
-                e'32
-                [
-            }
-            {
-                e'16.
-                f'8
-                )
-                ]
-            }
-        }
-        """
-    ), print(format(staff))
-
-    assert abjad.inspect(staff).wellformed()
-    assert len(result) == 4
-
-
-def test_Mutation_split_12():
+def test_Mutation_split_07():
     """
     Splits tuplet in score
     """
@@ -859,7 +489,7 @@ def test_Mutation_split_12():
     assert abjad.inspect(voice).wellformed()
 
 
-def test_Mutation_split_13():
+def test_Mutation_split_08():
     """
     Splits in-score measure with power-of-two denominator.
     """
@@ -898,7 +528,7 @@ def test_Mutation_split_13():
     assert abjad.inspect(voice).wellformed()
 
 
-def test_Mutation_split_14():
+def test_Mutation_split_09():
     """
     Splits container in middle.
     """
@@ -937,7 +567,7 @@ def test_Mutation_split_14():
     assert abjad.inspect(voice_2).wellformed()
 
 
-def test_Mutation_split_15():
+def test_Mutation_split_10():
     """
     Splits voice at negative index.
     """
@@ -999,7 +629,7 @@ def test_Mutation_split_15():
     assert abjad.inspect(staff).wellformed()
 
 
-def test_Mutation_split_16():
+def test_Mutation_split_11():
     """
     Splits container in score.
     """
@@ -1080,7 +710,7 @@ def test_Mutation_split_16():
     assert abjad.inspect(staff).wellformed()
 
 
-def test_Mutation_split_17():
+def test_Mutation_split_12():
     """
     Splits tuplet in score.
     """
@@ -1173,7 +803,7 @@ def test_Mutation_split_17():
     assert abjad.inspect(staff).wellformed()
 
 
-def test_Mutation_split_18():
+def test_Mutation_split_13():
     """
     Splits cyclically.
     """
@@ -1241,7 +871,7 @@ def test_Mutation_split_18():
     assert abjad.inspect(voice).wellformed()
 
 
-def test_Mutation_split_19():
+def test_Mutation_split_14():
     """
     Cyclically splits all components in container.
     """
@@ -1299,7 +929,7 @@ def test_Mutation_split_19():
     assert abjad.inspect(voice).wellformed()
 
 
-def test_Mutation_split_20():
+def test_Mutation_split_15():
     """
     Splits leaf at non-assignable, non-power-of-two offset.
     """

--- a/tests/test_TypedOrderedDict.py
+++ b/tests/test_TypedOrderedDict.py
@@ -307,7 +307,7 @@ def test_TypedOrderedDict_15():
 #    assert dictionary_1 == dictionary_2
 
 
-def test_TypedOrderedDict_17():
+def test_TypedOrderedDict_16():
     """
     Implements update().
     """


### PR DESCRIPTION
CHANGE: removed abjad.mutate().split(..., tie_split_notes=True) keyword.

Split now always ties split notes.