### PR TITLE
October 2019 update.

### DIFF
--- a/abjad/boilerplate/__make_layout_ly__.py
+++ b/abjad/boilerplate/__make_layout_ly__.py
@@ -79,7 +79,6 @@ if __name__ == '__main__':
             breaks=breaks,
             do_not_check_persistence=True,
             do_not_include_layout_ly=True,
-            final_bar_line=False,
             first_measure_number=first_measure_number,
             score_template=baca.SingleStaffScoreTemplate(),
             spacing=spacing,

--- a/abjad/core/Context.py
+++ b/abjad/core/Context.py
@@ -239,24 +239,26 @@ class Context(Container):
         self._update_now(indicators=True)
         return self._format_component()
 
-    def _get_persistent_wrappers(self, *, omit_with_indicator=None):
-        self._update_now(indicators=True)
+    @staticmethod
+    def _get_persistent_wrappers(
+        *, dependent_wrappers=None, omit_with_indicator=None
+    ):
         wrappers = {}
-        for wrapper in self._dependent_wrappers:
+        for wrapper in dependent_wrappers:
             if wrapper.annotation:
                 continue
             indicator = wrapper.indicator
             if not getattr(indicator, "persistent", False):
                 continue
             assert isinstance(indicator.persistent, bool)
-            is_phantom = False
+            should_omit = False
             if omit_with_indicator is not None:
                 parentage = inspect(wrapper.component).parentage()
                 for component in parentage:
                     if inspect(component).has_indicator(omit_with_indicator):
-                        is_phantom = True
+                        should_omit = True
                         continue
-            if is_phantom:
+            if should_omit:
                 continue
             if hasattr(indicator, "parameter"):
                 key = indicator.parameter

--- a/abjad/core/Label.py
+++ b/abjad/core/Label.py
@@ -1912,8 +1912,11 @@ class Label(object):
                     leaf = vertical_moment.start_leaves[-1]
                 self._attach(label, leaf)
 
-    def with_durations(self, direction=enums.Up, denominator=None):
-        r"""Labels logical ties with durations.
+    def with_durations(
+        self, *, denominator=None, direction=enums.Up, in_seconds: bool = None
+    ):
+        r"""
+        Labels logical ties with durations.
 
         ..  container:: example
 
@@ -1939,8 +1942,8 @@ class Label(object):
                         d'8
                         ^ \markup {
                             \fraction
-                                1
-                                2
+                                4
+                                8
                             }
                         ~
                         d'4.
@@ -1981,8 +1984,8 @@ class Label(object):
                         d'8
                         ^ \markup {
                             \fraction
-                                1
-                                2
+                                4
+                                8
                             }
                         ~
                         d'4.
@@ -2094,12 +2097,17 @@ class Label(object):
         if self._expression:
             return self._update_expression(inspect.currentframe())
         for logical_tie in iterate(self.client).logical_ties():
-            duration = abjad_inspect(logical_tie).duration()
+            duration = abjad_inspect(logical_tie).duration(
+                in_seconds=in_seconds
+            )
             if denominator is not None:
                 duration = NonreducedFraction(duration)
                 duration = duration.with_denominator(denominator)
             pair = duration.pair
-            label = Markup.fraction(*pair, direction=direction)
+            numerator, denominator = pair
+            label = Markup.fraction(
+                numerator, denominator, direction=direction
+            )
             self._attach(label, logical_tie.head)
 
     def with_indices(self, direction=enums.Up, prototype=None):

--- a/abjad/core/OnBeatGraceContainer.py
+++ b/abjad/core/OnBeatGraceContainer.py
@@ -3,6 +3,7 @@ from abjad import typings
 from abjad.indicators.LilyPondLiteral import LilyPondLiteral
 from abjad.system.LilyPondFormatManager import LilyPondFormatManager
 from abjad.system.Tag import Tag
+from abjad.system.Tags import Tags
 from abjad.top.attach import attach
 from abjad.top.inspect import inspect as abjad_inspect
 from abjad.top.mutate import mutate
@@ -11,6 +12,8 @@ from abjad.top.tweak import tweak
 from abjad.top.select import select
 from abjad.utilities.Duration import Duration
 from .Container import Container
+
+abjad_tags = Tags()
 
 
 class OnBeatGraceContainer(Container):
@@ -126,6 +129,7 @@ class OnBeatGraceContainer(Container):
             return
         site = "abjad.OnBeatGraceContainer._attach_lilypond_one_voice()"
         tag = Tag(site)
+        tag = tag.append(abjad_tags.ONE_VOICE_COMMAND)
         attach(literal, next_leaf, tag=tag)
 
     def _format_invocation(self):

--- a/abjad/indicators/Dynamic.py
+++ b/abjad/indicators/Dynamic.py
@@ -454,14 +454,6 @@ class Dynamic(object):
                 bundle.after.articulations.append(string)
         return bundle
 
-    @staticmethod
-    def _tag_hide(strings):
-        return LilyPondFormatManager.tag(
-            strings,
-            deactivate=False,
-            tag=abjad_tags.HIDE_TO_JOIN_BROKEN_SPANNERS,
-        )
-
     ### PUBLIC PROPERTIES ###
 
     @property

--- a/abjad/indicators/GlissandoIndicator.py
+++ b/abjad/indicators/GlissandoIndicator.py
@@ -47,7 +47,6 @@ class GlissandoIndicator(object):
         "_allow_repeats",
         "_allow_ties",
         "_parenthesize_repeats",
-        "_right_broken",
         "_stems",
         "_style",
         "_zero_padding",
@@ -68,7 +67,6 @@ class GlissandoIndicator(object):
         allow_repeats: bool = None,
         allow_ties: bool = None,
         parenthesize_repeats: bool = None,
-        right_broken: bool = None,
         stems: bool = None,
         style: str = None,
         tweaks: LilyPondTweakManager = None,
@@ -83,9 +81,6 @@ class GlissandoIndicator(object):
         if parenthesize_repeats is not None:
             parenthesize_repeats = bool(parenthesize_repeats)
         self._parenthesize_repeats = parenthesize_repeats
-        if right_broken is not None:
-            right_broken = bool(right_broken)
-        self._right_broken = right_broken
         if stems is not None:
             stems = bool(stems)
         self._stems = stems
