### PR TITLE
modified conf.py to import nauert

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,6 +103,13 @@ try:
 except ImportError:
     pass
 
+try:
+    from abjadext import nauert  # noqa
+
+    uqbar_book_console_setup.append("from abjadext import nauert")
+except ImportError:
+    pass
+
 ### OTHER EXTENSIONS ###
 
 autodoc_member_order = "groupwise"


### PR DESCRIPTION
This is to reflect the change of docstrings in Nauert from `abjadext.nauert.*` to `nauert.*`.

The docs seem to be building fine on my local mac apart from a LilyPond error in `abjad.Markups.literal`, which was probably due to a minor change of syntax of LilyPond from 2.20 to 2.22 (I'm still using 2.20).

This shouldn't be a problem however since I checked the Abjad docs online, and everything seems to be fine.