### PR TITLE
FIXED: abjad.Staccato now formats direction. Closes #1064.

### DIFF
--- a/abjad/indicators/Dynamic.py
+++ b/abjad/indicators/Dynamic.py
@@ -428,6 +428,12 @@ class Dynamic(object):
             string = self._format_textual(self.direction, self.name)
         else:
             string = rf"\{self.name}"
+            if self.direction is not None:
+                direction_ = self.direction
+                direction = String.to_tridirectional_lilypond_symbol(
+                    direction_
+                )
+                string = f"{direction} {string}"
         return string
 
     def _get_lilypond_format_bundle(self, component=None):
@@ -494,20 +500,146 @@ class Dynamic(object):
 
     @property
     def direction(self) -> typing.Optional[enums.VerticalAlignment]:
-        """
+        r"""
         Gets direction for effort dynamics only.
 
         ..  container:: example
 
-            Effort dynamics default to down:
+            With ``direction`` unset:
 
-            >>> abjad.Dynamic('"f"').direction
-            Down
+            >>> staff = abjad.Staff("c'2 c''2")
+            >>> abjad.attach(abjad.Dynamic("p"), staff[0])
+            >>> abjad.attach(abjad.Dynamic("f"), staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+            
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'2
+                    \p
+                    c''2
+                    \f
+                }
+
+            With ``direction=abjad.Up``:
+
+            >>> staff = abjad.Staff("c'2 c''2")
+            >>> abjad.attach(abjad.Dynamic("p", direction=abjad.Up), staff[0])
+            >>> abjad.attach(abjad.Dynamic("f", direction=abjad.Up), staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+            
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'2
+                    ^ \p
+                    c''2
+                    ^ \f
+                }
+
+            With ``direction=abjad.Down``:
+
+            >>> staff = abjad.Staff("c'2 c''2")
+            >>> abjad.attach(abjad.Dynamic("p", direction=abjad.Down), staff[0])
+            >>> abjad.attach(abjad.Dynamic("f", direction=abjad.Down), staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+            
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'2
+                    _ \p
+                    c''2
+                    _ \f
+                }
+
+        ..  container:: example
+
+            REGRESSION. Effort dynamics default to down:
+
+            >>> staff = abjad.Staff("c'2 c''2")
+            >>> abjad.attach(abjad.Dynamic('"p"'), staff[0])
+            >>> abjad.attach(abjad.Dynamic('"f"'), staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+            
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'2
+                    _ #(make-dynamic-script
+                        (markup
+                            #:whiteout
+                            #:line (
+                                #:general-align Y -2 #:normal-text #:larger "“"
+                                #:hspace -0.1
+                                #:dynamic "p"
+                                #:hspace -0.25
+                                #:general-align Y -2 #:normal-text #:larger "”"
+                                )
+                            )
+                        )
+                    c''2
+                    _ #(make-dynamic-script
+                        (markup
+                            #:whiteout
+                            #:line (
+                                #:general-align Y -2 #:normal-text #:larger "“"
+                                #:hspace -0.4
+                                #:dynamic "f"
+                                #:hspace -0.2
+                                #:general-align Y -2 #:normal-text #:larger "”"
+                                )
+                            )
+                        )
+                }
 
             And may be overriden:
 