@@ -226,18 +221,18 @@ class GlissandoIndicator(object):
                 \new Staff
                 {
                     d'8
-                    - \abjad-zero-padding-glissando
-                    \glissando
+                    - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                    \glissando                      %! abjad.glissando(7)
                     \once \override NoteHead.X-extent = #'(0 . 0)
                     \once \override NoteHead.transparent = ##t
                     d'4.
-                    - \abjad-zero-padding-glissando
-                    \glissando
+                    - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                    \glissando                      %! abjad.glissando(7)
                     \once \override NoteHead.X-extent = #'(0 . 0)
                     \once \override NoteHead.transparent = ##t
                     d'4.
-                    - \abjad-zero-padding-glissando
-                    \glissando
+                    - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                    \glissando                      %! abjad.glissando(7)
                     \once \override NoteHead.X-extent = #'(0 . 0)
                     \once \override NoteHead.transparent = ##t
                     d'8
@@ -262,18 +257,18 @@ class GlissandoIndicator(object):
                 \new Staff
                 {
                     c'8.
-                    - \abjad-zero-padding-glissando
-                    \glissando
+                    - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                    \glissando                      %! abjad.glissando(7)
                     \once \override NoteHead.X-extent = #'(0 . 0)
                     \once \override NoteHead.transparent = ##t
                     d'8.
-                    - \abjad-zero-padding-glissando
-                    \glissando
+                    - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                    \glissando                      %! abjad.glissando(7)
                     \once \override NoteHead.X-extent = #'(0 . 0)
                     \once \override NoteHead.transparent = ##t
                     e'8.
-                    - \abjad-zero-padding-glissando
-                    \glissando
+                    - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                    \glissando                      %! abjad.glissando(7)
                     f'8.
                 }
 

--- a/abjad/indicators/Ottava.py
+++ b/abjad/indicators/Ottava.py
@@ -36,7 +36,7 @@ class Ottava(object):
 
     ### CLASS VARIABLES ###
 
-    __slots__ = ("_format_slot", "_n", "_right_broken")
+    __slots__ = ("_format_slot", "_n")
 
     _persistent = True
 
@@ -44,22 +44,13 @@ class Ottava(object):
 
     ### INITIALIZER ###
 
-    def __init__(
-        self,
-        n: int = None,
-        *,
-        format_slot: str = None,
-        right_broken: bool = None,
-    ) -> None:
+    def __init__(self, n: int = None, *, format_slot: str = None) -> None:
         if n is not None:
             assert isinstance(n, int), repr(n)
         self._n = n
         if format_slot is not None:
             assert format_slot in ("before", "after"), repr(format_slot)
         self._format_slot = format_slot
-        if right_broken is not None:
-            right_broken = bool(right_broken)
-        self._right_broken = right_broken
 
     ### SPECIAL METHODS ###
 
@@ -83,7 +74,7 @@ class Ottava(object):
 
     def __repr__(self) -> str:
         """
-        Gets interpreter representation.
+        Delegates to storage format manager.
         """
         return StorageFormatManager(self).get_repr_format()
 
@@ -93,24 +84,12 @@ class Ottava(object):
         bundle = LilyPondFormatBundle()
         n = self.n or 0
         string = rf"\ottava {n}"
-        if self.right_broken:
-            string = self._tag_hide([string])[0]
-
         if self.format_slot in ("before", None):
             bundle.before.commands.append(string)
         else:
             assert self.format_slot == "after"
             bundle.after.commands.append(string)
         return bundle
-
-    @staticmethod
-    def _tag_hide(strings):
-        abjad_tags = Tags()
-        return LilyPondFormatManager.tag(
-            strings,
-            deactivate=False,
-            tag=abjad_tags.HIDE_TO_JOIN_BROKEN_SPANNERS,
-        )
 
     ### PUBLIC PROPERTIES ###
 
@@ -188,35 +167,3 @@ class Ottava(object):
         Class constant.
         """
         return self._persistent
-
-    @property
-    def right_broken(self) -> typing.Optional[bool]:
-        r"""
-        Is true when ottava is right-broken.
-
-        ..  container:: example
-
-            >>> staff = abjad.Staff("c'4 d' e' r")
-            >>> start_ottava = abjad.Ottava(n=1)
-            >>> abjad.attach(start_ottava, staff[0])
-            >>> stop_ottava = abjad.Ottava(
-            ...     n=0,
-            ...     format_slot='after',
-            ...     right_broken=True,
-            ...     )
-            >>> abjad.attach(stop_ottava, staff[-1])
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            >>> abjad.f(staff)
-            \new Staff
-            {
-                \ottava 1
-                c'4
-                d'4
-                e'4
-                r4
-                \ottava 0 %! HIDE_TO_JOIN_BROKEN_SPANNERS
-            }
-
-        """
-        return self._right_broken

--- a/abjad/indicators/RepeatTie.py
+++ b/abjad/indicators/RepeatTie.py
@@ -50,7 +50,7 @@ class RepeatTie(object):
 
     ### CLASS VARIABLES ###
 
-    __slots__ = ("_direction", "_left_broken", "_tweaks")
+    __slots__ = ("_direction", "_tweaks")
 
     _context = "Voice"
 
@@ -64,14 +64,10 @@ class RepeatTie(object):
         self,
         *,
         direction: enums.VerticalAlignment = None,
-        left_broken: bool = None,
         tweaks: LilyPondTweakManager = None,
     ) -> None:
         direction_ = String.to_tridirectional_lilypond_symbol(direction)
         self._direction = direction_
-        if left_broken is not None:
-            left_broken = bool(left_broken)
-        self._left_broken = left_broken
         if tweaks is not None:
             assert isinstance(tweaks, LilyPondTweakManager), repr(tweaks)
         self._tweaks = LilyPondTweakManager.set_tweaks(self, tweaks)
@@ -124,8 +120,6 @@ class RepeatTie(object):
         bundle = LilyPondFormatBundle()
         if self.tweaks:
             strings = self.tweaks._list_format_contributions()
-            if self.left_broken:
-                strings = self._tag_show(strings)
             bundle.after.spanners.extend(strings)
         strings = []
         if self.direction is not None:
@@ -135,8 +129,6 @@ class RepeatTie(object):
             string = r"- \tweak direction #up"
             strings.append(string)
         strings.append(r"\repeatTie")
-        if self.left_broken:
-            strings = self._tag_show(strings)
         bundle.after.spanners.extend(strings)
         return bundle
 
@@ -159,14 +151,6 @@ class RepeatTie(object):
             if staff_position.number == 0:
                 return True
         return False
-
-    @staticmethod
-    def _tag_show(strings):
-        return LilyPondFormatManager.tag(
-            strings,
-            deactivate=True,
-            tag=abjad_tags.SHOW_TO_JOIN_BROKEN_SPANNERS,
-        )
 
     ### PUBLIC PROPERTIES ###
 
@@ -277,33 +261,6 @@ class RepeatTie(object):
 
         """
         return self._direction
-
-    @property
-    def left_broken(self) -> typing.Optional[bool]:
-        r"""
-        Is true when tie is left-broken.
-
-        ..  container:: example
-
-            >>> staff = abjad.Staff("c'4 c' d' d'")
-            >>> repeat_tie = abjad.RepeatTie(left_broken=True)
-            >>> abjad.tweak(repeat_tie).color = 'blue'
-            >>> abjad.attach(repeat_tie, staff[1])
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            >>> abjad.f(staff, strict=29)
-            \new Staff
-            {
-                c'4
-                c'4
-            %@% - \tweak color #blue     %! SHOW_TO_JOIN_BROKEN_SPANNERS
-            %@% \repeatTie               %! SHOW_TO_JOIN_BROKEN_SPANNERS
-                d'4
-                d'4
-            }
-
-        """
-        return self._left_broken
 
     @property
     def persistent(self) -> bool:

--- a/abjad/indicators/StartHairpin.py
+++ b/abjad/indicators/StartHairpin.py
@@ -46,7 +46,7 @@ class StartHairpin(object):
 
     ### CLASS VARIABLES ###
 
-    __slots__ = ("_direction", "_left_broken", "_shape", "_tweaks")
+    __slots__ = ("_direction", "_shape", "_tweaks")
 
     _context = "Voice"
 
@@ -72,14 +72,10 @@ class StartHairpin(object):
         shape="<",
         *,
         direction: enums.VerticalAlignment = None,
-        left_broken: bool = None,
         tweaks: LilyPondTweakManager = None,
     ) -> None:
         direction_ = String.to_tridirectional_lilypond_symbol(direction)
         self._direction = direction_
-        if left_broken is not None:
-            left_broken = bool(left_broken)
-        self._left_broken = left_broken
         assert shape in self._known_shapes, repr(shape)
         self._shape = shape
         if tweaks is not None:
@@ -170,8 +166,6 @@ class StartHairpin(object):
             strings.append(string)
         else:
             raise ValueError(self.shape)
-        if self.left_broken is True:
-            strings = self._tag_hide(strings)
         return strings
 
     def _get_lilypond_format_bundle(self, component=None):
@@ -188,17 +182,6 @@ class StartHairpin(object):
         strings = self._get_lilypond_format()
         bundle.after.spanners.extend(strings)
         return bundle
-
-    @staticmethod
-    def _tag_hide(strings):
-        import abjad
-
-        abjad_tags = abjad.Tags()
-        return LilyPondFormatManager.tag(
-            strings,
-            deactivate=False,
-            tag=abjad_tags.HIDE_TO_JOIN_BROKEN_SPANNERS,
-        )
 
     ### PUBLIC PROPERTIES ###
 
@@ -277,39 +260,6 @@ class StartHairpin(object):
 
         """
         return self._known_shapes
-
-    @property
-    def left_broken(self) -> typing.Optional[bool]:
-        r"""
-        Is true when hairpin formats with left broken tag.
-
-        ..  container:: example
-
-            >>> staff = abjad.Staff("c'4 d' e' f'")
-            >>> start_hairpin = abjad.StartHairpin('<', left_broken=True)
-            >>> dynamic = abjad.Dynamic('f')
-            >>> abjad.attach(start_hairpin, staff[0])
-            >>> abjad.attach(dynamic, staff[-1])
-            >>> abjad.override(staff).dynamic_line_spanner.staff_padding = 4.5
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            >>> abjad.f(staff)
-            \new Staff
-            \with
-            {
-                \override DynamicLineSpanner.staff-padding = #4.5
-            }
-            {
-                c'4
-                \< %! HIDE_TO_JOIN_BROKEN_SPANNERS
-                d'4
-                e'4
-                f'4
-                \f
-            }
-
-        """
-        return self._left_broken
 
     @property
     def parameter(self) -> str:

--- a/abjad/indicators/StartTrillSpan.py
+++ b/abjad/indicators/StartTrillSpan.py
@@ -43,7 +43,7 @@ class StartTrillSpan(object):
 
     ### CLASS VARIABLES ###
 
-    __slots__ = ("_interval", "_left_broken", "_pitch", "_tweaks")
+    __slots__ = ("_interval", "_pitch", "_tweaks")
 
     _context = "Voice"
 

--- a/abjad/indicators/StopBeam.py
+++ b/abjad/indicators/StopBeam.py
@@ -40,7 +40,7 @@ class StopBeam(object):
 
     def __repr__(self) -> str:
         """
