### PR TITLE
Add sphinx-autodoc-typehints to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ extras_require = {
         "mypy>=0.770",
         "pytest>=5.4.3",
         "pytest-cov>=2.7.1",
+        "sphinx-autodoc-typehints",
     ],
 }
 


### PR DESCRIPTION
This is the patch for issue #1216 

