### PR TITLE
Cleaned up tuplet formatting. Closes #1338.

### DIFF
--- a/abjad/ext/sphinx.py
+++ b/abjad/ext/sphinx.py
@@ -289,10 +289,7 @@ class LilyPondExtension(Extension):
             includes = [stylesheet]
             illustration._includes = tuple(includes)
         code = illustration._get_lilypond_format()
-
-        # code += "% FLAMINGO"
         code = remove_tags(code)
-
         node = self.lilypond_block(code, code)
         node["kind"] = self.kind.name.lower()
         node["no-stylesheet"] = self.no_stylesheet

--- a/abjad/lilypondfile.py
+++ b/abjad/lilypondfile.py
@@ -207,11 +207,10 @@ class Block:
             string = f"{self._escaped_name} {{}}"
             result.append(string)
             return result
-        string = f"{self._escaped_name} {{"
+        strings = [f"{self._escaped_name}", "{"]
         if tag is not None:
-            strings = _tag.tag([string], tag=tag)
-            string = strings[0]
-        result.append(string)
+            strings = _tag.tag(strings, tag=tag)
+        result.extend(strings)
         for item in self.items:
             if isinstance(item, ContextBlock):
                 continue

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -5394,10 +5394,8 @@ class Tuplet(Container):
         if self.multiplier:
             if self.hide:
                 contributor = (self, "hide")
-                scale_durations_command_string = (
-                    self._get_scale_durations_command_string()
-                )
-                contributions = [scale_durations_command_string]
+                string = self._get_scale_durations_command_string()
+                contributions = [string, "{"]
             else:
                 contributor = ("self_brackets", "open")
                 contributions = []
@@ -5413,6 +5411,7 @@ class Tuplet(Container):
                 contributions.extend(strings)
                 times_command_string = self._get_times_command_string()
                 contributions.append(times_command_string)
+                contributions.append("{")
             if self.tag is not None:
                 contributions = _tag.tag(contributions, tag=self.tag)
             result.append([contributor, contributions])
@@ -5484,7 +5483,7 @@ class Tuplet(Container):
         multiplier = Multiplier(self.multiplier)
         numerator = multiplier.numerator
         denominator = multiplier.denominator
-        string = rf"\scaleDurations #'({numerator} . {denominator}) {{"
+        string = rf"\scaleDurations #'({numerator} . {denominator})"
         return string
 
     def _get_summary(self):
@@ -5494,7 +5493,7 @@ class Tuplet(Container):
             return ""
 
     def _get_times_command_string(self):
-        string = rf"\times {self._get_multiplier_fraction_string()} {{"
+        string = rf"\times {self._get_multiplier_fraction_string()}"
         return string
 
     def _scale(self, multiplier):
@@ -5963,7 +5962,8 @@ class Tuplet(Container):
 
             >>> string = abjad.lilypond(tuplet, tags=True)
             >>> print(string)