-        Gets interpreter representation.
+        Delegates to storage format manager.
         """
         return StorageFormatManager(self).get_repr_format()
 

--- a/abjad/indicators/StopTrillSpan.py
+++ b/abjad/indicators/StopTrillSpan.py
@@ -19,7 +19,7 @@ class StopTrillSpan(object):
 
     ### CLASS VARIABLES ###
 
-    __slots__ = ("_leak", "_right_broken")
+    __slots__ = ("_leak",)
 
     _context = "Voice"
 
@@ -33,21 +33,16 @@ class StopTrillSpan(object):
 
     ### INITIALIZER ###
 
-    def __init__(
-        self, *, leak: bool = None, right_broken: bool = None
-    ) -> None:
+    def __init__(self, *, leak: bool = None) -> None:
         if leak is not None:
             leak = bool(leak)
         self._leak = leak
-        if right_broken is not None:
-            right_broken = bool(right_broken)
-        self._right_broken = right_broken
 
     ### SPECIAL METHODS ###
 
     def __repr__(self) -> str:
         """
-        Gets interpreter representation.
+        Delegates to storage format manager.
         """
         return StorageFormatManager(self).get_repr_format()
 
@@ -56,23 +51,12 @@ class StopTrillSpan(object):
     def _get_lilypond_format_bundle(self, component=None):
         bundle = LilyPondFormatBundle()
         string = r"\stopTrillSpan"
-        if self.right_broken:
-            string = self._tag_hide([string])[0]
         if self.leak:
             string = f"<> {string}"
             bundle.after.leaks.append(string)
         else:
             bundle.after.spanner_stops.append(string)
         return bundle
-
-    @staticmethod
-    def _tag_hide(strings):
-        abjad_tags = Tags()
-        return LilyPondFormatManager.tag(
-            strings,
-            deactivate=False,
-            tag=abjad_tags.HIDE_TO_JOIN_BROKEN_SPANNERS,
-        )
 
     ### PUBLIC PROPERTIES ###
 
@@ -177,34 +161,6 @@ class StopTrillSpan(object):
         Class constant.
         """
         return self._persistent
-
-    @property
-    def right_broken(self) -> typing.Optional[bool]:
-        r"""
-        Is true when stop trill spanner is right-broken.
-
-        ..  container:: example
-
-            >>> staff = abjad.Staff("c'4 d' e' r")
-            >>> start_trill_span = abjad.StartTrillSpan()
-            >>> abjad.attach(start_trill_span, staff[0])
-            >>> stop_trill_span = abjad.StopTrillSpan(right_broken=True)
-            >>> abjad.attach(stop_trill_span, staff[-2])
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            >>> abjad.f(staff)
-            \new Staff
-            {
-                c'4
-                \startTrillSpan
-                d'4
-                e'4
-                \stopTrillSpan %! HIDE_TO_JOIN_BROKEN_SPANNERS
-                r4
-            }
-
-        """
-        return self._right_broken
 
     @property
     def spanner_stop(self) -> bool:

--- a/abjad/indicators/Tie.py
+++ b/abjad/indicators/Tie.py
@@ -48,7 +48,7 @@ class Tie(object):
 
     ### CLASS VARIABLES ###
 
-    __slots__ = ("_direction", "_right_broken", "_tweaks")
+    __slots__ = ("_direction", "_tweaks")
 
     _context = "Voice"
 
@@ -62,14 +62,10 @@ class Tie(object):
         self,
         *,
         direction: enums.VerticalAlignment = None,
-        right_broken: bool = None,
         tweaks: LilyPondTweakManager = None,
     ) -> None:
         direction_ = String.to_tridirectional_lilypond_symbol(direction)
         self._direction = direction_
-        if right_broken is not None:
-            right_broken = bool(right_broken)
-        self._right_broken = right_broken
         if tweaks is not None:
             assert isinstance(tweaks, LilyPondTweakManager), repr(tweaks)
         self._tweaks = LilyPondTweakManager.set_tweaks(self, tweaks)
@@ -125,23 +121,11 @@ class Tie(object):
         bundle = LilyPondFormatBundle()
         if self.tweaks:
             strings = self.tweaks._list_format_contributions()
-            if self.right_broken:
-                strings = self._tag_show(strings)
             bundle.after.spanner_starts.extend(strings)
         string = self._add_direction("~")
         strings = [string]
-        if self.right_broken:
-            strings = self._tag_show(strings)
         bundle.after.spanner_starts.extend(strings)
         return bundle
-
-    @staticmethod
-    def _tag_show(strings):
-        return LilyPondFormatManager.tag(
-            strings,
-            deactivate=True,
-            tag=abjad_tags.SHOW_TO_JOIN_BROKEN_SPANNERS,
-        )
 
     ### PUBLIC PROPERTIES ###
 
