### PR TITLE
Removed duplicate attachments when fusing leaves

### DIFF
--- a/abjad/__init__.py
+++ b/abjad/__init__.py
@@ -38,7 +38,6 @@ from .contextmanagers import (
 from .cyclictuple import CyclicTuple
 from .duration import Duration, Multiplier, NonreducedFraction, Offset
 from .enums import (
-    Both,
     Center,
     Comparison,
     Down,
@@ -46,6 +45,7 @@ from .enums import (
     HorizontalAlignment,
     Left,
     Less,
+    Middle,
     More,
     Right,
     Up,
@@ -396,7 +396,6 @@ __all__ = [
     "BeforeGraceContainer",
     "BendAfter",
     "Block",
-    "Both",
     "BowContactPoint",
     "BowMotionTechnique",
     "BowPressure",
@@ -509,6 +508,7 @@ __all__ = [
     "MetricModulation",
     "MetronomeMark",
     "MezzoSopranoVoice",
+    "Middle",
     "MissingMetronomeMarkError",
     "Mode",
     "More",

--- a/abjad/enums.py
+++ b/abjad/enums.py
@@ -27,7 +27,7 @@ class HorizontalAlignment(uqbar.enums.StrictEnumeration):
     """
 
     Left = -1
-    Both = 0
+    Middle = 0
     Right = 1
 
     def __repr__(self):
@@ -64,19 +64,18 @@ class VerticalAlignment(uqbar.enums.StrictEnumeration):
         return super().from_expr(expr)
 
 
-Both = HorizontalAlignment.Both
 Center = VerticalAlignment.Center
 Down = VerticalAlignment.Down
 Exact = Comparison.Exact
 Left = HorizontalAlignment.Left
 Less = Comparison.Less
+Middle = HorizontalAlignment.Middle
 More = Comparison.More
 Right = HorizontalAlignment.Right
 Up = VerticalAlignment.Up
 
 
 __all__ = [
-    "Both",
     "Center",
     "Comparison",
     "Down",
@@ -84,6 +83,7 @@ __all__ = [
     "HorizontalAlignment",
     "Left",
     "Less",
+    "Middle",
     "More",
     "Right",
     "Up",

--- a/abjad/indicators/KeyCluster.py
+++ b/abjad/indicators/KeyCluster.py
@@ -48,6 +48,8 @@ class KeyCluster:
         "_markup_direction",
     )
 
+    _time_orientation = enums.Middle
+
     ### INITIALIZER ###
 
     def __init__(

--- a/abjad/indicators/StemTremolo.py
+++ b/abjad/indicators/StemTremolo.py
@@ -1,4 +1,4 @@
-from .. import math
+from .. import enums, math
 from ..bundle import LilyPondFormatBundle
 from ..storage import FormatSpecification, StorageFormatManager
 
@@ -44,6 +44,8 @@ class StemTremolo:
     __slots__ = ("_tremolo_flags",)
 
     _format_slot = "after"
+
+    _time_orientation = enums.Middle
 
     ### INITIALIZER ###
 

--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -4,10 +4,19 @@ import itertools
 from . import enums, exceptions, get
 from .attach import attach, detach
 from .duration import Duration
-from .indicators.MetronomeMark import MetronomeMark
+from .indicators.BendAfter import BendAfter
+from .indicators.KeyCluster import KeyCluster
 from .indicators.RepeatTie import RepeatTie
+from .indicators.StemTremolo import StemTremolo
+from .indicators.StopBeam import StopBeam
+from .indicators.StopGroup import StopGroup
+from .indicators.StopHairpin import StopHairpin
+from .indicators.StopPhrasingSlur import StopPhrasingSlur
+from .indicators.StopPianoPedal import StopPianoPedal
+from .indicators.StopSlur import StopSlur
+from .indicators.StopTextSpan import StopTextSpan
+from .indicators.StopTrillSpan import StopTrillSpan
 from .indicators.Tie import Tie
-from .indicators.TimeSignature import TimeSignature
 from .iterate import Iteration
 from .makers import NoteMaker
 from .pitch.intervals import NamedInterval
@@ -98,6 +107,31 @@ def _get_leaves_grouped_by_immediate_parents(SELECTION):
     return result
 
 
+def _indicator_is_at_end(indicator):
+    classes = [
+        BendAfter,
+        StopBeam,
+        StopGroup,
+        StopHairpin,
+        StopPhrasingSlur,
+        StopPianoPedal,
+        StopSlur,
+        StopTrillSpan,
+    ]
+    for cls in classes:
+        if isinstance(indicator, cls):
+            return True
+    return False
+
+
+def _indicator_is_continuous(indicator):
+    classes = [StemTremolo, KeyCluster]
+    for cls in classes:
+        if isinstance(indicator, cls):
+            return True
+    return False
+
+
 def _move_indicators(donor_component, recipient_component):
     for wrapper in get.wrappers(donor_component):
         detach(wrapper, donor_component)
@@ -122,10 +156,20 @@ def _set_leaf_duration(leaf, new_duration):
     following_leaves = []
     for i in range(following_leaf_count):
         following_leaf = copy(leaf)
+        for indicator in get.indicators(following_leaf):
+            if i != following_leaf_count - 1:
+                if not _indicator_is_continuous(indicator):
+                    detach(indicator, following_leaf)
+            elif not _indicator_is_at_end(indicator) and not _indicator_is_continuous(
+                indicator
+            ):
+                detach(indicator, following_leaf)
         detach(BeforeGraceContainer, following_leaf)
-        detach(MetronomeMark, following_leaf)
-        detach(TimeSignature, following_leaf)
         following_leaves.append(following_leaf)
+    if following_leaf_count > 0:
+        for indicator in get.indicators(leaf):
+            if _indicator_is_at_end(indicator):
+                detach(indicator, leaf)
     all_leaves = [leaf] + following_leaves
     assert len(all_leaves) == len(new_leaves)
     for all_leaf, new_leaf in zip(all_leaves, new_leaves):
@@ -233,17 +277,13 @@ def _split_container_by_duration(CONTAINER, duration):
         did_split_leaf = True
         timespan = get.timespan(bottom)
         split_point_in_bottom = global_split_point - timespan.start_offset
-        new_leaves = _split_leaf_by_durations(
-            bottom,
-            [split_point_in_bottom],
-        )
+        new_leaves = _split_leaf_by_durations(bottom, [split_point_in_bottom],)
         if new_leaves[0]._parent is not original_bottom_parent:
             new_leaves_tuplet_wrapper = new_leaves[0]._parent
             assert isinstance(new_leaves_tuplet_wrapper, Tuplet)
             assert new_leaves_tuplet_wrapper._parent is original_bottom_parent
             _split_container_by_duration(
-                new_leaves_tuplet_wrapper,
-                split_point_in_bottom,
+                new_leaves_tuplet_wrapper, split_point_in_bottom,
             )
         for leaf in new_leaves:
             timespan = get.timespan(leaf)
@@ -1847,18 +1887,14 @@ def split(argument, durations, cyclic=False):
                 additional_required_duration -= local_split_duration
                 split_durations = Sequence(durations)
                 split_durations = split_durations.split(
-                    [additional_required_duration],
-                    cyclic=False,
-                    overhang=True,
+                    [additional_required_duration], cyclic=False, overhang=True,
                 )
                 split_durations = [list(_) for _ in split_durations]
                 additional_durations = split_durations[0]
                 leaf_split_durations.extend(additional_durations)
                 durations = split_durations[-1]
                 leaf_shards = _split_leaf_by_durations(
-                    current_component,
-                    leaf_split_durations,
-                    cyclic=False,
+                    current_component, leaf_split_durations, cyclic=False,
                 )
                 shard.extend(leaf_shards)
                 result.append(shard)
@@ -1866,8 +1902,7 @@ def split(argument, durations, cyclic=False):
             else:
                 assert isinstance(current_component, Container)
                 pair = _split_container_by_duration(
-                    current_component,
-                    local_split_duration,
+                    current_component, local_split_duration,
                 )
                 left_list, right_list = pair
                 shard.extend(left_list)

--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -116,6 +116,7 @@ def _indicator_is_at_end(indicator):
         StopPhrasingSlur,
         StopPianoPedal,
         StopSlur,
+        StopTextSpan,
         StopTrillSpan,
     ]
     for cls in classes:

--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -7,6 +7,7 @@ from .duration import Duration
 from .indicators.MetronomeMark import MetronomeMark
 from .indicators.RepeatTie import RepeatTie
 from .indicators.Tie import Tie
+from .indicators.TimeSignature import TimeSignature
 from .iterate import Iteration
 from .makers import NoteMaker
 from .pitch.intervals import NamedInterval
@@ -123,6 +124,7 @@ def _set_leaf_duration(leaf, new_duration):
         following_leaf = copy(leaf)
         detach(BeforeGraceContainer, following_leaf)
         detach(MetronomeMark, following_leaf)
+        detach(TimeSignature, following_leaf)
         following_leaves.append(following_leaf)
     all_leaves = [leaf] + following_leaves
     assert len(all_leaves) == len(new_leaves)

--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -4,13 +4,14 @@ import itertools
 from . import enums, exceptions, get
 from .attach import attach, detach
 from .duration import Duration
+from .indicators.MetronomeMark import MetronomeMark
 from .indicators.RepeatTie import RepeatTie
 from .indicators.Tie import Tie
 from .iterate import Iteration
 from .makers import NoteMaker
 from .pitch.intervals import NamedInterval
 from .ratio import Ratio
-from .score import Chord, Component, Container, Leaf, Note, Tuplet
+from .score import BeforeGraceContainer, Chord, Component, Container, Leaf, Note, Tuplet
 from .select import Selection
 from .sequence import Sequence
 from .spanners import tie
@@ -120,6 +121,8 @@ def _set_leaf_duration(leaf, new_duration):
     following_leaves = []
     for i in range(following_leaf_count):
         following_leaf = copy(leaf)
+        detach(BeforeGraceContainer, following_leaf)
+        detach(MetronomeMark, following_leaf)
         following_leaves.append(following_leaf)
     all_leaves = [leaf] + following_leaves
     assert len(all_leaves) == len(new_leaves)

--- a/tests/test_mutate__fuse_leaves_by_immediate_parent.py
+++ b/tests/test_mutate__fuse_leaves_by_immediate_parent.py
@@ -176,3 +176,37 @@ def test_mutate__fuse_leaves_by_immediate_parent_06():
 
     assert abjad.wf.wellformed(voice)
     assert len(result) == 1
+
+
+def test_mutate__fuse_leaves_by_immediate_parent_07():
+    """
+    Fuse leaves in logical tie with same immediate parent.
+    """
+
+    voice = abjad.Voice(r"\times 8/13 { \time 4/4 c'8 ~ c'8 ~ c'16 ~ c'32 r16 } r4 r2")
+    logical_tie = abjad.get.logical_tie(voice[0][0])
+    result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
+    staff = abjad.Staff([voice])
+
+    assert abjad.lilypond(staff) == abjad.String.normalize(
+        r"""
+        \new Staff
+        {
+            \new Voice
+            {
+                \times 8/13 {
+                    \time 4/4
+                    c'4
+                    ~
+                    c'16.
+                    r16
+                }
+                r4
+                r2
+            }
+        }
+        """
+    ), print(abjad.lilypond(staff))
+
+    assert abjad.wf.wellformed(staff)
+    assert len(result) == 1

--- a/tests/test_mutate__fuse_leaves_by_immediate_parent.py
+++ b/tests/test_mutate__fuse_leaves_by_immediate_parent.py
@@ -117,7 +117,9 @@ def test_mutate__fuse_leaves_by_immediate_parent_05():
     Fuse leaves in logical tie with same immediate parent.
     """
 
-    voice = abjad.Voice(r"\grace { b'16 } c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
+    voice = abjad.Voice(
+        r"\grace { b'16 } c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4"
+    )
     logical_tie = abjad.get.logical_tie(voice[0])
     result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
 
@@ -143,12 +145,15 @@ def test_mutate__fuse_leaves_by_immediate_parent_05():
     assert abjad.wf.wellformed(voice)
     assert len(result) == 1
 
+
 def test_mutate__fuse_leaves_by_immediate_parent_06():
     """
     Fuse leaves in logical tie with same immediate parent.
     """
 
-    voice = abjad.Voice(r"\tempo 4 = 120 c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
+    voice = abjad.Voice(
+        r"\tempo 4 = 120 c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4"
+    )
     logical_tie = abjad.get.logical_tie(voice[0])
     result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
 
@@ -171,4 +176,3 @@ def test_mutate__fuse_leaves_by_immediate_parent_06():
 
     assert abjad.wf.wellformed(voice)
     assert len(result) == 1
-

--- a/tests/test_mutate__fuse_leaves_by_immediate_parent.py
+++ b/tests/test_mutate__fuse_leaves_by_immediate_parent.py
@@ -110,3 +110,65 @@ def test_mutate__fuse_leaves_by_immediate_parent_04():
 
     assert abjad.wf.wellformed(voice)
     assert len(result) == 1
+
+
+def test_mutate__fuse_leaves_by_immediate_parent_05():
+    """
+    Fuse leaves in logical tie with same immediate parent.
+    """
+
+    voice = abjad.Voice(r"\grace { b'16 } c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
+    logical_tie = abjad.get.logical_tie(voice[0])
+    result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
+
+    assert abjad.lilypond(voice) == abjad.String.normalize(
+        r"""
+        \new Voice
+        {
+            \grace {
+                b'16
+            }
+            c'4
+            ~
+            c'16
+            r16
+            r16
+            r16
+            r4
+            r4
+        }
+        """
+    ), print(abjad.lilypond(voice))
+
+    assert abjad.wf.wellformed(voice)
+    assert len(result) == 1
+
+def test_mutate__fuse_leaves_by_immediate_parent_06():
+    """
+    Fuse leaves in logical tie with same immediate parent.
+    """
+
+    voice = abjad.Voice(r"\tempo 4 = 120 c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
+    logical_tie = abjad.get.logical_tie(voice[0])
+    result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
+
+    assert abjad.lilypond(voice) == abjad.String.normalize(
+        r"""
+        \new Voice
+        {
+            \tempo 4=120
+            c'4
+            ~
+            c'16
+            r16
+            r16
+            r16
+            r4
+            r4
+        }
+        """
+    ), print(abjad.lilypond(voice))
+
+    assert abjad.wf.wellformed(voice)
+    assert len(result) == 1
+

--- a/tests/test_mutate__fuse_leaves_by_immediate_parent.py
+++ b/tests/test_mutate__fuse_leaves_by_immediate_parent.py
@@ -263,10 +263,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_09():
 
     staff = abjad.Staff(r"d'8 c'8 ~ c'32 r16 r16 r16 r4")
 
-    indicators = (
-        abjad.TimeSignature((3, 4)),
-        abjad.StartBeam()
-    )
+    indicators = (abjad.TimeSignature((3, 4)), abjad.StartBeam())
     for indicator in indicators:
         abjad.attach(indicator, staff[0])
 
@@ -357,5 +354,3 @@ def test_mutate__fuse_leaves_by_immediate_parent_10():
 
     assert abjad.wf.wellformed(staff)
     assert len(result) == 1
-
-

--- a/tests/test_mutate__fuse_leaves_by_immediate_parent.py
+++ b/tests/test_mutate__fuse_leaves_by_immediate_parent.py
@@ -117,9 +117,8 @@ def test_mutate__fuse_leaves_by_immediate_parent_05():
     Fuse leaves in logical tie with same immediate parent.
     """
 
-    voice = abjad.Voice(
-        r"\grace { b'16 } c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4"
-    )
+    voice = abjad.Voice(r"c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
+    abjad.attach(abjad.BeforeGraceContainer("b'16"), voice[0])
     logical_tie = abjad.get.logical_tie(voice[0])
     result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
 
@@ -151,9 +150,8 @@ def test_mutate__fuse_leaves_by_immediate_parent_06():
     Fuse leaves in logical tie with same immediate parent.
     """
 
-    voice = abjad.Voice(
-        r"\tempo 4 = 120 c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4"
-    )
+    voice = abjad.Voice(r"c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
+    abjad.attach(abjad.MetronomeMark((1, 4), 120), voice[0])
     logical_tie = abjad.get.logical_tie(voice[0])
     result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
 
@@ -210,3 +208,154 @@ def test_mutate__fuse_leaves_by_immediate_parent_07():
 
     assert abjad.wf.wellformed(staff)
     assert len(result) == 1
+
+
+def test_mutate__fuse_leaves_by_immediate_parent_08():
+    """
+    Fuse leaves in logical tie with same immediate parent.
+    """
+
+    staff = abjad.Staff(r"c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
+    indicators = (
+        abjad.BeforeGraceContainer("b'16"),
+        abjad.Clef("alto"),
+        abjad.TimeSignature((3, 4)),
+        abjad.Articulation("staccato"),
+        abjad.Articulation("accent"),
+    )
+    for indicator in indicators:
+        abjad.attach(indicator, staff[0])
+    logical_tie = abjad.get.logical_tie(staff[0])
+    result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
+
+    assert abjad.lilypond(staff) == abjad.String.normalize(
+        r"""
+        \new Staff
+        {
+            \grace {
+                b'16
+            }
+            \time 3/4
+            \clef "alto"
+            c'4
+            - \staccato
+            - \accent
+            ~
+            c'16
+            r16
+            r16
+            r16
+            r4
+            r4
+        }
+        """
+    ), print(abjad.lilypond(staff))
+
+    assert abjad.wf.wellformed(staff)
+    assert len(result) == 1
+
+
+def test_mutate__fuse_leaves_by_immediate_parent_09():
+    """
+    Fuse leaves in logical tie with same immediate parent, with an indicator at
+    the end of the logical tie after fusing.
+    """
+
+    staff = abjad.Staff(r"d'8 c'8 ~ c'32 r16 r16 r16 r4")
+
+    indicators = (
+        abjad.TimeSignature((3, 4)),
+        abjad.StartBeam()
+    )
+    for indicator in indicators:
+        abjad.attach(indicator, staff[0])
+
+    indicators = (
+        abjad.BeforeGraceContainer("b'16"),
+        abjad.Articulation("staccato"),
+        abjad.Articulation("accent"),
+        abjad.StopBeam(),
+    )
+    for indicator in indicators:
+        abjad.attach(indicator, staff[1])
+
+    logical_tie = abjad.get.logical_tie(staff[1])
+    result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
+
+    assert abjad.lilypond(staff) == abjad.String.normalize(
+        r"""
+        \new Staff
+        {
+            \time 3/4
+            d'8
+            [
+            \grace {
+                b'16
+            }
+            c'8
+            - \staccato
+            - \accent
+            ~
+            c'32
+            ]
+            r16
+            r16
+            r16
+            r4
+        }
+        """
+    ), print(abjad.lilypond(staff))
+
+    assert abjad.wf.wellformed(staff)
+    assert len(result) == 1
+
+
+def test_mutate__fuse_leaves_by_immediate_parent_10():
+    """
+    Fuse leaves in logical tie with same immediate parent, with an indicator at
+    every leaf of the logical tie after fusing.
+    """
+
+    staff = abjad.Staff(r"c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
+    indicators = (
+        abjad.BeforeGraceContainer("b'16"),
+        abjad.Clef("alto"),
+        abjad.TimeSignature((3, 4)),
+        abjad.Articulation("staccato"),
+        abjad.Articulation("accent"),
+        abjad.StemTremolo(16),
+    )
+    for indicator in indicators:
+        abjad.attach(indicator, staff[0])
+    logical_tie = abjad.get.logical_tie(staff[0])
+    result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
+
+    assert abjad.lilypond(staff) == abjad.String.normalize(
+        r"""
+        \new Staff
+        {
+            \grace {
+                b'16
+            }
+            \time 3/4
+            \clef "alto"
+            c'4
+            :16
+            - \staccato
+            - \accent
+            ~
+            c'16
+            :16
+            r16
+            r16
+            r16
+            r4
+            r4
+        }
+        """
+    ), print(abjad.lilypond(staff))
+
+    assert abjad.wf.wellformed(staff)
+    assert len(result) == 1
+
+

--- a/tests/test_mutate__set_leaf_duration.py
+++ b/tests/test_mutate__set_leaf_duration.py
@@ -32,7 +32,6 @@ def test_mutate__set_leaf_duration_01():
             c'8
             [
             d'8
-            ]
             ~
             d'32
             ]
@@ -80,7 +79,6 @@ def test_mutate__set_leaf_duration_02():
             [
             ~
             c'8
-            ]
             ~
             c'32
             ]
@@ -169,7 +167,6 @@ def test_mutate__set_leaf_duration_04():
             \tweak edge-height #'(0.7 . 0)
             \times 2/3 {
                 d'8
-                ]
                 ~
                 d'32
                 ]


### PR DESCRIPTION
This is an attempt to fix #1245.
At the moment, I am just removing BeforeGraceContainer and MetronomeMark, but I suspect there might be other unnecessary duplicate attachments when fusing leaves.