-            >>> abjad.Dynamic('"f"', direction=abjad.Up).direction
-            Up
+            >>> staff = abjad.Staff("c'2 c''2")
+            >>> abjad.attach(abjad.Dynamic('"p"', direction=abjad.Up), staff[0])
+            >>> abjad.attach(abjad.Dynamic('"f"', direction=abjad.Up), staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+            
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'2
+                    ^ #(make-dynamic-script
+                        (markup
+                            #:whiteout
+                            #:line (
+                                #:general-align Y -2 #:normal-text #:larger "“"
+                                #:hspace -0.1
+                                #:dynamic "p"
+                                #:hspace -0.25
+                                #:general-align Y -2 #:normal-text #:larger "”"
+                                )
+                            )
+                        )
+                    c''2
+                    ^ #(make-dynamic-script
+                        (markup
+                            #:whiteout
+                            #:line (
+                                #:general-align Y -2 #:normal-text #:larger "“"
+                                #:hspace -0.4
+                                #:dynamic "f"
+                                #:hspace -0.2
+                                #:general-align Y -2 #:normal-text #:larger "”"
+                                )
+                            )
+                        )
+                }
 
         """
         if self._direction is not None:

--- a/abjad/indicators/RepeatTie.py
+++ b/abjad/indicators/RepeatTie.py
@@ -119,6 +119,8 @@ class RepeatTie(object):
         return True
 
     def _get_lilypond_format_bundle(self, component=None):
+        import abjad
+
         bundle = LilyPondFormatBundle()
         if self.tweaks:
             strings = self.tweaks._list_format_contributions()
@@ -126,7 +128,10 @@ class RepeatTie(object):
                 strings = self._tag_show(strings)
             bundle.after.spanners.extend(strings)
         strings = []
-        if self._should_force_repeat_tie_up(component):
+        if self.direction is not None:
+            assert isinstance(self.direction, str)
+            strings.append(self.direction)
+        elif self._should_force_repeat_tie_up(component):
             string = r"- \tweak direction #up"
             strings.append(string)
         strings.append(r"\repeatTie")
@@ -188,10 +193,15 @@ class RepeatTie(object):
 
         ..  container:: example
 
-            >>> staff = abjad.Staff("c'4 c' d' d'")
-            >>> tie = abjad.RepeatTie(direction=abjad.Up)
+            With ``direction`` unset:
+
+            >>> staff = abjad.Staff("c'4 c'4 c''4 c''4")
+            >>> tie = abjad.RepeatTie()
             >>> abjad.tweak(tie).color = 'blue'
-            >>> abjad.attach(tie, staff[0])
+            >>> abjad.attach(tie, staff[1])
+            >>> tie = abjad.RepeatTie()
+            >>> abjad.tweak(tie).color = 'blue'
+            >>> abjad.attach(tie, staff[3])
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -200,11 +210,69 @@ class RepeatTie(object):
                 \new Staff
                 {
                     c'4
+                    c'4
                     - \tweak color #blue
                     \repeatTie
+                    c''4
+                    c''4
+                    - \tweak color #blue
+                    \repeatTie
+                }
+
+            With ``direction=abjad.Up``:
+
+            >>> staff = abjad.Staff("c'4 c'4 c''4 c''4")
+            >>> tie = abjad.RepeatTie(direction=abjad.Up)
+            >>> abjad.tweak(tie).color = 'blue'
+            >>> abjad.attach(tie, staff[1])
+            >>> tie = abjad.RepeatTie(direction=abjad.Up)
+            >>> abjad.tweak(tie).color = 'blue'
+            >>> abjad.attach(tie, staff[3])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
                     c'4
-                    d'4
-                    d'4
+                    c'4
+                    - \tweak color #blue
+                    ^
+                    \repeatTie
+                    c''4
+                    c''4
+                    - \tweak color #blue
+                    ^
+                    \repeatTie
+                }
+
+            With ``direction=abjad.Down``:
+
+            >>> staff = abjad.Staff("c'4 c'4 c''4 c''4")
+            >>> tie = abjad.RepeatTie(direction=abjad.Down)
+            >>> abjad.tweak(tie).color = 'blue'
+            >>> abjad.attach(tie, staff[1])
+            >>> tie = abjad.RepeatTie(direction=abjad.Down)
+            >>> abjad.tweak(tie).color = 'blue'
+            >>> abjad.attach(tie, staff[3])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'4
+                    c'4
+                    - \tweak color #blue
+                    _
+                    \repeatTie
+                    c''4
+                    c''4
+                    - \tweak color #blue
+                    _
+                    \repeatTie
                 }
 
         """

--- a/abjad/indicators/Staccatissimo.py
+++ b/abjad/indicators/Staccatissimo.py
@@ -12,28 +12,8 @@ class Staccatissimo(object):
 
     ..  container:: example
 
