### PR TITLE
Taught abjad about dyadic rational

### DIFF
--- a/abjad/duration.py
+++ b/abjad/duration.py
@@ -817,7 +817,7 @@ class Duration(quicktions.Fraction):
         return max(count, 0)
 
     @property
-    def has_power_of_two_denominator(self) -> bool:
+    def is_dyadic_rational(self) -> bool:
         r"""
         Is true when duration is an integer power of two.
 
@@ -827,7 +827,7 @@ class Duration(quicktions.Fraction):
 
             >>> for n in range(1, 16 + 1):
             ...     duration = abjad.Duration(1, n)
-            ...     result = duration.has_power_of_two_denominator
+            ...     result = duration.is_dyadic_rational
             ...     print(f"{duration!s}\t{result}")
             ...
             1       True

--- a/abjad/indicators/TimeSignature.py
+++ b/abjad/indicators/TimeSignature.py
@@ -113,7 +113,7 @@ class TimeSignature:
 
     __slots__ = (
         "_denominator",
-        "_has_non_power_of_two_denominator",
+        "_is_non_dyadic_rational",
         "_hide",
         "_multiplier",
         "_numerator",
@@ -157,7 +157,7 @@ class TimeSignature:
         self._multiplier = self.implied_prolation
         result = math.is_nonnegative_integer_power_of_two(self.denominator)
         assert isinstance(result, bool)
-        self._has_non_power_of_two_denominator: bool = not (result)
+        self._is_non_dyadic_rational: bool = not (result)
 
     ### SPECIAL METHODS ###
 
@@ -311,7 +311,7 @@ class TimeSignature:
         result = []
         if self.hide:
             return result
-        if self.has_non_power_of_two_denominator:
+        if self.is_non_dyadic_rational:
             string = '#(ly:expect-warning "strange time signature found")'
             result.append(string)
         if self.partial is None:
@@ -369,7 +369,7 @@ class TimeSignature:
         return Duration(self.numerator, self.denominator)
 
     @property
-    def has_non_power_of_two_denominator(self) -> bool:
+    def is_non_dyadic_rational(self) -> bool:
         r"""
         Is true when time signature has non-power-of-two denominator.
 
@@ -378,7 +378,7 @@ class TimeSignature:
             With non-power-of-two denominator:
 
             >>> time_signature = abjad.TimeSignature((7, 12))
-            >>> time_signature.has_non_power_of_two_denominator
+            >>> time_signature.is_non_dyadic_rational
             True
 
         ..  container:: example
@@ -386,7 +386,7 @@ class TimeSignature:
             With power-of-two denominator:
 
             >>> time_signature = abjad.TimeSignature((3, 8))
-            >>> time_signature.has_non_power_of_two_denominator
+            >>> time_signature.is_non_dyadic_rational
             False
 
         ..  container::
@@ -415,7 +415,7 @@ class TimeSignature:
             }
 
         """
-        return self._has_non_power_of_two_denominator
+        return self._is_non_dyadic_rational
 
     @property
     def hide(self) -> typing.Optional[bool]:
@@ -562,7 +562,7 @@ class TimeSignature:
         numerator, denominator = numbers
         return TimeSignature((numerator, denominator))
 
-    def with_power_of_two_denominator(self, contents_multiplier=1) -> "TimeSignature":
+    def is_dyadic_rational(self, contents_multiplier=1) -> "TimeSignature":
         """
         Makes new time signature equivalent to current time signature with
         power-of-two denominator.
@@ -572,7 +572,7 @@ class TimeSignature:
             Non-power-of-two denominator with power-of-two denominator:
 
             >>> time_signature = abjad.TimeSignature((3, 12))