@@ -244,33 +228,6 @@ class Tie(object):
         Class constant.
         """
         return self._persistent
-
-    @property
-    def right_broken(self) -> typing.Optional[bool]:
-        r"""
-        Is true when tie is right-broken.
-
-        ..  container:: example
-
-            >>> staff = abjad.Staff("c'4 c' d' d'")
-            >>> tie = abjad.Tie(right_broken=True)
-            >>> abjad.tweak(tie).color = 'blue'
-            >>> abjad.attach(tie, staff[0])
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            >>> abjad.f(staff)
-            \new Staff
-            {
-                c'4
-            %@% - \tweak color #blue     %! SHOW_TO_JOIN_BROKEN_SPANNERS
-            %@% ~     %! SHOW_TO_JOIN_BROKEN_SPANNERS
-                c'4
-                d'4
-                d'4
-            }
-
-        """
-        return self._right_broken
 
     @property
     def tweaks(self) -> typing.Optional[LilyPondTweakManager]:

--- a/abjad/pitch/PitchRange.py
+++ b/abjad/pitch/PitchRange.py
@@ -351,7 +351,7 @@ class PitchRange(object):
                         {
                             \clef "bass"
                             c1 * 1/4
-                            \glissando
+                            \glissando %! abjad.glissando(7)
                             \change Staff = Treble_Staff
                             c''''1 * 1/4
                         }

--- a/abjad/segments/Job.py
+++ b/abjad/segments/Job.py
@@ -826,7 +826,10 @@ class Job(object):
         """
         Shows tag.
         """
-        assert isinstance(tag, Tag), repr(tag)
+        if isinstance(tag, str):
+            assert match is not None, repr(match)
+        else:
+            assert isinstance(tag, Tag), repr(tag)
         name = str(tag)
 
         if match is None:

--- a/abjad/spanners.py
+++ b/abjad/spanners.py
@@ -85,10 +85,9 @@ def beam(
     argument: typing.Union[Component, Selection],
     *,
     beam_lone_notes: bool = None,
-    # beam_rests: bool = None,
     beam_rests: typing.Optional[bool] = True,
     durations: typing.Sequence[Duration] = None,
-    selector: typings.SelectorTyping = "abjad.select().leaves()",
+    selector: typings.SelectorTyping = Expression().select().leaves(),
     span_beam_count: int = None,
     start_beam: StartBeam = None,
     stemlet_length: typings.Number = None,
@@ -759,6 +758,7 @@ def glissando(
     allow_ties: bool = None,
     hide_middle_note_heads: bool = None,
     hide_middle_stems: bool = None,
+    hide_stem_selector: Expression = None,
     left_broken: bool = None,
     parenthesize_repeats: bool = None,
     right_broken: bool = None,
@@ -782,11 +782,11 @@ def glissando(
             \new Staff
             {
                 c'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 d'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 e'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 f'8
             }
 
@@ -806,11 +806,11 @@ def glissando(
             \new Staff
             {
                 c'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 d'8
                 - \bendAfter #'-4
                 e'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 f'8
             }
 
@@ -832,14 +832,14 @@ def glissando(
             {
                 a8
                 a8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 b8
                 ~
                 b8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 c'8
                 c'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 d'8
                 ~
                 d'8
@@ -862,17 +862,17 @@ def glissando(
             \new Staff
             {
                 a8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 a8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 b8
                 ~
                 b8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 c'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 c'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 d'8
                 ~
                 d'8
@@ -896,21 +896,21 @@ def glissando(
             \new Staff
             {
                 a8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 a8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 b8
                 ~
-                \glissando
+                \glissando %! abjad.glissando(7)
                 b8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 c'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 c'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 d'8
                 ~
-                \glissando
+                \glissando %! abjad.glissando(7)
                 d'8
             }
 
@@ -935,20 +935,20 @@ def glissando(
             \new Staff
             {
                 a8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 \parenthesize
                 a8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 b8
                 ~
                 \parenthesize
                 b8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 c'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 \parenthesize
                 c'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 d'8
                 ~
                 \parenthesize
@@ -974,16 +974,16 @@ def glissando(
                 a8
                 \parenthesize
                 a8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 b8
                 ~
                 \parenthesize
                 b8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 c'8
                 \parenthesize
                 c'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 d'8
                 ~
                 \parenthesize
@@ -1007,17 +1007,17 @@ def glissando(
             \new Staff
             {
                 c'8
-                \glissando
-                \hide NoteHead
-                \override Accidental.stencil = ##f
-                \override NoteColumn.glissando-skip = ##t
-                \override NoteHead.no-ledgers = ##t
+                \glissando %! abjad.glissando(7)
+                \hide NoteHead                            %! abjad.glissando(1)
+                \override Accidental.stencil = ##f        %! abjad.glissando(1)
+                \override NoteColumn.glissando-skip = ##t %! abjad.glissando(1)
+                \override NoteHead.no-ledgers = ##t       %! abjad.glissando(1)
                 d'8
                 e'8
-                \revert Accidental.stencil
-                \revert NoteColumn.glissando-skip
-                \revert NoteHead.no-ledgers
-                \undo \hide NoteHead
+                \revert Accidental.stencil        %! abjad.glissando(6)
+                \revert NoteColumn.glissando-skip %! abjad.glissando(6)
+                \revert NoteHead.no-ledgers       %! abjad.glissando(6)
+                \undo \hide NoteHead              %! abjad.glissando(6)
                 f'8
             }
 
@@ -1040,21 +1040,21 @@ def glissando(
             \new Staff
             {
                 c'8
-                \glissando
-                \hide NoteHead
-                \override Accidental.stencil = ##f
-                \override NoteColumn.glissando-skip = ##t
-                \override NoteHead.no-ledgers = ##t
-                \override Dots.transparent = ##t
-                \override Stem.transparent = ##t
+                \glissando %! abjad.glissando(7)
+                \hide NoteHead                            %! abjad.glissando(1)
+                \override Accidental.stencil = ##f        %! abjad.glissando(1)
+                \override NoteColumn.glissando-skip = ##t %! abjad.glissando(1)
+                \override NoteHead.no-ledgers = ##t       %! abjad.glissando(1)
+                \override Dots.transparent = ##t          %! abjad.glissando(1)
+                \override Stem.transparent = ##t          %! abjad.glissando(1)
                 d'8
                 e'8
-                \revert Accidental.stencil
-                \revert NoteColumn.glissando-skip
-                \revert NoteHead.no-ledgers
-                \undo \hide NoteHead
-                \revert Dots.transparent
-                \revert Stem.transparent
+                \revert Accidental.stencil        %! abjad.glissando(6)
+                \revert NoteColumn.glissando-skip %! abjad.glissando(6)
+                \revert NoteHead.no-ledgers       %! abjad.glissando(6)
+                \undo \hide NoteHead              %! abjad.glissando(6)
+                \revert Dots.transparent          %! abjad.glissando(6)
+                \revert Stem.transparent          %! abjad.glissando(6)
                 f'8
             }
 
@@ -1078,13 +1078,13 @@ def glissando(
         \new Staff
         {
             c'8
-            \glissando
+            \glissando                                    %! abjad.glissando(7)
             d'8
-            \glissando
+            \glissando                                    %! abjad.glissando(7)
             e'8
-            \glissando
+            \glissando                                    %! abjad.glissando(7)
             f'8
-        %@% \glissando                                    %! SHOW_TO_JOIN_BROKEN_SPANNERS
+        %@% \glissando                                    %! abjad.glissando(7):SHOW_TO_JOIN_BROKEN_SPANNERS
         }
 
     ..  container:: example
@@ -1106,17 +1106,17 @@ def glissando(
         \new Staff
         {
             c'8
-            \glissando
-            \hide NoteHead
-            \override Accidental.stencil = ##f
-            \override NoteColumn.glissando-skip = ##t
-            \override NoteHead.no-ledgers = ##t
+            \glissando                                    %! abjad.glissando(7)
+            \hide NoteHead                                %! abjad.glissando(0):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \override Accidental.stencil = ##f            %! abjad.glissando(0):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \override NoteColumn.glissando-skip = ##t     %! abjad.glissando(0):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \override NoteHead.no-ledgers = ##t           %! abjad.glissando(0):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
             d'8
             e'8
-            \revert Accidental.stencil                    %! HIDE_TO_JOIN_BROKEN_SPANNERS
-            \revert NoteColumn.glissando-skip             %! HIDE_TO_JOIN_BROKEN_SPANNERS
-            \revert NoteHead.no-ledgers                   %! HIDE_TO_JOIN_BROKEN_SPANNERS
-            \undo \hide NoteHead                          %! HIDE_TO_JOIN_BROKEN_SPANNERS
+            \revert Accidental.stencil                    %! abjad.glissando(4):HIDE_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \revert NoteColumn.glissando-skip             %! abjad.glissando(4):HIDE_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \revert NoteHead.no-ledgers                   %! abjad.glissando(4):HIDE_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \undo \hide NoteHead                          %! abjad.glissando(4):HIDE_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
             f'8
         }
 
@@ -1140,22 +1140,22 @@ def glissando(
         \new Staff
         {
             c'8
-            \glissando
-            \hide NoteHead
-            \override Accidental.stencil = ##f
-            \override NoteColumn.glissando-skip = ##t
-            \override NoteHead.no-ledgers = ##t
+            \glissando                                    %! abjad.glissando(7)
+            \hide NoteHead                                %! abjad.glissando(0):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \override Accidental.stencil = ##f            %! abjad.glissando(0):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \override NoteColumn.glissando-skip = ##t     %! abjad.glissando(0):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \override NoteHead.no-ledgers = ##t           %! abjad.glissando(0):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
             d'8
             e'8
-            \revert Accidental.stencil                    %! HIDE_TO_JOIN_BROKEN_SPANNERS
-            \revert NoteColumn.glissando-skip             %! HIDE_TO_JOIN_BROKEN_SPANNERS
-            \revert NoteHead.no-ledgers                   %! HIDE_TO_JOIN_BROKEN_SPANNERS
-            \undo \hide NoteHead                          %! HIDE_TO_JOIN_BROKEN_SPANNERS
+            \revert Accidental.stencil                    %! abjad.glissando(4):HIDE_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \revert NoteColumn.glissando-skip             %! abjad.glissando(4):HIDE_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \revert NoteHead.no-ledgers                   %! abjad.glissando(4):HIDE_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
+            \undo \hide NoteHead                          %! abjad.glissando(4):HIDE_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN
             f'8
-        %@% \revert Accidental.stencil                    %! SHOW_TO_JOIN_BROKEN_SPANNERS
-        %@% \revert NoteColumn.glissando-skip             %! SHOW_TO_JOIN_BROKEN_SPANNERS
-        %@% \revert NoteHead.no-ledgers                   %! SHOW_TO_JOIN_BROKEN_SPANNERS
-        %@% \undo \hide NoteHead                          %! SHOW_TO_JOIN_BROKEN_SPANNERS
+        %@% \revert Accidental.stencil                    %! abjad.glissando(5):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN_SHOW_NEXT
+        %@% \revert NoteColumn.glissando-skip             %! abjad.glissando(5):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN_SHOW_NEXT
+        %@% \revert NoteHead.no-ledgers                   %! abjad.glissando(5):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN_SHOW_NEXT
+        %@% \undo \hide NoteHead                          %! abjad.glissando(5):SHOW_TO_JOIN_BROKEN_SPANNERS:RIGHT_BROKEN_SHOW_NEXT
         }
 
     ..  container:: example
@@ -1176,18 +1176,18 @@ def glissando(
         >>> abjad.f(staff, strict=50)
         \new Staff
         {
-            \hide NoteHead                                %! HIDE_TO_JOIN_BROKEN_SPANNERS
-            \override Accidental.stencil = ##f            %! HIDE_TO_JOIN_BROKEN_SPANNERS
-            \override NoteHead.no-ledgers = ##t           %! HIDE_TO_JOIN_BROKEN_SPANNERS
+            \hide NoteHead                                %! abjad.glissando(2):HIDE_TO_JOIN_BROKEN_SPANNERS:LEFT_BROKEN
+            \override Accidental.stencil = ##f            %! abjad.glissando(2):HIDE_TO_JOIN_BROKEN_SPANNERS:LEFT_BROKEN
+            \override NoteHead.no-ledgers = ##t           %! abjad.glissando(2):HIDE_TO_JOIN_BROKEN_SPANNERS:LEFT_BROKEN
             c'8
-            \glissando
-            \override NoteColumn.glissando-skip = ##t     %! HIDE_TO_JOIN_BROKEN_SPANNERS
+            \glissando                                    %! abjad.glissando(7)
+            \override NoteColumn.glissando-skip = ##t     %! abjad.glissando(3):HIDE_TO_JOIN_BROKEN_SPANNERS:LEFT_BROKEN
             d'8
             e'8
-            \revert Accidental.stencil
-            \revert NoteColumn.glissando-skip
-            \revert NoteHead.no-ledgers
-            \undo \hide NoteHead
+            \revert Accidental.stencil                    %! abjad.glissando(6)
+            \revert NoteColumn.glissando-skip             %! abjad.glissando(6)
+            \revert NoteHead.no-ledgers                   %! abjad.glissando(6)
+            \undo \hide NoteHead                          %! abjad.glissando(6)
             f'8
         }
 
@@ -1211,14 +1211,14 @@ def glissando(
             \new Staff
             {
                 c'8
-                - \tweak style #'trill
-                \glissando
+                - \tweak style #'trill %! abjad.glissando(7)
+                \glissando             %! abjad.glissando(7)
                 d'8
-                - \tweak style #'trill
-                \glissando
+                - \tweak style #'trill %! abjad.glissando(7)
+                \glissando             %! abjad.glissando(7)
                 e'8
-                - \tweak style #'trill
-                \glissando
+                - \tweak style #'trill %! abjad.glissando(7)
+                \glissando             %! abjad.glissando(7)
                 f'8
             }
 
@@ -1244,18 +1244,18 @@ def glissando(
             \new Staff
             {
                 d'8
-                - \abjad-zero-padding-glissando
-                \glissando
+                - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                \glissando                      %! abjad.glissando(7)
                 \once \override NoteHead.X-extent = #'(0 . 0)
                 \once \override NoteHead.transparent = ##t
                 d'4.
-                - \abjad-zero-padding-glissando
-                \glissando
+                - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                \glissando                      %! abjad.glissando(7)
                 \once \override NoteHead.X-extent = #'(0 . 0)
                 \once \override NoteHead.transparent = ##t
                 d'4.
-                - \abjad-zero-padding-glissando
-                \glissando
+                - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                \glissando                      %! abjad.glissando(7)
                 \once \override NoteHead.X-extent = #'(0 . 0)
                 \once \override NoteHead.transparent = ##t
                 d'8
@@ -1282,18 +1282,18 @@ def glissando(
             \new Staff
             {
                 c'8.
-                - \abjad-zero-padding-glissando
-                \glissando
+                - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                \glissando                      %! abjad.glissando(7)
                 \once \override NoteHead.X-extent = #'(0 . 0)
                 \once \override NoteHead.transparent = ##t
                 d'8.
-                - \abjad-zero-padding-glissando
-                \glissando
+                - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                \glissando                      %! abjad.glissando(7)
                 \once \override NoteHead.X-extent = #'(0 . 0)
                 \once \override NoteHead.transparent = ##t
                 e'8.
-                - \abjad-zero-padding-glissando
-                \glissando
+                - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                \glissando                      %! abjad.glissando(7)
                 f'8.
             }
 
@@ -1321,24 +1321,25 @@ def glissando(
             \new Staff
             {
                 d'4
-                - \abjad-zero-padding-glissando
-                - \tweak color #red
-                \glissando
+                - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                - \tweak color #red             %! abjad.glissando(7)
+                \glissando                      %! abjad.glissando(7)
                 \once \override NoteHead.X-extent = #'(0 . 0)
                 \once \override NoteHead.transparent = ##t
                 d'4
-                - \abjad-zero-padding-glissando
-                \glissando
+                - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                \glissando                      %! abjad.glissando(7)
                 \once \override NoteHead.X-extent = #'(0 . 0)
                 \once \override NoteHead.transparent = ##t
                 d'4
-                - \abjad-zero-padding-glissando
-                - \tweak color #red
-                \glissando
+                - \abjad-zero-padding-glissando %! abjad.glissando(7)
+                - \tweak color #red             %! abjad.glissando(7)
+                \glissando                      %! abjad.glissando(7)
                 d'4
             }
 
     """