-        Attached to a single note:
-
-        >>> note = abjad.Note("c'4")
-        >>> staccatissimo = abjad.Staccatissimo()
-        >>> abjad.attach(staccatissimo, note)
-        >>> abjad.show(note) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> abjad.f(note)
-            c'4
-            \staccatissimo
-
-    ..  container:: example
-
-        Attached to notes in a staff:
-
-        >>> staff = abjad.Staff("c'8 d' e' f' g' a' b' c''")
-        >>> abjad.beam(staff[:4])
-        >>> abjad.beam(staff[4:])
-        >>> abjad.attach(abjad.Staccatissimo(), staff[3])
-        >>> abjad.attach(abjad.Staccatissimo(), staff[7])
+        >>> staff = abjad.Staff("c'4")
+        >>> abjad.attach(abjad.Staccatissimo(), staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -41,19 +21,7 @@ class Staccatissimo(object):
             >>> abjad.f(staff)
             \new Staff
             {
-                c'8
-                [
-                d'8
-                e'8
-                f'8
-                ]
-                \staccatissimo
-                g'8
-                [
-                a'8
-                b'8
-                c''8
-                ]
+                c'4
                 \staccatissimo
             }
 
@@ -91,14 +59,13 @@ class Staccatissimo(object):
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to storage format manager.
         """
         return StorageFormatManager.compare_objects(self, argument)
 
     def __hash__(self) -> int:
         """
-        Hashes Abjad value object.
+        Delegates to storage format manager.
         """
         hash_values = StorageFormatManager(self).get_hash_values()
         try:
@@ -109,12 +76,13 @@ class Staccatissimo(object):
 
     def __repr__(self) -> str:
         """
-        Gets interpreter representation.
+        Delegates to storage format manager.
         """
         return StorageFormatManager(self).get_repr_format()
 
     def __str__(self) -> str:
-        r"""Gets string representation of staccatissimo.
+        r"""
+        Gets string representation of staccatissimo.
 
         ..  container:: example
 
@@ -122,7 +90,12 @@ class Staccatissimo(object):
             '\\staccatissimo'
 
         """
-        return r"\staccatissimo"
+        string = r"\staccatissimo"
+        if self.direction is None:
+            return string
+        direction = String.to_tridirectional_lilypond_symbol(self.direction)
+        assert isinstance(direction, String), repr(direction)
+        return fr"{direction} {string}"
 
     ### PRIVATE METHODS ###
 
@@ -141,18 +114,64 @@ class Staccatissimo(object):
 
     @property
     def direction(self) -> typing.Optional[enums.VerticalAlignment]:
-        """
-        Gets direction of articulation.
+        r"""
+        Gets direction of staccatissimo.
 
         ..  container:: example
 
-            Without direction:
+            With ``direction`` unset:
 
-            >>> abjad.Staccatissimo().direction is None
-            True
+            >>> staff = abjad.Staff("c'4 c''4")
+            >>> abjad.attach(abjad.Staccatissimo(), staff[0])
+            >>> abjad.attach(abjad.Staccatissimo(), staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+            
+            ..  docs::
 
-            >>> abjad.Staccatissimo(direction=abjad.Up).direction
-            Up
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'4
+                    \staccatissimo
+                    c''4
+                    \staccatissimo
+                }
+
+            With ``direction=abjad.Up``:
+
+            >>> staff = abjad.Staff("c'4 c''4")
+            >>> abjad.attach(abjad.Staccatissimo(direction=abjad.Up), staff[0])
+            >>> abjad.attach(abjad.Staccatissimo(direction=abjad.Up), staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+            
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'4
+                    ^ \staccatissimo
+                    c''4
+                    ^ \staccatissimo
+                }
+
+            With ``direction=abjad.Down``:
+
+            >>> staff = abjad.Staff("c'4 c''4")
+            >>> abjad.attach(abjad.Staccatissimo(direction=abjad.Down), staff[0])
+            >>> abjad.attach(abjad.Staccatissimo(direction=abjad.Down), staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+            
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'4
+                    _ \staccatissimo
+                    c''4
+                    _ \staccatissimo
+                }
 
         """
         return self._direction

--- a/abjad/indicators/Staccato.py
+++ b/abjad/indicators/Staccato.py
@@ -12,28 +12,8 @@ class Staccato(object):
 
     ..  container:: example
 
-        Attached to a single note:
-
-        >>> note = abjad.Note("c'4")
-        >>> staccato = abjad.Staccato()
-        >>> abjad.attach(staccato, note)
-        >>> abjad.show(note) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> abjad.f(note)
-            c'4
-            \staccato
-
-    ..  container:: example
-
-        Attached to notes in a staff:
-
-        >>> staff = abjad.Staff("c'8 d' e' f' g' a' b' c''")
-        >>> abjad.beam(staff[:4])
-        >>> abjad.beam(staff[4:])
-        >>> abjad.attach(abjad.Staccato(), staff[3])
-        >>> abjad.attach(abjad.Staccato(), staff[7])
+        >>> staff = abjad.Staff("c'4")
+        >>> abjad.attach(abjad.Staccato(), staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -41,19 +21,7 @@ class Staccato(object):
             >>> abjad.f(staff)
             \new Staff
             {
-                c'8
-                [
-                d'8
-                e'8
-                f'8
-                ]
-                \staccato
-                g'8
-                [
-                a'8
-                b'8
-                c''8
-                ]
+                c'4
                 \staccato
             }
 
@@ -123,7 +91,12 @@ class Staccato(object):
             '\\staccato'
 
         """
-        return r"\staccato"
+        string = r"\staccato"
+        if self.direction is None:
+            return string
+        direction = String.to_tridirectional_lilypond_symbol(self.direction)
+        assert isinstance(direction, String), repr(direction)
+        return fr"{direction} {string}"
 
     ### PRIVATE METHODS ###
 
@@ -142,18 +115,64 @@ class Staccato(object):
 
     @property
     def direction(self) -> typing.Optional[enums.VerticalAlignment]:
-        """
-        Gets direction of articulation.
+        r"""
+        Gets direction of staccato.
 
         ..  container:: example
 
-            Without direction:
+            With ``direction`` unset:
 
-            >>> abjad.Staccato().direction is None
-            True
+            >>> staff = abjad.Staff("c'4 c''4")
+            >>> abjad.attach(abjad.Staccato(), staff[0])
+            >>> abjad.attach(abjad.Staccato(), staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+            
+            ..  docs::
 
-            >>> abjad.Staccato(direction=abjad.Up).direction
-            Up
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'4
+                    \staccato
+                    c''4
+                    \staccato
+                }
+
+            With ``direction=abjad.Up``:
+
+            >>> staff = abjad.Staff("c'4 c''4")
+            >>> abjad.attach(abjad.Staccato(direction=abjad.Up), staff[0])
+            >>> abjad.attach(abjad.Staccato(direction=abjad.Up), staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+            
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'4
+                    ^ \staccato
+                    c''4
+                    ^ \staccato
+                }
+
+            With ``direction=abjad.Down``:
+
+            >>> staff = abjad.Staff("c'4 c''4")
+            >>> abjad.attach(abjad.Staccato(direction=abjad.Down), staff[0])
+            >>> abjad.attach(abjad.Staccato(direction=abjad.Down), staff[1])
+            >>> abjad.show(staff) # doctest: +SKIP
+            
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'4
+                    _ \staccato
+                    c''4
+                    _ \staccato
+                }
 
         """
         return self._direction

--- a/abjad/indicators/StartSlur.py
+++ b/abjad/indicators/StartSlur.py
@@ -132,8 +132,95 @@ class StartSlur(object):
 
     @property
     def direction(self) -> typing.Optional[str]:
-        """
+        r"""
         Gets direction.
+
+        ..  container:: example
+
+            With ``direction`` unset:
+
+            >>> staff = abjad.Staff("c'8 d' e' f' c'' d'' e'' f''")
+            >>> abjad.attach(abjad.StartSlur(), staff[0])
+            >>> abjad.attach(abjad.StopSlur(), staff[3])
+            >>> abjad.attach(abjad.StartSlur(), staff[4])
+            >>> abjad.attach(abjad.StopSlur(), staff[7])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'8
+                    (
+                    d'8
+                    e'8
+                    f'8
+                    )
+                    c''8
+                    (
+                    d''8
+                    e''8
+                    f''8
+                    )
+                }
+
+            With ``direction=abjad.Up``:
+
+            >>> staff = abjad.Staff("c'8 d' e' f' c'' d'' e'' f''")
+            >>> abjad.attach(abjad.StartSlur(direction=abjad.Up), staff[0])
+            >>> abjad.attach(abjad.StopSlur(), staff[3])
+            >>> abjad.attach(abjad.StartSlur(direction=abjad.Up), staff[4])
+            >>> abjad.attach(abjad.StopSlur(), staff[7])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'8
+                    ^ (
+                    d'8
+                    e'8
+                    f'8
+                    )
+                    c''8
+                    ^ (
+                    d''8
+                    e''8
+                    f''8
+                    )
+                }
+
+            With ``direction=abjad.Down``:
+
+            >>> staff = abjad.Staff("c'8 d' e' f' c'' d'' e'' f''")
+            >>> abjad.attach(abjad.StartSlur(direction=abjad.Down), staff[0])
+            >>> abjad.attach(abjad.StopSlur(), staff[3])
+            >>> abjad.attach(abjad.StartSlur(direction=abjad.Down), staff[4])
+            >>> abjad.attach(abjad.StopSlur(), staff[7])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'8
+                    _ (
+                    d'8
+                    e'8
+                    f'8
+                    )
+                    c''8
+                    _ (
+                    d''8
+                    e''8
+                    f''8
+                    )
+                }
+
         """
         return self._direction
 

