### PR TITLE
changed abjad.f to abjad.lilypond or abjad.storage

### DIFF
--- a/abjad/attach.py
+++ b/abjad/attach.py
@@ -20,7 +20,8 @@ class Wrapper:
         >>> abjad.attach(articulation, component)
         >>> wrapper = abjad.get.wrapper(component)
 
-        >>> abjad.f(wrapper)
+        >>> string = abjad.storage(wrapper)
+        >>> print(string)
         abjad.Wrapper(
             indicator=abjad.Articulation('accent', Up),
             tag=abjad.Tag(),
@@ -38,7 +39,8 @@ class Wrapper:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             <<
                 \context Voice = "VoiceI"
@@ -181,7 +183,8 @@ class Wrapper:
 
             >>> old_staff = abjad.Staff("c'4 d'4 e'4 f'4")
             >>> abjad.annotate(old_staff[0], 'bow_direction', abjad.Down)
-            >>> abjad.f(old_staff)
+            >>> string = abjad.lilypond(old_staff)
+            >>> print(string)
             \new Staff {
                 c'4
                 d'4
@@ -194,7 +197,8 @@ class Wrapper:
             Down
 
             >>> new_staff = abjad.mutate.copy(old_staff)
-            >>> abjad.f(new_staff)
+            >>> string = abjad.lilypond(new_staff)
+            >>> print(string)
             \new Staff {
                 c'4
                 d'4
@@ -213,7 +217,8 @@ class Wrapper:
             >>> old_staff = abjad.Staff("c'4 d'4 e'4 f'4")
             >>> clef = abjad.Clef("alto")
             >>> abjad.attach(clef, old_staff[0], tag=abjad.Tag("RED:M1"))
-            >>> abjad.f(old_staff)
+            >>> string = abjad.lilypond(old_staff)
+            >>> print(string)
             \new Staff {
                 \clef "alto" %! RED:M1
                 c'4
@@ -224,7 +229,8 @@ class Wrapper:
 
             >>> leaf = old_staff[0]
             >>> wrapper = abjad.get.wrapper(leaf)
-            >>> abjad.f(wrapper)
+            >>> string = abjad.storage(wrapper)
+            >>> print(string)
             abjad.Wrapper(
                 context='Staff',
                 indicator=abjad.Clef('alto'),
@@ -232,7 +238,8 @@ class Wrapper:
                 )
 
             >>> new_staff = abjad.mutate.copy(old_staff)
-            >>> abjad.f(new_staff)
+            >>> string = abjad.lilypond(new_staff)
+            >>> print(string)
             \new Staff {
                 \clef "alto" %! RED:M1
                 c'4
@@ -243,7 +250,8 @@ class Wrapper:
 
             >>> leaf = new_staff[0]
             >>> wrapper = abjad.get.wrapper(leaf)
-            >>> abjad.f(wrapper)
+            >>> string = abjad.storage(wrapper)
+            >>> print(string)
             abjad.Wrapper(
                 context='Staff',
                 indicator=abjad.Clef('alto'),
@@ -261,7 +269,8 @@ class Wrapper:
             ...     deactivate=True,
             ...     tag=abjad.Tag("RED:M1"),
             ...     )
-            >>> abjad.f(old_staff)
+            >>> string = abjad.lilypond(old_staff)
+            >>> print(string)
             \new Staff {
                 %@% \clef "alto" %! RED:M1
                 c'4
@@ -272,7 +281,8 @@ class Wrapper:
 
             >>> leaf = old_staff[0]
             >>> wrapper = abjad.get.wrapper(leaf)
-            >>> abjad.f(wrapper)
+            >>> string = abjad.storage(wrapper)
+            >>> print(string)
             abjad.Wrapper(
                 context='Staff',
                 deactivate=True,
@@ -281,7 +291,8 @@ class Wrapper:
                 )
 
             >>> new_staff = abjad.mutate.copy(old_staff)
-            >>> abjad.f(new_staff)
+            >>> string = abjad.lilypond(new_staff)
+            >>> print(string)
             \new Staff {
                 %@% \clef "alto" %! RED:M1
                 c'4
@@ -292,7 +303,8 @@ class Wrapper:
 
             >>> leaf = new_staff[0]
             >>> wrapper = abjad.get.wrapper(leaf)
-            >>> abjad.f(wrapper)
+            >>> string = abjad.storage(wrapper)
+            >>> print(string)
             abjad.Wrapper(
                 context='Staff',
                 deactivate=True,
@@ -597,7 +609,8 @@ class Wrapper:
             >>> abjad.attach(stop_text_span, voice[0])
             >>> abjad.show(voice) # doctest: +SKIP
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'2
@@ -682,7 +695,8 @@ def annotate(component, annotation, indicator) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -738,7 +752,8 @@ def attach(  # noqa: 302
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "alto"
@@ -758,7 +773,8 @@ def attach(  # noqa: 302
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -779,7 +795,8 @@ def attach(  # noqa: 302
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \context Staff = "MusicStaff"
             {
                 \context Voice = "MusicVoice"
@@ -836,7 +853,8 @@ def attach(  # noqa: 302
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "treble"
@@ -874,7 +892,8 @@ def attach(  # noqa: 302
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
             %@% \clef "alto" %! +PARTS
@@ -909,7 +928,8 @@ def attach(  # noqa: 302
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> wrapper = abjad.attach(abjad.Clef('alto'), staff[0], wrapper=True)
-        >>> abjad.f(wrapper)
+        >>> string = abjad.storage(wrapper)
+        >>> print(string)
         abjad.Wrapper(
             context='Staff',
             indicator=abjad.Clef('alto'),
@@ -1021,7 +1041,8 @@ def detach(argument, target=None, by_id=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1037,7 +1058,8 @@ def detach(argument, target=None, by_id=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1080,7 +1102,8 @@ def detach(argument, target=None, by_id=False):
         ...     )
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff, align_tags=50)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4
@@ -1103,7 +1126,8 @@ def detach(argument, target=None, by_id=False):
 
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff, align_tags=50)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4
@@ -1131,7 +1155,8 @@ def detach(argument, target=None, by_id=False):
         ...     )
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff, align_tags=50)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4
@@ -1152,7 +1177,8 @@ def detach(argument, target=None, by_id=False):
 
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff, align_tags=50)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4
@@ -1174,7 +1200,8 @@ def detach(argument, target=None, by_id=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "alto"
@@ -1192,7 +1219,8 @@ def detach(argument, target=None, by_id=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1206,7 +1234,8 @@ def detach(argument, target=None, by_id=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "tenor"

--- a/abjad/contextmanagers.py
+++ b/abjad/contextmanagers.py
@@ -182,7 +182,8 @@ class ForbidUpdate(ContextManager):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff {
                 <c' e'>8
                 <d' fs'>8

--- a/abjad/deprecated.py
+++ b/abjad/deprecated.py
@@ -22,7 +22,8 @@ def add_final_bar_line(score, abbreviation="|.", to_each_voice=False) -> BarLine
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -39,7 +40,8 @@ def add_final_bar_line(score, abbreviation="|.", to_each_voice=False) -> BarLine
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -88,7 +90,8 @@ def add_final_markup(score, markup, extra_offset=None) -> None:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -129,7 +132,8 @@ def add_final_markup(score, markup, extra_offset=None) -> None:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff

--- a/abjad/duration.py
+++ b/abjad/duration.py
@@ -1125,7 +1125,8 @@ class Duration(quicktions.Fraction):
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c'4
                 ^ \markup { 1'57'' }
 

--- a/abjad/expression.py
+++ b/abjad/expression.py
@@ -328,7 +328,8 @@ class Expression:
 
             >>> expression = abjad.sequence()
             >>> expression = expression + [4, 5, 6]
-            >>> abjad.f(expression)
+            >>> string = abjad.storage(expression)
+            >>> print(string)
             abjad.Expression(
                 callbacks=[
                     abjad.Expression(
@@ -1563,7 +1564,8 @@ class Expression:
 
             ..  docs::
 
-                >>> abjad.f(markup)
+                >>> string = abjad.lilypond(markup)
+                >>> print(string)
                 \markup {
                     \line
                         {
@@ -1790,7 +1792,8 @@ class Expression:
             >>> expression(abjad.Markup('Allegro assai'))
             [Markup(contents=['Allegro assai'])]
 
-            >>> abjad.f(expression)
+            >>> string = abjad.storage(expression)
+            >>> print(string)
             abjad.Expression(
                 callbacks=[
                     abjad.Expression(

--- a/abjad/format.py
+++ b/abjad/format.py
@@ -308,7 +308,8 @@ def f(argument, align_tags=None):
         >>> for leaf in staff:
         ...     abjad.attach(abjad.Articulation('.'), leaf)
         ...
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4

--- a/abjad/get.py
+++ b/abjad/get.py
@@ -41,7 +41,8 @@ def after_grace_container(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -129,7 +130,8 @@ def annotation(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -192,7 +194,8 @@ def annotation_wrappers(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -202,7 +205,8 @@ def annotation_wrappers(argument):
             }
 
         >>> for wrapper in abjad.get.annotation_wrappers(staff[0]):
-        ...     abjad.f(wrapper)
+        ...     string = abjad.storage(wrapper)
+        ...     print(string)
         ...
         abjad.Wrapper(
             annotation='default_instrument',
@@ -257,7 +261,8 @@ def bar_line_crossing(argument) -> bool:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 3/8
@@ -316,7 +321,8 @@ def before_grace_container(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -409,7 +415,8 @@ def contents(argument) -> typing.Optional["Selection"]:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -522,7 +529,8 @@ def contents(argument) -> typing.Optional["Selection"]:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -600,7 +608,8 @@ def descendants(argument) -> typing.Union["Descendants", "Selection"]:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -767,7 +776,8 @@ def duration(argument, in_seconds: bool = None) -> Duration:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -847,7 +857,8 @@ def duration(argument, in_seconds: bool = None) -> Duration:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -884,7 +895,8 @@ def duration(argument, in_seconds: bool = None) -> Duration:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -932,7 +944,8 @@ def effective(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -1014,7 +1027,8 @@ def effective(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -1053,7 +1067,8 @@ def effective(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -1084,7 +1099,8 @@ def effective(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -1150,7 +1166,8 @@ def effective(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "alto"
@@ -1199,7 +1216,8 @@ def effective(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "treble"
@@ -1238,7 +1256,8 @@ def effective(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 3/8
@@ -1273,7 +1292,8 @@ def effective(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \new Voice
@@ -1329,7 +1349,8 @@ def effective(
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'8
@@ -1366,7 +1387,8 @@ def effective(
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Voice
@@ -1422,7 +1444,8 @@ def effective_staff(argument) -> typing.Optional["Staff"]:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -1534,7 +1557,8 @@ def effective_wrapper(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -1651,7 +1675,8 @@ def grace(argument) -> bool:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -1751,7 +1776,8 @@ def has_effective_indicator(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -1834,7 +1860,8 @@ def has_effective_indicator(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -1901,7 +1928,8 @@ def has_indicator(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -1983,7 +2011,8 @@ def has_indicator(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -2023,7 +2052,8 @@ def has_indicator(
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 \clef "treble"
@@ -2095,7 +2125,8 @@ def indicator(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -2177,7 +2208,8 @@ def indicator(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -2246,7 +2278,8 @@ def indicators(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -2340,7 +2373,8 @@ def indicators(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -2404,7 +2438,8 @@ def leaf(argument, n: int = 0) -> typing.Optional["Leaf"]:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \new Voice
@@ -2472,7 +2507,8 @@ def leaf(argument, n: int = 0) -> typing.Optional["Leaf"]:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -2580,7 +2616,8 @@ def leaf(argument, n: int = 0) -> typing.Optional["Leaf"]:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -2653,7 +2690,8 @@ def lineage(argument) -> "Lineage":
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -2857,7 +2895,8 @@ def logical_tie(argument) -> "LogicalTie":
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -2930,7 +2969,8 @@ def logical_tie(argument) -> "LogicalTie":
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -2966,7 +3006,8 @@ def logical_tie(argument) -> "LogicalTie":
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2989,7 +3030,8 @@ def logical_tie(argument) -> "LogicalTie":
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 r4
@@ -3045,7 +3087,8 @@ def measure_number(argument) -> int:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -3124,7 +3167,8 @@ def measure_number(argument) -> int:
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 \grace {
@@ -3160,7 +3204,8 @@ def measure_number(argument) -> int:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -3216,7 +3261,8 @@ def parentage(argument) -> "Parentage":
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -3360,7 +3406,8 @@ def parentage(argument) -> "Parentage":
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -3428,7 +3475,8 @@ def pitches(argument) -> typing.Optional[PitchSet]:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -3517,7 +3565,8 @@ def report_modifications(argument) -> str:
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 \override NoteHead.color = #red
                 \override NoteHead.style = #'harmonic
@@ -3551,7 +3600,8 @@ def report_modifications(argument) -> str:
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 \once \override NoteHead.color = #red
                 \once \override Stem.color = #red
@@ -3612,7 +3662,8 @@ def sounding_pitch(argument) -> NamedPitch:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 d'8
@@ -3649,7 +3700,8 @@ def sounding_pitches(argument) -> PitchSet:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 <c' e'>4
@@ -3681,7 +3733,8 @@ def sustained(argument) -> bool:
 
         ..  container:: example
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 3/2 {
                 c'4
@@ -3732,7 +3785,8 @@ def timespan(argument, in_seconds: bool = False) -> Timespan:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -3812,7 +3866,8 @@ def timespan(argument, in_seconds: bool = False) -> Timespan:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -3849,7 +3904,8 @@ def timespan(argument, in_seconds: bool = False) -> Timespan:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -3894,7 +3950,8 @@ def wrapper(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -4012,7 +4069,8 @@ def wrappers(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -4119,7 +4177,8 @@ class Descendants(collections.abc.Sequence):
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \context Staff = "Treble_Staff"
@@ -4228,7 +4287,8 @@ class Descendants(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \times 2/3 {
@@ -4292,7 +4352,8 @@ class Lineage(collections.abc.Sequence):
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \context Staff = "Treble_Staff"

--- a/abjad/grace_corner_cases.py
+++ b/abjad/grace_corner_cases.py
@@ -18,7 +18,8 @@ r"""
 
     ..  docs::
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             \context Voice = "Music_Voice"
@@ -75,7 +76,8 @@ r"""
 
     ..  docs::
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             \context Voice = "Music_Voice"
@@ -133,7 +135,8 @@ r"""
 
     ..  docs::
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             \context Voice = "Music_Voice"
@@ -190,7 +193,8 @@ r"""
 
     ..  docs::
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             \context Voice = "Music_Voice"
@@ -239,7 +243,8 @@ r"""
 
     ..  docs::
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             \context Voice = "Music_Voice"

--- a/abjad/indicators/Arpeggio.py
+++ b/abjad/indicators/Arpeggio.py
@@ -20,7 +20,8 @@ class Arpeggio:
 
         ..  docs::
 
-            >>> abjad.f(chord)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             <c' e' g' c''>4
             \arpeggio
 
@@ -35,7 +36,8 @@ class Arpeggio:
 
         ..  docs::
 
-            >>> abjad.f(chord)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             \arpeggioArrowDown
             <c' e' g' c''>4
             \arpeggio
@@ -116,7 +118,8 @@ class Arpeggio:
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <c' e' g' c''>4
                 - \tweak color #blue
                 \arpeggio

--- a/abjad/indicators/Articulation.py
+++ b/abjad/indicators/Articulation.py
@@ -282,7 +282,8 @@ class Articulation:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c'4
                 - \tweak color #blue
                 - \marcato

--- a/abjad/indicators/BarLine.py
+++ b/abjad/indicators/BarLine.py
@@ -20,7 +20,8 @@ class BarLine:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -41,7 +42,8 @@ class BarLine:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -219,7 +221,8 @@ class BarLine:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'1

--- a/abjad/indicators/BendAfter.py
+++ b/abjad/indicators/BendAfter.py
@@ -21,7 +21,8 @@ class BendAfter:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c'4
             - \bendAfter #'-4
 
@@ -36,7 +37,8 @@ class BendAfter:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c'4
             - \bendAfter #'2
 
@@ -138,7 +140,8 @@ class BendAfter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4

--- a/abjad/indicators/BowContactPoint.py
+++ b/abjad/indicators/BowContactPoint.py
@@ -17,7 +17,8 @@ class BowContactPoint:
         Contact point exactly halfway from frog to tip of bow:
 
         >>> point = abjad.BowContactPoint((1, 2))
-        >>> abjad.f(point)
+        >>> string = abjad.storage(point)
+        >>> print(string)
         abjad.BowContactPoint(
             contact_point=abjad.Multiplier(1, 2),
             )
@@ -27,7 +28,8 @@ class BowContactPoint:
         Contact point 3/5 of the way from frog to tip of bow:
 
         >>> point = abjad.BowContactPoint((3, 5))
-        >>> abjad.f(point)
+        >>> string = abjad.storage(point)
+        >>> print(string)
         abjad.BowContactPoint(
             contact_point=abjad.Multiplier(3, 5),
             )

--- a/abjad/indicators/BowMotionTechnique.py
+++ b/abjad/indicators/BowMotionTechnique.py
@@ -10,7 +10,8 @@ class BowMotionTechnique:
         Jété:
 
         >>> bow_motion_technique = abjad.BowMotionTechnique('jete')
-        >>> abjad.f(bow_motion_technique)
+        >>> string = abjad.storage(bow_motion_technique)
+        >>> print(string)
         abjad.BowMotionTechnique(
             technique_name='jete',
             )
@@ -20,7 +21,8 @@ class BowMotionTechnique:
         Ordinario:
 
         >>> bow_motion_technique = abjad.BowMotionTechnique('ordinario')
-        >>> abjad.f(bow_motion_technique)
+        >>> string = abjad.storage(bow_motion_technique)
+        >>> print(string)
         abjad.BowMotionTechnique(
             technique_name='ordinario',
             )

--- a/abjad/indicators/BowPressure.py
+++ b/abjad/indicators/BowPressure.py
@@ -10,13 +10,15 @@ class BowPressure:
     ..  container:: example
 
         >>> bow_pressure = abjad.BowPressure('overpressure')
-        >>> abjad.f(bow_pressure)
+        >>> string = abjad.storage(bow_pressure)
+        >>> print(string)
         abjad.BowPressure(
             pressure='overpressure',
             )
 
         >>> bow_pressure = abjad.BowPressure('underpressure')
-        >>> abjad.f(bow_pressure)
+        >>> string = abjad.storage(bow_pressure)
+        >>> print(string)
         abjad.BowPressure(
             pressure='underpressure',
             )

--- a/abjad/indicators/BreathMark.py
+++ b/abjad/indicators/BreathMark.py
@@ -21,7 +21,8 @@ class BreathMark:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c'4
             \breathe
 
@@ -38,7 +39,8 @@ class BreathMark:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -66,7 +68,8 @@ class BreathMark:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -161,7 +164,8 @@ class BreathMark:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c'4
                 \tweak color #blue
                 \breathe

--- a/abjad/indicators/Clef.py
+++ b/abjad/indicators/Clef.py
@@ -37,7 +37,8 @@ class Clef:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "treble"
@@ -68,7 +69,8 @@ class Clef:
         ... )
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             \clef "treble" %! +PARTS
@@ -99,7 +101,8 @@ class Clef:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -374,7 +377,8 @@ class Clef:
             >>> abjad.attach(abjad.Clef('alto', hide=True), staff[2])
             >>> abjad.show(staff) # doctest: +SKIP
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "treble"
@@ -702,7 +706,8 @@ class StaffPosition:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -763,7 +768,8 @@ class StaffPosition:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {

--- a/abjad/indicators/ColorFingering.py
+++ b/abjad/indicators/ColorFingering.py
@@ -26,7 +26,8 @@ class ColorFingering:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c'4
             ^ \markup {
                 \override
@@ -48,7 +49,8 @@ class ColorFingering:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c'4
             ^ \markup {
                 \override
@@ -240,7 +242,8 @@ class ColorFingering:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4

--- a/abjad/indicators/Dynamic.py
+++ b/abjad/indicators/Dynamic.py
@@ -21,7 +21,8 @@ class Dynamic:
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'8
@@ -71,7 +72,8 @@ class Dynamic:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             <<
                 \new Voice
@@ -482,7 +484,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'2
@@ -500,7 +503,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'2
@@ -518,7 +522,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'2
@@ -538,7 +543,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'2
@@ -578,7 +584,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'2
@@ -636,7 +643,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 \with
                 {
@@ -713,7 +721,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 \with
                 {
@@ -801,7 +810,8 @@ class Dynamic:
             >>> abjad.attach(abjad.Dynamic('mf', hide=True), voice[2])
             >>> abjad.show(voice) # doctest: +SKIP
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'4
@@ -843,7 +853,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -873,7 +884,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -905,7 +917,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -934,7 +947,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -956,7 +970,8 @@ class Dynamic:
             >>> abjad.attach(dynamic, staff[0])
             >>> abjad.show(staff) # doctest: +SKIP
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 r4
@@ -1015,7 +1030,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 \with
                 {
@@ -1066,7 +1082,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 \with
                 {
@@ -1099,7 +1116,8 @@ class Dynamic:
             ``\appena_udibile`` shown here) are meant to be user-defined (and
             not included in Abjad):
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'4
@@ -1398,7 +1416,8 @@ class Dynamic:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c'4
                 - \tweak color #blue
                 \f

--- a/abjad/indicators/Fermata.py
+++ b/abjad/indicators/Fermata.py
@@ -20,7 +20,8 @@ class Fermata:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -41,7 +42,8 @@ class Fermata:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -62,7 +64,8 @@ class Fermata:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -83,7 +86,8 @@ class Fermata:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -269,7 +273,8 @@ class Fermata:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c'4
                 - \tweak color #blue
                 \fermata

--- a/abjad/indicators/Glissando.py
+++ b/abjad/indicators/Glissando.py
@@ -19,7 +19,8 @@ class Glissando:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -175,7 +176,8 @@ class Glissando:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -211,7 +213,8 @@ class Glissando:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     d'8
@@ -247,7 +250,8 @@ class Glissando:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'8.

--- a/abjad/indicators/KeyCluster.py
+++ b/abjad/indicators/KeyCluster.py
@@ -19,7 +19,8 @@ class KeyCluster:
 
         ..  docs::
 
-            >>> abjad.f(chord)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             \once \override Accidental.stencil = ##f
             \once \override AccidentalCautionary.stencil = ##f
             \once \override Arpeggio.X-offset = #-2
@@ -140,7 +141,8 @@ class KeyCluster:
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 \once \override Accidental.stencil = ##f
                 \once \override AccidentalCautionary.stencil = ##f
                 \once \override Arpeggio.X-offset = #-2
@@ -171,7 +173,8 @@ class KeyCluster:
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 \once \override Accidental.stencil = ##f
                 \once \override AccidentalCautionary.stencil = ##f
                 \once \override Arpeggio.X-offset = #-2
@@ -204,7 +207,8 @@ class KeyCluster:
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 \once \override Accidental.stencil = ##f
                 \once \override AccidentalCautionary.stencil = ##f
                 \once \override Arpeggio.X-offset = #-2
@@ -237,7 +241,8 @@ class KeyCluster:
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 \once \override Accidental.stencil = ##f
                 \once \override AccidentalCautionary.stencil = ##f
                 \once \override Arpeggio.X-offset = #-2
@@ -274,7 +279,8 @@ class KeyCluster:
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 \once \override Accidental.stencil = ##f
                 \once \override AccidentalCautionary.stencil = ##f
                 \once \override Arpeggio.X-offset = #-2
@@ -307,7 +313,8 @@ class KeyCluster:
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 \once \override Accidental.stencil = ##f
                 \once \override AccidentalCautionary.stencil = ##f
                 \once \override Arpeggio.X-offset = #-2
@@ -344,7 +351,8 @@ class KeyCluster:
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 \once \override Accidental.stencil = ##f
                 \once \override AccidentalCautionary.stencil = ##f
                 \once \override Arpeggio.X-offset = #-2
@@ -377,7 +385,8 @@ class KeyCluster:
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 \once \override Accidental.stencil = ##f
                 \once \override AccidentalCautionary.stencil = ##f
                 \once \override Arpeggio.X-offset = #-2
@@ -410,7 +419,8 @@ class KeyCluster:
             >>> chord = abjad.Chord("<c' e' g' b' d'' f''>8")
             >>> key_cluster = abjad.KeyCluster()
             >>> abjad.attach(key_cluster, chord)
-            >>> abjad.f(chord)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             \once \override Accidental.stencil = ##f
             \once \override AccidentalCautionary.stencil = ##f
             \once \override Arpeggio.X-offset = #-2

--- a/abjad/indicators/KeySignature.py
+++ b/abjad/indicators/KeySignature.py
@@ -20,7 +20,8 @@ class KeySignature:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \key e \major
@@ -39,7 +40,8 @@ class KeySignature:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \key e \minor
@@ -293,7 +295,8 @@ class KeySignature:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \tweak color #blue

--- a/abjad/indicators/LaissezVibrer.py
+++ b/abjad/indicators/LaissezVibrer.py
@@ -19,7 +19,8 @@ class LaissezVibrer:
 
         ..  docs::
 
-            >>> abjad.f(chord)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             <c' e' g' c''>4
             \laissezVibrer
 
@@ -110,7 +111,8 @@ class LaissezVibrer:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c'4
                 - \tweak color #blue
                 \laissezVibrer

--- a/abjad/indicators/LilyPondComment.py
+++ b/abjad/indicators/LilyPondComment.py
@@ -19,7 +19,8 @@ class LilyPondComment:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             % a comment
             c'4
 
@@ -34,7 +35,8 @@ class LilyPondComment:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             % yet another comment
             c'4
 

--- a/abjad/indicators/MarginMarkup.py
+++ b/abjad/indicators/MarginMarkup.py
@@ -21,7 +21,8 @@ class MarginMarkup:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \set Staff.shortInstrumentName =
@@ -44,7 +45,8 @@ class MarginMarkup:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \set Staff.shortInstrumentName = \my_custom_instrument_name

--- a/abjad/indicators/MetronomeMark.py
+++ b/abjad/indicators/MetronomeMark.py
@@ -36,7 +36,8 @@ class MetronomeMark:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -63,7 +64,8 @@ class MetronomeMark:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -91,7 +93,8 @@ class MetronomeMark:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -119,7 +122,8 @@ class MetronomeMark:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -145,7 +149,8 @@ class MetronomeMark:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -822,7 +827,8 @@ class MetronomeMark:
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new Staff
@@ -891,7 +897,8 @@ class MetronomeMark:
             >>> score = abjad.Score([staff])
             >>> abjad.show(score) # doctest: +SKIP
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff

--- a/abjad/indicators/Ottava.py
+++ b/abjad/indicators/Ottava.py
@@ -19,7 +19,8 @@ class Ottava:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \ottava 1
@@ -107,7 +108,8 @@ class Ottava:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \ottava 1
@@ -129,7 +131,8 @@ class Ottava:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \ottava 1

--- a/abjad/indicators/RehearsalMark.py
+++ b/abjad/indicators/RehearsalMark.py
@@ -24,7 +24,8 @@ class RehearsalMark:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             \with
             {
@@ -85,7 +86,8 @@ class RehearsalMark:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \tweak color #red
@@ -103,7 +105,8 @@ class RehearsalMark:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \tweak color #red
@@ -156,7 +159,8 @@ class RehearsalMark:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \mark #1
@@ -221,7 +225,8 @@ class RehearsalMark:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \mark \markup {
@@ -270,7 +275,8 @@ class RehearsalMark:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 \tweak color #blue
                 \mark A
                 c'4

--- a/abjad/indicators/Repeat.py
+++ b/abjad/indicators/Repeat.py
@@ -19,7 +19,8 @@ class Repeat:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -47,7 +48,8 @@ class Repeat:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff

--- a/abjad/indicators/RepeatTie.py
+++ b/abjad/indicators/RepeatTie.py
@@ -21,7 +21,8 @@ class RepeatTie:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -151,7 +152,8 @@ class RepeatTie:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -177,7 +179,8 @@ class RepeatTie:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -205,7 +208,8 @@ class RepeatTie:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -252,7 +256,8 @@ class RepeatTie:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4

--- a/abjad/indicators/StaffChange.py
+++ b/abjad/indicators/StaffChange.py
@@ -23,7 +23,8 @@ class StaffChange:
 
         ..  docs::
 
-            >>> abjad.f(staff_group)
+            >>> string = abjad.lilypond(staff_group)
+            >>> print(string)
             \new PianoStaff
             <<
                 \context Staff = "RHStaff"

--- a/abjad/indicators/StartBeam.py
+++ b/abjad/indicators/StartBeam.py
@@ -22,7 +22,8 @@ class StartBeam:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -180,13 +181,15 @@ class StartBeam:
             >>> import copy
             >>> start_beam = abjad.StartBeam()
             >>> abjad.tweak(start_beam).color = 'blue'
-            >>> abjad.f(start_beam)
+            >>> string = abjad.storage(start_beam)
+            >>> print(string)
             abjad.StartBeam(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )
 
             >>> start_beam_2 = copy.copy(start_beam)
-            >>> abjad.f(start_beam_2)
+            >>> string = abjad.storage(start_beam_2)
+            >>> print(string)
             abjad.StartBeam(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )

--- a/abjad/indicators/StartGroup.py
+++ b/abjad/indicators/StartGroup.py
@@ -21,7 +21,8 @@ class StartGroup:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -131,13 +132,15 @@ class StartGroup:
             >>> import copy
             >>> start_group = abjad.StartGroup()
             >>> abjad.tweak(start_group).color = 'blue'
-            >>> abjad.f(start_group)
+            >>> string = abjad.storage(start_group)
+            >>> print(string)
             abjad.StartGroup(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )
 
             >>> start_group_2 = copy.copy(start_group)
-            >>> abjad.f(start_group_2)
+            >>> string = abjad.storage(start_group_2)
+            >>> print(string)
             abjad.StartGroup(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )

--- a/abjad/indicators/StartHairpin.py
+++ b/abjad/indicators/StartHairpin.py
@@ -22,7 +22,8 @@ class StartHairpin:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -201,7 +202,8 @@ class StartHairpin:
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     c'4
@@ -301,7 +303,8 @@ class StartHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -328,7 +331,8 @@ class StartHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -355,7 +359,8 @@ class StartHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -383,7 +388,8 @@ class StartHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -413,7 +419,8 @@ class StartHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -440,7 +447,8 @@ class StartHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -468,7 +476,8 @@ class StartHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -496,7 +505,8 @@ class StartHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -527,7 +537,8 @@ class StartHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -592,7 +603,8 @@ class StartHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {

--- a/abjad/indicators/StartMarkup.py
+++ b/abjad/indicators/StartMarkup.py
@@ -19,7 +19,8 @@ class StartMarkup:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \set Staff.instrumentName =
@@ -38,7 +39,8 @@ class StartMarkup:
         >>> start_markup = abjad.StartMarkup(markup=r'\my_instrument_name')
         >>> abjad.attach(start_markup, staff[0])
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             \set Staff.instrumentName = \my_instrument_name

--- a/abjad/indicators/StartPhrasingSlur.py
+++ b/abjad/indicators/StartPhrasingSlur.py
@@ -22,7 +22,8 @@ class StartPhrasingSlur:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -184,13 +185,15 @@ class StartPhrasingSlur:
             >>> import copy
             >>> start_phrasing_slur = abjad.StartPhrasingSlur()
             >>> abjad.tweak(start_phrasing_slur).color = 'blue'
-            >>> abjad.f(start_phrasing_slur)
+            >>> string = abjad.storage(start_phrasing_slur)
+            >>> print(string)
             abjad.StartPhrasingSlur(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )
 
             >>> start_phrasing_slur_2 = copy.copy(start_phrasing_slur)
-            >>> abjad.f(start_phrasing_slur_2)
+            >>> string = abjad.storage(start_phrasing_slur_2)
+            >>> print(string)
             abjad.StartPhrasingSlur(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )

--- a/abjad/indicators/StartPianoPedal.py
+++ b/abjad/indicators/StartPianoPedal.py
@@ -37,7 +37,8 @@ class StartPianoPedal:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -204,13 +205,15 @@ class StartPianoPedal:
             >>> import copy
             >>> start_piano_pedal = abjad.StartPianoPedal()
             >>> abjad.tweak(start_piano_pedal).color = 'blue'
-            >>> abjad.f(start_piano_pedal)
+            >>> string = abjad.storage(start_piano_pedal)
+            >>> print(string)
             abjad.StartPianoPedal(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )
 
             >>> start_piano_pedal_2 = copy.copy(start_piano_pedal)
-            >>> abjad.f(start_piano_pedal_2)
+            >>> string = abjad.storage(start_piano_pedal_2)
+            >>> print(string)
             abjad.StartPianoPedal(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )

--- a/abjad/indicators/StartSlur.py
+++ b/abjad/indicators/StartSlur.py
@@ -23,7 +23,8 @@ class StartSlur:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -144,7 +145,8 @@ class StartSlur:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'8
@@ -172,7 +174,8 @@ class StartSlur:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'8
@@ -200,7 +203,8 @@ class StartSlur:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'8
@@ -273,13 +277,15 @@ class StartSlur:
             >>> import copy
             >>> start_slur = abjad.StartSlur()
             >>> abjad.tweak(start_slur).color = 'blue'
-            >>> abjad.f(start_slur)
+            >>> string = abjad.storage(start_slur)
+            >>> print(string)
             abjad.StartSlur(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )
 
             >>> start_slur_2 = copy.copy(start_slur)
-            >>> abjad.f(start_slur_2)
+            >>> string = abjad.storage(start_slur_2)
+            >>> print(string)
             abjad.StartSlur(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )

--- a/abjad/indicators/StartTextSpan.py
+++ b/abjad/indicators/StartTextSpan.py
@@ -27,7 +27,8 @@ class StartTextSpan:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -291,7 +292,8 @@ class StartTextSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -412,7 +414,8 @@ class StartTextSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -506,7 +509,8 @@ class StartTextSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -540,7 +544,8 @@ class StartTextSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -571,7 +576,8 @@ class StartTextSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -606,7 +612,8 @@ class StartTextSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -640,7 +647,8 @@ class StartTextSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -690,7 +698,8 @@ class StartTextSpan:
             ...     )
             >>> abjad.tweak(start_text_span).color = 'blue'
             >>> abjad.tweak(start_text_span).staff_padding = 2.5
-            >>> abjad.f(start_text_span)
+            >>> string = abjad.storage(start_text_span)
+            >>> print(string)
             abjad.StartTextSpan(
                 command='\\startTextSpan',
                 concat_hspace_left=0.5,
@@ -699,7 +708,8 @@ class StartTextSpan:
                 )
 
             >>> start_text_span_2 = copy.copy(start_text_span)
-            >>> abjad.f(start_text_span_2)
+            >>> string = abjad.storage(start_text_span_2)
+            >>> print(string)
             abjad.StartTextSpan(
                 command='\\startTextSpan',
                 concat_hspace_left=0.5,

--- a/abjad/indicators/StartTrillSpan.py
+++ b/abjad/indicators/StartTrillSpan.py
@@ -23,7 +23,8 @@ class StartTrillSpan:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -145,7 +146,8 @@ class StartTrillSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \pitchedTrill
@@ -206,7 +208,8 @@ class StartTrillSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \pitchedTrill
@@ -247,13 +250,15 @@ class StartTrillSpan:
             >>> import copy
             >>> start_trill_span = abjad.StartTrillSpan()
             >>> abjad.tweak(start_trill_span).color = 'blue'
-            >>> abjad.f(start_trill_span)
+            >>> string = abjad.storage(start_trill_span)
+            >>> print(string)
             abjad.StartTrillSpan(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )
 
             >>> start_trill_span_2 = copy.copy(start_trill_span)
-            >>> abjad.f(start_trill_span_2)
+            >>> string = abjad.storage(start_trill_span_2)
+            >>> print(string)
             abjad.StartTrillSpan(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )

--- a/abjad/indicators/StemTremolo.py
+++ b/abjad/indicators/StemTremolo.py
@@ -18,7 +18,8 @@ class StemTremolo:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c'4
             :16
 
@@ -33,7 +34,8 @@ class StemTremolo:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c'4
             :32
 
@@ -49,7 +51,8 @@ class StemTremolo:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -62,7 +65,8 @@ class StemTremolo:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4

--- a/abjad/indicators/StopBeam.py
+++ b/abjad/indicators/StopBeam.py
@@ -94,7 +94,8 @@ class StopBeam:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'8
@@ -118,7 +119,8 @@ class StopBeam:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'8

--- a/abjad/indicators/StopGroup.py
+++ b/abjad/indicators/StopGroup.py
@@ -72,7 +72,8 @@ class StopGroup:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -96,7 +97,8 @@ class StopGroup:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -124,7 +126,8 @@ class StopGroup:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'8

--- a/abjad/indicators/StopHairpin.py
+++ b/abjad/indicators/StopHairpin.py
@@ -90,7 +90,8 @@ class StopHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -114,7 +115,8 @@ class StopHairpin:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4

--- a/abjad/indicators/StopPhrasingSlur.py
+++ b/abjad/indicators/StopPhrasingSlur.py
@@ -89,7 +89,8 @@ class StopPhrasingSlur:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -113,7 +114,8 @@ class StopPhrasingSlur:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -141,7 +143,8 @@ class StopPhrasingSlur:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'8

--- a/abjad/indicators/StopPianoPedal.py
+++ b/abjad/indicators/StopPianoPedal.py
@@ -122,7 +122,8 @@ class StopPianoPedal:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -157,7 +158,8 @@ class StopPianoPedal:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -233,13 +235,15 @@ class StopPianoPedal:
             >>> import copy
             >>> stop_piano_pedal = abjad.StopPianoPedal()
             >>> abjad.tweak(stop_piano_pedal).color = 'blue'
-            >>> abjad.f(stop_piano_pedal)
+            >>> string = abjad.storage(stop_piano_pedal)
+            >>> print(string)
             abjad.StopPianoPedal(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )
 
             >>> stop_piano_pedal_2 = copy.copy(stop_piano_pedal)
-            >>> abjad.f(stop_piano_pedal_2)
+            >>> string = abjad.storage(stop_piano_pedal_2)
+            >>> print(string)
             abjad.StopPianoPedal(
                 tweaks=TweakInterface(('_literal', None), ('color', 'blue')),
                 )

--- a/abjad/indicators/StopSlur.py
+++ b/abjad/indicators/StopSlur.py
@@ -92,7 +92,8 @@ class StopSlur:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -116,7 +117,8 @@ class StopSlur:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -144,7 +146,8 @@ class StopSlur:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'8

--- a/abjad/indicators/StopTextSpan.py
+++ b/abjad/indicators/StopTextSpan.py
@@ -110,7 +110,8 @@ class StopTextSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -145,7 +146,8 @@ class StopTextSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4

--- a/abjad/indicators/StopTrillSpan.py
+++ b/abjad/indicators/StopTrillSpan.py
@@ -92,7 +92,8 @@ class StopTrillSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -116,7 +117,8 @@ class StopTrillSpan:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4

--- a/abjad/indicators/StringContactPoint.py
+++ b/abjad/indicators/StringContactPoint.py
@@ -11,7 +11,8 @@ class StringContactPoint:
         Sul ponticello:
 
         >>> indicator = abjad.StringContactPoint('sul ponticello')
-        >>> abjad.f(indicator)
+        >>> string = abjad.storage(indicator)
+        >>> print(string)
         abjad.StringContactPoint(
             contact_point='sul ponticello',
             )
@@ -21,7 +22,8 @@ class StringContactPoint:
         Sul tasto:
 
         >>> indicator = abjad.StringContactPoint('sul tasto')
-        >>> abjad.f(indicator)
+        >>> string = abjad.storage(indicator)
+        >>> print(string)
         abjad.StringContactPoint(
             contact_point='sul tasto',
             )
@@ -132,7 +134,8 @@ class StringContactPoint:
 
             ..  docs::
 
-                >>> abjad.f(indicator.markup)
+                >>> string = abjad.lilypond(indicator.markup)
+                >>> print(string)
                 \markup {
                     \caps
                         S.P.
@@ -147,7 +150,8 @@ class StringContactPoint:
 
             ..  docs::
 
-                >>> abjad.f(indicator.markup)
+                >>> string = abjad.lilypond(indicator.markup)
+                >>> print(string)
                 \markup {
                     \caps
                         S.T.

--- a/abjad/indicators/Tie.py
+++ b/abjad/indicators/Tie.py
@@ -21,7 +21,8 @@ class Tie:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -149,7 +150,8 @@ class Tie:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -169,7 +171,8 @@ class Tie:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -189,7 +192,8 @@ class Tie:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -232,7 +236,8 @@ class Tie:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4

--- a/abjad/indicators/TimeSignature.py
+++ b/abjad/indicators/TimeSignature.py
@@ -18,7 +18,8 @@ class TimeSignature:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 3/8
@@ -38,7 +39,8 @@ class TimeSignature:
         Score-contexted time signatures format behind comments when no Abjad
         score container is found:
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             %%% \time 3/8 %%%
@@ -56,7 +58,8 @@ class TimeSignature:
         container is found:
 
         >>> score = abjad.Score([staff])
-        >>> abjad.f(score)
+        >>> string = abjad.lilypond(score)
+        >>> print(string)
         \new Score
         <<
             \new Staff
@@ -88,7 +91,8 @@ class TimeSignature:
         >>> score = abjad.Score([staff])
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(score)
+        >>> string = abjad.lilypond(score)
+        >>> print(string)
         \new Score
         <<
             \new Staff
@@ -395,7 +399,8 @@ class TimeSignature:
             >>> abjad.attach(time_signature, tuplet[0])
             >>> abjad.show(staff) # doctest: +SKIP
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \tweak edge-height #'(0.7 . 0)
@@ -427,7 +432,8 @@ class TimeSignature:
             >>> abjad.attach(time_signature, staff[2])
             >>> abjad.show(staff) # doctest: +SKIP
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 4/4

--- a/abjad/indicators/WoodwindFingering.py
+++ b/abjad/indicators/WoodwindFingering.py
@@ -81,7 +81,8 @@ class WoodwindFingering:
 
         ..  docs::
 
-            >>> abjad.f(chord)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             <ds' fs''>4
             _ \markup {
                 \woodwind-diagram
@@ -131,7 +132,8 @@ class WoodwindFingering:
 
         ..  docs::
 
-            >>> abjad.f(chord)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             <e' as' gqf''>1
             _ \markup {
                 \override
@@ -174,7 +176,8 @@ class WoodwindFingering:
 
         ..  docs::
 
-            >>> abjad.f(chord)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             <e' as' gqf''>1
             _ \markup {
                 \override

--- a/abjad/instruments.py
+++ b/abjad/instruments.py
@@ -39,7 +39,8 @@ class Instrument:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             <<
                 \new Voice
@@ -364,7 +365,8 @@ class StringNumber:
         String I:
 
         >>> indicator = abjad.StringNumber(1)
-        >>> abjad.f(indicator)
+        >>> string = abjad.storage(indicator)
+        >>> print(string)
         abjad.StringNumber(
             numbers=(1,),
             )
@@ -374,7 +376,8 @@ class StringNumber:
         Strings II and III:
 
         >>> indicator = abjad.StringNumber((2, 3))
-        >>> abjad.f(indicator)
+        >>> string = abjad.storage(indicator)
+        >>> print(string)
         abjad.StringNumber(
             numbers=(2, 3),
             )
@@ -487,7 +490,8 @@ class Tuning:
         Violin tuning:
 
         >>> indicator = abjad.Tuning(pitches=('G3', 'D4', 'A4', 'E5'))
-        >>> abjad.f(indicator)
+        >>> string = abjad.storage(indicator)
+        >>> print(string)
         abjad.Tuning(
             pitches=abjad.PitchSegment(
                 (
@@ -579,7 +583,8 @@ class Tuning:
 
             >>> indicator = abjad.Tuning(pitches=('G3', 'D4', 'A4', 'E5'))
             >>> pitches = indicator.pitches
-            >>> abjad.f(pitches)
+            >>> string = abjad.storage(pitches)
+            >>> print(string)
             abjad.PitchSegment(
                 (
                     abjad.NamedPitch('g'),
@@ -779,7 +784,8 @@ class Accordion(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff_group)
+            >>> string = abjad.lilypond(staff_group)
+            >>> print(string)
             \new PianoStaff
             <<
                 \new Staff
@@ -844,7 +850,8 @@ class AltoFlute(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -899,7 +906,8 @@ class AltoSaxophone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -958,7 +966,8 @@ class AltoTrombone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "bass"
@@ -1014,7 +1023,8 @@ class AltoVoice(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1071,7 +1081,8 @@ class BaritoneSaxophone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1128,7 +1139,8 @@ class BaritoneVoice(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "bass"
@@ -1186,7 +1198,8 @@ class BassClarinet(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1241,7 +1254,8 @@ class BassFlute(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1296,7 +1310,8 @@ class BassSaxophone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1353,7 +1368,8 @@ class BassTrombone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "bass"
@@ -1411,7 +1427,8 @@ class BassVoice(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "bass"
@@ -1471,7 +1488,8 @@ class Bassoon(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "bass"
@@ -1531,7 +1549,8 @@ class Cello(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "bass"
@@ -1608,7 +1627,8 @@ class ClarinetInA(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1663,7 +1683,8 @@ class ClarinetInBFlat(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1722,7 +1743,8 @@ class ClarinetInEFlat(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1779,7 +1801,8 @@ class Contrabass(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "bass"
@@ -1856,7 +1879,8 @@ class ContrabassClarinet(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1911,7 +1935,8 @@ class ContrabassFlute(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1966,7 +1991,8 @@ class ContrabassSaxophone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2023,7 +2049,8 @@ class Contrabassoon(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "bass"
@@ -2079,7 +2106,8 @@ class EnglishHorn(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2134,7 +2162,8 @@ class Flute(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2152,7 +2181,8 @@ class Flute(Instrument):
         >>> abjad.attach(flute, staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4
@@ -2217,7 +2247,8 @@ class FrenchHorn(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2274,7 +2305,8 @@ class Glockenspiel(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2329,7 +2361,8 @@ class Guitar(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2408,7 +2441,8 @@ class Harp(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff_group)
+            >>> string = abjad.lilypond(staff_group)
+            >>> print(string)
             \new PianoStaff
             <<
                 \new Staff
@@ -2481,7 +2515,8 @@ class Harpsichord(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff_group)
+            >>> string = abjad.lilypond(staff_group)
+            >>> print(string)
             \new PianoStaff
             <<
                 \new Staff
@@ -2548,7 +2583,8 @@ class Marimba(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2604,7 +2640,8 @@ class MezzoSopranoVoice(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c''4
@@ -2662,7 +2699,8 @@ class Oboe(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2719,7 +2757,8 @@ class Percussion(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2833,7 +2872,8 @@ class Piano(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff_group)
+            >>> string = abjad.lilypond(staff_group)
+            >>> print(string)
             \new PianoStaff
             <<
                 \new Staff
@@ -2900,7 +2940,8 @@ class Piccolo(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2955,7 +2996,8 @@ class SopraninoSaxophone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -3010,7 +3052,8 @@ class SopranoSaxophone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -3065,7 +3108,8 @@ class SopranoVoice(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c''4
@@ -3124,7 +3168,8 @@ class TenorSaxophone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -3181,7 +3226,8 @@ class TenorTrombone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "bass"
@@ -3238,7 +3284,8 @@ class TenorVoice(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -3297,7 +3344,8 @@ class Trumpet(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -3356,7 +3404,8 @@ class Tuba(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "bass"
@@ -3414,7 +3463,8 @@ class Vibraphone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -3471,7 +3521,8 @@ class Viola(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "alto"
@@ -3548,7 +3599,8 @@ class Violin(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -3624,7 +3676,8 @@ class Xylophone(Instrument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4

--- a/abjad/io.py
+++ b/abjad/io.py
@@ -677,7 +677,8 @@ def show(illustrable, return_timing=False, **keywords):
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c'4
 
     ..  container:: example
@@ -689,7 +690,8 @@ def show(illustrable, return_timing=False, **keywords):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4

--- a/abjad/iterate.py
+++ b/abjad/iterate.py
@@ -20,7 +20,8 @@ class Iteration:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -95,7 +96,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -279,7 +281,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \time 2/8
@@ -319,7 +322,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -414,7 +418,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \time 2/8
@@ -514,7 +519,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -555,7 +561,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -681,7 +688,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -755,7 +763,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -827,7 +836,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     c'8
@@ -872,7 +882,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'8
@@ -970,7 +981,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new Staff
@@ -1031,7 +1043,8 @@ class Iteration:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -1140,7 +1153,8 @@ def iterate(client=None):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4

--- a/abjad/iterpitches.py
+++ b/abjad/iterpitches.py
@@ -22,7 +22,8 @@ def iterate_out_of_range(components) -> typing.Generator:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -58,7 +59,8 @@ def respell_with_flats(selection) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 cs'8
@@ -75,7 +77,8 @@ def respell_with_flats(selection) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 df'8
@@ -109,7 +112,8 @@ def respell_with_sharps(selection) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 cf'8
@@ -126,7 +130,8 @@ def respell_with_sharps(selection) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 b8
@@ -186,7 +191,8 @@ def transpose_from_sounding_pitch(argument) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 <c' e' g'>4
@@ -200,7 +206,8 @@ def transpose_from_sounding_pitch(argument) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 <d' fs' a'>4
@@ -239,7 +246,8 @@ def transpose_from_written_pitch(argument) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 <c' e' g'>4
@@ -253,7 +261,8 @@ def transpose_from_written_pitch(argument) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 <bf d' f'>4

--- a/abjad/label.py
+++ b/abjad/label.py
@@ -49,7 +49,8 @@ class Label:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -66,7 +67,8 @@ class Label:
 
             >>> staff = abjad.Staff("c'4 e'4 d'4 f'4")
             >>> expression = abjad.label().with_pitches(locale='us')
-            >>> abjad.f(expression)
+            >>> string = abjad.storage(expression)
+            >>> print(string)
             abjad.Expression(
                 callbacks=[
                     abjad.Expression(
@@ -89,7 +91,8 @@ class Label:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -115,7 +118,8 @@ class Label:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -148,7 +152,8 @@ class Label:
 
             >>> staff = abjad.Staff("c'4 e'4 d'4 f'4")
             >>> expression = abjad.label().with_durations()
-            >>> abjad.f(expression)
+            >>> string = abjad.storage(expression)
+            >>> print(string)
             abjad.Expression(
                 callbacks=[
                     abjad.Expression(
@@ -171,7 +176,8 @@ class Label:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -312,7 +318,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -341,7 +348,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -390,7 +398,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         \abjad-color-music #'red
@@ -415,7 +424,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         \abjad-color-music #'red
@@ -456,7 +466,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(chord)
+                    >>> string = abjad.lilypond(chord)
+                    >>> print(string)
                     <
                         \tweak color #red
                         c''
@@ -482,7 +493,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(chord)
+                    >>> string = abjad.lilypond(chord)
+                    >>> print(string)
                     <
                         \tweak color #red
                         c''
@@ -508,7 +520,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(note)
+                    >>> string = abjad.lilypond(note)
+                    >>> print(string)
                     \once \override NoteHead.color = #red
                     c'4
 
@@ -521,7 +534,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(note)
+                    >>> string = abjad.lilypond(note)
+                    >>> print(string)
                     \once \override NoteHead.color = #red
                     c'4
 
@@ -552,7 +566,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         \once \override NoteHead.color = #(x11-color 'red)
@@ -592,7 +607,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         \once \override NoteHead.color = #(x11-color 'red)
@@ -677,7 +693,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         c'8
@@ -695,7 +712,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         c'8
@@ -713,7 +731,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         c'8
@@ -732,7 +751,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         c'8
@@ -770,7 +790,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -828,7 +849,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -891,7 +913,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -975,7 +998,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -1062,7 +1086,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -1144,7 +1169,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -1229,7 +1255,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -1308,7 +1335,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -1390,7 +1418,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -1469,7 +1498,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -1551,7 +1581,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -1615,7 +1646,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -1682,7 +1714,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -1756,7 +1789,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff_group)
+                    >>> string = abjad.lilypond(staff_group)
+                    >>> print(string)
                     \new StaffGroup
                     <<
                         \new Staff
@@ -1948,7 +1982,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         c'4.
@@ -1990,7 +2025,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         c'4.
@@ -2035,7 +2071,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         c'4.
@@ -2077,7 +2114,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         c'4.
@@ -2140,7 +2178,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2171,7 +2210,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2205,7 +2245,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2238,7 +2279,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2272,7 +2314,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2303,7 +2346,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2335,7 +2379,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2370,7 +2415,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2408,7 +2454,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2463,7 +2510,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2540,7 +2588,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2577,7 +2626,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2618,7 +2668,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2656,7 +2707,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2697,7 +2749,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2735,7 +2788,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2777,7 +2831,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2815,7 +2870,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2857,7 +2913,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2895,7 +2952,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2963,7 +3021,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -2991,7 +3050,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -3022,7 +3082,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -3050,7 +3111,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -3082,7 +3144,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -3118,7 +3181,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -3157,7 +3221,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -3193,7 +3258,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -3238,7 +3304,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3279,7 +3346,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3324,7 +3392,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3366,7 +3435,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3412,7 +3482,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3454,7 +3525,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3569,7 +3641,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3624,7 +3697,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3684,7 +3758,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3740,7 +3815,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3799,7 +3875,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3855,7 +3932,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     \with
                     {
@@ -3949,7 +4027,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -3985,7 +4064,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -4026,7 +4106,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(score)
+                    >>> string = abjad.lilypond(score)
+                    >>> print(string)
                     \new Score
                     <<
                         \new Staff
@@ -4064,7 +4145,8 @@ class Label:
 
                 ..  docs::
 
-                    >>> abjad.f(score)
+                    >>> string = abjad.lilypond(score)
+                    >>> print(string)
                     \new Score
                     <<
                         \new Staff
@@ -4106,7 +4188,8 @@ class Label:
                 >>> abjad.override(staff).text_script.staff_padding = 4
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 0
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new Staff
@@ -4144,7 +4227,8 @@ class Label:
                 >>> abjad.override(staff).text_script.staff_padding = 4
                 >>> abjad.override(staff).tuplet_bracket.staff_padding = 0
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new Staff
@@ -4221,7 +4305,8 @@ class ColorMap:
         ...     ],
         ... )
 
-        >>> abjad.f(color_map)
+        >>> string = abjad.storage(color_map)
+        >>> print(string)
         abjad.ColorMap(
             colors=['red', 'green', 'blue'],
             pitch_iterables=[
@@ -4486,7 +4571,8 @@ def label(client=None, deactivate=None, tag=None):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -4539,7 +4625,8 @@ def label(client=None, deactivate=None, tag=None):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {

--- a/abjad/lilypondfile.py
+++ b/abjad/lilypondfile.py
@@ -48,7 +48,8 @@ class Block:
         >>> block
         <Block(name='paper')>
 
-        >>> abjad.f(block)
+        >>> string = abjad.lilypond(block)
+        >>> print(string)
         \paper {
             right-margin = 2\cm
             left-margin = 2\cm
@@ -62,7 +63,8 @@ class Block:
         >>> block
         <Block(name='score')>
 
-        >>> abjad.f(block)
+        >>> string = abjad.lilypond(block)
+        >>> print(string)
         \score {
             {
                 \markup { foo }
@@ -303,7 +305,8 @@ class Block:
             ... )
             >>> lilypond_file.items.append(score_block)
 
-            >>> abjad.f(lilypond_file)
+            >>> string = abjad.lilypond(lilypond_file)
+            >>> print(string)
             \score { %! abjad.LilyPondFile._get_formatted_blocks()
                 <<
                 { \include "layout.ly" }
@@ -1209,7 +1212,8 @@ class LilyPondFile:
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \context Score = "Custom_Score"
                 <<
                     \context Staff = "Custom_Staff"
@@ -1277,7 +1281,8 @@ class LilyPondFile:
                 ... )
                 >>> del(lilypond_file.items[:3])
 
-                >>> abjad.f(lilypond_file)
+                >>> string = abjad.lilypond(lilypond_file)
+                >>> print(string)
                 \score { %! abjad.LilyPondFile._get_formatted_blocks()
                     <<
                         {
@@ -1625,7 +1630,8 @@ class LilyPondFile:
             >>> lilypond_file.items.append(string)
             >>> lilypond_file.items.append(score_block)
 
-            >>> abjad.f(lilypond_file)
+            >>> string = abjad.lilypond(lilypond_file)
+            >>> print(string)
             \customCommand
             <BLANKLINE>
             \score { %! abjad.LilyPondFile._get_formatted_blocks()
@@ -1780,7 +1786,8 @@ class LilyPondFile:
 
             ::
 
-                >>> abjad.f(lilypond_file) # doctest: +SKIP
+                >>> string = abjad.lilypond(lilypond_file) # doctest: +SKIP
+                >>> print(string) # doctest: +SKIP
                 \header {
                     composer = \markup { Josquin }
                     title = \markup { Missa sexti tonus }
@@ -1876,7 +1883,8 @@ class LilyPondFile:
             ..  docs::
 
                 >>> score = lilypond_file[abjad.Score]
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -1938,7 +1946,8 @@ class LilyPondFile:
             ..  docs::
 
                 >>> score = lilypond_file[abjad.Score]
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -2000,7 +2009,8 @@ class LilyPondFile:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -2084,7 +2094,8 @@ class LilyPondFile:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext

--- a/abjad/lyproxy.py
+++ b/abjad/lyproxy.py
@@ -11,7 +11,8 @@ class LilyPondContext:
     ..  container:: example
 
         >>> context = abjad.LilyPondContext('MensuralStaff')
-        >>> abjad.f(context)
+        >>> string = abjad.storage(context)
+        >>> print(string)
         abjad.LilyPondContext(
             name='MensuralStaff',
             )

--- a/abjad/makers.py
+++ b/abjad/makers.py
@@ -34,7 +34,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 d'4
@@ -56,7 +57,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 <c' d' e'>2
@@ -77,7 +79,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new RhythmicStaff
             {
                 r4
@@ -99,7 +102,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 <c' d' e'>4
@@ -121,7 +125,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 e''4
@@ -145,7 +150,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c''4.
@@ -168,7 +174,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c''4
@@ -191,7 +198,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \times 2/3 {
@@ -217,7 +225,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 13/16
@@ -242,7 +251,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 13/16
@@ -269,7 +279,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 5/4
@@ -304,7 +315,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 5/4
@@ -336,7 +348,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \tweak edge-height #'(0.7 . 0)
@@ -371,7 +384,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new RhythmicStaff
             {
                 \time 3/8
@@ -393,7 +407,8 @@ class LeafMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 fs'2.
@@ -719,7 +734,8 @@ class LeafMaker:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     d'4 %! leaf_maker
@@ -757,7 +773,8 @@ class NoteMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'16
@@ -780,7 +797,8 @@ class NoteMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'16
@@ -801,7 +819,8 @@ class NoteMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'16
@@ -824,7 +843,8 @@ class NoteMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'2.
@@ -844,7 +864,8 @@ class NoteMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'16
@@ -864,7 +885,8 @@ class NoteMaker:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 bf8
@@ -990,7 +1012,8 @@ class NoteMaker:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'16 %! note_maker
@@ -1029,7 +1052,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \times 4/5 {
                 \time 3/16
                 c'32.
@@ -1055,7 +1079,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 6/11 {
                 \time 3/16
@@ -1083,7 +1108,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \times 8/11 {
                 \time 3/16
                 c'16...
@@ -1109,7 +1135,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \times 4/5 {
                 \time 3/16
                 c'32.
@@ -1136,7 +1163,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \times 8/11 {
                 \time 3/16
                 c'16...
@@ -1165,7 +1193,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \times 4/5 {
                 \time 3/16
                 c'32.
@@ -1191,7 +1220,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 6/11 {
                 \time 3/16
@@ -1219,7 +1249,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \times 8/11 {
                 \time 3/16
                 c'16...
@@ -1245,7 +1276,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \times 4/5 {
                 \time 3/16
                 c'32.
@@ -1271,7 +1303,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \times 8/11 {
                 \time 3/16
                 c'16...
@@ -1328,7 +1361,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 1/1 {
                 \time 3/16
@@ -1350,7 +1384,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 1/1 {
                 \time 3/16
@@ -1373,7 +1408,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \times 4/5 {
                 \time 3/16
                 c'32.
@@ -1396,7 +1432,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 6/8 {
                 \time 3/16
@@ -1421,7 +1458,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 6/11 {
                 \time 3/16
@@ -1447,7 +1485,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \times 4/5 {
                 \time 3/16
                 c'64
@@ -1473,7 +1512,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 1/1 {
                 \time 3/16
@@ -1495,7 +1535,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 1/1 {
                 \time 3/16
@@ -1518,7 +1559,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \times 4/5 {
                 \time 3/16
                 c'32.
@@ -1541,7 +1583,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 6/8 {
                 \time 3/16
@@ -1566,7 +1609,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 6/11 {
                 \time 3/16
@@ -1592,7 +1636,8 @@ def tuplet_from_leaf_and_ratio(
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \times 4/5 {
                 \time 3/16
                 c'64
@@ -1648,7 +1693,8 @@ def tuplet_from_ratio_and_pair(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 1/1 {
                 \time 7/16
@@ -1668,7 +1714,8 @@ def tuplet_from_ratio_and_pair(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 7/6 {
                 \time 7/16
@@ -1689,7 +1736,8 @@ def tuplet_from_ratio_and_pair(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 1/1 {
                 \time 7/16
@@ -1711,7 +1759,8 @@ def tuplet_from_ratio_and_pair(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 7/8 {
                 \time 7/16
@@ -1734,7 +1783,8 @@ def tuplet_from_ratio_and_pair(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 7/10 {
                 \time 7/16
@@ -1758,7 +1808,8 @@ def tuplet_from_ratio_and_pair(
 
         ..  docs::
 
-            >>> abjad.f(staff[0])
+            >>> string = abjad.lilypond(staff[0])
+            >>> print(string)
             \times 1/2 {
                 \time 7/16
                 c'16

--- a/abjad/markups.py
+++ b/abjad/markups.py
@@ -29,7 +29,8 @@ class Markup:
 
         >>> string = r'\italic { "Allegro assai" }'
         >>> markup = abjad.Markup(string)
-        >>> abjad.f(markup)
+        >>> string = abjad.lilypond(markup)
+        >>> print(string)
         \markup {
             \italic
                 {
@@ -45,7 +46,8 @@ class Markup:
 
         >>> markup = abjad.Markup(r'\italic "Allegro assai"', direction=abjad.Up)
         >>> markup = abjad.Markup(markup, direction=abjad.Down)
-        >>> abjad.f(markup)
+        >>> string = abjad.lilypond(markup)
+        >>> print(string)
         _ \markup {
             \italic
                 "Allegro assai"
@@ -60,7 +62,8 @@ class Markup:
         >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
         >>> string = r'\italic { "Allegro assai" }'
         >>> markup = abjad.Markup(string, direction=abjad.Up)
-        >>> abjad.f(markup)
+        >>> string = abjad.lilypond(markup)
+        >>> print(string)
         ^ \markup {
             \italic
                 {
@@ -73,7 +76,8 @@ class Markup:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -103,7 +107,8 @@ class Markup:
         >>> abjad.attach(markup, staff[0], tag=abjad.Tag("RED:M1"))
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4
@@ -130,7 +135,8 @@ class Markup:
         ...     )
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4
@@ -155,7 +161,8 @@ class Markup:
         >>> abjad.attach(markup_2, staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4
@@ -260,7 +267,8 @@ class Markup:
             Adds markup to markup:
 
             >>> markup = abjad.Markup("Allegro") + abjad.Markup("assai")
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 Allegro
                 assai
@@ -274,7 +282,8 @@ class Markup:
 
             >>> markup = abjad.Markup(r"Allegro \hspace #0.75")
             >>> markup = markup + abjad.Markup("assai")
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 Allegro
                 \hspace
@@ -460,7 +469,8 @@ class Markup:
             Adds markup to markup:
 
             >>> markup = abjad.Markup("Allegro") + abjad.Markup("assai")
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 Allegro
                 assai
@@ -474,7 +484,8 @@ class Markup:
 
             >>> markup = abjad.Markup(r"Allegro \hspace #0.75")
             >>> markup = markup + abjad.Markup("assai")
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 Allegro
                 \hspace
@@ -626,7 +637,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c'4
                 - \markup { Allegro }
 
@@ -639,7 +651,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c'4
                 ^ \markup { Allegro }
 
@@ -653,7 +666,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c'4
                 _ \markup { Allegro }
 
@@ -669,7 +683,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c'4
                 - \tweak color #red
                 - \markup { Allegro }
@@ -688,14 +703,16 @@ class Markup:
 
             >>> string = r"\custom-function #1 #4"
             >>> markup = abjad.Markup(string, literal=True)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \custom-function #1 #4
 
             Works with normal initializer, too:
 
             >>> string = r"\custom-function #1 #4"
             >>> markup = abjad.Markup(string, literal=True)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \custom-function #1 #4
 
         ..  container:: example
@@ -708,7 +725,8 @@ class Markup:
             ...     direction=abjad.Up,
             ...     literal=True,
             ...     )
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \custom-function #1 #4
 
             Works with normal initialier, too:
@@ -719,7 +737,8 @@ class Markup:
             ...     direction=abjad.Up,
             ...     literal=True,
             ...     )
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \custom-function #1 #4
 
         ..  container:: example
@@ -732,7 +751,8 @@ class Markup:
             ...     direction=abjad.Up,
             ...     literal=True,
             ...     )
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup { \note {4} #1 }
 
             >>> note = abjad.Note("c'4")
@@ -741,7 +761,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c'4
                 ^ \markup { \note {4} #1 }
 
@@ -760,7 +781,8 @@ class Markup:
             >>> abjad.tweak(markup).color = "blue"
             >>> staff = abjad.Staff("c'4 d' e' f'")
             >>> abjad.attach(markup, staff[0])
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -789,7 +811,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.bold()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \bold
                     "Allegro assai"
@@ -813,7 +836,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.box()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \box
                     "Allegro assai"
@@ -828,7 +852,8 @@ class Markup:
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.box()
             >>> markup = markup.override(("box-padding", 0.5))
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \override
                     #'(box-padding . 0.5)
@@ -854,7 +879,8 @@ class Markup:
 
                 >>> markup = abjad.Markup("Allegro assai")
                 >>> markup = markup.bracket()
-                >>> abjad.f(markup)
+                >>> string = abjad.lilypond(markup)
+                >>> print(string)
                 \markup {
                     \bracket
                         "Allegro assai"
@@ -876,7 +902,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.caps()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \caps
                     "Allegro assai"
@@ -900,7 +927,8 @@ class Markup:
             >>> markup_b = abjad.Markup("non").center_align()
             >>> markup_c = abjad.Markup("troppo")
             >>> markup = abjad.Markup.column([markup_a, markup_b, markup_c])
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \column
                     {
@@ -929,7 +957,8 @@ class Markup:
             >>> city = abjad.Markup("Los Angeles")
             >>> date = abjad.Markup("May - August 2014")
             >>> markup = abjad.Markup.center_column([city, date])
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \center-column
                     {
@@ -947,7 +976,8 @@ class Markup:
             >>> city = "Los Angeles"
             >>> date = "May - August 2014"
             >>> markup = abjad.Markup.center_column([city, date])
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \center-column
                     {
@@ -975,7 +1005,8 @@ class Markup:
             >>> markup = abjad.Markup.fraction(3, 5)
             >>> markup = markup.circle()
             >>> markup = markup.override(("circle-padding", 0.45))
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \override
                     #'(circle-padding . 0.45)
@@ -1003,7 +1034,8 @@ class Markup:
             >>> city = abjad.Markup("Los Angeles")
             >>> date = abjad.Markup("May - August 2014")
             >>> markup = abjad.Markup.column([city, date])
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \column
                     {
@@ -1033,7 +1065,8 @@ class Markup:
             >>> markup_two = abjad.Markup.draw_line(13, 0)
             >>> markup_list = [markup_one, markup_two]
             >>> markup = abjad.Markup.combine(markup_list, direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \combine
                     "Allegro assai"
@@ -1065,7 +1098,8 @@ class Markup:
             >>> upbow = abjad.Markup.musicglyph("scripts.upbow")
             >>> markup_list = [downbow, hspace, upbow]
             >>> markup = abjad.Markup.concat(markup_list, direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \concat
                     {
@@ -1097,7 +1131,8 @@ class Markup:
         ..  container:: example
 
             >>> markup = abjad.Markup.draw_circle(10, 1.5, direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \draw-circle
                     #10
@@ -1120,7 +1155,8 @@ class Markup:
         ..  container:: example
 
             >>> markup = abjad.Markup.draw_line(5, -2.5, direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \draw-line
                     #'(5 . -2.5)
@@ -1142,7 +1178,8 @@ class Markup:
 
             >>> markup = abjad.Markup("sffz")
             >>> markup = markup.dynamic()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \dynamic
                     sffz
@@ -1164,7 +1201,8 @@ class Markup:
         ..  container:: example
 
             >>> markup = abjad.Markup.filled_box((0, 10), (2, 5), 1.5, direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \filled-box
                     #'(0 . 10)
@@ -1190,7 +1228,8 @@ class Markup:
 
             >>> markup = abjad.Markup(1)
             >>> markup = markup.finger()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \finger
                     1
@@ -1212,7 +1251,8 @@ class Markup:
         ..  container:: example
 
             >>> markup = abjad.Markup.flat(direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \flat
                 }
@@ -1232,7 +1272,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.fontsize(-3)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \fontsize
                     #-3
@@ -1259,7 +1300,8 @@ class Markup:
             Fraction with integer numerator and denominator:
 
             >>> markup = abjad.Markup.fraction(1, 4, direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \fraction
                     1
@@ -1273,7 +1315,8 @@ class Markup:
             Fraction with string numerator and integer denominator:
 
             >>> markup = abjad.Markup.fraction("π", 4)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \fraction
                     π
@@ -1297,7 +1340,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.general_align("Y", direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \general-align
                     #Y
@@ -1313,7 +1357,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.general_align("Y", 0.75)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \general-align
                     #Y
@@ -1349,7 +1394,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.halign(0)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \halign
                     #0
@@ -1372,7 +1418,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.hcenter_in(12)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \hcenter-in
                     #12
@@ -1395,7 +1442,8 @@ class Markup:
         ..  container:: example
 
             >>> markup = abjad.Markup.hspace(0.75, direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \hspace
                     #0.75
@@ -1416,7 +1464,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.huge()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \huge
                     "Allegro assai"
@@ -1438,7 +1487,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.italic()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \italic
                     "Allegro assai"
@@ -1460,7 +1510,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.larger()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \larger
                     "Allegro assai"
@@ -1484,7 +1535,8 @@ class Markup:
             >>> city = abjad.Markup("Los Angeles")
             >>> date = abjad.Markup("May - August 2014")
             >>> markup = abjad.Markup.left_column([city, date])
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \left-column
                     {
@@ -1513,7 +1565,8 @@ class Markup:
             >>> markups = ["Allegro", "assai"]
             >>> markups = [abjad.Markup(_) for _ in markups]
             >>> markup = abjad.Markup.line(markups)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \line
                     {
@@ -1549,7 +1602,8 @@ class Markup:
             ...     quicktions.Fraction(6, 3),
             ...     direction=abjad.Up,
             ...     )
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup { 2 }
 
             >>> abjad.show(markup) # doctest: +SKIP
@@ -1561,7 +1615,8 @@ class Markup:
             >>> markup = abjad.Markup.make_improper_fraction_markup(
             ...     quicktions.Fraction(7, 3),
             ...     )
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 2
                 \tiny
@@ -1599,7 +1654,8 @@ class Markup:
             ...     "accidentals.sharp",
             ...     direction=abjad.Up,
             ...     )
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \musicglyph
                     #"accidentals.sharp"
@@ -1624,7 +1680,8 @@ class Markup:
         ..  container:: example
 
             >>> markup = abjad.Markup.natural(direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \natural
                 }
@@ -1644,7 +1701,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.normal_text()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \normal-text
                     "Allegro assai"
@@ -1666,7 +1724,8 @@ class Markup:
         ..  container:: example
 
             >>> markup = abjad.Markup.note_by_number(3, 2, 1, direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \note-by-number
                     #3
@@ -1689,7 +1748,8 @@ class Markup:
         ..  container:: example
 
             >>> markup = abjad.Markup.null()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \null
                 }
@@ -1711,7 +1771,8 @@ class Markup:
             >>> city = abjad.Markup("Los Angeles")
             >>> date = abjad.Markup("May - August 2014")
             >>> markup = abjad.Markup.overlay([city, date], direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \overlay
                     {
@@ -1739,7 +1800,8 @@ class Markup:
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.parenthesize()
             >>> markup = markup.override(("padding", 0.75))
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \override
                     #'(padding . 0.75)
@@ -1765,7 +1827,8 @@ class Markup:
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.pad_around(10)
             >>> markup = markup.box()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \box
                     \pad-around
@@ -1790,7 +1853,8 @@ class Markup:
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.pad_markup(10)
             >>> markup = markup.box()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \box
                     \pad-markup
@@ -1828,7 +1892,8 @@ class Markup:
             >>> up_postscript = up_postscript.setgray(0.75)
             >>> up_postscript = up_postscript.fill()
             >>> up_postscript_markup = up_postscript.as_markup()
-            >>> abjad.f(up_postscript_markup)
+            >>> string = abjad.lilypond(up_postscript_markup)
+            >>> print(string)
             \markup {
                 \postscript
                     #"
@@ -1887,7 +1952,8 @@ class Markup:
             >>> down_postscript = down_postscript.setgray(0.75)
             >>> down_postscript = down_postscript.fill()
             >>> down_postscript_markup = down_postscript.as_markup()
-            >>> abjad.f(down_postscript_markup)
+            >>> string = abjad.lilypond(down_postscript_markup)
+            >>> print(string)
             \markup {
                 \postscript
                     #"
@@ -1951,7 +2017,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.parenthesize()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \parenthesize
                     "Allegro assai"
@@ -1979,7 +2046,8 @@ class Markup:
             >>> postscript = postscript.lineto(3, -4)
             >>> postscript = postscript.stroke()
             >>> markup = abjad.Markup.postscript(postscript, direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \postscript
                     #"
@@ -2009,7 +2077,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.raise_(0.35)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \raise
                     #0.35
@@ -2037,7 +2106,8 @@ class Markup:
             ...     [city, date],
             ...     direction=abjad.Up,
             ...     )
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \right-column
                     {
@@ -2064,7 +2134,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.rotate(45)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \rotate
                     #45
@@ -2087,7 +2158,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.sans()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \sans
                     "Allegro assai"
@@ -2109,7 +2181,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.scale((0.75, 0.75))
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \scale
                     #'(0.75 . 0.75)
@@ -2133,7 +2206,8 @@ class Markup:
         ..  container:: example
 
             >>> markup = abjad.Markup.sharp(direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \sharp
                 }
@@ -2153,7 +2227,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.small()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \small
                     "Allegro assai"
@@ -2175,7 +2250,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.smaller()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \smaller
                     "Allegro assai"
@@ -2200,7 +2276,8 @@ class Markup:
             ...     abjad.Markup("j").sub(),
             ...     ]
             >>> markup = abjad.Markup.concat(markup_list)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \concat
                     {
@@ -2226,7 +2303,8 @@ class Markup:
 
             >>> string = rf"\concat {{ 1 \super st }}"
             >>> markup = abjad.Markup(string)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \concat
                     {
@@ -2252,7 +2330,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.tiny()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \tiny
                     "Allegro assai"
@@ -2274,7 +2353,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.translate((2, 1))
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \translate
                     #'(2 . 1)
@@ -2298,7 +2378,8 @@ class Markup:
         ..  container:: example
 
             >>> markup = abjad.Markup.triangle(direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \triangle
                     ##t
@@ -2319,7 +2400,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.upright()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \upright
                     "Allegro assai"
@@ -2341,7 +2423,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.vcenter()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \vcenter
                     "Allegro assai"
@@ -2363,7 +2446,8 @@ class Markup:
         ..  container:: example
 
             >>> markup = abjad.Markup.vspace(0.75, direction=abjad.Up)
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             ^ \markup {
                 \vspace
                     #0.75
@@ -2384,7 +2468,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.whiteout()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \whiteout
                     "Allegro assai"
@@ -2406,7 +2491,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.with_color("blue")
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \with-color
                     #blue
@@ -2421,7 +2507,8 @@ class Markup:
 
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.with_color(abjad.SchemeColor("LimeGreen"))
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \with-color
                     #(x11-color 'LimeGreen)
@@ -2483,7 +2570,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(up_markup.box())
+                >>> string = abjad.lilypond(up_markup.box())
+                >>> print(string)
                 \markup {
                     \box
                         \postscript
@@ -2505,7 +2593,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(up_markup)
+                >>> string = abjad.lilypond(up_markup)
+                >>> print(string)
                 \markup {
                     \box
                         \with-dimensions
@@ -2531,7 +2620,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(up_markup)
+                >>> string = abjad.lilypond(up_markup)
+                >>> print(string)
                 \markup {
                     \box
                         \with-dimensions
@@ -2557,7 +2647,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(up_markup)
+                >>> string = abjad.lilypond(up_markup)
+                >>> print(string)
                 \markup {
                     \box
                         \with-dimensions
@@ -2616,7 +2707,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(markup)
+                >>> string = abjad.lilypond(markup)
+                >>> print(string)
                 \markup {
                     \box
                         Allegro
@@ -2629,7 +2721,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(markup)
+                >>> string = abjad.lilypond(markup)
+                >>> print(string)
                 \markup {
                     \box
                         \with-dimensions
@@ -2663,7 +2756,8 @@ class Markup:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'8
@@ -2696,7 +2790,8 @@ class Markup:
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.bold()
             >>> markup = markup.with_literal(r"\user-markup-command")
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \user-markup-command
                     \bold
@@ -2706,7 +2801,8 @@ class Markup:
             >>> markup = abjad.Markup("Allegro assai")
             >>> markup = markup.with_literal(r"\user-markup-command")
             >>> markup = markup.bold()
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \bold
                     \user-markup-command
@@ -2758,7 +2854,8 @@ class MarkupCommand:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c'4
             - \markup {
                 \combine
@@ -2792,7 +2889,8 @@ class MarkupCommand:
         ...     [small_staff, layout_block],
         ...     )
 
-        >>> abjad.f(command)
+        >>> string = abjad.lilypond(command)
+        >>> print(string)
         \score
             {
                 \new Staff
@@ -2821,7 +2919,8 @@ class MarkupCommand:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -3065,7 +3164,8 @@ class MarkupCommand:
             >>> command = abjad.MarkupCommand("column", lines)
             >>> markup = abjad.Markup(command)
 
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \column
                     {
@@ -3087,7 +3187,8 @@ class MarkupCommand:
                 >>> command.force_quotes = True
                 >>> markup = abjad.Markup(command)
 
-            >>> abjad.f(markup)
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
             \markup {
                 \column
                     {
@@ -4299,7 +4400,8 @@ def abjad_metronome_mark(
         >>> markup = abjad.markups.abjad_metronome_mark(
         ...     2, 0, 1, 67.5, direction=abjad.Up,
         ... )
-        >>> abjad.f(markup)
+        >>> string = abjad.lilypond(markup)
+        >>> print(string)
         ^ \markup {
             \abjad-metronome-mark-markup #2 #0 #1 #"67.5"
             }

--- a/abjad/meter.py
+++ b/abjad/meter.py
@@ -1230,17 +1230,18 @@ class Meter:
             Rewrites the contents of a measure in a staff using the default
             meter for that measure's time signature:
 
-            >>> string = "| 2/4 c'2 ~ |"
-            >>> string += "| 4/4 c'32 d'2.. ~ d'16 e'32 ~ |"
-            >>> string += "| 2/4 e'2 |"
-            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(string)
+            >>> lily_string = "| 2/4 c'2 ~ |"
+            >>> lily_string += "| 4/4 c'32 d'2.. ~ d'16 e'32 ~ |"
+            >>> lily_string += "| 2/4 e'2 |"
+            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
             >>> staff = abjad.Staff()
             >>> staff[:] = container
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1276,7 +1277,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1305,14 +1307,15 @@ class Meter:
 
             Rewrites the contents of a measure in a staff using a custom meter:
 
-            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(string)
+            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
             >>> staff = abjad.Staff()
             >>> staff[:] = container
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1351,7 +1354,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1379,15 +1383,16 @@ class Meter:
             Limit the maximum number of dots per leaf using
             ``maximum_dot_count``:
 
-            >>> string = "| 3/4 c'32 d'8 e'8 fs'4... |"
-            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(string)
+            >>> lily_string = "| 3/4 c'32 d'8 e'8 fs'4... |"
+            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
             >>> staff = abjad.Staff()
             >>> staff.append(container)
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1411,7 +1416,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1429,8 +1435,8 @@ class Meter:
 
             Constraining the ``maximum_dot_count`` to ``2``:
 
-            >>> string = "| 3/4 c'32 d'8 e'8 fs'4... |"
-            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(string)
+            >>> lily_string = "| 3/4 c'32 d'8 e'8 fs'4... |"
+            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
             >>> staff = abjad.Staff()
             >>> staff.append(container)
             >>> measure = staff[0]
@@ -1447,7 +1453,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1467,8 +1474,8 @@ class Meter:
 
             Constraining the ``maximum_dot_count`` to ``1``:
 
-            >>> string = "| 3/4 c'32 d'8 e'8 fs'4... |"
-            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(string)
+            >>> lily_string = "| 3/4 c'32 d'8 e'8 fs'4... |"
+            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
             >>> staff = abjad.Staff()
             >>> staff.append(container)
             >>> measure = staff[0]
@@ -1485,7 +1492,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1507,8 +1515,8 @@ class Meter:
 
             Constraining the ``maximum_dot_count`` to ``0``:
 
-            >>> string = "| 3/4 c'32 d'8 e'8 fs'4... |"
-            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(string)
+            >>> lily_string = "| 3/4 c'32 d'8 e'8 fs'4... |"
+            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
             >>> staff = abjad.Staff()
             >>> staff.append(container)
             >>> measure = staff[0]
@@ -1525,7 +1533,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1578,15 +1587,16 @@ class Meter:
             We can establish that meter without specifying
             a ``boundary_depth``:
 
-            >>> string = "| 9/8 c'2 d'2 e'8 |"
-            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(string)
+            >>> lily_string = "| 9/8 c'2 d'2 e'8 |"
+            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
             >>> staff = abjad.Staff()
             >>> staff.append(container)
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1607,7 +1617,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1625,8 +1636,8 @@ class Meter:
             tree - i.e.  ``0/8`` ``3/8`` ``6/8`` and ``9/8`` - which do not also
             begin and end at any of those offsets, will be split:
 
-            >>> string = "| 9/8 c'2 d'2 e'8 |"
-            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(string)
+            >>> lily_string = "| 9/8 c'2 d'2 e'8 |"
+            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
             >>> staff = abjad.Staff()
             >>> staff.append(container)
             >>> measure = staff[0]
@@ -1643,7 +1654,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1662,8 +1674,8 @@ class Meter:
             of ``2`` causes no change, as all logical ties already align to
             multiples of ``1/8``
 
-            >>> string = "| 9/8 c'2 d'2 e'8 |"
-            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(string)
+            >>> lily_string = "| 9/8 c'2 d'2 e'8 |"
+            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
             >>> staff = abjad.Staff()
             >>> staff.append(container)
             >>> measure = staff[0]
@@ -1680,7 +1692,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -1725,7 +1738,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 \with
                 {
@@ -1827,7 +1841,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 \with
                 {
@@ -1933,7 +1948,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 \with
                 {
@@ -2035,17 +2051,18 @@ class Meter:
 
             Establishing meter recursively in measures with nested tuplets:
 
-            >>> string = "| 4/4 c'16 ~ c'4 d'8. ~ "
-            >>> string += "2/3 { d'8. ~ 3/5 { d'16 e'8. f'16 ~ } } "
-            >>> string += "f'4 |"
-            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(string)
+            >>> lily_string = "| 4/4 c'16 ~ c'4 d'8. ~ "
+            >>> lily_string += "2/3 { d'8. ~ 3/5 { d'16 e'8. f'16 ~ } } "
+            >>> lily_string += "f'4 |"
+            >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
             >>> staff = abjad.Staff()
             >>> staff.append(container)
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -2090,7 +2107,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     {
@@ -2133,7 +2151,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \time 6/8
@@ -2154,7 +2173,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \time 6/8
@@ -2180,7 +2200,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \time 6/8
@@ -2199,15 +2220,16 @@ class Meter:
 
             Rewrites notes and tuplets:
 
-            >>> string = r"c'8 ~ c'8 ~ c'8 \times 6/7 { c'4. r16 }"
-            >>> string += r" \times 6/7 { r16 c'4. } c'8 ~ c'8 ~ c'8"
-            >>> staff = abjad.Staff(string)
+            >>> lily_string = r"c'8 ~ c'8 ~ c'8 \times 6/7 { c'4. r16 }"
+            >>> lily_string += r" \times 6/7 { r16 c'4. } c'8 ~ c'8 ~ c'8"
+            >>> staff = abjad.Staff(lily_string)
             >>> abjad.attach(abjad.TimeSignature((6, 4)), staff[0])
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \time 6/4
@@ -2243,7 +2265,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \time 6/4
@@ -2272,15 +2295,16 @@ class Meter:
 
             Rewrites notes but not tuplets:
 
-            >>> string = r"c'8 ~ c'8 ~ c'8 \times 6/7 { c'4. r16 }"
-            >>> string += r" \times 6/7 { r16 c'4. } c'8 ~ c'8 ~ c'8"
-            >>> staff = abjad.Staff(string)
+            >>> lily_string = r"c'8 ~ c'8 ~ c'8 \times 6/7 { c'4. r16 }"
+            >>> lily_string += r" \times 6/7 { r16 c'4. } c'8 ~ c'8 ~ c'8"
+            >>> staff = abjad.Staff(lily_string)
             >>> abjad.attach(abjad.TimeSignature((6, 4)), staff[0])
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \time 6/4
@@ -2317,7 +2341,8 @@ class Meter:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \time 6/4
@@ -2497,7 +2522,8 @@ class MeterList(TypedList):
         ...     (3, 4), (5, 16), (7, 8),
         ...     ])
 
-        >>> abjad.f(meters)
+        >>> string = abjad.storage(meters)
+        >>> print(string)
         abjad.MeterList(
             [
                 abjad.Meter(
@@ -2535,7 +2561,8 @@ class MeterList(TypedList):
 
                 >>> lilypond_file = meters.__illustrate__()
                 >>> markup = lilypond_file.items[0]
-                >>> abjad.f(markup)
+                >>> string = abjad.lilypond(markup)
+                >>> print(string)
                 \markup {
                     \column
                         {
@@ -2918,7 +2945,8 @@ class MetricAccentKernel:
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new Staff
@@ -3293,7 +3321,8 @@ class _MeterManager:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 {

--- a/abjad/metricmodulation.py
+++ b/abjad/metricmodulation.py
@@ -286,7 +286,8 @@ class MetricModulation:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -698,7 +699,8 @@ class MetricModulation:
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new Staff

--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -429,7 +429,8 @@ def copy(argument, n=1):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "treble"
@@ -461,7 +462,8 @@ def copy(argument, n=1):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "treble"
@@ -490,7 +492,8 @@ def copy(argument, n=1):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 2/4
@@ -511,7 +514,8 @@ def copy(argument, n=1):
 
         ..  docs::
 
-            >>> abjad.f(new_staff)
+            >>> string = abjad.lilypond(new_staff)
+            >>> print(string)
             \new Staff
             {
                 e'8
@@ -554,7 +558,8 @@ def eject_contents(argument):
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'4
                 ~
@@ -577,7 +582,8 @@ def eject_contents(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new RhythmicStaff
             {
                 c'4
@@ -624,7 +630,8 @@ def extract(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \tweak text #tuplet-number::calc-fraction-text
@@ -649,7 +656,8 @@ def extract(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 3/4
@@ -677,7 +685,8 @@ def extract(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \tweak text #tuplet-number::calc-fraction-text
@@ -704,7 +713,8 @@ def extract(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 3/4
@@ -727,7 +737,8 @@ def extract(argument):
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 3/2 {
                 c'4
@@ -741,7 +752,8 @@ def extract(argument):
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 3/2 {
                 c'4
@@ -770,7 +782,8 @@ def fuse(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -790,7 +803,8 @@ def fuse(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \times 2/3 {
@@ -816,7 +830,8 @@ def fuse(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \times 2/3 {
@@ -854,7 +869,8 @@ def fuse(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 d'8
@@ -873,7 +889,8 @@ def fuse(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 d'8..
@@ -910,7 +927,8 @@ def logical_tie_to_tuplet(argument, proportions) -> Tuplet:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -934,7 +952,8 @@ def logical_tie_to_tuplet(argument, proportions) -> Tuplet:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -969,7 +988,8 @@ def logical_tie_to_tuplet(argument, proportions) -> Tuplet:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -1027,7 +1047,8 @@ def replace(argument, recipients, wrappers=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \times 2/3 {
@@ -1056,7 +1077,8 @@ def replace(argument, recipients, wrappers=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'16
@@ -1090,7 +1112,8 @@ def replace(argument, recipients, wrappers=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "alto"
@@ -1112,7 +1135,8 @@ def replace(argument, recipients, wrappers=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 <d' e'>2
@@ -1142,7 +1166,8 @@ def replace(argument, recipients, wrappers=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "alto"
@@ -1164,7 +1189,8 @@ def replace(argument, recipients, wrappers=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \clef "alto"
@@ -1194,7 +1220,8 @@ def replace(argument, recipients, wrappers=False):
         >>> tied_notes = maker(0, abjad.Duration(5, 8))
         >>> abjad.mutate.replace(staff[:1], tied_notes)
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'2
@@ -1258,7 +1285,8 @@ def scale(argument, multiplier) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -1280,7 +1308,8 @@ def scale(argument, multiplier) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 3/8
@@ -1297,7 +1326,8 @@ def scale(argument, multiplier) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 3/8
@@ -1317,7 +1347,8 @@ def scale(argument, multiplier) -> None:
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'8
                 (
@@ -1332,7 +1363,8 @@ def scale(argument, multiplier) -> None:
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'8.
                 (
@@ -1356,7 +1388,8 @@ def scale(argument, multiplier) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \times 4/5 {
@@ -1374,7 +1407,8 @@ def scale(argument, multiplier) -> None:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \times 4/5 {
@@ -1396,7 +1430,8 @@ def scale(argument, multiplier) -> None:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c'8 * 1/2
 
         >>> abjad.mutate.scale(note, abjad.Multiplier(1, 2))
@@ -1404,7 +1439,8 @@ def scale(argument, multiplier) -> None:
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c'16 * 1/2
 
     """
@@ -1434,7 +1470,8 @@ def split(argument, durations, cyclic=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -1458,7 +1495,8 @@ def split(argument, durations, cyclic=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -1492,7 +1530,8 @@ def split(argument, durations, cyclic=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -1521,7 +1560,8 @@ def split(argument, durations, cyclic=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -1605,7 +1645,8 @@ def split(argument, durations, cyclic=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 <<
@@ -1648,7 +1689,8 @@ def split(argument, durations, cyclic=False):
         ...     )
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             <<
@@ -1717,7 +1759,8 @@ def split(argument, durations, cyclic=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1740,7 +1783,8 @@ def split(argument, durations, cyclic=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -1770,7 +1814,8 @@ def split(argument, durations, cyclic=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 d'2
@@ -1783,7 +1828,8 @@ def split(argument, durations, cyclic=False):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 d'32
@@ -1933,7 +1979,8 @@ def swap(argument, container):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 {
@@ -1962,7 +2009,8 @@ def swap(argument, container):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \times 4/6 {
@@ -2014,7 +2062,8 @@ def transpose(argument, interval):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 4/4
@@ -2033,7 +2082,8 @@ def transpose(argument, interval):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 4/4
@@ -2075,7 +2125,8 @@ def wrap(argument, container):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -2100,7 +2151,8 @@ def wrap(argument, container):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -2133,7 +2185,8 @@ def wrap(argument, container):
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \times 2/3 {
                 c'8
                 d'8
@@ -2155,7 +2208,8 @@ def wrap(argument, container):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 {
@@ -2184,7 +2238,8 @@ def wrap(argument, container):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \tweak edge-height #'(0.7 . 0)
@@ -2231,7 +2286,8 @@ def wrap(argument, container):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 {

--- a/abjad/new.py
+++ b/abjad/new.py
@@ -18,7 +18,8 @@ def new(argument, *arguments, **keywords):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -38,7 +39,8 @@ def new(argument, *arguments, **keywords):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -57,14 +59,16 @@ def new(argument, *arguments, **keywords):
         REGRESSION. Can be used to set existing properties to none:
 
         >>> markup = abjad.Markup(r'\italic "Andante assai"', direction=abjad.Up)
-        >>> abjad.f(markup)
+        >>> string = abjad.lilypond(markup)
+        >>> print(string)
         ^ \markup {
             \italic
                 "Andante assai"
             }
 
         >>> markup = abjad.new(markup, direction=None)
-        >>> abjad.f(markup)
+        >>> string = abjad.lilypond(markup)
+        >>> print(string)
         \markup {
             \italic
                 "Andante assai"

--- a/abjad/obgc.py
+++ b/abjad/obgc.py
@@ -35,7 +35,8 @@ class OnBeatGraceContainer(Container):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -307,7 +308,8 @@ def on_beat_grace_container(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -366,7 +368,8 @@ def on_beat_grace_container(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -423,7 +426,8 @@ def on_beat_grace_container(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -483,7 +487,8 @@ def on_beat_grace_container(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -549,7 +554,8 @@ def on_beat_grace_container(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -612,7 +618,8 @@ def on_beat_grace_container(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -673,7 +680,8 @@ def on_beat_grace_container(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"
@@ -737,7 +745,8 @@ def on_beat_grace_container(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \context Voice = "Music_Voice"

--- a/abjad/ordereddict.py
+++ b/abjad/ordereddict.py
@@ -16,7 +16,8 @@ class OrderedDict(collections.abc.MutableMapping):
         ...     ('directive', abjad.Markup(r'\italic Allegretto')),
         ...     ])
 
-        >>> abjad.f(dictionary)
+        >>> string = abjad.storage(dictionary)
+        >>> print(string)
         abjad.OrderedDict(
             [
                 ('color', 'red'),
@@ -46,7 +47,8 @@ class OrderedDict(collections.abc.MutableMapping):
         ...     dictionary
         ...     )
 
-        >>> abjad.f(dictionary)
+        >>> string = abjad.storage(dictionary)
+        >>> print(string)
         abjad.OrderedDict(
             [
                 ('color', 'red'),
@@ -76,7 +78,8 @@ class OrderedDict(collections.abc.MutableMapping):
         ...     dictionary_1
         ...     )
 
-        >>> abjad.f(dictionary_2)
+        >>> string = abjad.storage(dictionary_2)
+        >>> print(string)
         abjad.OrderedDict(
             [
                 ('color', 'red'),
@@ -352,7 +355,8 @@ class OrderedDict(collections.abc.MutableMapping):
             >>> dictionary['colors']['red'] = 3
             >>> dictionary['colors']['green'] = 2
             >>> dictionary['colors']['blue'] = 1
-            >>> abjad.f(dictionary)
+            >>> string = abjad.storage(dictionary)
+            >>> print(string)
             abjad.OrderedDict(
                 [
                     ('flavor', 'cherry'),
@@ -370,7 +374,8 @@ class OrderedDict(collections.abc.MutableMapping):
                 )
 
             >>> dictionary.sort()
-            >>> abjad.f(dictionary)
+            >>> string = abjad.storage(dictionary)
+            >>> print(string)
             abjad.OrderedDict(
                 [
                     (
@@ -388,7 +393,8 @@ class OrderedDict(collections.abc.MutableMapping):
                 )
 
             >>> dictionary.sort(recurse=True)
-            >>> abjad.f(dictionary)
+            >>> string = abjad.storage(dictionary)
+            >>> print(string)
             abjad.OrderedDict(
                 [
                     (

--- a/abjad/overrides.py
+++ b/abjad/overrides.py
@@ -27,7 +27,8 @@ class LilyPondLiteral:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \slurDotted
@@ -60,7 +61,8 @@ class LilyPondLiteral:
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
             <BLANKLINE>
@@ -85,7 +87,8 @@ class LilyPondLiteral:
         >>> abjad.attach(literal, staff[0], tag=abjad.Tag("+PARTS"))
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             \slurDotted %! +PARTS
@@ -112,7 +115,8 @@ class LilyPondLiteral:
         >>> abjad.attach(literal, staff[2], tag=abjad.Tag("+PARTS"))
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'8
@@ -136,7 +140,8 @@ class LilyPondLiteral:
         >>> literal = abjad.LilyPondLiteral("% text")
         >>> abjad.attach(literal, staff[0])
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             % text
@@ -279,7 +284,8 @@ class LilyPondLiteral:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -307,7 +313,8 @@ class LilyPondLiteral:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -355,7 +362,8 @@ class LilyPondLiteral:
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     c'4
@@ -1326,7 +1334,8 @@ def override(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -1349,7 +1358,8 @@ def override(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \once \override Staff.StaffSymbol.color = #blue
@@ -1399,7 +1409,8 @@ class SettingInterface(Interface):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -1533,7 +1544,8 @@ def setting(argument):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -1624,7 +1636,8 @@ class TweakInterface(Interface):
             >>> abjad.attach(markup, staff[0])
             >>> abjad.show(staff) # doctest: +SKIP
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1648,7 +1661,8 @@ class TweakInterface(Interface):
             >>> abjad.attach(markup, staff[0])
             >>> abjad.show(staff) # doctest: +SKIP
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1670,7 +1684,8 @@ class TweakInterface(Interface):
             >>> abjad.attach(markup, staff[0], tag=abjad.Tag("RED:M1"))
             >>> abjad.show(staff) # doctest: +SKIP
 
-            >>> abjad.f(staff, align_tags=40)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1949,7 +1964,8 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1972,7 +1988,8 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1993,7 +2010,8 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2021,7 +2039,8 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2049,7 +2068,8 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2073,7 +2093,8 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2091,7 +2112,8 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2110,7 +2132,8 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
         >>> abjad.tweak(dynamic, tag=abjad.Tag("RED")).color = "red"
         >>> abjad.attach(dynamic, staff[0])
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4
@@ -2131,7 +2154,8 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
         >>> abjad.tweak(dynamic, tag=abjad.Tag("BLUE")).color = "blue"
         >>> abjad.attach(dynamic, staff[0])
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4

--- a/abjad/parentage.py
+++ b/abjad/parentage.py
@@ -35,7 +35,8 @@ class Parentage(collections.abc.Sequence):
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \context Staff = "Treble_Staff"
@@ -146,7 +147,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -239,7 +241,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -397,7 +400,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -490,7 +494,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -587,7 +592,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -687,7 +693,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -776,7 +783,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \times 2/3 {
@@ -835,7 +843,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(outer_red_voice)
+                >>> string = abjad.lilypond(outer_red_voice)
+                >>> print(string)
                 \context Voice = "Red_Voice"
                 \with
                 {
@@ -900,7 +909,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -1004,7 +1014,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(outer_red_voice)
+                >>> string = abjad.lilypond(outer_red_voice)
+                >>> print(string)
                 \context Voice = "Red_Voice"
                 \with
                 {
@@ -1154,7 +1165,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -1258,7 +1270,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \context Score = "Score"
                 <<
                     \context Staff = "Music_Staff"
@@ -1276,7 +1289,8 @@ class Parentage(collections.abc.Sequence):
             >>> note = voice[0]
             >>> parentage = abjad.get.parentage(note)
             >>> logical_voice = parentage.logical_voice()
-            >>> abjad.f(logical_voice)
+            >>> string = abjad.storage(logical_voice)
+            >>> print(string)
             abjad.OrderedDict(
                 [
                     ('score', "Score-'Score'"),
@@ -1299,7 +1313,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \context Voice = "Music_Voice"
                 {
                     c'4
@@ -1316,7 +1331,8 @@ class Parentage(collections.abc.Sequence):
                 }
 
             >>> lv = abjad.get.parentage(voice).logical_voice()
-            >>> abjad.f(lv)
+            >>> string = abjad.storage(lv)
+            >>> print(string)
             abjad.OrderedDict(
                 [
                     ('score', ''),
@@ -1327,7 +1343,8 @@ class Parentage(collections.abc.Sequence):
                 )
 
             >>> lv = abjad.get.parentage(container_1).logical_voice()
-            >>> abjad.f(lv)
+            >>> string = abjad.storage(lv)
+            >>> print(string)
             abjad.OrderedDict(
                 [
                     ('score', ''),
@@ -1338,7 +1355,8 @@ class Parentage(collections.abc.Sequence):
                 )
 
             >>> lv = abjad.get.parentage(container_1[0]).logical_voice()
-            >>> abjad.f(lv)
+            >>> string = abjad.storage(lv)
+            >>> print(string)
             abjad.OrderedDict(
                 [
                     ('score', ''),
@@ -1349,7 +1367,8 @@ class Parentage(collections.abc.Sequence):
                 )
 
             >>> lv = abjad.get.parentage(container_2).logical_voice()
-            >>> abjad.f(lv)
+            >>> string = abjad.storage(lv)
+            >>> print(string)
             abjad.OrderedDict(
                 [
                     ('score', ''),
@@ -1360,7 +1379,8 @@ class Parentage(collections.abc.Sequence):
                 )
 
             >>> lv = abjad.get.parentage(container_2[0]).logical_voice()
-            >>> abjad.f(lv)
+            >>> string = abjad.storage(lv)
+            >>> print(string)
             abjad.OrderedDict(
                 [
                     ('score', ''),
@@ -1407,7 +1427,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new Staff
@@ -1459,7 +1480,8 @@ class Parentage(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"

--- a/abjad/parsers/parser.py
+++ b/abjad/parsers/parser.py
@@ -2407,7 +2407,8 @@ class LilyPondParser(Parser):
         >>> staff = parser(string)
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4
@@ -2441,7 +2442,8 @@ class LilyPondParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -2493,7 +2495,8 @@ class LilyPondParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \context Staff = "Treble Staff"
@@ -2546,7 +2549,8 @@ class LilyPondParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(blocks) # doctest: +SKIP
+            >>> string = abjad.lilypond(blocks) # doctest: +SKIP
+            >>> print(string) # doctest: +SKIP
             % 2017-07-11 15:13
             <BLANKLINE>
             \version "2.19.63"
@@ -2602,7 +2606,8 @@ class LilyPondParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c32
@@ -2641,7 +2646,8 @@ class LilyPondParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c4
                 df4

--- a/abjad/parsers/reduced.py
+++ b/abjad/parsers/reduced.py
@@ -32,7 +32,8 @@ class ReducedLyParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'4
                 r8.
@@ -48,7 +49,8 @@ class ReducedLyParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'4
                 r8
@@ -68,7 +70,8 @@ class ReducedLyParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'4
                 d'4
@@ -82,7 +85,8 @@ class ReducedLyParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'4
                 d'4
@@ -102,7 +106,8 @@ class ReducedLyParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak edge-height #'(0.7 . 0)
             \times 2/3 {
                 c'4
@@ -127,7 +132,8 @@ class ReducedLyParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 {
@@ -157,7 +163,8 @@ class ReducedLyParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c16
                 [

--- a/abjad/pattern.py
+++ b/abjad/pattern.py
@@ -201,7 +201,8 @@ class Pattern:
             >>> pattern_2 = abjad.index_last(3)
             >>> pattern = pattern_1 & pattern_2
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='and',
                 patterns=(
@@ -219,7 +220,8 @@ class Pattern:
             >>> pattern_3 = abjad.index([0], 2)
             >>> pattern = pattern_1 & pattern_2 & pattern_3
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='and',
                 patterns=(
@@ -241,7 +243,8 @@ class Pattern:
             >>> pattern_3 = abjad.index([0], 2)
             >>> pattern = pattern_1 & pattern_2 | pattern_3
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='or',
                 patterns=(
@@ -266,7 +269,8 @@ class Pattern:
             >>> pattern = abjad.index_first(3)
             >>> pattern &= abjad.index_last(3)
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='and',
                 patterns=(
@@ -295,18 +299,21 @@ class Pattern:
         ..  container:: example
 
             >>> pattern = abjad.index_first(3)
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.index_first(3)
 
             >>> pattern = ~pattern
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 indices=[0, 1, 2],
                 inverted=True,
                 )
 
             >>> pattern = ~pattern
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 indices=[0, 1, 2],
                 inverted=False,
@@ -323,7 +330,8 @@ class Pattern:
             >>> pattern_2 = abjad.index_last(3)
             >>> pattern = pattern_1 | pattern_2
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='or',
                 patterns=(
@@ -341,7 +349,8 @@ class Pattern:
             (one of the last three indices):
 
             >>> pattern = ~pattern
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 inverted=True,
                 operator='or',
@@ -433,7 +442,8 @@ class Pattern:
             >>> pattern_2 = abjad.index_last(3)
             >>> pattern = pattern_1 | pattern_2
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='or',
                 patterns=(
@@ -451,7 +461,8 @@ class Pattern:
             >>> pattern_3 = abjad.index([0], 2)
             >>> pattern = pattern_1 | pattern_2 | pattern_3
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='or',
                 patterns=(
@@ -473,7 +484,8 @@ class Pattern:
             >>> pattern_3 = abjad.index([0], 2)
             >>> pattern = pattern_1 | pattern_2 & pattern_3
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='or',
                 patterns=(
@@ -498,7 +510,8 @@ class Pattern:
             >>> pattern = abjad.index_first(3)
             >>> pattern |= abjad.index_last(3)
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='or',
                 patterns=(
@@ -536,7 +549,8 @@ class Pattern:
             >>> pattern_2 = abjad.index_last(3)
             >>> pattern = pattern_1 ^ pattern_2
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='xor',
                 patterns=(
@@ -554,7 +568,8 @@ class Pattern:
             >>> pattern_3 = abjad.index([0], 2)
             >>> pattern = pattern_1 ^ pattern_2 ^ pattern_3
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='xor',
                 patterns=(
@@ -576,7 +591,8 @@ class Pattern:
             >>> pattern_3 = abjad.index([0], 2)
             >>> pattern = pattern_1 ^ pattern_2 & pattern_3
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='xor',
                 patterns=(
@@ -601,7 +617,8 @@ class Pattern:
             >>> pattern = abjad.index_first(3)
             >>> pattern ^= abjad.index_last(3)
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='xor',
                 patterns=(
@@ -959,7 +976,8 @@ class Pattern:
             >>> pattern_2 = abjad.Pattern([0], period=5)
             >>> pattern = pattern_1 | pattern_2
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='or',
                 patterns=(
@@ -986,7 +1004,8 @@ class Pattern:
             >>> pattern_2 = abjad.Pattern([0])
             >>> pattern = pattern_1 | pattern_2
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='or',
                 patterns=(
@@ -1124,7 +1143,8 @@ class Pattern:
 
             >>> pattern = [1, 0, 0, 1, 1]
             >>> pattern = abjad.Pattern.from_vector(pattern)
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 indices=[0, 3, 4],
                 period=5,
@@ -1152,7 +1172,8 @@ class Pattern:
 
             >>> pattern = [1, 0, 0, 1, 1, 0]
             >>> pattern = abjad.Pattern.from_vector(pattern)
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 indices=[0, 3, 4],
                 period=6,
@@ -1326,7 +1347,8 @@ class Pattern:
             >>> pattern_2 = abjad.Pattern([0], period=5)
             >>> pattern = pattern_1 | pattern_2
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='or',
                 patterns=(
@@ -1424,7 +1446,8 @@ class Pattern:
 
             >>> pattern = abjad.index([2])
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.index([2])
 
         ..  container:: example
@@ -1433,7 +1456,8 @@ class Pattern:
 
             >>> pattern = abjad.index([2, 3, 5])
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.index([2, 3, 5])
 
         Returns pattern.
@@ -1459,7 +1483,8 @@ class Pattern:
 
             >>> pattern = abjad.index_all()
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.index_all()
 
         Returns pattern.
@@ -1478,7 +1503,8 @@ class Pattern:
 
             >>> pattern = abjad.index_first(1)
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.index_first(1)
 
         ..  container:: example
@@ -1487,7 +1513,8 @@ class Pattern:
 
             >>> pattern = abjad.index_first(2)
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.index_first(2)
 
         ..  container:: example
@@ -1496,7 +1523,8 @@ class Pattern:
 
             >>> pattern = abjad.index_first(0)
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.index_first(0)
 
         Returns pattern.
@@ -1520,7 +1548,8 @@ class Pattern:
 
             >>> pattern = abjad.index_last(2)
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.index_last(2)
 
         ..  container:: example
@@ -1529,7 +1558,8 @@ class Pattern:
 
             >>> pattern = abjad.index_last(0)
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.index_last(0)
 
         Returns pattern.
@@ -2223,7 +2253,8 @@ class Pattern:
             ...         ],
             ...     )
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='or',
                 patterns=(
@@ -2392,7 +2423,8 @@ class Pattern:
             ...     )
 
             >>> pattern = pattern.reverse()
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 indices=[-1, -2, -8],
                 period=8,
@@ -2439,7 +2471,8 @@ class Pattern:
             ...         ],
             ...     )
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='and',
                 patterns=(
@@ -2457,7 +2490,8 @@ class Pattern:
             Reverses pattern:
 
             >>> pattern = pattern.reverse()
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='and',
                 patterns=(
@@ -2526,7 +2560,8 @@ class Pattern:
             ...     )
 
             >>> pattern = pattern.rotate(n=2)
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 indices=[2, 3, 9],
                 period=8,
@@ -2593,7 +2628,8 @@ class Pattern:
             ...     )
 
             >>> pattern = pattern.rotate(n=2)
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 indices=[-1, 0, 1],
                 period=8,
@@ -2640,7 +2676,8 @@ class Pattern:
             ...         ],
             ...     )
 
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='and',
                 patterns=(
@@ -2658,7 +2695,8 @@ class Pattern:
             Rotates pattern two elements to the right:
 
             >>> pattern = pattern.rotate(n=2)
-            >>> abjad.f(pattern)
+            >>> string = abjad.storage(pattern)
+            >>> print(string)
             abjad.Pattern(
                 operator='and',
                 patterns=(
@@ -2707,7 +2745,8 @@ class PatternTuple(TypedTuple):
         ...         ),
         ...     ])
 
-        >>> abjad.f(patterns)
+        >>> string = abjad.storage(patterns)
+        >>> print(string)
         abjad.PatternTuple(
             (
                 abjad.Pattern(
@@ -2738,7 +2777,8 @@ class PatternTuple(TypedTuple):
         ...         ),
         ...     ])
 
-        >>> abjad.f(patterns)
+        >>> string = abjad.storage(patterns)
+        >>> print(string)
         abjad.PatternTuple(
             (
                 abjad.Pattern(

--- a/abjad/pitch/PitchRange.py
+++ b/abjad/pitch/PitchRange.py
@@ -24,7 +24,8 @@ class PitchRange:
 
         ..  docs::
 
-            >>> abjad.f(pitch_range)
+            >>> string = abjad.storage(pitch_range)
+            >>> print(string)
             abjad.PitchRange('[C3, C7]')
 
     ..  container:: example
@@ -35,7 +36,8 @@ class PitchRange:
 
         ..  docs::
 
-            >>> abjad.f(lilypond_file[abjad.Score])
+            >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+            >>> print(string)
             \new Score
             \with
             {

--- a/abjad/pitch/operators.py
+++ b/abjad/pitch/operators.py
@@ -81,7 +81,8 @@ class CompoundOperator:
             >>> str(operator_3)
             'IRIT1'
 
-            >>> abjad.f(operator_3)
+            >>> string = abjad.storage(operator_3)
+            >>> print(string)
             abjad.CompoundOperator(
                 operators=[
                     Transposition(n=1),
@@ -339,7 +340,8 @@ class CompoundOperator:
 
             >>> operator = abjad.CompoundOperator()
             >>> operator = operator.duplicate(counts=1)
-            >>> abjad.f(operator)
+            >>> string = abjad.storage(operator)
+            >>> print(string)
             abjad.CompoundOperator(
                 operators=[
                     Duplication(counts=1),
@@ -359,7 +361,8 @@ class CompoundOperator:
 
             >>> operator = abjad.CompoundOperator()
             >>> operator = operator.invert(axis=2)
-            >>> abjad.f(operator)
+            >>> string = abjad.storage(operator)
+            >>> print(string)
             abjad.CompoundOperator(
                 operators=[
                     Inversion(axis=NamedPitch("d'")),
@@ -379,7 +382,8 @@ class CompoundOperator:
 
             >>> operator = abjad.CompoundOperator()
             >>> operator = operator.multiply(n=3)
-            >>> abjad.f(operator)
+            >>> string = abjad.storage(operator)
+            >>> print(string)
             abjad.CompoundOperator(
                 operators=[
                     Multiplication(n=3),
@@ -399,7 +403,8 @@ class CompoundOperator:
 
             >>> operator = abjad.CompoundOperator()
             >>> operator = operator.retrograde()
-            >>> abjad.f(operator)
+            >>> string = abjad.storage(operator)
+            >>> print(string)
             abjad.CompoundOperator(
                 operators=[
                     Retrograde(),
@@ -419,7 +424,8 @@ class CompoundOperator:
 
             >>> operator = abjad.CompoundOperator()
             >>> operator = operator.rotate(n=-1)
-            >>> abjad.f(operator)
+            >>> string = abjad.storage(operator)
+            >>> print(string)
             abjad.CompoundOperator(
                 operators=[
                     Rotation(n=-1),
@@ -440,7 +446,8 @@ class CompoundOperator:
             >>> operator = abjad.CompoundOperator()
             >>> operator = operator.transpose(n=1)
 
-            >>> abjad.f(operator)
+            >>> string = abjad.storage(operator)
+            >>> print(string)
             abjad.CompoundOperator(
                 operators=[
                     Transposition(n=1),
@@ -461,7 +468,8 @@ class Duplication:
 
         >>> operator_ = abjad.Duplication(counts=2, period=4)
 
-        >>> abjad.f(operator_)
+        >>> string = abjad.storage(operator_)
+        >>> print(string)
         abjad.Duplication(
             counts=2,
             period=4,
@@ -788,7 +796,8 @@ class Inversion:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     a'8
@@ -813,7 +822,8 @@ class Inversion:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     ef'8
@@ -828,7 +838,8 @@ class Inversion:
 
             Returns compound operator:
 
-            >>> abjad.f(operator)
+            >>> string = abjad.storage(operator)
+            >>> print(string)
             abjad.CompoundOperator(
                 operators=[
                     Inversion(),
@@ -1073,7 +1084,8 @@ class Multiplication:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     ef'8
@@ -1098,7 +1110,8 @@ class Multiplication:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     ef'8
@@ -1296,7 +1309,8 @@ class Retrograde:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     af'8
@@ -1321,7 +1335,8 @@ class Retrograde:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     af'8
@@ -1336,7 +1351,8 @@ class Retrograde:
 
             Returns compound operator:
 
-            >>> abjad.f(operator)
+            >>> string = abjad.storage(operator)
+            >>> print(string)
             abjad.CompoundOperator(
                 operators=[
                     Retrograde(),
@@ -1543,7 +1559,8 @@ class Rotation:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     f'8
@@ -1568,7 +1585,8 @@ class Rotation:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     f'8
@@ -1583,7 +1601,8 @@ class Rotation:
 
             Returns compound operator:
 
-            >>> abjad.f(operator)
+            >>> string = abjad.storage(operator)
+            >>> print(string)
             abjad.CompoundOperator(
                 operators=[
                     Rotation(n=-1),
@@ -1870,7 +1889,8 @@ class Transposition:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     e'8
@@ -1895,7 +1915,8 @@ class Transposition:
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     e'8

--- a/abjad/pitch/segments.py
+++ b/abjad/pitch/segments.py
@@ -422,7 +422,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -446,7 +447,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -475,7 +477,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     c'8
@@ -499,7 +502,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     c'8
@@ -568,7 +572,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -603,7 +608,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         c'8
@@ -643,7 +649,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -686,7 +693,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -742,7 +750,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         g'8
@@ -778,7 +787,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         g'8
@@ -826,7 +836,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         ef'8
@@ -863,7 +874,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         ef'8
@@ -921,7 +933,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     g'8
@@ -978,7 +991,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     af'8
@@ -1093,7 +1107,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -1129,7 +1144,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -1155,7 +1171,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -1184,7 +1201,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -1219,7 +1237,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         g'8
@@ -1249,7 +1268,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         g'8
@@ -1288,7 +1308,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         g'8
@@ -1318,7 +1339,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         g'8
@@ -1777,7 +1799,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         d'8
@@ -1808,7 +1831,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         d'8
@@ -1844,7 +1868,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -1879,7 +1904,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -1949,7 +1975,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -1980,7 +2007,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -2018,7 +2046,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         d'8
@@ -2049,7 +2078,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         d'8
@@ -2087,7 +2117,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -2118,7 +2149,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -2156,7 +2188,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         d'8
@@ -2187,7 +2220,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         d'8
@@ -2240,7 +2274,8 @@ class PitchClassSegment(Segment):
 
             ..  doctest:
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -2262,7 +2297,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     e'8
@@ -2294,7 +2330,8 @@ class PitchClassSegment(Segment):
 
             ..  doctest:
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     e'8
@@ -2356,7 +2393,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         g'8
@@ -2387,7 +2425,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         g'8
@@ -2423,7 +2462,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -2458,7 +2498,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -2534,7 +2575,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         g'8
@@ -2565,7 +2607,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         g'8
@@ -2603,7 +2646,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bqf'8
@@ -2634,7 +2678,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bqf'8
@@ -2672,7 +2717,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -2706,7 +2752,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -2748,7 +2795,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         c'8
@@ -2779,7 +2827,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         c'8
@@ -2838,7 +2887,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -2860,7 +2910,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -2890,7 +2941,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -2912,7 +2964,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -2947,7 +3000,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -2969,7 +3023,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -3011,7 +3066,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -3033,7 +3089,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -3096,7 +3153,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         b'8
@@ -3127,7 +3185,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         b'8
@@ -3165,7 +3224,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         a'8
@@ -3196,7 +3256,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         a'8
@@ -3234,7 +3295,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -3268,7 +3330,8 @@ class PitchClassSegment(Segment):
 
                 ..  docs::
 
-                    >>> abjad.f(lilypond_file[abjad.Voice])
+                    >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                    >>> print(string)
                     \new Voice
                     {
                         bf'8
@@ -3329,7 +3392,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 \with
                 {
@@ -3425,7 +3489,8 @@ class PitchClassSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 \with
                 {
@@ -3508,7 +3573,8 @@ class PitchSegment(Segment):
 
         ..  docs::
 
-            >>> abjad.f(lilypond_file[abjad.StaffGroup])
+            >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+            >>> print(string)
             \new PianoStaff
             <<
                 \context Staff = "Treble_Staff"
@@ -3547,7 +3613,8 @@ class PitchSegment(Segment):
 
         ..  docs::
 
-            >>> abjad.f(lilypond_file[abjad.StaffGroup])
+            >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+            >>> print(string)
             \new PianoStaff
             <<
                 \context Staff = "Treble_Staff"
@@ -3724,7 +3791,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -3770,7 +3838,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -3822,7 +3891,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -3882,7 +3952,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -3946,7 +4017,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -3981,7 +4053,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4024,7 +4097,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4059,7 +4133,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4102,7 +4177,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4137,7 +4213,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4179,7 +4256,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4214,7 +4292,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4264,7 +4343,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4299,7 +4379,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -4323,7 +4404,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4358,7 +4440,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -4392,7 +4475,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4427,7 +4511,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4463,7 +4548,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4498,7 +4584,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4540,7 +4627,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4575,7 +4663,8 @@ class PitchSegment(Segment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.StaffGroup])
+                >>> string = abjad.lilypond(lilypond_file[abjad.StaffGroup])
+                >>> print(string)
                 \new PianoStaff
                 <<
                     \context Staff = "Treble_Staff"
@@ -4690,7 +4779,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     af'8
@@ -4714,7 +4804,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     c'8
@@ -4739,7 +4830,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     cs'8
@@ -4769,7 +4861,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     b'8
@@ -4794,7 +4887,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     c'8
@@ -4824,7 +4918,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     bf'8
@@ -4849,7 +4944,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     af'8
@@ -4902,7 +4998,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     cs'8
@@ -4924,7 +5021,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     f'8
@@ -4969,7 +5067,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     c'8
@@ -5016,7 +5115,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     cs'8
@@ -5076,7 +5176,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     c'8
@@ -5122,7 +5223,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     cs'8
@@ -5427,7 +5529,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     cs'8
@@ -5461,7 +5564,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     cs'8
@@ -5492,7 +5596,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     b'8
@@ -5521,7 +5626,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     a'8
@@ -5576,7 +5682,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     f'8
@@ -5605,7 +5712,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     g'8
@@ -5634,7 +5742,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     cs'8
@@ -5686,7 +5795,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     c'8
@@ -5715,7 +5825,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     cs'8
@@ -5770,7 +5881,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     c'8
@@ -5799,7 +5911,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     b'8
@@ -5828,7 +5941,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     cs'8
@@ -5860,7 +5974,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     c'8
@@ -5912,7 +6027,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     d'8
@@ -5941,7 +6057,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     c'8
@@ -5970,7 +6087,8 @@ class TwelveToneRow(PitchClassSegment):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Voice])
+                >>> string = abjad.lilypond(lilypond_file[abjad.Voice])
+                >>> print(string)
                 \new Voice
                 {
                     cs'8

--- a/abjad/pitch/sets.py
+++ b/abjad/pitch/sets.py
@@ -189,7 +189,8 @@ class IntervalClassSet(Set):
 
             ..  docs::
 
-                >>> abjad.f(staff_group)
+                >>> string = abjad.lilypond(staff_group)
+                >>> print(string)
                 \new StaffGroup
                 <<
                     \new Staff
@@ -835,7 +836,8 @@ class PitchSet(Set):
         >>> set_
         PitchSet([-2, -1.5, 6, 7])
 
-        >>> abjad.f(set_)
+        >>> string = abjad.storage(set_)
+        >>> print(string)
         abjad.PitchSet(
             [-2, -1.5, 6, 7]
             )
@@ -851,7 +853,8 @@ class PitchSet(Set):
         >>> set_
         PitchSet(['bf,', 'aqs', 'bqf', "fs'", "g'"])
 
-        >>> abjad.f(set_)
+        >>> string = abjad.storage(set_)
+        >>> print(string)
         abjad.PitchSet(
             ['bf,', 'aqs', 'bqf', "fs'", "g'"]
             )

--- a/abjad/rhythmtrees.py
+++ b/abjad/rhythmtrees.py
@@ -414,7 +414,8 @@ class RhythmTreeContainer(RhythmTreeMixin, uqbar.containers.UniqueTreeList):
         ...     children=[],
         ...     )
 
-        >>> abjad.f(container)
+        >>> string = abjad.storage(container)
+        >>> print(string)
         abjad.rhythmtrees.RhythmTreeContainer(
             children=(),
             preprolated_duration=abjad.Duration(1, 1),
@@ -429,7 +430,8 @@ class RhythmTreeContainer(RhythmTreeMixin, uqbar.containers.UniqueTreeList):
         >>> leaf_a = abjad.rhythmtrees.RhythmTreeLeaf(preprolated_duration=1)
         >>> leaf_b = abjad.rhythmtrees.RhythmTreeLeaf(preprolated_duration=2)
         >>> container.extend([leaf_a, leaf_b])
-        >>> abjad.f(container)
+        >>> string = abjad.storage(container)
+        >>> print(string)
         abjad.rhythmtrees.RhythmTreeContainer(
             children=(
                 abjad.rhythmtrees.RhythmTreeLeaf(
@@ -450,7 +452,8 @@ class RhythmTreeContainer(RhythmTreeMixin, uqbar.containers.UniqueTreeList):
         ...     abjad.rhythmtrees.RhythmTreeLeaf(preprolated_duration=3))
         >>> another_container.append(container[1])
         >>> container.append(another_container)
-        >>> abjad.f(container)
+        >>> string = abjad.storage(container)
+        >>> print(string)
         abjad.rhythmtrees.RhythmTreeContainer(
             children=(
                 abjad.rhythmtrees.RhythmTreeLeaf(
@@ -485,7 +488,8 @@ class RhythmTreeContainer(RhythmTreeMixin, uqbar.containers.UniqueTreeList):
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \times 2/3 {
                 c'8
                 \times 4/5 {
@@ -525,7 +529,8 @@ class RhythmTreeContainer(RhythmTreeMixin, uqbar.containers.UniqueTreeList):
         >>> c.preprolated_duration
         Duration(3, 1)
 
-        >>> abjad.f(c)
+        >>> string = abjad.storage(c)
+        >>> print(string)
         abjad.rhythmtrees.RhythmTreeContainer(
             children=(
                 abjad.rhythmtrees.RhythmTreeLeaf(
@@ -583,7 +588,8 @@ class RhythmTreeContainer(RhythmTreeMixin, uqbar.containers.UniqueTreeList):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \times 4/5 {
@@ -801,7 +807,8 @@ class RhythmTreeParser(Parser):
         >>> rhythm_tree_container.rtm_format
         '(3 (1 (1 ((2 (1 1 1)) 2 2 1))))'
 
-        >>> abjad.f(rhythm_tree_container)
+        >>> string = abjad.storage(rhythm_tree_container)
+        >>> print(string)
         abjad.rhythmtrees.RhythmTreeContainer(
             children=(
                 abjad.rhythmtrees.RhythmTreeLeaf(
@@ -852,7 +859,8 @@ class RhythmTreeParser(Parser):
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 3/4 {
                 c'2
@@ -1000,7 +1008,8 @@ def parse_rtm_syntax(rtm):
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \times 2/3 {
                 c'8
                 c'16
@@ -1018,7 +1027,8 @@ def parse_rtm_syntax(rtm):
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \times 9/17 {
                 c'8

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -756,7 +756,8 @@ class Container(Component):
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'4
                 e'4
@@ -781,7 +782,8 @@ class Container(Component):
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'4
                 e'4
@@ -807,7 +809,8 @@ class Container(Component):
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'4
                 e'4
@@ -832,7 +835,8 @@ class Container(Component):
 
         ..  docs::
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'4
                 e'4
@@ -869,7 +873,8 @@ class Container(Component):
         >>> abjad.attach(abjad.StemTremolo(), staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> abjad.f(staff)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'4
@@ -961,7 +966,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     \times 4/6 {
@@ -990,7 +996,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     \times 2/3 {
@@ -1014,7 +1021,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(tuplet_1)
+                >>> string = abjad.lilypond(tuplet_1)
+                >>> print(string)
                 \times 4/6 {
                     c'4
                     d'4
@@ -1440,7 +1448,8 @@ class Container(Component):
             ...     )
             >>> abjad.show(container) # doctest: +SKIP
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {   %*% AB
                 c'4
                 d'4
@@ -1470,7 +1479,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     c'4
                     d'4
@@ -1496,7 +1506,8 @@ class Container(Component):
 
             Container name does not appear in LilyPond output:
 
-            >>> abjad.f(container)
+            >>> string = abjad.lilypond(container)
+            >>> print(string)
             {
                 c'4
                 d'4
@@ -1542,7 +1553,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     \new Voice
                     {
@@ -1570,7 +1582,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     \new Voice
                     {
@@ -1589,7 +1602,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 <<
                     \new Voice
                     {
@@ -1633,7 +1647,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     c'4
                     (
@@ -1647,7 +1662,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     c'4
                     (
@@ -1677,7 +1693,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     c'4
                     (
@@ -1692,7 +1709,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     c'4
                     (
@@ -1732,7 +1750,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     c'4
                     d'4
@@ -1772,7 +1791,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     fs16
                     _ (
@@ -1795,7 +1815,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     fs16
                     _ (
@@ -1836,7 +1857,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     c'4
                     (
@@ -1852,7 +1874,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     c'4
                     (
@@ -1880,7 +1903,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     c'4
                     d'4
@@ -1897,7 +1921,8 @@ class Container(Component):
 
             ..  docs::
 
-                >>> abjad.f(container)
+                >>> string = abjad.lilypond(container)
+                >>> print(string)
                 {
                     c'4
                     d'4
@@ -1928,7 +1953,8 @@ class AfterGraceContainer(Container):
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 #(define afterGraceFraction (cons 15 16))
@@ -1978,7 +2004,8 @@ class AfterGraceContainer(Container):
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 #(define afterGraceFraction (cons 15 16))
@@ -2012,7 +2039,8 @@ class AfterGraceContainer(Container):
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 #(define afterGraceFraction (cons 15 16))
@@ -2092,7 +2120,8 @@ class BeforeGraceContainer(Container):
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'4
@@ -2121,7 +2150,8 @@ class BeforeGraceContainer(Container):
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'4
@@ -2145,7 +2175,8 @@ class BeforeGraceContainer(Container):
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'4
@@ -2168,7 +2199,8 @@ class BeforeGraceContainer(Container):
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'4
@@ -2188,7 +2220,8 @@ class BeforeGraceContainer(Container):
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'4
@@ -2208,7 +2241,8 @@ class BeforeGraceContainer(Container):
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'4
@@ -2320,7 +2354,8 @@ class BeforeGraceContainer(Container):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     c'4
@@ -2342,7 +2377,8 @@ class BeforeGraceContainer(Container):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     c'4
@@ -2369,7 +2405,8 @@ class BeforeGraceContainer(Container):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     c'4
@@ -2395,7 +2432,8 @@ class BeforeGraceContainer(Container):
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     {
                         c'4
@@ -2424,7 +2462,8 @@ class BeforeGraceContainer(Container):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     c'4
@@ -2447,7 +2486,8 @@ class BeforeGraceContainer(Container):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     c'4
@@ -2474,7 +2514,8 @@ class BeforeGraceContainer(Container):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     c'4
@@ -2500,7 +2541,8 @@ class BeforeGraceContainer(Container):
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     {
                         c'4
@@ -2533,7 +2575,8 @@ class BeforeGraceContainer(Container):
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     {
                         c'4
@@ -2563,7 +2606,8 @@ class BeforeGraceContainer(Container):
 
                 ..  docs::
 
-                    >>> abjad.f(voice)
+                    >>> string = abjad.lilypond(voice)
+                    >>> print(string)
                     \new Voice
                     {
                         c'4
@@ -2592,7 +2636,8 @@ class Chord(Leaf):
 
         ..  docs::
 
-            >>> abjad.f(chord)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             <e' cs'' f''>4
 
     ..  container:: example
@@ -2604,7 +2649,8 @@ class Chord(Leaf):
 
         ..  docs::
 
-            >>> abjad.f(chord)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             <e' cs'' f''>4 * 1/2
 
         >>> new_chord = abjad.Chord(chord)
@@ -2612,7 +2658,8 @@ class Chord(Leaf):
 
         ..  docs::
 
-            >>> abjad.f(new_chord)
+            >>> string = abjad.lilypond(new_chord)
+            >>> print(string)
             <e' cs'' f''>4 * 1/2
 
     """
@@ -2792,7 +2839,8 @@ class Chord(Leaf):
             >>> chord = abjad.Chord("<g' c'' e''>4")
             >>> abjad.show(chord) # doctest: +SKIP
 
-            >>> abjad.f(chord.note_heads)
+            >>> string = abjad.storage(chord.note_heads)
+            >>> print(string)
             abjad.NoteHeadList(
                 [
                     abjad.NoteHead(
@@ -2819,7 +2867,8 @@ class Chord(Leaf):
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <c' d' fs'>4
 
         ..  container:: example
@@ -2834,7 +2883,8 @@ class Chord(Leaf):
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <e'' f'' g''>4
 
         Set note-heads with any iterable.
@@ -2909,7 +2959,8 @@ class Chord(Leaf):
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <f' b' d''>4
 
             >>> chord.written_pitches
@@ -2938,7 +2989,8 @@ class Cluster(Container):
 
         ..  docs::
 
-            >>> abjad.f(cluster)
+            >>> string = abjad.lilypond(cluster)
+            >>> print(string)
             \makeClusters {
                 c'8
                 <d' g'>8
@@ -2990,7 +3042,8 @@ class Context(Container):
 
         ..  docs::
 
-            >>> abjad.f(context)
+            >>> string = abjad.lilypond(context)
+            >>> print(string)
             \context GlobalContext = "Meter_Voice"
             {
             }
@@ -3228,7 +3281,8 @@ class Context(Container):
 
             >>> staff = abjad.Staff([])
             >>> staff.consists_commands.append('Horizontal_bracket_engraver')
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -3292,7 +3346,8 @@ class Context(Container):
 
             >>> staff = abjad.Staff([])
             >>> staff.remove_commands.append('Time_signature_engraver')
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -3318,7 +3373,8 @@ class Context(Container):
             ...     )
             >>> abjad.show(context) # doctest: +SKIP
 
-            >>> abjad.f(context, align_tags=20)
+            >>> string = abjad.lilypond(context)
+            >>> print(string)
             \new CustomContext  %! RED
             {                   %! RED
                 c'4
@@ -3347,7 +3403,8 @@ class MultimeasureRest(Leaf):
         >>> rest = abjad.MultimeasureRest(
         ...     'R1', tag=abjad.Tag('GLOBAL_MULTIMEASURE_REST')
         ... )
-        >>> abjad.f(rest)
+        >>> string = abjad.lilypond(rest)
+        >>> print(string)
         R1 %! GLOBAL_MULTIMEASURE_REST
 
     ..  container:: example
@@ -3359,7 +3416,8 @@ class MultimeasureRest(Leaf):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 3/8
@@ -3415,7 +3473,8 @@ class MultimeasureRest(Leaf):
             ... )
             >>> rest.multiplier = (3, 8)
 
-            >>> abjad.f(rest)
+            >>> string = abjad.lilypond(rest)
+            >>> print(string)
             R1 * 3/8 %! MULTIMEASURE_REST
 
         """
@@ -3644,7 +3703,8 @@ class NoteHead:
             >>> note.note_head.alternative = (alternative, '-PARTS', '+PARTS')
             >>> abjad.show(note) # doctest: +SKIP
 
-            >>> abjad.f(note, align_tags=50)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             c''4                                              %! +PARTS
             %@% c''!4                                         %! -PARTS
 
@@ -3653,7 +3713,8 @@ class NoteHead:
             >>> note.written_pitch = 'D5'
             >>> abjad.show(note) # doctest: +SKIP
 
-            >>> abjad.f(note, align_tags=50)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             d''4                                              %! +PARTS
             %@% d''!4                                         %! -PARTS
 
@@ -3662,7 +3723,8 @@ class NoteHead:
             >>> note.note_head.alternative = None
             >>> abjad.show(note) # doctest: +SKIP
 
-            >>> abjad.f(note, align_tags=50)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             d''4
 
         ..  container:: example
@@ -3673,7 +3735,8 @@ class NoteHead:
             >>> chord.note_heads[0].alternative = (alternative, '-PARTS', '+PARTS')
             >>> abjad.show(chord) # doctest: +SKIP
 
-            >>> abjad.f(chord, align_tags=50)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             <
                 c'                                            %! +PARTS
             %@% c'!                                           %! -PARTS
@@ -3686,7 +3749,8 @@ class NoteHead:
             >>> chord.note_heads[0].written_pitch = 'B3'
             >>> abjad.show(chord) # doctest: +SKIP
 
-            >>> abjad.f(chord, align_tags=50)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             <
                 b                                             %! +PARTS
             %@% b!                                            %! -PARTS
@@ -3697,7 +3761,8 @@ class NoteHead:
             Clear with none:
 
             >>> chord.note_heads[0].alternative = None
-            >>> abjad.f(chord, align_tags=50)
+            >>> string = abjad.lilypond(chord)
+            >>> print(string)
             <b d' bf''>4
 
         """
@@ -3742,7 +3807,8 @@ class NoteHead:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c''?4
 
             >>> note = abjad.Note("cs''")
@@ -3751,7 +3817,8 @@ class NoteHead:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 cs''?4
 
         """
@@ -3776,7 +3843,8 @@ class NoteHead:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 c''!4
 
             >>> note = abjad.Note("cs''")
@@ -3785,7 +3853,8 @@ class NoteHead:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 cs''!4
 
         """
@@ -3810,7 +3879,8 @@ class NoteHead:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 \parenthesize
                 c''4
 
@@ -3820,7 +3890,8 @@ class NoteHead:
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 \parenthesize
                 cs''4
 
@@ -3862,7 +3933,8 @@ class NoteHead:
             >>> note_head.tweaks
             TweakInterface(('_literal', None), ('color', 'red'))
 
-            >>> abjad.f(note_head)
+            >>> string = abjad.lilypond(note_head)
+            >>> print(string)
             \tweak color #red
             cs''
 
@@ -3882,7 +3954,8 @@ class NoteHead:
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <
                     \tweak color #red
                     \tweak thickness #2
@@ -3967,7 +4040,8 @@ class NoteHeadList(TypedList):
         ...     items=[11, 10, 9],
         ...     )
 
-        >>> abjad.f(note_heads)
+        >>> string = abjad.storage(note_heads)
+        >>> print(string)
         abjad.NoteHeadList(
             [
                 abjad.NoteHead(
@@ -4041,7 +4115,8 @@ class NoteHeadList(TypedList):
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <ef'>4
 
             >>> note_heads = []
@@ -4056,7 +4131,8 @@ class NoteHeadList(TypedList):
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <
                     ef'
                     \tweak color #blue
@@ -4086,7 +4162,8 @@ class NoteHeadList(TypedList):
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <
                     \tweak color #red
                     e'
@@ -4107,7 +4184,8 @@ class NoteHeadList(TypedList):
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <
                     \tweak color #red
                     e'
@@ -4148,7 +4226,8 @@ class NoteHeadList(TypedList):
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <ef' c'' f''>4
 
             >>> chord.note_heads.pop(1)
@@ -4158,7 +4237,8 @@ class NoteHeadList(TypedList):
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <ef' f''>4
 
         Returns note-head.
@@ -4176,7 +4256,8 @@ class NoteHeadList(TypedList):
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <ef' c'' f''>4
 
             >>> note_head = chord.note_heads[1]
@@ -4185,7 +4266,8 @@ class NoteHeadList(TypedList):
 
             ..  docs::
 
-                >>> abjad.f(chord)
+                >>> string = abjad.lilypond(chord)
+                >>> print(string)
                 <ef' f''>4
 
         """
@@ -4256,7 +4338,8 @@ class Note(Leaf):
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             cs''8.
 
     ..  container:: example
@@ -4268,7 +4351,8 @@ class Note(Leaf):
 
         ..  docs::
 
-            >>> abjad.f(note)
+            >>> string = abjad.lilypond(note)
+            >>> print(string)
             cs''4 * 1
 
         >>> new_note = abjad.Note(note)
@@ -4276,7 +4360,8 @@ class Note(Leaf):
 
         ..  docs::
 
-            >>> abjad.f(new_note)
+            >>> string = abjad.lilypond(new_note)
+            >>> print(string)
             cs''4 * 1
 
     ..  container:: example
@@ -4400,7 +4485,8 @@ class Note(Leaf):
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 cs''8.
 
             >>> note.note_head = 'D5'
@@ -4411,7 +4497,8 @@ class Note(Leaf):
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 d''8.
 
         """
@@ -4442,7 +4529,8 @@ class Note(Leaf):
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 cs''8.
 
             >>> note.written_duration = (1, 16)
@@ -4453,7 +4541,8 @@ class Note(Leaf):
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 cs''16
 
         """
@@ -4478,7 +4567,8 @@ class Note(Leaf):
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 cs''8.
 
             >>> note.written_pitch = 'D5'
@@ -4489,7 +4579,8 @@ class Note(Leaf):
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 d''8.
 
         """
@@ -4524,7 +4615,8 @@ class Note(Leaf):
 
             ..  docs::
 
-                >>> abjad.f(note)
+                >>> string = abjad.lilypond(note)
+                >>> print(string)
                 cs''8.
 
         """
@@ -4545,7 +4637,8 @@ class Rest(Leaf):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \time 3/16
@@ -4610,7 +4703,8 @@ class Score(Context):
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -4676,7 +4770,8 @@ class Score(Context):
             >>> score = abjad.Score([staff], tag=abjad.Tag('GREEN'))
             >>> abjad.show(score) # doctest: +SKIP
 
-            >>> abjad.f(score, align_tags=20)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score          %! GREEN
             <<                  %! GREEN
                 \new Staff      %! BLUE
@@ -4707,7 +4802,8 @@ class Skip(Leaf):
 
         ..  docs::
 
-            >>> abjad.f(skip)
+            >>> string = abjad.lilypond(skip)
+            >>> print(string)
             s8.
 
     ..  container:: example
@@ -4715,7 +4811,8 @@ class Skip(Leaf):
         Skips can be tagged:
 
         >>> skip = abjad.Skip('s8.', tag=abjad.Tag('GLOBAL_SKIP'))
-        >>> abjad.f(skip)
+        >>> string = abjad.lilypond(skip)
+        >>> print(string)
         s8. %! GLOBAL_SKIP
 
     """
@@ -4778,7 +4875,8 @@ class Staff(Context):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -4800,7 +4898,8 @@ class Staff(Context):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 {
@@ -4883,7 +4982,8 @@ class StaffGroup(Context):
 
         ..  docs::
 
-            >>> abjad.f(staff_group)
+            >>> string = abjad.lilypond(staff_group)
+            >>> print(string)
             \new StaffGroup
             <<
                 \new Staff
@@ -4951,7 +5051,8 @@ class TremoloContainer(Container):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \repeat tremolo 2 {
@@ -5072,7 +5173,8 @@ class Tuplet(Container):
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \times 4/6 {
                 c'8
                 d'8
@@ -5089,7 +5191,8 @@ class Tuplet(Container):
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak edge-height #'(0.7 . 0)
             \times 4/6 {
                 c'8
@@ -5115,7 +5218,8 @@ class Tuplet(Container):
 
         ..  docs::
 
-            >>> abjad.f(tuplet)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \tweak edge-height #'(0.7 . 0)
             \times 4/6 {
                 c'8
@@ -5406,7 +5510,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'4
                     d'4
@@ -5436,7 +5541,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'8
                     d'8
@@ -5452,7 +5558,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'8
                     d'8
@@ -5464,7 +5571,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 4/6 {
                     c'8
                     d'8
@@ -5505,7 +5613,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \times 2/3 {
@@ -5539,7 +5648,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5572,7 +5682,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5611,7 +5722,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \override TupletNumber.text = \markup {
@@ -5681,7 +5793,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'8
                     d'8
@@ -5700,7 +5813,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \times 2/3 {
@@ -5720,7 +5834,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \scaleDurations #'(2 . 3) {
@@ -5801,7 +5916,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 4/3 {
                     c'8
@@ -5837,7 +5953,8 @@ class Tuplet(Container):
             ... )
             >>> abjad.show(tuplet) # doctest: +SKIP
 
-            >>> abjad.f(tuplet, align_tags=20)
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
             \times 2/3 {        %! RED
                 c'4
                 d'4
@@ -5875,7 +5992,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \set tupletFullLength = ##t
@@ -5929,7 +6047,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'4
                     (
@@ -5943,7 +6062,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak edge-height #'(0.7 . 0)
                 \times 2/3 {
                     c'4
@@ -5963,7 +6083,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'4
                     (
@@ -5977,7 +6098,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 1/2 {
                     c'4
                     (
@@ -6092,7 +6214,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'4
                     (
@@ -6107,7 +6230,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak edge-height #'(0.7 . 0)
                 \times 2/3 {
                     c'4
@@ -6129,7 +6253,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'4
                     (
@@ -6144,7 +6269,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 4/7 {
                     c'4
                     (
@@ -6182,7 +6308,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'8
                     d'8
@@ -6210,7 +6337,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 1/3 {
                     c'4
                     d'4
@@ -6225,7 +6353,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'8
                     d'8
@@ -6242,7 +6371,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 8/3 {
                     c'32
@@ -6258,7 +6388,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 4/3 {
                     c'16
@@ -6276,7 +6407,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 5/12 {
                     c'4
@@ -6292,7 +6424,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 10/12 {
                     c'8
@@ -6329,7 +6462,8 @@ class Tuplet(Container):
 
             ..  container:: example
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/2 {
                     r4
@@ -6356,7 +6490,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'8.
@@ -6368,7 +6503,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/2 {
                     c'8
@@ -6384,7 +6520,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'8..
@@ -6396,7 +6533,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 7/4 {
                     c'8
@@ -6412,7 +6550,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'8.
@@ -6425,7 +6564,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'8.
@@ -6442,7 +6582,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/2 {
                     c'8
@@ -6455,7 +6596,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/2 {
                     c'8
@@ -6496,7 +6638,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/5 {
                     c'4
@@ -6511,7 +6654,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 6/10 {
                     c'4
@@ -6545,7 +6689,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 4/3 {
                     c'8
@@ -6558,7 +6703,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'4
                     d'4
@@ -6577,7 +6723,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \times 2/3 {
                     c'4
                     d'4
@@ -6589,7 +6736,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 4/3 {
                     c'8
@@ -6609,7 +6757,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'4
@@ -6622,7 +6771,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'4
@@ -6657,7 +6807,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'8
@@ -6679,7 +6830,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'8 * 3/2
@@ -6716,7 +6868,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/4 {
                     \time 3/8
@@ -6735,7 +6888,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \time 3/8
@@ -6754,7 +6908,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \tweak text #tuplet-number::calc-fraction-text
@@ -6784,7 +6939,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \tweak text #tuplet-number::calc-fraction-text
@@ -6819,7 +6975,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 3/4 {
                     c'2
@@ -6833,7 +6990,8 @@ class Tuplet(Container):
 
             ..  docs::
 
-                >>> abjad.f(tuplet)
+                >>> string = abjad.lilypond(tuplet)
+                >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
                 \times 1/1 {
                     c'4.
@@ -6863,7 +7021,8 @@ class Voice(Context):
 
         ..  docs::
 
-            >>> abjad.f(voice)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice
             {
                 c'8
@@ -6899,7 +7058,8 @@ class Voice(Context):
 
         ..  docs::
 
-            >>> abjad.f(outer_red_voice)
+            >>> string = abjad.lilypond(outer_red_voice)
+            >>> print(string)
             \context Voice = "Red_Voice"
             \with
             {
@@ -6971,7 +7131,8 @@ class Voice(Context):
 
         ..  docs::
 
-            >>> abjad.f(outer_red_voice)
+            >>> string = abjad.lilypond(outer_red_voice)
+            >>> print(string)
             \context Voice = "Red_Voice"
             \with
             {
@@ -7043,7 +7204,8 @@ class Voice(Context):
 
         ..  docs::
 
-            >>> abjad.f(outer_red_voice)
+            >>> string = abjad.lilypond(outer_red_voice)
+            >>> print(string)
             \context Voice = "Red_Voice"
             \with
             {
@@ -7117,7 +7279,8 @@ class Voice(Context):
 
         ..  docs::
 
-            >>> abjad.f(outer_red_voice)
+            >>> string = abjad.lilypond(outer_red_voice)
+            >>> print(string)
             \context Voice = "Red_Voice"
             \with
             {
@@ -7217,7 +7380,8 @@ class Voice(Context):
             >>> voice = abjad.Voice("c'4 d' e' f'", tag=abjad.Tag('RED'))
             >>> abjad.show(voice) # doctest: +SKIP
 
-            >>> abjad.f(voice, align_tags=20)
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
             \new Voice          %! RED
             {                   %! RED
                 c'4

--- a/abjad/select.py
+++ b/abjad/select.py
@@ -119,7 +119,8 @@ class DurationInequality(Inequality):
     ..  container:: example
 
         >>> inequality = abjad.DurationInequality('<', (3, 4))
-        >>> abjad.f(inequality)
+        >>> string = abjad.storage(inequality)
+        >>> print(string)
         abjad.DurationInequality(
             operator_string='<',
             duration=abjad.Duration(3, 4),
@@ -207,7 +208,8 @@ class LengthInequality(Inequality):
     ..  container:: example
 
         >>> inequality = abjad.LengthInequality('<', 4)
-        >>> abjad.f(inequality)
+        >>> string = abjad.storage(inequality)
+        >>> print(string)
         abjad.LengthInequality(
             operator_string='<',
             length=4,
@@ -271,7 +273,8 @@ class PitchInequality:
     ..  container:: example
 
         >>> inequality = abjad.PitchInequality('&', 'C4 E4')
-        >>> abjad.f(inequality)
+        >>> string = abjad.storage(inequality)
+        >>> print(string)
         abjad.PitchInequality(
             operator_string='&',
             pitches=abjad.PitchSet(
@@ -437,7 +440,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -935,7 +939,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     c'4
@@ -967,7 +972,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     \afterGrace
@@ -1059,7 +1065,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     c'4
@@ -1091,7 +1098,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(voice)
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
                 \new Voice
                 {
                     \afterGrace
@@ -1230,7 +1238,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -1347,7 +1356,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -1460,7 +1470,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -1500,7 +1511,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -1562,7 +1574,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -1608,7 +1621,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -1662,7 +1676,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -1704,7 +1719,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -1758,7 +1774,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -1834,7 +1851,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -1891,7 +1909,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -1953,7 +1972,8 @@ class Selection(collections.abc.Sequence):
 
         ..  docs::
 
-            >>> abjad.f(staff, align_tags=89)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -2023,7 +2043,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2091,7 +2112,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2144,7 +2166,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2208,7 +2231,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2262,7 +2286,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2330,7 +2355,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2390,7 +2416,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2447,7 +2474,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2511,7 +2539,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2564,7 +2593,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2639,7 +2669,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -2745,7 +2776,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -2847,7 +2879,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2904,7 +2937,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -2967,7 +3001,8 @@ class Selection(collections.abc.Sequence):
 
         ..  docs::
 
-            >>> abjad.f(staff, align_tags=89)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -3038,7 +3073,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3114,7 +3150,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3210,7 +3247,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3278,7 +3316,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3343,7 +3382,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3410,7 +3450,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3489,7 +3530,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3592,7 +3634,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3675,7 +3718,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3764,7 +3808,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3833,7 +3878,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3903,7 +3949,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -3970,7 +4017,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -4031,7 +4079,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -4095,7 +4144,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -4190,7 +4240,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -4288,7 +4339,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -4417,7 +4469,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -4493,7 +4546,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -4573,7 +4627,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -4658,7 +4713,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -4744,7 +4800,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -4822,7 +4879,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -4892,7 +4950,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -4962,7 +5021,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5035,7 +5095,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5103,7 +5164,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5179,7 +5241,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5226,7 +5289,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -5282,7 +5346,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5328,7 +5393,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -5376,7 +5442,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5418,7 +5485,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -5466,7 +5534,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5591,7 +5660,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5656,7 +5726,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5720,7 +5791,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5786,7 +5858,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5867,7 +5940,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -5920,7 +5994,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -5976,7 +6051,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -6022,7 +6098,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -6070,7 +6147,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -6112,7 +6190,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     \with
                     {
@@ -6160,7 +6239,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -6223,7 +6303,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -6286,7 +6367,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -6368,7 +6450,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -6440,7 +6523,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -6510,7 +6594,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -6579,7 +6664,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -6651,7 +6737,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -6762,7 +6849,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -6875,7 +6963,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -6936,7 +7025,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7002,7 +7092,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7070,7 +7161,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7145,7 +7237,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7218,7 +7311,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7287,7 +7381,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7351,7 +7446,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7488,7 +7584,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7579,7 +7676,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7673,7 +7771,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7776,7 +7875,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7866,7 +7966,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -7955,7 +8056,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -8051,7 +8153,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -8146,7 +8249,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -8248,7 +8352,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -8342,7 +8447,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -8510,7 +8616,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -8576,7 +8683,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -8660,7 +8768,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -8765,7 +8874,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -8866,7 +8976,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -8975,7 +9086,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -9058,7 +9170,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -9135,7 +9248,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -9253,7 +9367,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -9340,7 +9455,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(lilypond_file[abjad.Score], align_tags=89)
+                >>> string = abjad.lilypond(lilypond_file[abjad.Score])
+                >>> print(string)
                 \new Score
                 <<
                     \new GlobalContext
@@ -9418,7 +9534,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         \times 2/3 {
@@ -9460,7 +9577,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \times 2/3 {
@@ -9501,7 +9619,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         \times 2/3 {
@@ -9541,7 +9660,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \times 2/3 {
@@ -9582,7 +9702,8 @@ class Selection(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(staff)
+                    >>> string = abjad.lilypond(staff)
+                    >>> print(string)
                     \new Staff
                     {
                         \times 2/3 {
@@ -9622,7 +9743,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \times 2/3 {
@@ -9716,7 +9838,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -9780,7 +9903,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -9853,7 +9977,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -9909,7 +10034,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -9990,7 +10116,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -10102,7 +10229,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -10166,7 +10294,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 \with
                 {
@@ -10210,7 +10339,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -10292,7 +10422,8 @@ class Selection(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(staff, align_tags=89)
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
                 \new Staff
                 {
                     \context Voice = "Music_Voice"
@@ -10475,7 +10606,8 @@ def select(items=None, previous=None):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \once \override NoteHead.color = #red

--- a/abjad/sequence.py
+++ b/abjad/sequence.py
@@ -132,7 +132,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \line
                             {
@@ -168,7 +169,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \line
                             {
@@ -206,7 +208,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \line
                             {
@@ -246,7 +249,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -327,7 +331,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -365,7 +370,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -404,7 +410,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -457,7 +464,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -547,7 +555,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \line
                             {
@@ -583,7 +592,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \line
                             {
@@ -619,7 +629,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \line
                             {
@@ -1029,7 +1040,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -1068,7 +1080,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -1107,7 +1120,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -1146,7 +1160,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -1441,7 +1456,8 @@ class Sequence(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(markup)
+                >>> string = abjad.lilypond(markup)
+                >>> print(string)
                 \markup {
                     \concat
                         {
@@ -1511,7 +1527,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \line
                             {
@@ -1811,7 +1828,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -1862,7 +1880,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -1919,7 +1938,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -1974,7 +1994,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2025,7 +2046,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2078,7 +2100,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2137,7 +2160,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2194,7 +2218,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2245,7 +2270,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2298,7 +2324,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2357,7 +2384,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2414,7 +2442,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2467,7 +2496,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2522,7 +2552,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2583,7 +2614,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2642,7 +2674,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2696,7 +2729,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2755,7 +2789,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2806,7 +2841,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2866,7 +2902,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2928,7 +2965,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -2986,7 +3024,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -3027,7 +3066,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -3129,7 +3169,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -3175,7 +3216,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -3635,7 +3677,8 @@ class Sequence(collections.abc.Sequence):
 
             ..  docs::
 
-                >>> abjad.f(markup)
+                >>> string = abjad.lilypond(markup)
+                >>> print(string)
                 \markup {
                     \concat
                         {
@@ -3792,7 +3835,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -3826,7 +3870,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -3860,7 +3905,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -4264,7 +4310,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -4312,7 +4359,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -4370,7 +4418,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -4409,7 +4458,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -4448,7 +4498,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -4543,7 +4594,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -4645,7 +4697,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -4727,7 +4780,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {
@@ -4765,7 +4819,8 @@ class Sequence(collections.abc.Sequence):
 
                 ..  docs::
 
-                    >>> abjad.f(markup)
+                    >>> string = abjad.lilypond(markup)
+                    >>> print(string)
                     \markup {
                         \concat
                             {

--- a/abjad/spanners.py
+++ b/abjad/spanners.py
@@ -86,7 +86,8 @@ def beam(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -325,7 +326,8 @@ def bow_contact_spanner(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -444,7 +446,8 @@ def bow_contact_spanner(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -555,7 +558,8 @@ def bow_contact_spanner(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -751,7 +755,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -775,7 +780,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -800,7 +806,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 a8
@@ -831,7 +838,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 a8
@@ -865,7 +873,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 a8
@@ -904,7 +913,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 a8
@@ -941,7 +951,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 a8
@@ -976,7 +987,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -1009,7 +1021,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -1047,7 +1060,8 @@ def glissando(
 
         LilyPond output looks like this:
 
-        >>> abjad.f(staff, align_tags=50)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'8
@@ -1075,7 +1089,8 @@ def glissando(
 
         LilyPond output looks like this:
 
-        >>> abjad.f(staff, align_tags=50)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'8
@@ -1109,7 +1124,8 @@ def glissando(
 
         LilyPond output looks like this:
 
-        >>> abjad.f(staff, align_tags=50)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             c'8
@@ -1146,7 +1162,8 @@ def glissando(
 
         LilyPond output looks like this:
 
-        >>> abjad.f(staff, align_tags=50)
+        >>> string = abjad.lilypond(staff)
+        >>> print(string)
         \new Staff
         {
             \hide NoteHead                                %! abjad.glissando(2):HIDE_TO_JOIN_BROKEN_SPANNERS:LEFT_BROKEN
@@ -1180,7 +1197,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8
@@ -1213,7 +1231,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 d'8
@@ -1251,7 +1270,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'8.
@@ -1290,7 +1310,8 @@ def glissando(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 d'4
@@ -1536,7 +1557,8 @@ def hairpin(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \once \override DynamicLineSpanner.staff-padding = #4
@@ -1560,7 +1582,8 @@ def hairpin(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \once \override DynamicLineSpanner.staff-padding = #4
@@ -1587,7 +1610,8 @@ def hairpin(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \once \override DynamicLineSpanner.staff-padding = #4
@@ -1689,7 +1713,8 @@ def horizontal_bracket(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1731,7 +1756,8 @@ def ottava(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \ottava 1
@@ -1773,7 +1799,8 @@ def phrasing_slur(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1820,7 +1847,8 @@ def piano_pedal(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -1867,7 +1895,8 @@ def slur(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -1918,7 +1947,8 @@ def text_spanner(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 \once \override TextSpanner.staff-padding = #4
@@ -1958,7 +1988,8 @@ def text_spanner(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -2002,7 +2033,8 @@ def text_spanner(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             \with
             {
@@ -2057,7 +2089,8 @@ def tie(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2079,7 +2112,8 @@ def tie(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2101,7 +2135,8 @@ def tie(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2124,7 +2159,8 @@ def tie(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 <c'>4
@@ -2144,7 +2180,8 @@ def tie(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4
@@ -2166,7 +2203,8 @@ def tie(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 d'4.
@@ -2187,7 +2225,8 @@ def tie(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 d'2
@@ -2206,7 +2245,8 @@ def tie(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 d'2
@@ -2273,7 +2313,8 @@ def trill_spanner(
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 c'4

--- a/abjad/templates.py
+++ b/abjad/templates.py
@@ -184,7 +184,8 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
 
         ..  docs::
 
-            >>> abjad.f(template_1.__illustrate__()[abjad.Score], align_tags=60)
+            >>> string = abjad.lilypond(template_1.__illustrate__()[abjad.Score])
+            >>> print(string)
             \context Score = "Grouped_Rhythmic_Staves_Score"            %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
             <<                                                          %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
                 \context StaffGroup = "Grouped_Rhythmic_Staves_Staff_Group" %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
@@ -227,7 +228,8 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
         >>> score = template_1()
         >>> abjad.show(score) # doctest: +SKIP
 
-        >>> abjad.f(score, align_tags=60)
+        >>> string = abjad.lilypond(score)
+        >>> print(string)
         \context Score = "Grouped_Rhythmic_Staves_Score"            %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
         <<                                                          %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
             \context StaffGroup = "Grouped_Rhythmic_Staves_Staff_Group" %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
@@ -268,7 +270,8 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
 
         ..  docs::
 
-            >>> abjad.f(template_2.__illustrate__()[abjad.Score], align_tags=60)
+            >>> string = abjad.lilypond(template_2.__illustrate__()[abjad.Score])
+            >>> print(string)
             \context Score = "Grouped_Rhythmic_Staves_Score"            %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
             <<                                                          %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
                 \context StaffGroup = "Grouped_Rhythmic_Staves_Staff_Group" %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
@@ -308,7 +311,8 @@ class GroupedRhythmicStavesScoreTemplate(ScoreTemplate):
         >>> score = template_2()
         >>> abjad.show(score) # doctest: +SKIP
 
-        >>> abjad.f(score, align_tags=60)
+        >>> string = abjad.lilypond(score)
+        >>> print(string)
         \context Score = "Grouped_Rhythmic_Staves_Score"            %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
         <<                                                          %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
             \context StaffGroup = "Grouped_Rhythmic_Staves_Staff_Group" %! abjad.GroupedRhythmicStavesScoreTemplate.__call__()
@@ -454,7 +458,8 @@ class GroupedStavesScoreTemplate(ScoreTemplate):
 
         ..  docs::
 
-            >>> abjad.f(template.__illustrate__()[abjad.Score], align_tags=60)
+            >>> string = abjad.lilypond(template.__illustrate__()[abjad.Score])
+            >>> print(string)
             \context Score = "Grouped_Staves_Score"                     %! abjad.GroupedStavesScoreTemplate.__call__()
             <<                                                          %! abjad.GroupedStavesScoreTemplate.__call__()
                 \context StaffGroup = "Grouped_Staves_Staff_Group"      %! abjad.GroupedStavesScoreTemplate.__call__()
@@ -491,7 +496,8 @@ class GroupedStavesScoreTemplate(ScoreTemplate):
             >>                                                          %! abjad.GroupedStavesScoreTemplate.__call__()
 
         >>> score = template()
-        >>> abjad.f(score, align_tags=60)
+        >>> string = abjad.lilypond(score)
+        >>> print(string)
         \context Score = "Grouped_Staves_Score"                     %! abjad.GroupedStavesScoreTemplate.__call__()
         <<                                                          %! abjad.GroupedStavesScoreTemplate.__call__()
             \context StaffGroup = "Grouped_Staves_Staff_Group"      %! abjad.GroupedStavesScoreTemplate.__call__()
@@ -598,7 +604,8 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         >>> template = abjad.StringOrchestraScoreTemplate()
         >>> abjad.show(template) # doctest: +SKIP
 
-        >>> abjad.f(template.__illustrate__()[abjad.Score], align_tags=89)
+        >>> string = abjad.lilypond(template.__illustrate__()[abjad.Score])
+        >>> print(string)
         \context Score = "Score"                                                                 %! abjad.StringOrchestraScoreTemplate.__call__()
         <<                                                                                       %! abjad.StringOrchestraScoreTemplate.__call__()
             \tag #'(Violin_1 Violin_2 Violin_3 Violin_4 Violin_5 Violin_6 Viola_1 Viola_2 Viola_3 Viola_4 Cello_1 Cello_2 Cello_3 Contrabass_1 Contrabass_2) %! abjad.StringOrchestraScoreTemplate.__call__()
@@ -919,7 +926,8 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         ...     )
         >>> abjad.show(template) # doctest: +SKIP
 
-        >>> abjad.f(template.__illustrate__()[abjad.Score], align_tags=89)
+        >>> string = abjad.lilypond(template.__illustrate__()[abjad.Score])
+        >>> print(string)
         \context Score = "Score"                                                                 %! abjad.StringOrchestraScoreTemplate.__call__()
         <<                                                                                       %! abjad.StringOrchestraScoreTemplate.__call__()
             \tag #'(Violin_1 Violin_2 Viola Cello)                                               %! abjad.StringOrchestraScoreTemplate.__call__()
@@ -1028,7 +1036,8 @@ class StringOrchestraScoreTemplate(ScoreTemplate):
         ...     )
         >>> abjad.show(template) # doctest: +SKIP
 
-        >>> abjad.f(template.__illustrate__()[abjad.Score], align_tags=89)
+        >>> string = abjad.lilypond(template.__illustrate__()[abjad.Score])
+        >>> print(string)
         \context Score = "Score"                                                                 %! abjad.StringOrchestraScoreTemplate.__call__()
         <<                                                                                       %! abjad.StringOrchestraScoreTemplate.__call__()
             \tag #'(Cello)                                                                       %! abjad.StringOrchestraScoreTemplate.__call__()
@@ -1367,7 +1376,8 @@ class StringQuartetScoreTemplate(ScoreTemplate):
         >>> template = abjad.StringQuartetScoreTemplate()
         >>> abjad.show(template) # doctest: +SKIP
 
-        >>> abjad.f(template.__illustrate__()[abjad.Score], align_tags=60)
+        >>> string = abjad.lilypond(template.__illustrate__()[abjad.Score])
+        >>> print(string)
         \context Score = "String_Quartet_Score"                     %! abjad.StringQuartetScoreTemplate.__call__()
         <<                                                          %! abjad.StringQuartetScoreTemplate.__call__()
             \context StaffGroup = "String_Quartet_Staff_Group"      %! abjad.StringQuartetScoreTemplate.__call__()
@@ -1513,7 +1523,8 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
         >>> template = abjad.TwoStaffPianoScoreTemplate()
         >>> abjad.show(template) # doctest: +SKIP
 
-        >>> abjad.f(template.__illustrate__()[abjad.Score], align_tags=60)
+        >>> string = abjad.lilypond(template.__illustrate__()[abjad.Score])
+        >>> print(string)
         \context Score = "Two_Staff_Piano_Score"                    %! abjad.TwoStaffPianoScoreTemplate.__call__()
         <<                                                          %! abjad.TwoStaffPianoScoreTemplate.__call__()
             \context GlobalContext = "Global_Context"               %! abjad.ScoreTemplate._make_global_context()
@@ -1581,7 +1592,8 @@ class TwoStaffPianoScoreTemplate(ScoreTemplate):
 
             ..  docs::
 
-                >>> abjad.f(score, align_tags=60)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \context Score = "Two_Staff_Piano_Score"                    %! abjad.TwoStaffPianoScoreTemplate.__call__()
                 <<                                                          %! abjad.TwoStaffPianoScoreTemplate.__call__()
                     \context GlobalContext = "Global_Context"               %! abjad.ScoreTemplate._make_global_context()

--- a/abjad/timespan.py
+++ b/abjad/timespan.py
@@ -35,7 +35,8 @@ class OffsetCounter(TypedCounter):
         >>> timespans = timespans - timespan_operand
         >>> offset_counter = abjad.OffsetCounter(timespans)
 
-        >>> abjad.f(offset_counter)
+        >>> string = abjad.storage(offset_counter)
+        >>> print(string)
         abjad.OffsetCounter(
             {
                 abjad.Offset((-2, 1)): 1,
@@ -94,7 +95,8 @@ class OffsetCounter(TypedCounter):
             ..  docs::
 
                 >>> markup = offset_counter._make_markup()
-                >>> abjad.f(markup)
+                >>> string = abjad.lilypond(markup)
+                >>> print(string)
                 \markup { \overlay {
                 \postscript #"
                 0.2 setlinewidth
@@ -496,7 +498,8 @@ class Timespan:
             >>> timespan_4 = abjad.Timespan(10, 20)
 
             >>> new_timespan = timespan_1 | timespan_2
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -507,7 +510,8 @@ class Timespan:
                 )
 
             >>> new_timespan = timespan_1 | timespan_3
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -518,7 +522,8 @@ class Timespan:
                 )
 
             >>> new_timespan = timespan_1 | timespan_4
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -529,7 +534,8 @@ class Timespan:
                 )
 
             >>> new_timespan = timespan_2 | timespan_3
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -544,7 +550,8 @@ class Timespan:
                 )
 
             >>> new_timespan = timespan_2 | timespan_4
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -555,7 +562,8 @@ class Timespan:
                 )
 
             >>> new_timespan = timespan_3 | timespan_4
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -728,7 +736,8 @@ class Timespan:
             >>> timespan_4 = abjad.Timespan(10, 20)
 
             >>> new_timespan = timespan_1 ^ timespan_2
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -743,7 +752,8 @@ class Timespan:
                 )
 
             >>> new_timespan = timespan_1 ^ timespan_3
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -758,7 +768,8 @@ class Timespan:
                 )
 
             >>> new_timespan = timespan_1 ^ timespan_4
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -773,7 +784,8 @@ class Timespan:
                 )
 
             >>> new_timespan = timespan_2 ^ timespan_3
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -788,7 +800,8 @@ class Timespan:
                 )
 
             >>> new_timespan = timespan_2 ^ timespan_4
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -803,7 +816,8 @@ class Timespan:
                 )
 
             >>> new_timespan = timespan_3 ^ timespan_4
-            >>> abjad.f(new_timespan)
+            >>> string = abjad.storage(new_timespan)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -1809,7 +1823,8 @@ class Timespan:
             >>> timespan = abjad.Timespan(0, 10)
 
             >>> result = timespan.split_at_offsets((1, 3, 7))
-            >>> abjad.f(result)
+            >>> string = abjad.storage(result)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -1834,7 +1849,8 @@ class Timespan:
             Otherwise return a timespan list containing a copy of timespan:
 
             >>> result = timespan.split_at_offsets((-100,))
-            >>> abjad.f(result)
+            >>> string = abjad.storage(result)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -2812,7 +2828,8 @@ class AnnotatedTimespan(Timespan):
         ...    start_offset=(1, 4),
         ...    stop_offset=(7, 8),
         ...    )
-        >>> abjad.f(annotated_timespan)
+        >>> string = abjad.storage(annotated_timespan)
+        >>> print(string)
         abjad.AnnotatedTimespan(
             start_offset=abjad.Offset((1, 4)),
             stop_offset=abjad.Offset((7, 8)),
@@ -2825,7 +2842,8 @@ class AnnotatedTimespan(Timespan):
 
         >>> left, right = annotated_timespan.split_at_offset((1, 2))
         >>> left.annotation.append('foo')
-        >>> abjad.f(right)
+        >>> string = abjad.storage(right)
+        >>> print(string)
         abjad.AnnotatedTimespan(
             start_offset=abjad.Offset((1, 2)),
             stop_offset=abjad.Offset((7, 8)),
@@ -2899,7 +2917,8 @@ class TimespanList(TypedList):
         ...     ])
         >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-        >>> abjad.f(timespans)
+        >>> string = abjad.storage(timespans)
+        >>> print(string)
         abjad.TimespanList(
             [
                 abjad.Timespan(
@@ -2930,7 +2949,8 @@ class TimespanList(TypedList):
         ...     ])
         >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-        >>> abjad.f(timespans)
+        >>> string = abjad.storage(timespans)
+        >>> print(string)
         abjad.TimespanList(
             [
                 abjad.Timespan(
@@ -2973,7 +2993,8 @@ class TimespanList(TypedList):
         ...     abjad.Timespan((3, 4), 1),
         ...     ])
 
-        >>> abjad.f(timespans)
+        >>> string = abjad.storage(timespans)
+        >>> print(string)
         abjad.TimespanList(
             [
                 abjad.Timespan(
@@ -3021,7 +3042,8 @@ class TimespanList(TypedList):
             >>> _ = timespans & timespan
             >>> abjad.show(timespans, range_=(-2, 12), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -3078,7 +3100,8 @@ class TimespanList(TypedList):
 
                 >>> lilypond_file = abjad.illustrate(timespans)
                 >>> markup = lilypond_file.items[-1]
-                >>> abjad.f(markup)
+                >>> string = abjad.lilypond(markup)
+                >>> print(string)
                 \markup \column {
                 \overlay {
                 \translate #'(1.0 . 1)
@@ -3208,7 +3231,8 @@ class TimespanList(TypedList):
                 ...     sort_callable=human_sorted_keys,
                 ...     )
                 >>> markup = lilypond_file.items[-1]
-                >>> abjad.f(markup)
+                >>> string = abjad.lilypond(markup)
+                >>> print(string)
                 \markup
                 \left-column {
                 \fontsize #-1 \sans \line { "voice 1:" }
@@ -3389,7 +3413,8 @@ class TimespanList(TypedList):
 
             >>> abjad.show(~timespans, range_=(-2, 30), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(~timespans)
+            >>> string = abjad.storage(~timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -3441,7 +3466,8 @@ class TimespanList(TypedList):
 
             >>> timespan = abjad.Timespan(5, 10)
             >>> _ = timespans - timespan
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4042,7 +4068,8 @@ class TimespanList(TypedList):
             ...     )
             >>> abjad.show(result, range_=(0, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(result)
+            >>> string = abjad.storage(result)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4071,7 +4098,8 @@ class TimespanList(TypedList):
             ...     )
             >>> abjad.show(result, range_=(0, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(result)
+            >>> string = abjad.storage(result)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4101,7 +4129,8 @@ class TimespanList(TypedList):
             ...     )
             >>> abjad.show(result, range_=(0, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(result)
+            >>> string = abjad.storage(result)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4132,7 +4161,8 @@ class TimespanList(TypedList):
             ...     )
             >>> abjad.show(result, range_=(-2, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(result)
+            >>> string = abjad.storage(result)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4197,7 +4227,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.compute_logical_and()
             >>> abjad.show(timespans, range_=(0, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4220,7 +4251,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.compute_logical_and()
             >>> abjad.show(timespans, range_=(0, 12), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4244,7 +4276,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.compute_logical_and()
             >>> abjad.show(timespans, range_=(-2, 12), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4296,7 +4329,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.compute_logical_or()
             >>> abjad.show(timespans, range_=(0, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4319,7 +4353,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.compute_logical_or()
             >>> abjad.show(timespans, range_=(0, 12), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4343,7 +4378,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.compute_logical_or()
             >>> abjad.show(timespans, range_=(-2, 12), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4366,7 +4402,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.compute_logical_or()
             >>> abjad.show(timespans, range_=(-2, 20), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4420,7 +4457,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.compute_logical_xor()
             >>> abjad.show(timespans, range_=(0, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4445,7 +4483,8 @@ class TimespanList(TypedList):
 
             ..  docs::
 
-                >>> abjad.f(timespans)
+                >>> string = abjad.storage(timespans)
+                >>> print(string)
                 abjad.TimespanList(
                     [
                         abjad.Timespan(
@@ -4475,7 +4514,8 @@ class TimespanList(TypedList):
 
             ..  docs::
 
-                >>> abjad.f(timespans)
+                >>> string = abjad.storage(timespans)
+                >>> print(string)
                 abjad.TimespanList(
                     [
                         abjad.Timespan(
@@ -4508,7 +4548,8 @@ class TimespanList(TypedList):
 
             ..  docs::
 
-                >>> abjad.f(timespans)
+                >>> string = abjad.storage(timespans)
+                >>> print(string)
                 abjad.TimespanList(
                     [
                         abjad.Timespan(
@@ -4536,7 +4577,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.compute_logical_xor()
             >>> abjad.show(timespans, range_=(0, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4729,7 +4771,8 @@ class TimespanList(TypedList):
             ...     ])
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4772,7 +4815,8 @@ class TimespanList(TypedList):
             ...     ])
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -4874,7 +4918,8 @@ class TimespanList(TypedList):
             timespan_lists:
 
             >>> for exploded_timespan_list in timespans.explode():
-            ...     abjad.f(exploded_timespan_list)
+            ...     string = abjad.storage(exploded_timespan_list)
+            ...     print(string)
             ...
             abjad.TimespanList(
                 [
@@ -4944,7 +4989,8 @@ class TimespanList(TypedList):
 
             >>> for exploded_timespan_list in timespans.explode(
             ...     inventory_count=6):
-            ...     abjad.f(exploded_timespan_list)
+            ...     string = abjad.storage(exploded_timespan_list)
+            ...     print(string)
             ...
             abjad.TimespanList(
                 [
@@ -5136,7 +5182,8 @@ class TimespanList(TypedList):
             ...     time_relation)
             >>> abjad.show(result, range_=(0, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(result)
+            >>> string = abjad.storage(result)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5214,7 +5261,8 @@ class TimespanList(TypedList):
             ...     ])
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5233,7 +5281,8 @@ class TimespanList(TypedList):
                 )
 
             >>> for timespan_list in timespans.partition():
-            ...     abjad.f(timespan_list)
+            ...     string = abjad.storage(timespan_list)
+            ...     print(string)
             ...
             abjad.TimespanList(
                 [
@@ -5273,7 +5322,8 @@ class TimespanList(TypedList):
             ...     ])
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5300,7 +5350,8 @@ class TimespanList(TypedList):
                 )
 
             >>> for timespan_list in timespans.partition():
-            ...     abjad.f(timespan_list)
+            ...     string = abjad.storage(timespan_list)
+            ...     print(string)
             ...
             abjad.TimespanList(
                 [
@@ -5346,7 +5397,8 @@ class TimespanList(TypedList):
             >>> for timespan_list in timespans.partition(
             ...     include_tangent_timespans=True,
             ...     ):
-            ...     abjad.f(timespan_list)
+            ...     string = abjad.storage(timespan_list)
+            ...     print(string)
             ...
             abjad.TimespanList(
                 [
@@ -5408,7 +5460,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.reflect()
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5440,7 +5493,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.reflect(axis=abjad.Offset(15))
             >>> abjad.show(timespans, range_=(0, 30), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5488,7 +5542,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.remove_degenerate_timespans()
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5526,7 +5581,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.repeat_to_stop_offset(15)
             >>> abjad.show(timespans, range_=(0, 15), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5587,7 +5643,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.rotate(-1)
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5619,7 +5676,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.rotate(1)
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5686,7 +5744,8 @@ class TimespanList(TypedList):
             >>> rounded_timespans = timespans.round_offsets(3)
             >>> abjad.show(rounded_timespans, range_=(0, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(rounded_timespans)
+            >>> string = abjad.storage(rounded_timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5718,7 +5777,8 @@ class TimespanList(TypedList):
             >>> rounded_timespans = timespans.round_offsets(5)
             >>> abjad.show(rounded_timespans, scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(rounded_timespans)
+            >>> string = abjad.storage(rounded_timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5753,7 +5813,8 @@ class TimespanList(TypedList):
             ...     )
             >>> abjad.show(rounded_timespans, range_=(-5, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(rounded_timespans)
+            >>> string = abjad.storage(rounded_timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5788,7 +5849,8 @@ class TimespanList(TypedList):
             ...     must_be_wellformed=False,
             ...     )
 
-            >>> abjad.f(rounded_timespans)
+            >>> string = abjad.storage(rounded_timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5837,7 +5899,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.scale(2)
             >>> abjad.show(timespans, range_=(0, 14), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5869,7 +5932,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.scale(2, anchor=abjad.Right)
             >>> abjad.show(timespans, range_=(-3, 10), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5914,7 +5978,8 @@ class TimespanList(TypedList):
             >>> left, right = timespans.split_at_offset(4)
 
             >>> abjad.show(left, range_=(0, 10), scale=0.5) # doctest: +SKIP
-            >>> abjad.f(left)
+            >>> string = abjad.storage(left)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5929,7 +5994,8 @@ class TimespanList(TypedList):
                 )
 
             >>> abjad.show(right, range_=(0, 10), scale=0.5) # doctest: +SKIP
-            >>> abjad.f(right)
+            >>> string = abjad.storage(right)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5957,7 +6023,8 @@ class TimespanList(TypedList):
             >>> left, right = timespans.split_at_offset(6)
 
             >>> abjad.show(left, range_=(0, 10), scale=0.5) # doctest: +SKIP
-            >>> abjad.f(left)
+            >>> string = abjad.storage(left)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5972,7 +6039,8 @@ class TimespanList(TypedList):
                 )
 
             >>> abjad.show(right, range_=(0, 10), scale=0.5) # doctest: +SKIP
-            >>> abjad.f(right)
+            >>> string = abjad.storage(right)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -5999,7 +6067,8 @@ class TimespanList(TypedList):
             TimespanList([])
 
             >>> abjad.show(right, range_=(0, 10), scale=0.5) # doctest: +SKIP
-            >>> abjad.f(right)
+            >>> string = abjad.storage(right)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -6056,7 +6125,8 @@ class TimespanList(TypedList):
             >>> offsets = [-1, 3, 6, 12, 13]
             >>> for timespan_list in timespans.split_at_offsets(offsets):
             ...     abjad.show(timespan_list, range_=(0, 20), scale=0.5) # doctest: +SKIP
-            ...     abjad.f(timespan_list)
+            ...     string = abjad.storage(timespan_list)
+            ...     print(string)
             ...
 
         ..  container:: example
@@ -6097,7 +6167,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.stretch(2)
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -6129,7 +6200,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.stretch(2, anchor=abjad.Offset(8))
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -6176,7 +6248,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.translate(50)
             >>> abjad.show(timespans, range_=(0, 60), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -6219,7 +6292,8 @@ class TimespanList(TypedList):
             >>> _ = timespans.translate_offsets(50, 50)
             >>> abjad.show(timespans, range_=(0, 60), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(
@@ -6252,7 +6326,8 @@ class TimespanList(TypedList):
             ...     stop_offset_translation=20)
             >>> abjad.show(timespans, range_=(0, 30), scale=0.5) # doctest: +SKIP
 
-            >>> abjad.f(timespans)
+            >>> string = abjad.storage(timespans)
+            >>> print(string)
             abjad.TimespanList(
                 [
                     abjad.Timespan(

--- a/abjad/typedcollections.py
+++ b/abjad/typedcollections.py
@@ -149,7 +149,8 @@ class TypedCounter(TypedCollection, collections.abc.MutableMapping):
         ...     item_class=abjad.NumberedPitch,
         ...     )
 
-        >>> abjad.f(counter)
+        >>> string = abjad.storage(counter)
+        >>> print(string)
         abjad.TypedCounter(
             {
                 abjad.NumberedPitch(0): 2,
@@ -624,7 +625,8 @@ class TypedList(TypedCollection, collections.abc.MutableSequence):
         >>> list_.append((1, 2, 3))
         >>> list_.append(3.14159)
 
-        >>> abjad.f(list_)
+        >>> string = abjad.storage(list_)
+        >>> print(string)
         abjad.TypedList(
             [
                 23,
@@ -647,7 +649,8 @@ class TypedList(TypedCollection, collections.abc.MutableSequence):
         >>> pitch_list.append(('e', 4))
         >>> pitch_list.append(abjad.NamedPitch("f'"))
 
-        >>> abjad.f(pitch_list)
+        >>> string = abjad.storage(pitch_list)
+        >>> print(string)
         abjad.TypedList(
             [
                 abjad.NamedPitch("c'"),
@@ -710,7 +713,8 @@ class TypedList(TypedCollection, collections.abc.MutableSequence):
             >>> dynamic_list.append('ppp')
             >>> dynamic_list += ['p', 'mp', 'mf', 'fff']
 
-            >>> abjad.f(dynamic_list)
+            >>> string = abjad.storage(dynamic_list)
+            >>> print(string)
             abjad.TypedList(
                 [
                     abjad.Dynamic('ppp'),
@@ -752,7 +756,8 @@ class TypedList(TypedCollection, collections.abc.MutableSequence):
             >>> pitch_list.append(abjad.NamedPitch("f'"))
 
             >>> pitch_list[-1] = 'gqs,'
-            >>> abjad.f(pitch_list)
+            >>> string = abjad.storage(pitch_list)
+            >>> print(string)
             abjad.TypedList(
                 [
                     abjad.NamedPitch("c'"),
@@ -768,7 +773,8 @@ class TypedList(TypedCollection, collections.abc.MutableSequence):
             Sets slice:
 
             >>> pitch_list[-1:] = ["f'", "g'", "a'", "b'", "c''"]
-            >>> abjad.f(pitch_list)
+            >>> string = abjad.storage(pitch_list)
+            >>> print(string)
             abjad.TypedList(
                 [
                     abjad.NamedPitch("c'"),

--- a/abjad/verticalmoment.py
+++ b/abjad/verticalmoment.py
@@ -24,7 +24,8 @@ class VerticalMoment:
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new PianoStaff
@@ -142,7 +143,8 @@ class VerticalMoment:
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new Staff
@@ -239,7 +241,8 @@ class VerticalMoment:
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new Staff
@@ -339,7 +342,8 @@ class VerticalMoment:
 
             ..  docs::
 
-                >>> abjad.f(score)
+                >>> string = abjad.lilypond(score)
+                >>> print(string)
                 \new Score
                 <<
                     \new Staff
@@ -510,7 +514,8 @@ def iterate_vertical_moments(components, reverse=None):
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -574,7 +579,8 @@ def iterate_vertical_moments(components, reverse=None):
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -672,7 +678,8 @@ def iterate_leaf_pairs(components):
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -742,7 +749,8 @@ def iterate_pitch_pairs(components):
 
         ..  docs::
 
-            >>> abjad.f(score)
+            >>> string = abjad.lilypond(score)
+            >>> print(string)
             \new Score
             <<
                 \new Staff
@@ -788,7 +796,8 @@ def iterate_pitch_pairs(components):
 
         ..  docs::
 
-            >>> abjad.f(staff)
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
             \new Staff
             {
                 <c' d' e'>4

--- a/tests/test_Container___delitem__.py
+++ b/tests/test_Container___delitem__.py
@@ -211,7 +211,8 @@ def test_Container___delitem___08():
     leaves = abjad.select(voice).leaves()
     abjad.glissando(leaves)
 
-    assert abjad.lilypond(voice) == abjad.String.normalize(
+    string = abjad.lilypond(voice)
+    assert string == abjad.String.normalize(
         r"""
         \new Voice
         {
@@ -228,12 +229,13 @@ def test_Container___delitem___08():
             ]
         }
         """
-    ), abjad.f(voice)
+    ), print(string)
 
     leaf = leaves[1]
     del voice[1][0]
 
-    assert abjad.lilypond(voice) == abjad.String.normalize(
+    string = abjad.lilypond(voice)
+    assert string == abjad.String.normalize(
         r"""
         \new Voice
         {
@@ -248,7 +250,7 @@ def test_Container___delitem___08():
             ]
         }
         """
-    ), abjad.f(voice)
+    ), print(string)
 
     assert abjad.wf.wellformed(voice)
     assert abjad.wf.wellformed(leaf)


### PR DESCRIPTION
Hopefully I have changed every instance of `abjad.f()` to either `abjad.lilypond()` or `abjad.storage()`.

During the process, I found there were some instances where an extra argument `align_tags` is provided to `abjad.f()`.
In those instances, I simply deleted the extra argument.
Although all tests are passing (probably due to some sort of white-space insensitivity), some of the tags might not be aligned properly when the doctest's code is executed by hand.