### PR TITLE
Feature Request: Docs: Add sphinx.ext.viewcode

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,7 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
     "abjad.ext.sphinx",
     "sphinx_autodoc_typehints",
     "uqbar.sphinx.api",


### PR DESCRIPTION
I want to make a feature request for the online docs.

This adds jump to source for classes and objects in the generated docs. 

I think this could prove very convenient when browsing the docs to allow the ability to be able to quickly jump to the class or function definition in the source code.

I built and tested the docs successfully with [sphinx.ext.viewcode](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html).

# Here is an example screenshot of the green source link that is created next to the PitchSet Class:

![source_link_abjad](https://user-images.githubusercontent.com/47760695/93676575-62dfa700-fa7a-11ea-8c5f-5090c9f50197.png)

# And the page it jumps to showing the line where the source code for the implementation of that class begins:

![pitch_set_abjad_source_code](https://user-images.githubusercontent.com/47760695/93676576-65da9780-fa7a-11ea-9ad6-981d062b3166.png)

There is also a module called [sphinx.ext.linkcode](https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html) which requires extra configuration (see my attempt below).

The idea with `sphinx.ext.linkcode` is that it opens the browser page to the project's github repo where the relevant class/function is defined. 

`sphinx.ext.viewcode` jumps to the relevant function or class in the source file directly while staying on the documentation site (see screenshots above).

I was not able to get `sphinx.ext.linkcode` to work.

Here is the config I started working on for `sphinx.ext.linkcode`:

```python
def linkcode_resolve(domain, info):
    if domain != 'py':
        return None
    if not info['module']:
        return None
    filename = info['module'].replace('.', '/')
    return "https://github.com/Abjad/%s.py" % filename
```