--- a/abjad/indicators/Tie.py
+++ b/abjad/indicators/Tie.py
@@ -168,10 +168,11 @@ class Tie(object):
 
         ..  container:: example
 
-            >>> staff = abjad.Staff("c'4 c' d' d'")
-            >>> tie = abjad.Tie(direction=abjad.Up)
-            >>> abjad.tweak(tie).color = 'blue'
-            >>> abjad.attach(tie, staff[0])
+            With ``direction`` unset:
+
+            >>> staff = abjad.Staff("c'4 c' c'' c''")
+            >>> abjad.attach(abjad.Tie(), staff[0])
+            >>> abjad.attach(abjad.Tie(), staff[2])
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -180,11 +181,51 @@ class Tie(object):
                 \new Staff
                 {
                     c'4
-                    - \tweak color #blue
+                    ~
+                    c'4
+                    c''4
+                    ~
+                    c''4
+                }
+
+            With ``direction=abjad.Up``:
+
+            >>> staff = abjad.Staff("c'4 c' c'' c''")
+            >>> abjad.attach(abjad.Tie(direction=abjad.Up), staff[0])
+            >>> abjad.attach(abjad.Tie(direction=abjad.Up), staff[2])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'4
                     ^ ~
                     c'4
-                    d'4
-                    d'4
+                    c''4
+                    ^ ~
+                    c''4
+                }
+
+            With ``direction=abjad.Down``:
+
+            >>> staff = abjad.Staff("c'4 c' c'' c''")
+            >>> abjad.attach(abjad.Tie(direction=abjad.Down), staff[0])
+            >>> abjad.attach(abjad.Tie(direction=abjad.Down), staff[2])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> abjad.f(staff)
+                \new Staff
+                {
+                    c'4
+                    _ ~
+                    c'4
+                    c''4
+                    _ ~
+                    c''4
                 }
 
         """


### PR DESCRIPTION
    staff = abjad.Staff("c'4 c'4")
    articulation = abjad.Articulation('staccato', direction=abjad.Up)
    abjad.attach(articulation, staff[0])
    staccato = abjad.Staccato(direction=abjad.Up)
    abjad.attach(staccato, staff[1])

    abjad.f(staff)
    \new Staff
    {
        c'4
        ^ \staccato
        c'4
        ^ \staccato
    }

FIXED:

    * abjad.Dynamic.direction
    * abjad.RepeatTie.direction
    * abjad.Staccatissimo.direction