-            >>> time_signature.with_power_of_two_denominator()
+            >>> time_signature.is_dyadic_rational()
             TimeSignature((2, 8))
 
         """
@@ -587,9 +587,9 @@ class TimeSignature:
             power_of_two_denominator = math.greatest_power_of_two_less_equal(
                 non_power_of_two_denominator, 1
             )
-        non_power_of_two_pair = NonreducedFraction(self.pair)
-        power_of_two_fraction = non_power_of_two_pair.with_denominator(
+        non_dyadic_rational_pair = NonreducedFraction(self.pair)
+        dyadic_rational = non_dyadic_rational_pair.with_denominator(
             power_of_two_denominator
         )
-        power_of_two_pair = power_of_two_fraction.pair
-        return type(self)(power_of_two_pair)
+        dyadic_rational_pair = dyadic_rational.pair
+        return type(self)(dyadic_rational_pair)

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -5374,7 +5374,7 @@ class Tuplet(Container):
             return ""
         if (
             self.augmentation()
-            or not self._get_power_of_two_denominator()
+            or not self._is_dyadic_rational()
             or self.multiplier.denominator == 1
             or self.force_fraction
         ):
@@ -5452,7 +5452,7 @@ class Tuplet(Container):
             denominator = self.multiplier.denominator
         return f"{numerator}/{denominator}"
 
-    def _get_power_of_two_denominator(self):
+    def _is_dyadic_rational(self):
         if self.multiplier:
             numerator = self.multiplier.numerator
             return _math.is_nonnegative_integer_power_of_two(numerator)

--- a/tests/test_TimeSignature_with_power_of_two_denominator.py
+++ b/tests/test_TimeSignature_with_power_of_two_denominator.py
@@ -1,137 +1,145 @@
 import abjad
 
 
-def test_TimeSignature_with_power_of_two_denominator_01():
+def test_TimeSignature_is_dyadic_rational_01():
     """
     Make n/12 time_signatures into n/8 time_signatures, where possible.
     """
 
-    assert abjad.TimeSignature((1, 12)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((1, 12)).is_dyadic_rational() == (
         1,
         12,
     )
-    assert abjad.TimeSignature((2, 12)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((2, 12)).is_dyadic_rational() == (
         2,
         12,
     )
-    assert abjad.TimeSignature((3, 12)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((3, 12)).is_dyadic_rational() == (
         2,
         8,
     )
-    assert abjad.TimeSignature((4, 12)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((4, 12)).is_dyadic_rational() == (
         4,
         12,
     )
-    assert abjad.TimeSignature((5, 12)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((5, 12)).is_dyadic_rational() == (
         5,
         12,
     )
-    assert abjad.TimeSignature((6, 12)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((6, 12)).is_dyadic_rational() == (
         4,
         8,
     )
 
 
-def test_TimeSignature_with_power_of_two_denominator_02():
+def test_TimeSignature_is_dyadic_rational_02():
     """
     Make n/14 time_signatures into n/8 time_signatures, where possible.
     """
 
-    assert abjad.TimeSignature((1, 14)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((1, 14)).is_dyadic_rational() == (
         1,
         14,
     )
-    assert abjad.TimeSignature((2, 14)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((2, 14)).is_dyadic_rational() == (
         2,
         14,
     )
-    assert abjad.TimeSignature((3, 14)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((3, 14)).is_dyadic_rational() == (
         3,
         14,
     )
-    assert abjad.TimeSignature((4, 14)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((4, 14)).is_dyadic_rational() == (
         4,
         14,
     )
-    assert abjad.TimeSignature((5, 14)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((5, 14)).is_dyadic_rational() == (
         5,
         14,
     )
-    assert abjad.TimeSignature((6, 14)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((6, 14)).is_dyadic_rational() == (
         6,
         14,
     )
-    assert abjad.TimeSignature((7, 14)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((7, 14)).is_dyadic_rational() == (
         4,
         8,
     )
 
 
-def test_TimeSignature_with_power_of_two_denominator_03():
+def test_TimeSignature_is_dyadic_rational_03():
     """
     Make n/24 time_signatures into n/16 time_signatures, where possible.
     """
 
-    assert abjad.TimeSignature((1, 24)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((1, 24)).is_dyadic_rational() == (
         1,
         24,
     )
-    assert abjad.TimeSignature((2, 24)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((2, 24)).is_dyadic_rational() == (
         2,
         24,
     )
-    assert abjad.TimeSignature((3, 24)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((3, 24)).is_dyadic_rational() == (
         2,
         16,
     )
-    assert abjad.TimeSignature((4, 24)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((4, 24)).is_dyadic_rational() == (
         4,
         24,
     )
-    assert abjad.TimeSignature((5, 24)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((5, 24)).is_dyadic_rational() == (
         5,
         24,
     )
-    assert abjad.TimeSignature((6, 24)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((6, 24)).is_dyadic_rational() == (
         4,
         16,
     )
-    assert abjad.TimeSignature((7, 24)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((7, 24)).is_dyadic_rational() == (
         7,
         24,
     )
-    assert abjad.TimeSignature((8, 24)).with_power_of_two_denominator() == (
+    assert abjad.TimeSignature((8, 24)).is_dyadic_rational() == (
         8,
         24,
     )
 
 
-def test_TimeSignature_with_power_of_two_denominator_04():
+def test_TimeSignature_is_dyadic_rational_04():
     """
     Make n/24 time_signatures into n/8 time_signatures, where possible.
     """
 
-    assert abjad.TimeSignature((1, 24)).with_power_of_two_denominator(
-        abjad.Multiplier(99)
-    ) == (1, 24)
-    assert abjad.TimeSignature((2, 24)).with_power_of_two_denominator(
-        abjad.Multiplier(99)
-    ) == (2, 24)
-    assert abjad.TimeSignature((3, 24)).with_power_of_two_denominator(
-        abjad.Multiplier(99)
-    ) == (1, 8)
-    assert abjad.TimeSignature((4, 24)).with_power_of_two_denominator(
-        abjad.Multiplier(99)
-    ) == (4, 24)
-    assert abjad.TimeSignature((5, 24)).with_power_of_two_denominator(
-        abjad.Multiplier(99)
-    ) == (5, 24)
-    assert abjad.TimeSignature((6, 24)).with_power_of_two_denominator(
-        abjad.Multiplier(99)
-    ) == (2, 8)
-    assert abjad.TimeSignature((7, 24)).with_power_of_two_denominator(
-        abjad.Multiplier(99)
-    ) == (7, 24)
-    assert abjad.TimeSignature((8, 24)).with_power_of_two_denominator(
-        abjad.Multiplier(99)
-    ) == (8, 24)
+    assert abjad.TimeSignature((1, 24)).is_dyadic_rational(abjad.Multiplier(99)) == (
+        1,
+        24,
+    )
+    assert abjad.TimeSignature((2, 24)).is_dyadic_rational(abjad.Multiplier(99)) == (
+        2,
+        24,
+    )
+    assert abjad.TimeSignature((3, 24)).is_dyadic_rational(abjad.Multiplier(99)) == (
+        1,
+        8,
+    )
+    assert abjad.TimeSignature((4, 24)).is_dyadic_rational(abjad.Multiplier(99)) == (
+        4,
+        24,
+    )
+    assert abjad.TimeSignature((5, 24)).is_dyadic_rational(abjad.Multiplier(99)) == (
+        5,
+        24,
+    )
+    assert abjad.TimeSignature((6, 24)).is_dyadic_rational(abjad.Multiplier(99)) == (
+        2,
+        8,
+    )
+    assert abjad.TimeSignature((7, 24)).is_dyadic_rational(abjad.Multiplier(99)) == (
+        7,
+        24,
+    )
+    assert abjad.TimeSignature((8, 24)).is_dyadic_rational(abjad.Multiplier(99)) == (
+        8,
+        24,
+    )


### PR DESCRIPTION
Tag #1313.

This PR changes the naming of methods, properties, and variables where the name contains `with_power_of_two_denominator` (or something similar) to `is_dyadic_rational` (or something similar).

There are still a number of `power_of_two` in the codebase because "dyadic rational" seems to be referring to fraction with a power-of-two denominator only.
It seems like it would be more appropriate to just leave `power_of_two` as it is in the case of an integer.