+    tag = tag or Tag()
 
     if right_broken_show_next and not right_broken:
         message = "set right_broken_show_next only when right_broken is true."
@@ -1392,6 +1393,10 @@ def glissando(
             return False
         return True
 
+    should_hide_stem = Selection()
+    if hide_stem_selector is not None:
+        should_hide_stem = hide_stem_selector(argument)
+
     leaves = select(argument).leaves()
     total = len(leaves) - 1
     for i, leaf in enumerate(leaves):
@@ -1420,6 +1425,13 @@ def glissando(
             if _next_leaf_changes_current_pitch(leaf):
                 if _is_last_in_tie_chain(leaf):
                     should_attach_glissando = True
+        if leaf in should_hide_stem:
+            strings = [
+                r"\once \override Dots.transparent = ##t",
+                r"\once \override Stem.transparent = ##t",
+            ]
+            literal = LilyPondLiteral(strings)
+            attach(literal, leaf, tag=tag.append(Tag("abjad.glissando(-1)")))
         if hide_middle_note_heads:
             if leaf is not leaves[0]:
                 should_attach_glissando = False
@@ -1438,7 +1450,20 @@ def glissando(
                         ]
                     )
                 literal = LilyPondLiteral(strings)
-                attach(literal, leaf, tag=tag)
+                if right_broken is True:
+                    attach(
+                        literal,
+                        leaf,
+                        tag=tag.append(Tag("abjad.glissando(0)"))
+                        .append(abjad_tags.SHOW_TO_JOIN_BROKEN_SPANNERS)
+                        .append(abjad_tags.RIGHT_BROKEN),
+                    )
+                else:
+                    attach(
+                        literal,
+                        leaf,
+                        tag=tag.append(Tag("abjad.glissando(1)")),
+                    )
             elif left_broken and leaf is leaves[0]:
                 strings = [
                     r"\hide NoteHead",
@@ -1454,13 +1479,21 @@ def glissando(
                     )
                 literal = LilyPondLiteral(strings)
                 attach(
-                    literal, leaf, tag=abjad_tags.HIDE_TO_JOIN_BROKEN_SPANNERS
+                    literal,
+                    leaf,
+                    tag=tag.append(Tag("abjad.glissando(2)"))
+                    .append(abjad_tags.HIDE_TO_JOIN_BROKEN_SPANNERS)
+                    .append(abjad_tags.LEFT_BROKEN),
                 )
             elif left_broken and leaf is leaves[1]:
                 string = r"\override NoteColumn.glissando-skip = ##t"
                 literal = LilyPondLiteral(string)
                 attach(
-                    literal, leaf, tag=abjad_tags.HIDE_TO_JOIN_BROKEN_SPANNERS
+                    literal,
+                    leaf,
+                    tag=tag.append(Tag("abjad.glissando(3)"))
+                    .append(abjad_tags.HIDE_TO_JOIN_BROKEN_SPANNERS)
+                    .append(abjad_tags.LEFT_BROKEN),
                 )
             if leaf is leaves[-1]:
                 strings = [
@@ -1483,7 +1516,9 @@ def glissando(
                         literal,
                         leaf,
                         deactivate=False,
-                        tag=abjad_tags.HIDE_TO_JOIN_BROKEN_SPANNERS,
+                        tag=tag.append(Tag("abjad.glissando(4)"))
+                        .append(abjad_tags.HIDE_TO_JOIN_BROKEN_SPANNERS)
+                        .append(abjad_tags.RIGHT_BROKEN),
                     )
                     if right_broken_show_next:
                         literal = LilyPondLiteral(strings, format_slot="after")
@@ -1491,17 +1526,23 @@ def glissando(
                             literal,
                             leaf,
                             deactivate=True,
-                            tag=abjad_tags.SHOW_TO_JOIN_BROKEN_SPANNERS,
+                            tag=tag.append(Tag("abjad.glissando(5)"))
+                            .append(abjad_tags.SHOW_TO_JOIN_BROKEN_SPANNERS)
+                            .append(abjad_tags.RIGHT_BROKEN_SHOW_NEXT),
                         )
                 else:
                     literal = LilyPondLiteral(strings)
-                    attach(literal, leaf, tag=tag)
+                    attach(
+                        literal,
+                        leaf,
+                        tag=tag.append(Tag("abjad.glissando(6)")),
+                    )
         if should_attach_glissando:
             glissando = GlissandoIndicator(zero_padding=zero_padding)
             _apply_tweaks(glissando, tweaks, i=i, total=total)
-            tag_ = tag
+            tag_ = tag.append(Tag("abjad.glissando(7)"))
             if deactivate_glissando:
-                tag_ = abjad_tags.SHOW_TO_JOIN_BROKEN_SPANNERS
+                tag_ = tag_.append(abjad_tags.SHOW_TO_JOIN_BROKEN_SPANNERS)
             attach(glissando, leaf, deactivate=deactivate_glissando, tag=tag_)
 
 
@@ -1509,7 +1550,7 @@ def hairpin(
     descriptor: str,
     argument: typing.Union[Component, Selection],
     *,
-    selector: typings.SelectorTyping = "abjad.select().leaves()",
+    selector: typings.SelectorTyping = Expression().select().leaves(),
     tag: Tag = None,
 ) -> None:
     r"""
@@ -1667,7 +1708,7 @@ def hairpin(
 def horizontal_bracket(
     argument: typing.Union[Component, Selection],
     *,
-    selector: typings.SelectorTyping = "abjad.select().leaves()",
+    selector: typings.SelectorTyping = Expression().select().leaves(),
     start_group: StartGroup = None,
     stop_group: StopGroup = None,
     tag: Tag = None,
@@ -1714,7 +1755,7 @@ def horizontal_bracket(
 def ottava(
     argument: typing.Union[Component, Selection],
     *,
-    selector: typings.SelectorTyping = "abjad.select().leaves()",
+    selector: typings.SelectorTyping = Expression().select().leaves(),
     start_ottava: Ottava = Ottava(n=1),
     stop_ottava: Ottava = Ottava(n=0, format_slot="after"),
     tag: Tag = None,
@@ -1761,7 +1802,7 @@ def ottava(
 def phrasing_slur(
     argument: typing.Union[Component, Selection],
     *,
-    selector: typings.SelectorTyping = "abjad.select().leaves()",
+    selector: typings.SelectorTyping = Expression().select().leaves(),
     start_phrasing_slur: StartPhrasingSlur = None,
     stop_phrasing_slur: StopPhrasingSlur = None,
     tag: Tag = None,
@@ -1811,7 +1852,7 @@ def phrasing_slur(
 def piano_pedal(
     argument: typing.Union[Component, Selection],
     *,
-    selector: typings.SelectorTyping = "abjad.select().leaves()",
+    selector: typings.SelectorTyping = Expression().select().leaves(),
     start_piano_pedal: StartPianoPedal = None,
     stop_piano_pedal: StopPianoPedal = None,
     tag: Tag = None,
@@ -1865,7 +1906,7 @@ def piano_pedal(
 def slur(
     argument: typing.Union[Component, Selection],
     *,
-    selector: typings.SelectorTyping = "abjad.select().leaves()",
+    selector: typings.SelectorTyping = Expression().select().leaves(),
     start_slur: StartSlur = None,
     stop_slur: StopSlur = None,
     tag: Tag = None,
@@ -1913,7 +1954,7 @@ def slur(
 def text_spanner(
     argument: typing.Union[Component, Selection],
     *,
-    selector: typings.SelectorTyping = "abjad.select().leaves()",
+    selector: typings.SelectorTyping = Expression().select().leaves(),
     start_text_span: StartTextSpan = None,
     stop_text_span: StopTextSpan = None,
     tag: Tag = None,
@@ -2101,8 +2142,7 @@ def tie(
     *,
     direction: enums.VerticalAlignment = None,
     repeat: typing.Union[bool, typings.IntegerPair, DurationInequality] = None,
-    selector: typings.SelectorTyping = "abjad.select().leaves()",
-    # tie: Tie = None,
+    selector: typings.SelectorTyping = Expression().select().leaves(),
     tag: Tag = None,
 ) -> None:
     r"""
@@ -2320,7 +2360,7 @@ def tie(
 def trill_spanner(
     argument: typing.Union[Component, Selection],
     *,
-    selector: typings.SelectorTyping = "abjad.select().leaves()",
+    selector: typings.SelectorTyping = Expression().select().leaves(),
     start_trill_span: StartTrillSpan = None,
     stop_trill_span: StopTrillSpan = None,
     tag: Tag = None,

--- a/abjad/system/Tag.py
+++ b/abjad/system/Tag.py
@@ -100,7 +100,7 @@ class Tag(object):
             >>> bool(abjad.Tag())
             False
 
-            >>> bool(abjad.Tag('+PARTS'))
+            >>> bool(abjad.tags.ONLY_PARTS)
             True
 
         """
@@ -112,7 +112,7 @@ class Tag(object):
 
         ..  container:: example
 
-            >>> tag = abjad.Tag('-PARTS')
+            >>> tag = abjad.tags.NOT_PARTS
             >>> tag = tag.append(abjad.tags.DEFAULT_CLEF)
 
             >>> 'PARTS' in tag

--- a/abjad/system/Tags.py
+++ b/abjad/system/Tags.py
@@ -55,6 +55,8 @@ class Tags(object):
         "REDUNDANT_CLEF_COLOR",
         "REDUNDANT_CLEF_COLOR_CANCELLATION",
         "REDUNDANT_CLEF_REDRAW_COLOR",
+        ### COMMANDS, IMPORTANT ###
+        "ONE_VOICE_COMMAND",
         ### DOCUMENT ANNOTATIONS ###
         "BREAK",
         "CLOCK_TIME",
@@ -145,8 +147,6 @@ class Tags(object):
         "REAPPLIED_METRONOME_MARK_WITH_COLOR",
         "REDUNDANT_METRONOME_MARK",
         "REDUNDANT_METRONOME_MARK_WITH_COLOR",
-        ### MM SPANNER ###
-        "EOS_STOP_MM_SPANNER",
         ### PERSISTENT OVERRIDE ###
         "EXPLICIT_PERSISTENT_OVERRIDE",
         "REAPPLIED_PERSISTENT_OVERRIDE",
@@ -169,10 +169,32 @@ class Tags(object):
         "REDUNDANT_SPACING_SECTION",
         "REDUNDANT_SPACING_SECTION_COLOR",
         ### SPANNERS, BROKEN ###
+        "AUTODETECT",
         "HIDE_TO_JOIN_BROKEN_SPANNERS",
-        "SHOW_TO_JOIN_BROKEN_SPANNERS",
+        "LEFT_BROKEN",
+        "RIGHT_BROKEN",
         "RIGHT_BROKEN_BEAM",  # used in figure-maker
+        "RIGHT_BROKEN_SHOW_NEXT",
+        "SHOW_TO_JOIN_BROKEN_SPANNERS",
+        ### SPANNERS, CUSTOM ###
+        "BOW_SPEED_SPANNER",
+        "CIRCLE_BOW_SPANNER",
+        "CLB_SPANNER",
+        "COVERED_SPANNER",
+        "DAMP_SPANNER",
+        "EOS_STOP_MM_SPANNER",
+        "HALF_CLT_SPANNER",
+        "MATERIAL_ANNOTATION_SPANNER",
+        "METRIC_MODULATION_SPANNER",
+        "PITCH_ANNOTATION_SPANNER",
+        "RHYTHM_ANNOTATION_SPANNER",
+        "SCP_SPANNER",
+        "SPAZZOLATO_SPANNER",
+        "STRING_NUMBER_SPANNER",
+        "TASTO_SPANNER",
+        "VIBRATO_SPANNER",
         ### SPANNERS, OTHER ###
+        "SPANNER_START",
         "SPANNER_STOP",
         ### STAFF LINES ###
         "EXPLICIT_STAFF_LINES",
@@ -253,6 +275,25 @@ class Tags(object):
         return Tag("+SEGMENT")
 
     ### PUBLIC METHODS ###
+
+    def annotation_spanner_tags(self) -> typing.List[Tag]:
+        """
+        Gets annotation spanner tags.
+
+        ..  container:: example
+
+            >>> for tag in abjad.tags.annotation_spanner_tags():
+            ...     tag
+            Tag('MATERIAL_ANNOTATION_SPANNER')
+            Tag('PITCH_ANNOTATION_SPANNER')
+            Tag('RHYTHM_ANNOTATION_SPANNER')
+
+        """
+        return [
+            self.MATERIAL_ANNOTATION_SPANNER,
+            self.PITCH_ANNOTATION_SPANNER,
+            self.RHYTHM_ANNOTATION_SPANNER,
+        ]
 
     def clef_color_tags(self, path=None) -> typing.List[Tag]:
         """
@@ -544,11 +585,17 @@ class Tags(object):
             Tag('FIGURE_NAME')
             Tag('INVISIBLE_MUSIC_COLORING')
             Tag('LOCAL_MEASURE_NUMBER')
+            Tag('MATERIAL_ANNOTATION_SPANNER')
             Tag('MOCK_COLORING')
             Tag('NOT_YET_PITCHED_COLORING')
+            Tag('OCTAVE_COLORING')
+            Tag('PITCH_ANNOTATION_SPANNER')
+            Tag('REPEAT_PITCH_CLASS_COLORING')
+            Tag('RHYTHM_ANNOTATION_SPANNER')
             Tag('SPACING')
             Tag('SPACING_OVERRIDE')
             Tag('STAGE_NUMBER')
+            Tag('TACET_COLORING')
 
         """
         return [
@@ -556,11 +603,17 @@ class Tags(object):
             self.FIGURE_NAME,
             self.INVISIBLE_MUSIC_COLORING,
             self.LOCAL_MEASURE_NUMBER,
+            self.MATERIAL_ANNOTATION_SPANNER,
             self.MOCK_COLORING,
             self.NOT_YET_PITCHED_COLORING,
+            self.OCTAVE_COLORING,
+            self.PITCH_ANNOTATION_SPANNER,
+            self.REPEAT_PITCH_CLASS_COLORING,
+            self.RHYTHM_ANNOTATION_SPANNER,
             self.SPACING,
             self.SPACING_OVERRIDE,
             self.STAGE_NUMBER,
+            self.TACET_COLORING,
         ]
 
     def persistent_indicator_color_expression_tags(

--- a/abjad/system/Wrapper.py
+++ b/abjad/system/Wrapper.py
@@ -594,6 +594,61 @@ class Wrapper(object):
         return self._indicator
 
     @property
+    def leaked_start_offset(self):
+        r"""
+        Gets start offset and checks to see whether indicator leaks to the
+        right.
+
+        This is either the wrapper's synthetic offset (if set); or the START
+        offset of the wrapper's component (if indicator DOES NOT leak); or else
+        the STOP offset of the wrapper's component (if indicator DOES leak).
+
+        ..  container:: example
+
+            Start- and stop-text-spans attach to the same leaf. But
+            stop-text-span leaks to the right:
+
+            >>> voice = abjad.Voice("c'2 d'2")
+            >>> start_text_span = abjad.StartTextSpan()
+            >>> abjad.attach(start_text_span, voice[0])
+            >>> stop_text_span = abjad.StopTextSpan(leak=True)
+            >>> abjad.attach(stop_text_span, voice[0])
+            >>> abjad.show(voice) # doctest: +SKIP
+
+            >>> abjad.f(voice)
+            \new Voice
+            {
+                c'2
+                \startTextSpan
+                <> \stopTextSpan
+                d'2
+            }
+
+            Start offset and leaked start offset are the same for
+            start-text-span:
+
+            >>> wrapper = abjad.inspect(voice[0]).wrapper(abjad.StartTextSpan)
+            >>> wrapper.start_offset, wrapper.leaked_start_offset
+            (Offset((0, 1)), Offset((0, 1)))
+
+            Start offset and leaked start offset differ for stop-text-span:
+
+            >>> wrapper = abjad.inspect(voice[0]).wrapper(abjad.StopTextSpan)
+            >>> wrapper.start_offset, wrapper.leaked_start_offset
+            (Offset((0, 1)), Offset((1, 2)))
+
+        Returns offset.
+        """
+        from abjad.top.inspect import inspect
+
+        if self._synthetic_offset is not None:
+            return self._synthetic_offset
+        if not getattr(self.indicator, "leak", False):
+            return inspect(self._component).timespan().start_offset
+        else:
+            return inspect(self._component).timespan().stop_offset
+
+    @property
     def start_offset(self):
         """
         Gets start offset.

--- a/abjad/typings.py
+++ b/abjad/typings.py
@@ -20,12 +20,16 @@ Number = typing.Union[int, float]
 
 NumberPair = typing.Tuple[Number, Number]
 
+PatternTyping = typing.Union[
+    typing.Tuple[IntegerSequence], typing.Tuple[IntegerSequence, int]
+]
+
 Prototype = typing.Union[typing.Type, typing.Tuple[typing.Type, ...]]
 
 RatioTyping = typing.Union[Duration, Ratio, typing.Tuple[int, ...]]
 
 RatioSequenceTyping = typing.Sequence[RatioTyping]
 
-SelectorTyping = typing.Union[str, Expression]
+SelectorTyping = Expression
 
 Strings = typing.Union[str, typing.Sequence[str]]

--- a/abjad/utilities/Expression.py
+++ b/abjad/utilities/Expression.py
@@ -1147,6 +1147,8 @@ class Expression(object):
 
     @staticmethod
     def _to_evaluable_string(argument):
+        from . import Sequence
+
         if argument is None:
             pass
         elif isinstance(argument, str):
@@ -1155,14 +1157,16 @@ class Expression(object):
             argument = f"abjad.{argument.__repr__()}"
         elif isinstance(argument, numbers.Number):
             argument = str(argument)
-        elif isinstance(argument, (list, tuple)):
+        # elif isinstance(argument, (list, tuple)):
+        elif isinstance(argument, (list, tuple, Sequence)):
             item_strings = []
             item_count = len(argument)
             for item in argument:
                 item_string = Expression._to_evaluable_string(item)
                 item_strings.append(item_string)
             items = ", ".join(item_strings)
-            if isinstance(argument, list):
+            # if isinstance(argument, list):
+            if isinstance(argument, (list, Sequence)):
                 argument = f"[{items}]"
             elif isinstance(argument, tuple):
                 if item_count == 1:
@@ -1193,22 +1197,28 @@ class Expression(object):
         return argument
 
     @staticmethod
-    def _wrap_arguments(frame, static_class=None):
+    def _wrap_arguments(frame, *, static_class=None):
         try:
             frame_info = inspect.getframeinfo(frame)
             function_name = frame_info.function
             argument_info = inspect.getargvalues(frame)
+            # static method
             if static_class:
                 method_name = frame.f_code.co_name
                 static_method = getattr(static_class, method_name)
                 signature = inspect.signature(static_method)
                 argument_names = argument_info.args[:]
-            else:
-                assert argument_info.args[0] == "self"
+            # bound method
+            elif argument_info.args and argument_info.args[0] == "self":
                 self = argument_info.locals["self"]
                 function = getattr(self, function_name)
                 signature = inspect.signature(function)
                 argument_names = argument_info.args[1:]
+            # function
+            else:
+                function = frame.f_globals[function_name]
+                signature = inspect.signature(function)
+                argument_names = argument_info.args[:]
             argument_strings = []
             for argument_name in argument_names:
                 argument_value = argument_info.locals[argument_name]
@@ -1760,8 +1770,8 @@ class Expression(object):
                         d'8
                         ^ \markup {
                             \fraction
-                                1
-                                2
+                                4
+                                8
                             }
                         ~
                         d'4.

--- a/docs/source/_stylesheets/abjad-coloring.ily
+++ b/docs/source/_stylesheets/abjad-coloring.ily
@@ -1,0 +1,45 @@
+%%% COLORED MUSIC %%%
+
+abjad-color-music = #(
+    define-music-function (parser location color music) (symbol? ly:music?)
+    #{
+    \once \override Accidental.color = #(x11-color #'color)
+    \once \override Beam.color = #(x11-color #'color)
+    \once \override Dots.color = #(x11-color #'color)
+    \once \override Flag.color = #(x11-color #'color)
+    \once \override MultiMeasureRest.color = #(x11-color #'color)
+    \once \override NoteHead.color = #(x11-color #'color)
+    \once \override RepeatTie.color = #(x11-color #'color)
+    \once \override Rest.color = #(x11-color #'color)
+    \once \override Stem.color = #(x11-color #'color)
+    \once \override StemTremolo.color = #(x11-color #'color)
+    $music
+    #}
+    )
+
+abjad-invisible-music = #(
+    define-music-function
+    (parser location music)
+    (ly:music?)
+    #{
+    \once \override Accidental.transparent = ##t
+    \once \override Dots.transparent = ##t
+    \once \override MultiMeasureRest.transparent = ##t
+    \once \override NoteHead.no-ledgers = ##t
+    \once \override NoteHead.transparent = ##t
+    \once \override RepeatTie.transparent = ##t
+    \once \override Stem.transparent = ##t
+    \once \override StemTremolo.transparent = ##t
+    $music
+    #}
+    )
+
+abjad-invisible-music-coloring = #(
+    define-music-function
+    (parser location music)
+    (ly:music?)
+    #{
+    \abjad-color-music #'salmon
+    $music
+    #}
+    )

--- a/docs/source/_stylesheets/abjad-spanners.ily
+++ b/docs/source/_stylesheets/abjad-spanners.ily
@@ -1,0 +1,21 @@
+%%% GLISSANDO OVERRIDES %%%
+
+abjad-continuous-glissando = #(
+    define-music-function (parser location music) (ly:music?)
+    #{
+    \override Glissando.bound-details.left.padding = -1
+    \override Glissando.bound-details.left.start-at-dot = ##f
+    \override Glissando.bound-details.right.padding = 0
+    $music
+    #}
+    )
+
+abjad-revert-continuous-glissando = #(
+    define-music-function (parser location music) (ly:music?)
+    #{
+    \revert Glissando.bound-details.left.padding
+    \revert Glissando.bound-details.left.start-at-dot
+    \revert Glissando.bound-details.right.padding
+    $music
+    #}
+    )