-            \times 2/3 {        %! RED
+            \times 2/3          %! RED
+            {                   %! RED
                 c'4
                 d'4
                 e'4

--- a/tests/test_Component__sibling.py
+++ b/tests/test_Component__sibling.py
@@ -29,7 +29,8 @@ def test_Component__sibling_03():
         \new Staff
         {
             c'4
-            \times 2/3 {
+            \times 2/3
+            {
                 d'8
                 e'8
                 f'8

--- a/tests/test_Container___delitem__.py
+++ b/tests/test_Container___delitem__.py
@@ -190,7 +190,8 @@ def test_Container___delitem___07():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak edge-height #'(0.7 . 0)
-        \times 2/3 {
+        \times 2/3
+        {
             c'8
             [
             e'8

--- a/tests/test_Container___setitem__.py
+++ b/tests/test_Container___setitem__.py
@@ -165,7 +165,8 @@ def test_Container___setitem___04():
                 [
                 d'8
             }
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 d'8
                 e'8

--- a/tests/test_Container_append.py
+++ b/tests/test_Container_append.py
@@ -42,7 +42,8 @@ def test_Container_append_02():
 
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
-        \times 4/7 {
+        \times 4/7
+        {
             c'8
             [
             d'8

--- a/tests/test_LilyPondParser__containers__Tuplet.py
+++ b/tests/test_LilyPondParser__containers__Tuplet.py
@@ -9,7 +9,8 @@ def test_LilyPondParser__containers__Tuplet_01():
 
     assert abjad.lilypond(target) == abjad.String.normalize(
         r"""
-        \times 2/3 {
+        \times 2/3
+        {
             c'8
             d'8
             e'8

--- a/tests/test_RhythmTreeContainer___call__.py
+++ b/tests/test_RhythmTreeContainer___call__.py
@@ -13,9 +13,11 @@ def test_RhythmTreeContainer___call___01():
 
     assert abjad.lilypond(result[0]) == abjad.String.normalize(
         r"""
-        \times 4/5 {
+        \times 4/5
+        {
             c'16
-            \times 2/3 {
+            \times 2/3
+            {
                 c'16
                 c'16
                 c'16

--- a/tests/test_RhythmTreeNode___call__.py
+++ b/tests/test_RhythmTreeNode___call__.py
@@ -24,9 +24,11 @@ def test_RhythmTreeNode___call___02():
     assert len(result) == 1
     assert abjad.lilypond(result[0]) == abjad.String.normalize(
         r"""
-        \times 4/5 {
+        \times 4/5
+        {
             c'16
-            \times 2/3 {
+            \times 2/3
+            {
                 c'16
                 c'16
                 c'16
@@ -45,7 +47,8 @@ def test_RhythmTreeNode___call___03():
 
     assert abjad.lilypond(result[0]) == abjad.String.normalize(
         r"""
-        \times 4/5 {
+        \times 4/5
+        {
             c'16
             c'32
             c'32

--- a/tests/test_Selection__immediately_precedes.py
+++ b/tests/test_Selection__immediately_precedes.py
@@ -74,12 +74,14 @@ def test_Selection__immediately_precedes_06():
         r"""
         \new Voice
         {
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 d'8
                 e'8
             }
-            \times 2/3 {
+            \times 2/3
+            {
                 f'8
                 e'8
                 d'8

--- a/tests/test_Selection_are_logical_voice.py
+++ b/tests/test_Selection_are_logical_voice.py
@@ -44,7 +44,8 @@ def test_Selection_are_logical_voice_03():
     tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
 
     r"""
-    \times 2/3 {
+    \times 2/3
+    {
         c'8
         d'8
         e'8
@@ -144,12 +145,14 @@ def test_Selection_are_logical_voice_07():
 
     voice = abjad.Voice(
         r"""
-        \times 2/3 {
+        \times 2/3
+        {
             c'8
             d'8
             e'8
         }
-        \times 2/3 {
+        \times 2/3
+        {
             f'8
             g'8
             a'8
@@ -161,12 +164,14 @@ def test_Selection_are_logical_voice_07():
         r"""
         \new Voice
         {
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 d'8
                 e'8
             }
-            \times 2/3 {
+            \times 2/3
+            {
                 f'8
                 g'8
                 a'8

--- a/tests/test_Tuplet___copy__.py
+++ b/tests/test_Tuplet___copy__.py
@@ -11,7 +11,8 @@ def test_Tuplet___copy___01():
     assert abjad.lilypond(tuplet_1) == abjad.String.normalize(
         r"""
         \override NoteHead.color = #red
-        \times 2/3 {
+        \times 2/3
+        {
             c'8
             d'8
             e'8
@@ -25,7 +26,8 @@ def test_Tuplet___copy___01():
     assert abjad.lilypond(tuplet_2) == abjad.String.normalize(
         r"""
         \override NoteHead.color = #red
-        \times 2/3 {
+        \times 2/3
+        {
         }
         \revert NoteHead.color
         """

--- a/tests/test_Tuplet___init__.py
+++ b/tests/test_Tuplet___init__.py
@@ -8,6 +8,6 @@ def test_Tuplet___init___01():
 
     tuplet = abjad.Tuplet()
 
-    assert abjad.lilypond(tuplet) == "\\times 2/3 {\n}"
+    assert abjad.lilypond(tuplet) == "\\times 2/3\n{\n}"
     assert tuplet.multiplier == abjad.Multiplier(2, 3)
     assert not len(tuplet)

--- a/tests/test_Tuplet_get_timespan.py
+++ b/tests/test_Tuplet_get_timespan.py
@@ -18,7 +18,8 @@ def test_Tuplet_get_timespan_01():
                 \tempo 4=60
                 c'4
                 d'4
-                \times 2/3 {
+                \times 2/3
+                {
                     e'4
                     f'4
                     g'4

--- a/tests/test_Tuplet_grob_override.py
+++ b/tests/test_Tuplet_grob_override.py
@@ -13,7 +13,8 @@ def test_Tuplet_grob_override_01():
         r"""
         \override Glissando.thickness = 3
         \tweak edge-height #'(0.7 . 0)
-        \times 2/3 {
+        \times 2/3
+        {
             c'8
             d'8
             e'8

--- a/tests/test_Tuplet_set_minimum_denominator.py
+++ b/tests/test_Tuplet_set_minimum_denominator.py
@@ -9,7 +9,8 @@ def test_Tuplet_set_minimum_denominator_01():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/10 {
+        \times 6/10
+        {
             c'4
             d'8
             e'8
@@ -30,7 +31,8 @@ def test_Tuplet_set_minimum_denominator_02():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 12/20 {
+        \times 12/20
+        {
             c'4
             d'8
             e'8
@@ -51,7 +53,8 @@ def test_Tuplet_set_minimum_denominator_03():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/5 {
+        \times 3/5
+        {
             c'4
             d'8
             e'8

--- a/tests/test_Tuplet_timespan.py
+++ b/tests/test_Tuplet_timespan.py
@@ -11,7 +11,8 @@ def test_Tuplet_timespan_01():
         {
             c'4
             d'4
-            \times 2/3 {
+            \times 2/3
+            {
                 e'4
                 f'4
                 g'4

--- a/tests/test_ext_sphinx.py
+++ b/tests/test_ext_sphinx.py
@@ -19,38 +19,38 @@ def test_ext_sphinx_01(app, status, warning, rm_dirs):
     assert not warning.getvalue().strip()
     images_path = pathlib.Path(app.outdir) / "_images"
     assert sorted(path.name for path in images_path.iterdir()) == [
-        "lilypond-3783b6e7181254e55e3b7d08e13d0d33e6c38f876cfd5940ccb4463d330038c9.cropped.svg",
-        "lilypond-3783b6e7181254e55e3b7d08e13d0d33e6c38f876cfd5940ccb4463d330038c9.ly",
-        "lilypond-3783b6e7181254e55e3b7d08e13d0d33e6c38f876cfd5940ccb4463d330038c9.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-1.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-2.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-3.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-4.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6.cropped.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6.ly",
+        "lilypond-1b04f9f8fd31f6d75e5d921820d087ed565936b5fffd3298d46750eba5a4d433.cropped.svg",
+        "lilypond-1b04f9f8fd31f6d75e5d921820d087ed565936b5fffd3298d46750eba5a4d433.ly",
+        "lilypond-1b04f9f8fd31f6d75e5d921820d087ed565936b5fffd3298d46750eba5a4d433.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-1.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-2.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-3.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-4.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d.cropped.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d.ly",
     ]
 
     index_path = pathlib.Path(app.srcdir) / "_build" / "html" / "index.html"
     index_source = index_path.read_text()
     assert re.findall(r"lilypond-\w{64}(?:-\d+|.cropped)?\.svg", index_source) == [
-        "lilypond-3783b6e7181254e55e3b7d08e13d0d33e6c38f876cfd5940ccb4463d330038c9.cropped.svg",
-        "lilypond-3783b6e7181254e55e3b7d08e13d0d33e6c38f876cfd5940ccb4463d330038c9.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6.cropped.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-1.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-2.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-3.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-4.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-2.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-3.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-1.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-1.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-1.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-2.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-2.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-3.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-3.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-4.svg",
-        "lilypond-ae85543c2c6b55401c314d48f1cbccc7cb9b73226151a6a2d3453333945d0be6-4.svg",
+        "lilypond-1b04f9f8fd31f6d75e5d921820d087ed565936b5fffd3298d46750eba5a4d433.cropped.svg",
+        "lilypond-1b04f9f8fd31f6d75e5d921820d087ed565936b5fffd3298d46750eba5a4d433.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d.cropped.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-1.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-2.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-3.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-4.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-2.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-3.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-1.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-1.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-1.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-2.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-2.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-3.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-3.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-4.svg",
+        "lilypond-dc77e95b8af18eb69dd49918ff1a2411b50d5d6ffbf734e33f36272be3ffff7d-4.svg",
     ]
 
 
@@ -74,7 +74,8 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
            #(ly:set-option 'relative-includes #t)
            \include "default.ily"
 
-           \score {
+           \score
+           {
                \new Staff
                {
                    c'4
@@ -93,7 +94,8 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
            #(ly:set-option 'relative-includes #t)
            \include "default.ily"
 
-           \score {
+           \score
+           {
                \new Staff
                {
                    c'4
@@ -117,7 +119,8 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
            #(ly:set-option 'relative-includes #t)
            \include "default.ily"
 
-           \score {
+           \score
+           {
                \new Staff
                {
                    c'1
@@ -141,7 +144,8 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
            #(ly:set-option 'relative-includes #t)
            \include "default.ily"
 
-           \score {
+           \score
+           {
                \new Staff
                {
                    c'1
@@ -164,7 +168,8 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
            #(ly:set-option 'relative-includes #t)
            \include "default.ily"
 
-           \score {
+           \score
+           {
                \new Staff
                {
                    c'1
@@ -187,7 +192,8 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
            #(ly:set-option 'relative-includes #t)
            \include "default.ily"
 
-           \score {
+           \score
+           {
                \new Staff
                {
                    c'1

--- a/tests/test_get_leaf.py
+++ b/tests/test_get_leaf.py
@@ -133,7 +133,8 @@ def test_get_leaf_05():
 
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
-        \times 2/3 {
+        \times 2/3
+        {
             c'8
             cs'8
             d'8
@@ -203,12 +204,14 @@ def test_get_leaf_07():
         r"""
         \new Voice
         {
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 cs'8
                 d'8
             }
-            \times 2/3 {
+            \times 2/3
+            {
                 ef'8
                 e'8
                 f'8
@@ -659,13 +662,15 @@ def test_get_leaf_17():
         r"""
         \new Voice
         {
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 cs'8
                 d'8
             }
             ef'8
-            \times 2/3 {
+            \times 2/3
+            {
                 e'8
                 f'8
                 fs'8
@@ -692,9 +697,11 @@ def test_get_leaf_18():
 
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
-        \times 2/3 {
+        \times 2/3
+        {
             c'4
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 c'8
                 c'8

--- a/tests/test_makers_tuplet_from_ratio_and_pair.py
+++ b/tests/test_makers_tuplet_from_ratio_and_pair.py
@@ -10,7 +10,8 @@ def test_makers_tuplet_from_ratio_and_pair_01():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/7 {
+        \times 6/7
+        {
             c'16
             c'8
             c'4
@@ -28,7 +29,8 @@ def test_makers_tuplet_from_ratio_and_pair_02():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/4 {
+        \times 3/4
+        {
             c'16
             c'16
             c'8
@@ -47,7 +49,8 @@ def test_makers_tuplet_from_ratio_and_pair_03():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 7/12 {
+        \times 7/12
+        {
             r8
             c'8.
             c'4..
@@ -64,7 +67,8 @@ def test_makers_tuplet_from_ratio_and_pair_04():
 
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
-        \times 16/19 {
+        \times 16/19
+        {
             c'16..
             c'16..
             r16
@@ -83,7 +87,8 @@ def test_makers_tuplet_from_ratio_and_pair_05():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5 {
+        \times 6/5
+        {
             c'8
             c'4
             c'4
@@ -101,7 +106,8 @@ def test_makers_tuplet_from_ratio_and_pair_06():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5 {
+        \times 6/5
+        {
             c'8
             c'4
             c'4
@@ -119,7 +125,8 @@ def test_makers_tuplet_from_ratio_and_pair_07():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/5 {
+        \times 3/5
+        {
             c'4
             c'2
             c'2
@@ -137,7 +144,8 @@ def test_makers_tuplet_from_ratio_and_pair_08():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/5 {
+        \times 3/5
+        {
             c'4
             c'2
             c'2
@@ -155,7 +163,8 @@ def test_makers_tuplet_from_ratio_and_pair_09():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/5 {
+        \times 3/5
+        {
             c'16
             c'8
             c'8
@@ -173,7 +182,8 @@ def test_makers_tuplet_from_ratio_and_pair_10():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/5 {
+        \times 3/5
+        {
             c'8
             c'4
             c'4
@@ -191,7 +201,8 @@ def test_makers_tuplet_from_ratio_and_pair_11():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5 {
+        \times 6/5
+        {
             c'8
             c'4
             c'4
@@ -209,7 +220,8 @@ def test_makers_tuplet_from_ratio_and_pair_12():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5 {
+        \times 6/5
+        {
             c'4
             c'2
             c'2
@@ -227,7 +239,8 @@ def test_makers_tuplet_from_ratio_and_pair_13():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5 {
+        \times 6/5
+        {
             c'2
             c'1
             c'1
@@ -245,7 +258,8 @@ def test_makers_tuplet_from_ratio_and_pair_14():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5 {
+        \times 6/5
+        {
             c'4
             c'2
             c'2
@@ -263,7 +277,8 @@ def test_makers_tuplet_from_ratio_and_pair_15():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5 {
+        \times 6/5
+        {
             c'8
             c'4
             c'4
@@ -281,7 +296,8 @@ def test_makers_tuplet_from_ratio_and_pair_16():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5 {
+        \times 6/5
+        {
             c'16
             c'8
             c'8
@@ -299,7 +315,8 @@ def test_makers_tuplet_from_ratio_and_pair_17():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 1/1 {
+        \times 1/1
+        {
             c'16
             r16
             r16
@@ -317,7 +334,8 @@ def test_makers_tuplet_from_ratio_and_pair_18():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 1/1 {
+        \times 1/1
+        {
             c'16
             c'16
             r16
@@ -337,7 +355,8 @@ def test_makers_tuplet_from_ratio_and_pair_19():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 1/1 {
+        \times 1/1
+        {
             c'16
             c'16
             c'16
@@ -358,7 +377,8 @@ def test_makers_tuplet_from_ratio_and_pair_20():
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 1/1 {
+        \times 1/1
+        {
             c'16
             c'16
             c'16

--- a/tests/test_mutate__fuse_leaves_by_immediate_parent.py
+++ b/tests/test_mutate__fuse_leaves_by_immediate_parent.py
@@ -192,7 +192,8 @@ def test_mutate__fuse_leaves_by_immediate_parent_07():
         {
             \new Voice
             {
-                \times 8/13 {
+                \times 8/13
+                {
                     \time 4/4
                     c'4
                     ~

--- a/tests/test_mutate__set_leaf_duration.py
+++ b/tests/test_mutate__set_leaf_duration.py
@@ -165,7 +165,8 @@ def test_mutate__set_leaf_duration_04():
             c'8
             [
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3 {
+            \times 2/3
+            {
                 d'8
                 ~
                 d'32
@@ -212,7 +213,8 @@ def test_mutate__set_leaf_duration_05():
             c'8
             [
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3 {
+            \times 2/3
+            {
                 d'8
                 ]
             }

--- a/tests/test_mutate__split_container_by_duration.py
+++ b/tests/test_mutate__split_container_by_duration.py
@@ -114,14 +114,16 @@ def test_mutate__split_container_by_duration_02():
                 [
                 (
                 \tweak edge-height #'(0.7 . 0)
-                \times 4/5 {
+                \times 4/5
+                {
                     d'16.
                     ~
                 }
             }
             {
                 \tweak edge-height #'(0.7 . 0)
-                \times 4/5 {
+                \times 4/5
+                {
                     d'16
                     ]
                 }

--- a/tests/test_mutate__split_leaf_by_durations.py
+++ b/tests/test_mutate__split_leaf_by_durations.py
@@ -62,8 +62,10 @@ def test_mutate__split_leaf_by_durations_02():
         r"""
         \new Staff
         {
-            \times 2/3 {
-                \times 4/5 {
+            \times 2/3
+            {
+                \times 4/5
+                {
                     c'16.
                     [
                     ~

--- a/tests/test_mutate_fuse.py
+++ b/tests/test_mutate_fuse.py
@@ -118,7 +118,8 @@ def test_mutate_fuse_06():
 
     assert abjad.lilypond(tuplet_1) == abjad.String.normalize(
         r"""
-        \times 2/3 {
+        \times 2/3
+        {
             c'8
             [
             d'8
@@ -130,7 +131,8 @@ def test_mutate_fuse_06():
 
     assert abjad.lilypond(tuplet_2) == abjad.String.normalize(
         r"""
-        \times 2/3 {
+        \times 2/3
+        {
             c'16
             (
             d'16
@@ -145,7 +147,8 @@ def test_mutate_fuse_06():
 
     assert abjad.lilypond(new) == abjad.String.normalize(
         r"""
-        \times 2/3 {
+        \times 2/3
+        {
             c'8
             [
             d'8
@@ -181,14 +184,16 @@ def test_mutate_fuse_07():
         r"""
         \new Voice
         {
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 [
                 d'8
                 e'8
                 ]
             }
-            \times 2/3 {
+            \times 2/3
+            {
                 c'16
                 (
                 d'16
@@ -206,7 +211,8 @@ def test_mutate_fuse_07():
         r"""
         \new Voice
         {
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 [
                 d'8
@@ -240,7 +246,8 @@ def test_mutate_fuse_08():
         r"""
         \new Voice
         {
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 [
                 d'8
@@ -248,7 +255,8 @@ def test_mutate_fuse_08():
                 ]
             }
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 (
                 d'8
@@ -269,7 +277,8 @@ def test_mutate_fuse_08():
         \new Voice
         {
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 [
                 d'8
@@ -316,12 +325,14 @@ def test_mutate_fuse_10():
         \new Voice
         {
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 (
             }
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3 {
+            \times 2/3
+            {
                 c'4
             }
             c'4
@@ -337,7 +348,8 @@ def test_mutate_fuse_10():
         r"""
         \new Voice
         {
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 (
                 c'4

--- a/tests/test_mutate_split.py
+++ b/tests/test_mutate_split.py
@@ -480,18 +480,21 @@ def test_mutate_split_07():
         r"""
         \new Voice
         {
-            \times 2/3 {
+            \times 2/3
+            {
                 c'8
                 [
                 d'8
                 e'8
             }
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3 {
+            \times 2/3
+            {
                 f'8
             }
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3 {
+            \times 2/3
+            {
                 g'8
                 a'8
                 ]
@@ -742,7 +745,8 @@ def test_mutate_split_12():
     assert abjad.lilypond(left) == abjad.String.normalize(
         r"""
         \tweak edge-height #'(0.7 . 0)
-        \times 4/5 {
+        \times 4/5
+        {
             c'8
             [
             c'8
@@ -753,7 +757,8 @@ def test_mutate_split_12():
     assert abjad.lilypond(right) == abjad.String.normalize(
         r"""
         \tweak edge-height #'(0.7 . 0)
-        \times 4/5 {
+        \times 4/5
+        {
             c'8
             c'8
             c'8
@@ -764,7 +769,8 @@ def test_mutate_split_12():
 
     assert abjad.lilypond(tuplet) == abjad.String.normalize(
         r"""
-        \times 4/5 {
+        \times 4/5
+        {
         }
         """
     ), print(abjad.lilypond(tuplet))
@@ -774,13 +780,15 @@ def test_mutate_split_12():
         \new Voice
         {
             \tweak edge-height #'(0.7 . 0)
-            \times 4/5 {
+            \times 4/5
+            {
                 c'8
                 [
                 c'8
             }
             \tweak edge-height #'(0.7 . 0)
-            \times 4/5 {
+            \times 4/5
+            {
                 c'8
                 c'8
                 c'8
@@ -797,13 +805,15 @@ def test_mutate_split_12():
             \new Voice
             {
                 \tweak edge-height #'(0.7 . 0)
-                \times 4/5 {
+                \times 4/5
+                {
                     c'8
                     [
                     c'8
                 }
                 \tweak edge-height #'(0.7 . 0)
-                \times 4/5 {
+                \times 4/5
+                {
                     c'8
                     c'8
                     c'8
@@ -955,7 +965,8 @@ def test_mutate_split_15():
         r"""
         \new Staff
         {
-            \times 2/3 {
+            \times 2/3
+            {
                 c'4
                 ~
                 c'16

--- a/tests/test_mutate_swap.py
+++ b/tests/test_mutate_swap.py
@@ -42,7 +42,8 @@ def test_Mutation_swap_01():
         \new Voice
         {
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/4 {
+            \times 3/4
+            {
                 c'8
                 [
                 d'8
@@ -167,7 +168,8 @@ def test_Mutation_swap_03():
                 d'8
             }
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/4 {
+            \times 3/4
+            {
                 e'8
                 f'8
             }

--- a/tests/test_parse_rtm_syntax.py
+++ b/tests/test_parse_rtm_syntax.py
@@ -10,16 +10,20 @@ def test_parse_rtm_syntax_01():
     assert abjad.lilypond(result) == abjad.String.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/4 {
+        \times 3/4
+        {
             c'4
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/4 {
+            \times 3/4
+            {
                 c'4
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 3/4 {
+                \times 3/4
+                {
                     c'4
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 3/4 {
+                    \times 3/4
+                    {
                         c'4
                         c'4
                         c'4


### PR DESCRIPTION
    Example tuplet:

        >>> tuplet = abjad.Tuplet("3:2", "c'4 d' e'")
        >>> string = abjad.lilypond(tuplet)

    OLD:

        >>> print(string)
        \times 2/3 {
            c'4
            d'4
            e'4
        }

    NEW:

        >>> print(string)
        \times 2/3
        {
            c'4
            d'4
            e'4
        }

Cleaned up abjad.Block formatting. Tag #1293.

    Example:

        >>> staff = abjad.Staff("c'4 d' e' f'")
        >>> block = abjad.Block(name="score")
        >>> block.items.append(staff)
        >>> string = abjad.lilypond(block)

    OLD:

        >>> print(string)
        \score {
            \new Staff
            {
                c'4
                d'4
                e'4
                f'4
            }
        }

    OLD:

        >>> print(string)
        \score
        {
            \new Staff
            {
                c'4
                d'4
                e'4
                f'4
            }
        }