### PR TITLE
fixed fuse leaves by immediate parent

### DIFF
--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -81,17 +81,20 @@ class Mutation:
         leaves = SELECTION
         if len(leaves) <= 1:
             return leaves
-        originally_tied = SELECTION[-1]._has_indicator(Tie)
+        originally_tied_after_first_leaf = SELECTION[0]._has_indicator(Tie)
+        originally_tied_at_end = SELECTION[-1]._has_indicator(Tie)
         total_preprolated = leaves._get_preprolated_duration()
         for leaf in leaves[1:]:
             parent = leaf._parent
             if parent:
                 index = parent.index(leaf)
                 del parent[index]
+        if originally_tied_after_first_leaf:
+            detach(Tie, leaves[0])
         result = Mutation._set_leaf_duration(leaves[0], total_preprolated)
-        if not originally_tied:
+        if originally_tied_at_end:
             last_leaf = Selection(result).leaf(-1)
-            detach(Tie, last_leaf)
+            attach(Tie(), last_leaf)
         return result
 
     @staticmethod

--- a/tests/test_Mutation__fuse_leaves_by_immediate_parent.py
+++ b/tests/test_Mutation__fuse_leaves_by_immediate_parent.py
@@ -82,12 +82,12 @@ def test_Mutation__fuse_leaves_by_immediate_parent_03():
     assert len(result) == 1
     assert abjad.wellformed(note)
 
+
 def test_Mutation__fuse_leaves_by_immediate_parent_04():
     """
     Fuse leaves in logical tie with same immediate parent.
     """
 
-    
     voice = abjad.Voice(r"c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
     logical_tie = abjad.inspect(voice[0]).logical_tie()
     result = abjad.Mutation._fuse_leaves_by_immediate_parent(logical_tie)

--- a/tests/test_Mutation__fuse_leaves_by_immediate_parent.py
+++ b/tests/test_Mutation__fuse_leaves_by_immediate_parent.py
@@ -81,3 +81,32 @@ def test_Mutation__fuse_leaves_by_immediate_parent_03():
     result = abjad.Mutation._fuse_leaves_by_immediate_parent(logical_tie)
     assert len(result) == 1
     assert abjad.wellformed(note)
+
+def test_Mutation__fuse_leaves_by_immediate_parent_04():
+    """
+    Fuse leaves in logical tie with same immediate parent.
+    """
+
+    
+    voice = abjad.Voice(r"c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
+    logical_tie = abjad.inspect(voice[0]).logical_tie()
+    result = abjad.Mutation._fuse_leaves_by_immediate_parent(logical_tie)
+
+    assert abjad.lilypond(voice) == abjad.String.normalize(
+        r"""
+        \new Voice
+        {
+            c'4
+            ~
+            c'16
+            r16
+            r16
+            r16
+            r4
+            r4
+        }
+        """
+    ), print(abjad.lilypond(voice))
+
+    assert abjad.wellformed(voice)
+    assert len(result) == 1


### PR DESCRIPTION
Originally in the `_fuse_leaves_by_immediate_parent` method, if the new duration is not assignable (e.g. 5/16), then there would be an exception raised due to abjad trying to fuse the leaves with an extra leaf right after the selection. (I have also raised an issue at #1222 )By detaching the tie at the first leaf before setting the leaf duration, we could avoid the above problem.

I have also added a test to further illustrate this problem.

I ran pytest locally and all the tests have passed.