--- a/docs/source/_stylesheets/abjad.ily
+++ b/docs/source/_stylesheets/abjad.ily
@@ -1,46 +1,8 @@
 #(ly:set-option 'relative-includes #t)
+\include "abjad-coloring.ily"
 \include "abjad-metric-modulations.ily"
+\include "abjad-spanners.ily"
 \include "abjad-text-spanner-line-styles.ily"
 \include "nalesnik-slash.ily"
 \include "nalesnik-text-spanner-id.ily"
 \include "solomon-flared-hairpin.ily"
-
-
-%%% COLOR OVERRIDES %%%
-
-abjad-color-music = #(
-    define-music-function (parser location color music) (symbol? ly:music?)
-    #{
-    \once \override Accidental.color = #(x11-color #'color)
-    \once \override Beam.color = #(x11-color #'color)
-    \once \override Dots.color = #(x11-color #'color)
-    \once \override Flag.color = #(x11-color #'color)
-    \once \override MultiMeasureRest.color = #(x11-color #'color)
-    \once \override NoteHead.color = #(x11-color #'color)
-    \once \override Rest.color = #(x11-color #'color)
-    \once \override Stem.color = #(x11-color #'color)
-    $music
-    #}
-    )
-
-%%% GLISSANDO OVERRIDES %%%
-
-abjad-continuous-glissando = #(
-    define-music-function (parser location music) (ly:music?)
-    #{
-    \override Glissando.bound-details.left.padding = -1
-    \override Glissando.bound-details.left.start-at-dot = ##f
-    \override Glissando.bound-details.right.padding = 0
-    $music
-    #}
-    )
-
-abjad-revert-continuous-glissando = #(
-    define-music-function (parser location music) (ly:music?)
-    #{
-    \revert Glissando.bound-details.left.padding
-    \revert Glissando.bound-details.left.start-at-dot
-    \revert Glissando.bound-details.right.padding
-    $music
-    #}
-    )

