### PR TITLE
taught iterpitches about trill spans

### DIFF
--- a/abjad/iterpitches.py
+++ b/abjad/iterpitches.py
@@ -1,6 +1,8 @@
 import typing
 
 from . import _inspect
+from . import get as _get
+from .indicators.StartTrillSpan import StartTrillSpan
 from .instruments import Instrument
 from .iterate import Iteration
 from .pitch.PitchRange import PitchRange
@@ -231,6 +233,11 @@ def transpose_from_sounding_pitch(argument) -> None:
         elif hasattr(leaf, "written_pitches"):
             pitches = [interval.transpose(pitch) for pitch in leaf.written_pitches]
             leaf.written_pitches = pitches
+        start_trill_span = _get.indicator(leaf, StartTrillSpan)
+        if start_trill_span is not None:
+            pitch = start_trill_span.pitch
+            pitch = interval.transpose(pitch)
+            start_trill_span._pitch = pitch
 
 
 def transpose_from_written_pitch(argument) -> None:
@@ -285,3 +292,8 @@ def transpose_from_written_pitch(argument) -> None:
         elif hasattr(leaf, "written_pitches"):
             pitches = [interval.transpose(pitch) for pitch in leaf.written_pitches]
             leaf.written_pitches = pitches
+        start_trill_span = _get.indicator(leaf, StartTrillSpan)
+        if start_trill_span is not None:
+            pitch = start_trill_span.pitch
+            pitch = interval.transpose(pitch)
+            start_trill_span._pitch = pitch

--- a/tests/test_iterpitches_transpose_from_sounding_pitch.py
+++ b/tests/test_iterpitches_transpose_from_sounding_pitch.py
@@ -1,0 +1,30 @@
+import abjad
+
+
+def test_transpose_from_sounding_pitch_01():
+    staff = abjad.Staff("c'4 c'4 c'4 c'4")
+    trill_pitch = abjad.NamedPitch("d'")
+    start_trill_span = abjad.StartTrillSpan(pitch=trill_pitch)
+    abjad.attach(start_trill_span, staff[1])
+    stop_trill_span = abjad.StopTrillSpan()
+    abjad.attach(stop_trill_span, staff[2])
+    instrument = abjad.AltoSaxophone()
+    abjad.attach(instrument, staff[0])
+
+    abjad.iterpitches.transpose_from_sounding_pitch(staff)
+
+    string = abjad.lilypond(staff)
+    assert string == abjad.String.normalize(
+        r"""
+        \new Staff
+        {
+            a'4
+            \pitchedTrill
+            a'4
+            \startTrillSpan b'
+            a'4
+            \stopTrillSpan
+            a'4
+        }
+        """
+    )

--- a/tests/test_iterpitches_transpose_from_written_pitch.py
+++ b/tests/test_iterpitches_transpose_from_written_pitch.py
@@ -1,0 +1,30 @@
+import abjad
+
+
+def test_transpose_from_written_pitch_01():
+    staff = abjad.Staff("a'4 a'4 a'4 a'4")
+    trill_pitch = abjad.NamedPitch("b'")
+    start_trill_span = abjad.StartTrillSpan(pitch=trill_pitch)
+    abjad.attach(start_trill_span, staff[1])
+    stop_trill_span = abjad.StopTrillSpan()
+    abjad.attach(stop_trill_span, staff[2])
+    instrument = abjad.AltoSaxophone()
+    abjad.attach(instrument, staff[0])
+
+    abjad.iterpitches.transpose_from_written_pitch(staff)
+
+    string = abjad.lilypond(staff)
+    assert string == abjad.String.normalize(
+        r"""
+        \new Staff
+        {
+            c'4
+            \pitchedTrill
+            c'4
+            \startTrillSpan d'
+            c'4
+            \stopTrillSpan
+            c'4
+        }
+        """
+    )


### PR DESCRIPTION
I've taught both the `transpose_from_sounding_pitch` and `transpose_from_written_pitch` to check for `StartTrillSpan`, which should fix #1172.

While I was on it, this also got me thinking we can probably refactor these two methods into the `abjad.mutate.transpose` method, the difference is just that the former twos keep checking for the instrument at every pitched leaf, while the last one would be supplied with an interval when called. So to move forward, we can probably refactor these three methods so that they all make use of a new (if not already existing the `abjad.pitch` package) method that transposes only one leaf at a time.  