--- a/tests/test_Container___delitem__.py
+++ b/tests/test_Container___delitem__.py
@@ -217,18 +217,18 @@ def test_Container___delitem___08():
         {
             c'8
             [
-            \glissando
+            \glissando %! abjad.glissando(7)
             {
                 d'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 e'8
-                \glissando
+                \glissando %! abjad.glissando(7)
             }
             f'8
             ]
         }
         """
-    )
+    ), abjad.f(voice)
 
     leaf = leaves[1]
     del voice[1][0]
@@ -239,16 +239,16 @@ def test_Container___delitem___08():
         {
             c'8
             [
-            \glissando
+            \glissando %! abjad.glissando(7)
             {
                 e'8
-                \glissando
+                \glissando %! abjad.glissando(7)
             }
             f'8
             ]
         }
         """
-    )
+    ), abjad.f(voice)
 
     assert abjad.inspect(voice).wellformed()
     assert abjad.inspect(leaf).wellformed()

--- a/tests/test_Container___setitem__.py
+++ b/tests/test_Container___setitem__.py
@@ -234,7 +234,6 @@ def test_Container___setitem___06():
     voice = abjad.Voice(2 * abjad.Container("c'8 c'8 c'8 c'8"))
     voice = abjad.Voice("{ c'8 d'8 e'8 f'8 } { g'8 a'8 b'8 c''8 }")
     leaves = abjad.select(voice).leaves()
-    abjad.beam(leaves[0:6])
 
     assert format(voice) == abjad.String.normalize(
         r"""
@@ -242,7 +241,6 @@ def test_Container___setitem___06():
         {
             {
                 c'8
-                [
                 d'8
                 e'8
                 f'8
@@ -250,7 +248,6 @@ def test_Container___setitem___06():
             {
                 g'8
                 a'8
-                ]
                 b'8
                 c''8
             }
@@ -266,7 +263,6 @@ def test_Container___setitem___06():
         {
             {
                 c'8
-                [
                 d'8
                 e'8
                 f'8

--- a/tests/test_Mutation_extract.py
+++ b/tests/test_Mutation_extract.py
@@ -16,11 +16,11 @@ def test_Mutation_extract_01():
         {
             c'8
             [
-            \glissando
+            \glissando %! abjad.glissando(7)
             d'8
-            \glissando
+            \glissando %! abjad.glissando(7)
             e'8
-            \glissando
+            \glissando %! abjad.glissando(7)
             f'8
             ]
         }
@@ -36,9 +36,9 @@ def test_Mutation_extract_01():
         {
             c'8
             [
-            \glissando
+            \glissando %! abjad.glissando(7)
             e'8
-            \glissando
+            \glissando %! abjad.glissando(7)
             f'8
             ]
         }
@@ -64,11 +64,11 @@ def test_Mutation_extract_02():
         {
             c'8
             [
-            \glissando
+            \glissando %! abjad.glissando(7)
             d'8
-            \glissando
+            \glissando %! abjad.glissando(7)
             e'8
-            \glissando
+            \glissando %! abjad.glissando(7)
             f'8
             ]
         }
@@ -84,7 +84,7 @@ def test_Mutation_extract_02():
         \new Voice
         {
             e'8
-            \glissando
+            \glissando %! abjad.glissando(7)
             f'8
             ]
         }
@@ -169,19 +169,19 @@ def test_Mutation_extract_04():
             {
                 c'8
                 [
-                \glissando
+                \glissando %! abjad.glissando(7)
                 d'8
-                \glissando
+                \glissando %! abjad.glissando(7)
             }
             {
                 e'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 f'8
-                \glissando
+                \glissando %! abjad.glissando(7)
             }
             {
                 g'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 a'8
                 ]
             }
@@ -199,16 +199,16 @@ def test_Mutation_extract_04():
         {
             c'8
             [
-            \glissando
+            \glissando %! abjad.glissando(7)
             d'8
-            \glissando
+            \glissando %! abjad.glissando(7)
             e'8
-            \glissando
+            \glissando %! abjad.glissando(7)
             f'8
-            \glissando
+            \glissando %! abjad.glissando(7)
             {
                 g'8
-                \glissando
+                \glissando %! abjad.glissando(7)
                 a'8
                 ]
             }


### PR DESCRIPTION
SPANNER UPDATES:

    * Taught abjad.glissando() to tag all attachment sites.
    * Added abjad.glissando(..., hide_stem_selector=None) keyword.

LABEL UPDATES:

    * Added abjad.label().with_durations(..., in_seconds=None) keyword.

SELECTOR UPDATES:

    * Selectors must be passed as expressions (not as strings).

SYSTEM INTERNAL UPDATES:

    * Changed _get_persistent_wrappers() to handle nested voices.
    * abjad.Expression._wrap_arguments() about functions.
    * Added abjad.Wrapper.leaked_start_offset property.

WELLFORMEDNESS UPDATES:

    CHANGE: removed abjad.WellformednessManager.allow_percussion_clef property
        wellformedness now always allows percussion clefs for any instrument.

    NEW: added bjad.Wellformedness.check_beamed_long_notes().

    * Taught wellformedness manager about on-beat container nested voices.

NEW SCHEME FUNCTIONS:

    * Added \abjad-invisible-music
    * Added \abjad-invisible-music-coloring