### PR TITLE
Removed expression protocol from all classes except selectors.

### DIFF
--- a/abjad/__init__.py
+++ b/abjad/__init__.py
@@ -61,7 +61,7 @@ from .exceptions import (
     UnboundedTimeIntervalError,
     WellformednessError,
 )
-from .expression import Expression, Signature
+from .expression import Expression
 from .format import LilyPondFormatManager
 from .get import Descendants, Lineage
 from .illustrators import illustrate
@@ -166,7 +166,7 @@ from .instruments import (
 )
 from .io import graph, play, show
 from .iterate import Iteration, iterate
-from .label import ColorMap, Label, label
+from .label import ColorMap, Label
 from .lilypond import lilypond
 from .lilypondfile import (
     Block,
@@ -241,16 +241,8 @@ from .pitch.segments import (
     PitchSegment,
     Segment,
     TwelveToneRow,
-    pitch_class_segment,
 )
-from .pitch.sets import (
-    IntervalClassSet,
-    IntervalSet,
-    PitchClassSet,
-    PitchSet,
-    Set,
-    pitch_set,
-)
+from .pitch.sets import IntervalClassSet, IntervalSet, PitchClassSet, PitchSet, Set
 from .pitch.vectors import (
     IntervalClassVector,
     IntervalVector,
@@ -292,7 +284,7 @@ from .select import (
     Selection,
     select,
 )
-from .sequence import Sequence, sequence
+from .sequence import Sequence
 from .spanners import (
     beam,
     bow_contact_spanner,
@@ -323,7 +315,7 @@ from .templates import (
     StringQuartetScoreTemplate,
     TwoStaffPianoScoreTemplate,
 )
-from .timespan import AnnotatedTimespan, Timespan, TimespanList, timespan
+from .timespan import AnnotatedTimespan, Timespan, TimespanList
 from .typedcollections import (
     TypedCollection,
     TypedCounter,
@@ -575,7 +567,6 @@ __all__ = [
     "Set",
     "SetClass",
     "SettingInterface",
-    "Signature",
     "Skip",
     "SlotContributions",
     "SopraninoSaxophone",
@@ -676,7 +667,6 @@ __all__ = [
     "iterate_pitch_pairs",
     "iterate_vertical_moments",
     "iterpitches",
-    "label",
     "lilypond",
     "list_all_classes",
     "list_all_functions",
@@ -694,17 +684,14 @@ __all__ = [
     "phrasing_slur",
     "piano_pedal",
     "pitch_class_segment",
-    "pitch_set",
     "play",
     "select",
-    "sequence",
     "setting",
     "show",
     "slur",
     "storage",
     "text_spanner",
     "tie",
-    "timespan",
     "trill_spanner",
     "tweak",
     "wf",

--- a/abjad/enumerate.py
+++ b/abjad/enumerate.py
@@ -60,7 +60,7 @@ def _partition_by_rgf(sequence, rgf):
     """
     Partitions ``sequence`` by restricted growth function ``rgf``.
 
-    >>> sequence = abjad.sequence(range(10))
+    >>> sequence = abjad.Sequence(range(10))
     >>> rgf = [1, 1, 2, 2, 1, 2, 3, 3, 2, 4]
 
     >>> abjad.enumerate._partition_by_rgf(sequence, rgf)
@@ -140,7 +140,7 @@ def yield_combinations(argument, minimum_length=None, maximum_length=None):
 
     ..  container:: example
 
-        >>> sequence = abjad.sequence([1, 2, 3, 4])
+        >>> sequence = abjad.Sequence([1, 2, 3, 4])
         >>> for combination in abjad.enumerate.yield_combinations(sequence):
         ...     combination
         Sequence([])
@@ -162,7 +162,7 @@ def yield_combinations(argument, minimum_length=None, maximum_length=None):
 
     ..  container:: example
 
-        >>> sequence = abjad.sequence([1, 2, 3, 4])
+        >>> sequence = abjad.Sequence([1, 2, 3, 4])
         >>> for combination in abjad.enumerate.yield_combinations(
         ...     sequence,
         ...     minimum_length=3,
@@ -176,7 +176,7 @@ def yield_combinations(argument, minimum_length=None, maximum_length=None):
 
     ..  container:: example
 
-        >>> sequence = abjad.sequence([1, 2, 3, 4])
+        >>> sequence = abjad.Sequence([1, 2, 3, 4])
         >>> for combination in abjad.enumerate.yield_combinations(
         ...     sequence,
         ...     maximum_length=2,
@@ -196,7 +196,7 @@ def yield_combinations(argument, minimum_length=None, maximum_length=None):
 
     ..  container:: example
 
-        >>> sequence = abjad.sequence([1, 2, 3, 4])
+        >>> sequence = abjad.Sequence([1, 2, 3, 4])
         >>> for combination in abjad.enumerate.yield_combinations(
         ...     sequence,
         ...     minimum_length=2,
@@ -212,7 +212,7 @@ def yield_combinations(argument, minimum_length=None, maximum_length=None):
 
     ..  container:: example
 
-        >>> sequence = abjad.sequence("text")
+        >>> sequence = abjad.Sequence("text")
         >>> for combination in abjad.enumerate.yield_combinations(sequence):
         ...     ''.join([str(_) for _ in combination])
         ''
@@ -264,7 +264,7 @@ def yield_outer_product(argument):
 
     ..  container:: example
 
-        >>> sequences = [abjad.sequence([1, 2, 3]), abjad.sequence(['a', 'b'])]
+        >>> sequences = [abjad.Sequence([1, 2, 3]), abjad.Sequence(['a', 'b'])]
         >>> for sequence_ in abjad.enumerate.yield_outer_product(sequences):
         ...     sequence_
         ...
@@ -278,7 +278,7 @@ def yield_outer_product(argument):
     ..  container:: example
 
         >>> sequences = [[1, 2, 3], ['a', 'b'], ['X', 'Y']]
-        >>> sequences = [abjad.sequence(_) for _ in sequences]
+        >>> sequences = [abjad.Sequence(_) for _ in sequences]
         >>> for sequence_ in abjad.enumerate.yield_outer_product(sequences):
         ...     sequence_
         ...
@@ -298,7 +298,7 @@ def yield_outer_product(argument):
     ..  container:: example
 
         >>> sequences = [[1, 2, 3], [4, 5], [6, 7, 8]]
-        >>> sequences = [abjad.sequence(_) for _ in sequences]
+        >>> sequences = [abjad.Sequence(_) for _ in sequences]
         >>> for sequence_ in abjad.enumerate.yield_outer_product(sequences):
         ...     sequence_
         ...

--- a/abjad/expression.py
+++ b/abjad/expression.py
@@ -7,144 +7,8 @@ import typing
 import quicktions
 import uqbar.enums
 
-from . import markups, storage
+from . import storage
 from .new import new
-
-
-class Signature:
-    """
-    Signature.
-
-    Decorates expression-enabled methods.
-    """
-
-    ### CLASS VARIABLES ###
-
-    __slots__ = (
-        "_argument_list_callback",
-        "_is_operator",
-        "_markup_maker_callback",
-        "_method_name",
-        "_method_name_callback",
-        "_string_template_callback",
-        "_subscript",
-        "_superscript",
-    )
-
-    ### INITIALIZER ###
-
-    def __init__(
-        self,
-        argument_list_callback=None,
-        is_operator=None,
-        markup_maker_callback=None,
-        method_name=None,
-        method_name_callback=None,
-        string_template_callback=None,
-        subscript=None,
-        superscript=None,
-    ):
-        self._argument_list_callback = argument_list_callback
-        self._is_operator = is_operator
-        self._markup_maker_callback = markup_maker_callback
-        self._method_name = method_name
-        self._method_name_callback = method_name_callback
-        self._string_template_callback = string_template_callback
-        self._subscript = subscript
-        self._superscript = superscript
-
-    ### SPECIAL METHODS ###
-
-    def __call__(self, method):
-        """
-        Calls signature decorator on ``method``.
-
-        Returns ``method`` with metadata attached.
-        """
-        method.argument_list_callback = self.argument_list_callback
-        method.is_operator = self.is_operator
-        method.markup_maker_callback = self.markup_maker_callback
-        method.method_name = self.method_name
-        method.method_name_callback = self.method_name_callback
-        method.string_template_callback = self.string_template_callback
-        method.subscript = self.subscript
-        method.superscript = self.superscript
-        method.has_signature_decorator = True
-        return method
-
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def argument_list_callback(self):
-        """
-        Gets argument list callback.
-
-        Returns string or none.
-        """
-        return self._argument_list_callback
-
-    @property
-    def is_operator(self):
-        """
-        Is true when method typesets like operator.
-
-        Returns true, false or none.
-        """
-        return self._is_operator
-
-    @property
-    def markup_maker_callback(self):
-        """
-        Gets markup maker callback.
-
-        Returns string or none.
-        """
-        return self._markup_maker_callback
-
-    @property
-    def method_name(self):
-        """
-        Gets method name.
-
-        Returns string or none.
-        """
-        return self._method_name
-
-    @property
-    def method_name_callback(self):
-        """
-        Gets method name callback.
-
-        Returns string or none.
-        """
-        return self._method_name_callback
-
-    @property
-    def string_template_callback(self):
-        """
-        Gets string template callback.
-
-        Returns string or none.
-        """
-        return self._string_template_callback
-
-    @property
-    def subscript(self):
-        """
-        Gets subscript.
-
-        Returns string or none.
-        """
-        return self._subscript
-
-    @property
-    def superscript(self):
-        """
-        Gets superscript.
-
-        Returns string or none.
-        """
-        return self._superscript
 
 
 class Expression:
@@ -204,24 +68,13 @@ class Expression:
         "_argument_values",
         "_callbacks",
         "_evaluation_template",
-        "_force_return",
-        "_has_parentheses",
-        "_is_composite",
         "_is_initializer",
-        "_is_postfix",
         "_keywords",
         "_lone",
-        "_map_index",
         "_map_operand",
-        "_markup_maker_callback",
         "_module_names",
-        "_name",
-        "_next_name",
-        "_precedence",
         "_proxy_class",
         "_qualified_method_name",
-        "_string_template",
-        "_subclass_hook",
         "_subexpressions",
         "_template",
     )
@@ -235,24 +88,13 @@ class Expression:
         argument_values=None,
         callbacks=None,
         evaluation_template=None,
-        force_return=None,
-        has_parentheses=None,
-        is_composite=None,
         is_initializer=None,
-        is_postfix=None,
         keywords=None,
         lone=None,
-        map_index=None,
         map_operand=None,
-        markup_maker_callback=None,
         module_names=None,
-        name=None,
-        next_name=None,
-        precedence=None,
         proxy_class=None,
         qualified_method_name=None,
-        string_template=None,
-        subclass_hook=None,
         subexpressions=None,
         template=None,
     ):
@@ -267,113 +109,26 @@ class Expression:
             message = f"must be string or none: {evaluation_template!r}."
             raise TypeError(message)
         self._evaluation_template = evaluation_template
-        self._force_return = force_return
-        if has_parentheses is not None:
-            has_parentheses = bool(has_parentheses)
-        self._has_parentheses = has_parentheses
-        if is_composite is not None:
-            is_composite = bool(is_composite)
-        self._is_composite = is_composite
         self._is_initializer = is_initializer
         if not isinstance(keywords, (dict, type(None))):
             raise TypeError(f"keywords must be dictionary or none: {keywords!r}.")
-        if is_postfix is not None:
-            is_postfix = bool(is_postfix)
-        self._is_postfix = is_postfix
         self._keywords = keywords
         if not isinstance(map_operand, (Expression, list, type(None))):
             message = f"must be expression, expression list or none: {map_operand!r}."
             raise TypeError(message)
         self._lone = lone
-        if map_index is not None:
-            assert isinstance(map_index, int), repr(map_index)
-        self._map_index = map_index
         self._map_operand = map_operand
-        if markup_maker_callback is not None:
-            assert isinstance(markup_maker_callback, str)
-        self._markup_maker_callback = markup_maker_callback
         self._module_names = module_names
-        if not isinstance(name, (str, type(None))):
-            raise TypeError(f"name must be string or none: {name!r}.")
-        self._name = name
-        if not isinstance(next_name, (str, type(None))):
-            raise TypeError(f"next name must be string or none: {next_name!r}.")
-        self._next_name = next_name
-        self._precedence = precedence
         self._proxy_class = proxy_class
-        if not isinstance(string_template, (str, type(None))):
-            raise TypeError(f"must be string or none: {string_template!r}.")
         if qualified_method_name is not None:
             assert isinstance(qualified_method_name, str)
         self._qualified_method_name = qualified_method_name
-        self._string_template = string_template
-        if not isinstance(subclass_hook, (str, type(None))):
-            raise TypeError(f"must be string or none: {subclass_hook!r}.")
-        self._subclass_hook = subclass_hook
         if subexpressions is not None:
             subexpressions = tuple(subexpressions)
         self._subexpressions = subexpressions
         self._template = template
 
     ### SPECIAL METHODS ###
-
-    @Signature(markup_maker_callback="_make_expression_add_markup")
-    def __add__(self, i):
-        """
-        Gets proxy method or adds expressions.
-
-        ..  container:: example expression
-
-            Adds expressions:
-
-            >>> expression = abjad.sequence()
-            >>> expression = expression + [4, 5, 6]
-            >>> string = abjad.storage(expression)
-            >>> print(string)
-            abjad.Expression(
-                callbacks=[
-                    abjad.Expression(
-                        evaluation_template='abjad.Sequence',
-                        is_initializer=True,
-                        string_template='{}',
-                        ),
-                    abjad.Expression(
-                        argument_values={
-                            'argument': [4, 5, 6],
-                            },
-                        evaluation_template='{}.__add__([4, 5, 6])',
-                        qualified_method_name='abjad.Sequence.__add__',
-                        string_template='{} + [4, 5, 6]',
-                        ),
-                    ],
-                proxy_class=abjad.Sequence,
-                )
-
-            >>> expression([1, 2, 3])
-            Sequence([1, 2, 3, 4, 5, 6])
-
-        """
-        if not isinstance(i, Expression):
-            proxy_method = self.__getattr__("__add__")
-            return proxy_method(i)
-        evaluation_template = "{}.__add__({})"
-        template = "{} + {}"
-        lhs_module_names = self.module_names or []
-        rhs_module_names = i.module_names or []
-        module_names = lhs_module_names + rhs_module_names
-        module_names = list(set(module_names))
-        module_names.sort()
-        module_names = module_names or None
-        return type(self)(
-            evaluation_template=evaluation_template,
-            is_composite=True,
-            markup_maker_callback="_make_add_expression_markup",
-            module_names=module_names,
-            proxy_class=self.proxy_class,
-            qualified_method_name="abjad.Expression.__add__",
-            string_template=template,
-            subexpressions=[self, i],
-        )
 
     def __call__(self, *arguments, **keywords):
         """
@@ -409,7 +164,6 @@ class Expression:
             thread_arguments = True
         for expression in self.callbacks or []:
             assert isinstance(expression, Expression)
-            expression._set_map_index(self._map_index)
             if expression.evaluation_template:
                 if thread_arguments:
                     result = expression._evaluate(*result, **keywords)
@@ -432,32 +186,7 @@ class Expression:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when expression storage format equals ``argument`` storage
-        format.
-
-        ..  container:: example
-
-            >>> expression_1 = abjad.sequence()
-            >>> expression_2 = abjad.sequence()
-            >>> expression_1 == expression_2
-            True
-
-            >>> expression_1 = abjad.sequence()
-            >>> expression_2 = abjad.new(expression_1)
-            >>> expression_1 == expression_2
-            True
-
-        ..  container:: example
-
-            >>> expression_1 = abjad.sequence()
-            >>> expression_2 = abjad.sequence().reverse()
-            >>> expression_1 == expression_2
-            False
-
-            >>> expression_1 = abjad.sequence()
-            >>> expression_1 == 'text'
-            False
-
+        Is true when expression storage format equals ``argument`` storage format.
         """
         return storage.StorageFormatManager.compare_objects(self, argument)
 
@@ -558,75 +287,12 @@ class Expression:
 
     ### PRIVATE METHODS ###
 
-    def _apply_callback_markup(self, name, direction=None, previous_callback=None):
-        if previous_callback and previous_callback.next_name:
-            name = previous_callback.next_name
-        markup = name
-        if isinstance(markup, str):
-            markup = markups.Markup(rf'\bold "{markup}"')
-        if not self.callbacks:
-            return markup
-        callback = self.callbacks[0]
-        if (
-            previous_callback
-            and previous_callback.is_composite
-            and not callback.is_composite
-        ):
-            markup = markups.Markup(rf"\concat {{ ( {markup.contents[0]} ) }}")
-        markup = callback._make_method_markup(markup)
-        previous_precedence = callback.precedence or 0
-        previous_callback = callback
-        for callback in self.callbacks[1:]:
-            if previous_callback and previous_callback.next_name:
-                markup = previous_callback.next_name
-                if isinstance(markup, str):
-                    markup = markups.Markup(rf'\bold "{markup}"')
-            current_precedence = callback.precedence or 0
-            parenthesize_argument = False
-            if (
-                previous_precedence < current_precedence
-                and not previous_callback.is_initializer
-            ):
-                parenthesize_argument = True
-            elif previous_callback.is_composite:
-                parenthesize_argument = True
-            if previous_callback and previous_callback.next_name:
-                parenthesize_argument = False
-            if parenthesize_argument:
-                markup = markups.Markup(rf"\concat {{ ( {markup.contents[0]} ) }}")
-            markup = callback._make_method_markup(markup)
-            previous_callback = callback
-        markup = new(markup, direction=direction)
-        return markup
-
-    def _compile_callback_strings(self, name):
-        string = name
-        previous_callback = None
-        for callback in self.callbacks or []:
-            if previous_callback and previous_callback.next_name:
-                string = previous_callback.next_name
-            template = callback.string_template
-            if template is None:
-                raise ValueError(f"callback {callback!r} has no string template.")
-            try:
-                string = template.format(string)
-            except Exception as e:
-                message = f"callback {callback!r} with template {template!r}"
-                message += f" and name {string!r} raises {e!r}."
-                raise Exception(message)
-            previous_callback = callback
-        return string
-
     def _evaluate(self, *arguments, **keywords):
         assert self.evaluation_template
         if self.evaluation_template == "map":
             return self._evaluate_map(*arguments)
         if self.evaluation_template == "group_by":
             return self._evaluate_group_by(*arguments)
-        if self.subclass_hook:
-            assert isinstance(self.subclass_hook, str)
-            subclass_hook = getattr(self, self.subclass_hook)
-            return subclass_hook(*arguments)
         globals_ = self._make_globals()
         statement = self.evaluation_template
         strings = []
@@ -651,7 +317,6 @@ class Expression:
                 statement = statement.replace("{}", "")
             else:
                 strings = []
-                __argument_0 = arguments[0]
                 for i, argument in enumerate(arguments):
                     string = "__argument_" + str(i)
                     globals_[string] = argument
@@ -662,18 +327,12 @@ class Expression:
                     arg = exception.args[0]
                     message = f"statement {statement!r} raises {arg!r}."
                     raise type(exception)(message)
-        old_phrase = "_map_index=None"
-        if old_phrase in statement:
-            new_phrase = f"_map_index={self._map_index}"
-            statement = statement.replace(old_phrase, new_phrase)
         try:
             result = eval(statement, globals_)
         except Exception as exception:
             arg = exception.args[0]
             message = f"evaluable statement {statement!r} raises {arg!r}."
             raise type(exception)(message)
-        if self.force_return:
-            result = __argument_0
         return result
 
     def _evaluate_group_by(self, *arguments):
@@ -725,8 +384,6 @@ class Expression:
         def make_items(map_operand, ___argument_0):
             items = []
             for i, item in enumerate(__argument_0):
-                if hasattr(map_operand, "_set_map_index"):
-                    map_operand._set_map_index(i)
                 item_ = map_operand(item)
                 items.append(item_)
             return items
@@ -748,37 +405,24 @@ class Expression:
         class_,
         frame,
         evaluation_template=None,
-        force_return=None,
-        is_composite=None,
         is_initializer=None,
-        is_postfix=None,
         keywords=None,
         map_operand=None,
         module_names=None,
-        precedence=None,
-        string_template=None,
-        subclass_hook=None,
     ):
         if evaluation_template is None:
             evaluation_template = class_._get_evaluation_template(frame)
         result = class_._read_signature_decorator(frame)
         argument_values = result["argument_values"]
         qualified_method_name = result["qualified_method_name"]
-        string_template = result["string_template"] or string_template
         return class_(
             argument_values=argument_values,
             evaluation_template=evaluation_template,
-            force_return=force_return,
-            is_composite=is_composite,
             is_initializer=is_initializer,
-            is_postfix=is_postfix,
             keywords=keywords,
             map_operand=map_operand,
             module_names=module_names,
-            precedence=precedence,
             qualified_method_name=qualified_method_name,
-            string_template=string_template,
-            subclass_hook=subclass_hook,
         )
 
     @staticmethod
@@ -795,11 +439,11 @@ class Expression:
         return callback
 
     @staticmethod
-    def _get_evaluation_template(frame, static_class=None):
+    def _get_evaluation_template(frame):
         try:
             frame_info = inspect.getframeinfo(frame)
             function_name = frame_info.function
-            arguments = Expression._wrap_arguments(frame, static_class=static_class)
+            arguments = Expression._wrap_arguments(frame)
             template = f"{{}}.{function_name}({arguments})"
         finally:
             del frame
@@ -816,17 +460,6 @@ class Expression:
             storage_format_forced_override=self.template,
             storage_format_keyword_names=(),
         )
-
-    @staticmethod
-    def _get_method_name(function_name, function, function_self, argument_values):
-        if getattr(function, "method_name", None) is not None:
-            return getattr(function, "method_name")
-        method_name_callback = Expression._get_callback(
-            "method_name_callback", function, function_self
-        )
-        if method_name_callback:
-            return method_name_callback(**argument_values)
-        return function_name
 
     def _is_singular_get_item(self):
         if not self.callbacks:
@@ -848,41 +481,9 @@ class Expression:
         return True
 
     @staticmethod
-    def _make___add___markup(markup, argument):
-        markup = markups.Markup(rf'\line {{ {markup.contents[0]} + "{argument}" }}')
-        return markup
-
-    @staticmethod
-    def _make___add___string_template(argument):
-        return "{} + " + str(argument)
-
-    @staticmethod
-    def _make___getitem___markup(markup, argument):
-        string = Expression._make_subscript_string(argument, markup=True)
-        string = fr'\concat {{ {markup.contents[0]} \sub "{string}" }}'
-        markup = markups.Markup(string)
-        return markup
-
-    @staticmethod
     def _make___getitem___string_template(argument):
         string = Expression._make_subscript_string(argument, markup=False)
         return "{}" + string
-
-    @staticmethod
-    def _make___radd___markup(markup, argument):
-        string = rf'\line {{ "{argument}" + {markup.contents[0]} }}'
-        markup = markups.Markup(string)
-        return markup
-
-    @staticmethod
-    def _make___radd___string_template(argument):
-        return str(argument) + " + {}"
-
-    @staticmethod
-    def _make_establish_equivalence_markup(lhs, rhs):
-        string = rf'\line {{ \bold "{lhs}" = {rhs.contents[0]} }}'
-        markup = markups.Markup(string)
-        return markup
 
     @staticmethod
     def _make_evaluable_keywords(keywords):
@@ -892,45 +493,6 @@ class Expression:
                 value = Expression._to_evaluable_string(value)
             result[key] = value
         return result
-
-    @staticmethod
-    def _make_expression_add_markup(markups_):
-        assert len(markups_) == 2
-        string = rf"\line {{ {markups_[0].contents[0]} + {markups_[1].contents[0]} }}"
-        markup = markups.Markup(string)
-        return markup
-
-    @staticmethod
-    def _make_function_markup(
-        markup, method_name, argument_list_callback, method, argument_values
-    ):
-        if argument_list_callback:
-            arguments = argument_list_callback(**argument_values)
-        else:
-            arguments = Expression._wrap_arguments_new(method, argument_values)
-        string = f"{method_name}({markup.contents[0]}"
-        if arguments:
-            string += f'", {arguments})"'
-        else:
-            string += " )"
-        string = rf"\concat {{ {string} }}"
-        markup = markups.Markup(string)
-        return markup
-
-    # TODO: eventually do not pass frame
-    @staticmethod
-    def _make_function_string_template(
-        frame, method_name, argument_values, argument_list_callback
-    ):
-        if argument_list_callback:
-            arguments = argument_list_callback(**argument_values)
-        else:
-            arguments = Expression._wrap_arguments(frame)
-        if arguments:
-            template = f"{method_name}({{}}, {arguments})"
-        else:
-            template = method_name + "({})"
-        return template
 
     def _make_globals(self):
         abjad = importlib.import_module("abjad")
@@ -952,7 +514,6 @@ class Expression:
         *,
         callback_class=None,
         module_names=None,
-        string_template=None,
         **keywords,
     ):
         assert isinstance(class_, type), repr(class_)
@@ -976,103 +537,7 @@ class Expression:
             is_initializer=True,
             keywords=keywords,
             module_names=module_names,
-            string_template=string_template,
         )
-
-    def _make_method_markup(self, markup):
-        if self.is_initializer:
-            assert self.qualified_method_name is None
-            return markups.Markup(markup)
-        qualified_method_name = self.qualified_method_name
-        assert isinstance(qualified_method_name, str), repr(self)
-        if qualified_method_name == "abjad.Expression.establish_equivalence":
-            markup = self._make_establish_equivalence_markup(self.next_name, markup)
-            return markup
-        assert "." in qualified_method_name, repr(self)
-        globals_ = self._make_globals()
-        method = eval(qualified_method_name, globals_)
-        if not getattr(method, "has_signature_decorator", False):
-            raise Exception(f"{method} has no signature decorator.")
-        callback_name = getattr(method, "markup_maker_callback", None)
-        if callback_name is not None:
-            parts = qualified_method_name.split(".")
-            parts.pop(-1)
-            parts.append(callback_name)
-            qualified_callback_name = ".".join(parts)
-            try:
-                callback = eval(qualified_callback_name, globals_)
-            except AttributeError:
-                callback = getattr(self, callback_name)
-            argument_values = self.argument_values or {}
-            markup = callback(markup, **argument_values)
-            return markup
-        callback_name = getattr(method, "method_name_callback", None)
-        if callback_name is not None:
-            parts = qualified_method_name.split(".")
-            parts.pop(-1)
-            parts.append(callback_name)
-            callback_name = ".".join(parts)
-            callback = eval(callback_name, globals_)
-            method_name = callback(**self.argument_values)
-        elif getattr(method, "method_name", None) is not None:
-            method_name = method.method_name
-        else:
-            method_name = method.__name__
-        assert isinstance(method_name, str), repr((self, method))
-        if getattr(method, "is_operator", None):
-            subscript = getattr(method, "subscript", None)
-            if subscript is not None:
-                subscript = self.argument_values[subscript]
-            superscript = getattr(method, "superscript", None)
-            if superscript is not None:
-                superscript = self.argument_values[superscript]
-            markup = Expression._make_operator_markup(
-                markup,
-                method_name=method_name,
-                subscript=subscript,
-                superscript=superscript,
-            )
-        else:
-            argument_list_callback = getattr(method, "argument_list_callback")
-            if argument_list_callback is not None:
-                parts = qualified_method_name.split(".")
-                parts.pop(-1)
-                parts.append(argument_list_callback)
-                qualified_callback_name = ".".join(parts)
-                argument_list_callback = eval(qualified_callback_name, globals_)
-            markup = Expression._make_function_markup(
-                markup,
-                method_name,
-                argument_list_callback,
-                method,
-                self.argument_values,
-            )
-        return markup
-
-    @staticmethod
-    def _make_operator_markup(
-        markup, method_name=None, subscript=None, superscript=None
-    ):
-        string = f"{method_name}"
-        if superscript is not None:
-            string += rf" \super {superscript}"
-        if subscript is not None:
-            string += rf"\sub {subscript}"
-        string = rf"\concat {{ {string} {markup.contents[0]} }}"
-        markup = markups.Markup(string)
-        return markup
-
-    @staticmethod
-    def _make_operator_string_template(
-        method_name=None, subscript=None, superscript=None
-    ):
-        template = method_name
-        if superscript is not None:
-            template += str(superscript)
-        if subscript is not None:
-            template += str(subscript)
-        template += "({})"
-        return template
 
     @staticmethod
     def _make_subscript_string(i, markup=False):
@@ -1115,7 +580,6 @@ class Expression:
             argument_info = inspect.getargvalues(frame)
             assert argument_info.args[0] == "self"
             function_self = argument_info.locals["self"]
-            function = getattr(function_self, function_name)
             class_ = function_self.__class__
             parts = class_.__module__.split(".")
             if parts[-1] != class_.__name__:
@@ -1127,59 +591,16 @@ class Expression:
             qualified_method_name = ".".join(parts)
             assert "." in qualified_method_name
             argument_values = {}
-            if not getattr(function, "has_signature_decorator", False):
-                return {
-                    "argument_values": argument_values,
-                    "qualified_method_name": qualified_method_name,
-                    "string_template": None,
-                }
-            argument_names = argument_info.args[1:]
-            for argument_name in argument_names:
-                argument_value = argument_info.locals[argument_name]
-                argument_values[argument_name] = argument_value
-            string_template_callback = Expression._get_callback(
-                "string_template_callback", function, function_self
-            )
-            if string_template_callback is not None:
-                string_template = string_template_callback(**argument_values)
-            elif getattr(function, "is_operator", None):
-                method_name = Expression._get_method_name(
-                    function_name, function, function_self, argument_values
-                )
-                subscript = getattr(function, "subscript", None)
-                if subscript is not None:
-                    subscript = argument_info.locals[subscript]
-                superscript = getattr(function, "superscript", None)
-                if superscript is not None:
-                    superscript = argument_info.locals[superscript]
-                string_template = Expression._make_operator_string_template(
-                    method_name=method_name,
-                    subscript=subscript,
-                    superscript=superscript,
-                )
-            else:
-                method_name = Expression._get_method_name(
-                    function_name, function, function_self, argument_values
-                )
-                argument_list_callback = Expression._get_callback(
-                    "argument_list_callback", function, function_self
-                )
-                # TODO: eventually do not pass frame
-                string_template = Expression._make_function_string_template(
-                    frame, method_name, argument_values, argument_list_callback
-                )
+            return {
+                "argument_values": argument_values,
+                "qualified_method_name": qualified_method_name,
+            }
         finally:
             del frame
         return {
             "argument_values": argument_values,
             "qualified_method_name": qualified_method_name,
-            "string_template": string_template,
         }
-
-    def _set_map_index(self, i):
-        if i is not None:
-            assert isinstance(i, int), repr(i)
-        self._map_index = i
 
     @staticmethod
     def _to_evaluable_string(argument):
@@ -1234,19 +655,13 @@ class Expression:
         return argument
 
     @staticmethod
-    def _wrap_arguments(frame, *, static_class=None):
+    def _wrap_arguments(frame):
         try:
             frame_info = inspect.getframeinfo(frame)
             function_name = frame_info.function
             argument_info = inspect.getargvalues(frame)
-            # static method
-            if static_class:
-                method_name = frame.f_code.co_name
-                static_method = getattr(static_class, method_name)
-                signature = inspect.signature(static_method)
-                argument_names = argument_info.args[:]
             # bound method
-            elif argument_info.args and argument_info.args[0] == "self":
+            if argument_info.args and argument_info.args[0] == "self":
                 self = argument_info.locals["self"]
                 function = getattr(self, function_name)
                 signature = inspect.signature(function)
@@ -1265,9 +680,6 @@ class Expression:
                     argument_value = Expression._to_evaluable_string(argument_value)
                     argument_string = argument_value
                     argument_strings.append(argument_string)
-                elif argument_name == "_map_index":
-                    argument_string = "_map_index=None"
-                    argument_strings.append(argument_string)
                 # keyword argument
                 elif argument_value != parameter.default:
                     argument_string = "{argument_name}={argument_value}"
@@ -1280,24 +692,6 @@ class Expression:
             arguments = ", ".join(argument_strings)
         finally:
             del frame
-        return arguments
-
-    @staticmethod
-    def _wrap_arguments_new(method, argument_values):
-        signature = inspect.signature(method)
-        argument_names = [_ for _ in signature.parameters][1:]
-        argument_strings = []
-        for argument_name in argument_names:
-            argument_value = argument_values[argument_name]
-            parameter = signature.parameters[argument_name]
-            if argument_value != parameter.default:
-                argument_string = "{argument_name}={argument_value}"
-                argument_value = Expression._to_evaluable_string(argument_value)
-                argument_string = argument_string.format(
-                    argument_name=argument_name, argument_value=argument_value
-                )
-                argument_strings.append(argument_string)
-        arguments = ", ".join(argument_strings)
         return arguments
 
     ### PUBLIC PROPERTIES ###
@@ -1335,61 +729,11 @@ class Expression:
         return self._evaluation_template
 
     @property
-    def force_return(self) -> typing.Optional[bool]:
-        """
-        Is true when expression should return primary input argument.
-        """
-        return self._force_return
-
-    @property
-    def has_parentheses(self) -> typing.Optional[bool]:
-        """
-        Is true when expression has parentheses.
-        """
-        return self._has_parentheses
-
-    @property
-    def is_composite(self) -> typing.Optional[bool]:
-        """
-        Is true when expression is composite.
-        """
-        return self._is_composite
-
-    @property
     def is_initializer(self) -> typing.Optional[bool]:
         """
         Is true when expression is initializer.
         """
         return self._is_initializer
-
-    @property
-    def is_postfix(self) -> typing.Optional[bool]:
-        """
-        Is true when expression is postfix.
-        """
-        return self._is_postfix
-
-    @property
-    def is_selector(self) -> typing.Optional[bool]:
-        """
-        Is true when expression is selector.
-
-        ..  container:: example
-
-            >>> expression = abjad.select().leaf(0)
-            >>> expression.is_selector
-            True
-
-            >>> expression = abjad.sequence().rotate(n=-1)
-            >>> expression.is_selector
-            False
-
-        """
-        if self.callbacks:
-            first_callback = self.callbacks[0]
-            if ".Selection" in first_callback.evaluation_template:
-                return True
-        return False
 
     @property
     def keywords(self) -> typing.Dict:
@@ -1413,52 +757,11 @@ class Expression:
         return self._map_operand
 
     @property
-    def markup_maker_callback(self) -> typing.Optional[str]:
-        """
-        Gets markup-maker callback.
-        """
-        return self._markup_maker_callback
-
-    @property
     def module_names(self) -> typing.Optional[typing.List[str]]:
         """
         Gets module names.
         """
         return self._module_names
-
-    @property
-    def name(self) -> typing.Optional[str]:
-        """
-        Gets name.
-
-        ..  container:: example expression
-
-            Preserves name after initializer callback:
-
-            >>> expression = abjad.Expression(name='J')
-            >>> expression.name
-            'J'
-
-            >>> expression = abjad.sequence(name="J")
-            >>> expression.name
-            'J'
-
-        """
-        return self._name
-
-    @property
-    def next_name(self) -> typing.Optional[str]:
-        """
-        Gets next name.
-        """
-        return self._next_name
-
-    @property
-    def precedence(self) -> typing.Optional[int]:
-        """
-        Gets precedence.
-        """
-        return self._precedence
 
     @property
     def proxy_class(self):
@@ -1479,24 +782,6 @@ class Expression:
         Gets qualified method name of expression.
         """
         return self._qualified_method_name
-
-    @property
-    def string_template(self) -> typing.Optional[str]:
-        """
-        Gets string template.
-        """
-        return self._string_template
-
-    @property
-    def subclass_hook(self) -> typing.Optional[str]:
-        """
-        Gets subclass hook.
-
-        Only to be set by expression subclasses.
-
-        Set to name of custom evaluation method.
-        """
-        return self._subclass_hook
 
     @property
     def subexpressions(self) -> typing.Optional[typing.List["Expression"]]:
@@ -1542,234 +827,6 @@ class Expression:
         callbacks = callbacks + [callback]
         return new(self, callbacks=callbacks)
 
-    def establish_equivalence(self, name) -> "Expression":
-        r"""
-        Makes new expression with ``name``.
-
-        ..  container:: example expression
-
-            >>> expression = abjad.pitch_class_segment(name='J')
-            >>> expression = expression.rotate(n=1)
-            >>> expression = expression.rotate(n=2)
-            >>> expression = expression.establish_equivalence(name='Q')
-
-            >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-            PitchClassSegment([7, 10.5, 7, 10, 10.5, 6])
-
-            >>> expression.get_string()
-            'Q = r2(r1(J))'
-
-            >>> markup = expression.get_markup()
-            >>> abjad.show(markup) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(markup)
-                >>> print(string)
-                \markup {
-                    \line
-                        {
-                            \bold
-                                Q
-                            =
-                            \concat
-                                {
-                                    r
-                                    \sub
-                                        2
-                                    \concat
-                                        {
-                                            r
-                                            \sub
-                                                1
-                                            \bold
-                                                J
-                                        }
-                                }
-                        }
-                    }
-
-        """
-        template = f"{name} = {{}}"
-        callback = self.make_callback(
-            evaluation_template="{}",
-            is_composite=True,
-            next_name=name,
-            qualified_method_name="abjad.Expression.establish_equivalence",
-            string_template=template,
-        )
-        return self.append_callback(callback)
-
-    def get_markup(self, direction=None, name=None):
-        """
-        Gets markup directly.
-
-        Avoids markup expressions.
-
-        Returns markup or none.
-        """
-        markup = None
-        if self.subexpressions:
-            markups = []
-            for subexpression in self.subexpressions or []:
-                markup = subexpression.get_markup()
-                markups.append(markup)
-            markup = self._make_method_markup(markups)
-            markup = self._apply_callback_markup(markup, previous_callback=self)
-        else:
-            if name is None:
-                name = self.name
-            if name is None:
-                for callback in self.callbacks or []:
-                    if callback.name is not None:
-                        name = callback.name
-                        break
-            if name is None:
-                raise ValueError(f"expression name not found: {self!r}.")
-            markup = self._apply_callback_markup(name)
-        if markup is not None:
-            markup = new(markup, direction=direction)
-        return markup
-
-    def get_string(self, name=None) -> typing.Optional[str]:
-        """
-        Gets string.
-
-        ..  container:: example
-
-            Gets string for sequence expression:
-
-            ..  container:: example expression
-
-                Without name:
-
-                >>> expression = abjad.sequence()
-                >>> expression = expression.reverse()
-                >>> expression = expression.rotate(n=2)
-
-                >>> expression([1, 2, 3, 4, 5, 6])
-                Sequence([2, 1, 6, 5, 4, 3])
-
-                >>> abjad.Expression.get_string(expression, name='J')
-                'r2(R(J))'
-
-            ..  container:: example expression
-
-                With name:
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.reverse()
-                >>> expression = expression.rotate(n=2)
-
-                >>> expression([1, 2, 3, 4, 5, 6])
-                Sequence([2, 1, 6, 5, 4, 3])
-
-                >>> abjad.Expression.get_string(expression)
-                'r2(R(J))'
-
-                Overrides name:
-
-                >>> abjad.Expression.get_string(expression, name='K')
-                'r2(R(K))'
-
-        ..  container:: example
-
-            Gets string for segment expression:
-
-            ..  container:: example expression
-
-                Without name:
-
-                >>> expression = abjad.pitch_class_segment()
-                >>> expression = expression.invert()
-                >>> expression = expression.rotate(n=2)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([1.5, 5, 2, 1.5, 6, 5])
-
-                >>> abjad.Expression.get_string(expression, name='J')
-                'r2(I(J))'
-
-            ..  container:: example expression
-
-                With name:
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.invert()
-                >>> expression = expression.rotate(n=2)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([1.5, 5, 2, 1.5, 6, 5])
-
-                >>> abjad.Expression.get_string(expression)
-                'r2(I(J))'
-
-                Overrides name:
-
-                >>> abjad.Expression.get_string(expression, name='K')
-                'r2(I(K))'
-
-        """
-        if self.subexpressions:
-            strings = []
-            for subexpression in self.subexpressions or []:
-                string = subexpression.get_string()
-                strings.append(string)
-            template = self.string_template
-            if template is None:
-                raise ValueError(f"expression has no string template: {self!r}.")
-            try:
-                string = template.format(*strings)
-            except Exception as e:
-                raise Exception(f"{self!r} with template {template!r} raises {e!r}.")
-            return self._compile_callback_strings(string)
-        else:
-            if name is None:
-                name = self.name
-            if name is None:
-                for callback in self.callbacks or []:
-                    if callback.name is not None:
-                        name = callback.name
-                        break
-            if name is None:
-                raise ValueError(f"expression name not found: {self!r}.")
-            return self._compile_callback_strings(name)
-
-    @staticmethod
-    def make_callback(
-        evaluation_template=None,
-        force_return=None,
-        has_parentheses=None,
-        is_composite=None,
-        is_initializer=None,
-        is_postfix=None,
-        keywords=None,
-        map_operand=None,
-        module_names=None,
-        next_name=None,
-        precedence=None,
-        qualified_method_name=None,
-        string_template=None,
-    ) -> "Expression":
-        """
-        Makes callback.
-        """
-        return Expression(
-            evaluation_template=evaluation_template,
-            force_return=force_return,
-            has_parentheses=has_parentheses,
-            is_composite=is_composite,
-            is_initializer=is_initializer,
-            is_postfix=is_postfix,
-            keywords=keywords,
-            map_operand=map_operand,
-            module_names=module_names,
-            next_name=next_name,
-            precedence=precedence,
-            qualified_method_name=qualified_method_name,
-            string_template=string_template,
-        )
-
     def print(self, argument) -> None:
         """
         Prints ``argument``.
@@ -1779,29 +836,3 @@ class Expression:
         else:
             for item in argument:
                 print(repr(item))
-
-    def wrap_in_list(self) -> "Expression":
-        """
-        Makes expression to wrap argument in list.
-
-        ..  container:: example expression
-
-            >>> expression = abjad.Expression()
-            >>> expression = expression.wrap_in_list()
-
-            >>> expression(abjad.Markup('Allegro assai'))
-            [Markup(contents=['Allegro assai'])]
-
-            >>> string = abjad.storage(expression)
-            >>> print(string)
-            abjad.Expression(
-                callbacks=[
-                    abjad.Expression(
-                        evaluation_template='[{}]',
-                        ),
-                    ],
-                )
-
-        """
-        callback = self.make_callback(evaluation_template="[{}]")
-        return self.append_callback(callback)

--- a/abjad/iterate.py
+++ b/abjad/iterate.py
@@ -1,7 +1,6 @@
 import typing
 
 from . import _iterate, score
-from .expression import Expression
 from .ordereddict import OrderedDict
 from .pitch.pitches import NamedPitch, Pitch
 from .pitch.sets import PitchSet
@@ -1172,8 +1171,4 @@ def iterate(client=None):
         Note("f'4")
 
     """
-    if client is not None:
-        return Iteration(client=client)
-    expression = Expression()
-    expression = expression.iterate()
-    return expression
+    return Iteration(client=client)

--- a/abjad/label.py
+++ b/abjad/label.py
@@ -1,12 +1,10 @@
 import collections
-import inspect
 import typing
 
 from . import _inspect, _iterate, enums
 from .attach import attach, detach
 from .cyclictuple import CyclicTuple
 from .duration import Duration, NonreducedFraction
-from .expression import Expression
 from .indicators.LilyPondComment import LilyPondComment
 from .iterate import Iteration
 from .markups import Markup
@@ -42,50 +40,8 @@ class Label:
         ..  container:: example
 
             >>> staff = abjad.Staff("c'4 e'4 d'4 f'4")
-            >>> abjad.label(staff).with_pitches(locale='us')
+            >>> abjad.Label(staff).with_pitches(locale='us')
 
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(staff)
-                >>> print(string)
-                \new Staff
-                {
-                    c'4
-                    ^ \markup { C4 }
-                    e'4
-                    ^ \markup { E4 }
-                    d'4
-                    ^ \markup { D4 }
-                    f'4
-                    ^ \markup { F4 }
-                }
-
-        ..  container:: example expression
-
-            >>> staff = abjad.Staff("c'4 e'4 d'4 f'4")
-            >>> expression = abjad.label().with_pitches(locale='us')
-            >>> string = abjad.storage(expression)
-            >>> print(string)
-            abjad.Expression(
-                callbacks=[
-                    abjad.Expression(
-                        evaluation_template='abjad.Label',
-                        is_initializer=True,
-                        keywords={
-                            'tag': None,
-                            },
-                        ),
-                    abjad.Expression(
-                        evaluation_template="{}.with_pitches(locale='us')",
-                        qualified_method_name='abjad.Label.with_pitches',
-                        ),
-                    ],
-                proxy_class=abjad.Label,
-                )
-
-            >>> expression(staff)
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -111,66 +67,8 @@ class Label:
         ..  container:: example
 
             >>> staff = abjad.Staff("c'4 e'4 d'4 f'4")
-            >>> abjad.label(staff).with_durations()
+            >>> abjad.Label(staff).with_durations()
 
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(staff)
-                >>> print(string)
-                \new Staff
-                {
-                    c'4
-                    ^ \markup {
-                        \fraction
-                            1
-                            4
-                        }
-                    e'4
-                    ^ \markup {
-                        \fraction
-                            1
-                            4
-                        }
-                    d'4
-                    ^ \markup {
-                        \fraction
-                            1
-                            4
-                        }
-                    f'4
-                    ^ \markup {
-                        \fraction
-                            1
-                            4
-                        }
-                }
-
-        ..  container:: example expression
-
-            >>> staff = abjad.Staff("c'4 e'4 d'4 f'4")
-            >>> expression = abjad.label().with_durations()
-            >>> string = abjad.storage(expression)
-            >>> print(string)
-            abjad.Expression(
-                callbacks=[
-                    abjad.Expression(
-                        evaluation_template='abjad.Label',
-                        is_initializer=True,
-                        keywords={
-                            'tag': None,
-                            },
-                        ),
-                    abjad.Expression(
-                        evaluation_template='{}.with_durations()',
-                        qualified_method_name='abjad.Label.with_durations',
-                        ),
-                    ],
-                proxy_class=abjad.Label,
-                )
-
-            >>> expression(staff)
             >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -265,10 +163,6 @@ class Label:
             self._attach(literal, leaf)
         return leaf
 
-    def _update_expression(self, frame):
-        callback = Expression._frame_to_callback(frame)
-        return self._expression.append_callback(callback)
-
     ### PUBLIC PROPERTIES ###
 
     @property
@@ -314,37 +208,7 @@ class Label:
 
                 >>> staff = abjad.Staff("c'8 d'8")
                 >>> abjad.attach(abjad.TimeSignature((2, 8)), staff[0])
-                >>> abjad.label(staff).color_container("#red")
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override Accidental.color = #red
-                        \override Beam.color = #red
-                        \override Dots.color = #red
-                        \override NoteHead.color = #red
-                        \override Rest.color = #red
-                        \override Stem.color = #red
-                        \override TupletBracket.color = #red
-                        \override TupletNumber.color = #red
-                    }
-                    {
-                        \time 2/8
-                        c'8
-                        d'8
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("c'8 d'8")
-                >>> abjad.attach(abjad.TimeSignature((2, 8)), staff[0])
-                >>> expression = abjad.label().color_container("#red")
-                >>> expression(staff)
+                >>> abjad.Label(staff).color_container("#red")
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 ..  docs::
@@ -371,8 +235,6 @@ class Label:
 
         Returns none.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         override(self.client).Accidental.color = color
         override(self.client).Beam.color = color
         override(self.client).Dots.color = color
@@ -394,33 +256,7 @@ class Label:
 
                 >>> staff = abjad.Staff("cs'8. r8. s8. <c' cs' a'>8.")
                 >>> abjad.beam(staff[:])
-                >>> abjad.label(staff).color_leaves("#red")
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    {
-                        \abjad-color-music #'red
-                        cs'8.
-                        [
-                        \abjad-color-music #'red
-                        r8.
-                        % red
-                        s8.
-                        \abjad-color-music #'red
-                        <c' cs' a'>8.
-                        ]
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("cs'8. r8. s8. <c' cs' a'>8.")
-                >>> abjad.beam(staff[:])
-                >>> expression = abjad.label().color_leaves("#red")
-                >>> expression(staff)
+                >>> abjad.Label(staff).color_leaves("#red")
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 ..  docs::
@@ -443,8 +279,6 @@ class Label:
 
         Returns none.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         for leaf in Iteration(self.client).leaves():
             self._color_leaf(leaf, color)
 
@@ -462,34 +296,7 @@ class Label:
                 >>> pitches = [[-12, -10, 4], [-2, 8, 11, 17], [19, 27, 30, 33, 37]]
                 >>> colors = ["#red", "#blue", "#green"]
                 >>> color_map = abjad.ColorMap(colors=colors, pitch_iterables=pitches)
-                >>> abjad.label(chord).color_note_heads(color_map)
-                >>> abjad.show(chord) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(chord)
-                    >>> print(string)
-                    <
-                        \tweak color #red
-                        c''
-                        \tweak color #red
-                        d''
-                        \tweak color #green
-                        fs''
-                        \tweak color #green
-                        a''
-                        \tweak color #blue
-                        b''
-                    >4
-
-            ..  container:: example expression
-
-                >>> chord = abjad.Chord([12, 14, 18, 21, 23], (1, 4))
-                >>> pitches = [[-12, -10, 4], [-2, 8, 11, 17], [19, 27, 30, 33, 37]]
-                >>> colors = ["#red", "#blue", "#green"]
-                >>> color_map = abjad.ColorMap(colors=colors, pitch_iterables=pitches)
-                >>> expression = abjad.label().color_note_heads(color_map)
-                >>> expression(chord)
+                >>> abjad.Label(chord).color_note_heads(color_map)
                 >>> abjad.show(chord) # doctest: +SKIP
 
                 ..  docs::
@@ -516,21 +323,7 @@ class Label:
             ..  container:: example
 
                 >>> note = abjad.Note("c'4")
-                >>> abjad.label(note).color_note_heads(color_map)
-                >>> abjad.show(note) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(note)
-                    >>> print(string)
-                    \once \override NoteHead.color = #red
-                    c'4
-
-            ..  container:: example expression
-
-                >>> note = abjad.Note("c'4")
-                >>> expression = abjad.label().color_note_heads(color_map)
-                >>> expression(note)
+                >>> abjad.Label(note).color_note_heads(color_map)
                 >>> abjad.show(note) # doctest: +SKIP
 
                 ..  docs::
@@ -547,13 +340,7 @@ class Label:
             ..  container:: example
 
                 >>> staff = abjad.Staff()
-                >>> abjad.label(staff).color_note_heads(color_map)
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff()
-                >>> expression = abjad.label().color_note_heads(color_map)
-                >>> expression(staff)
+                >>> abjad.Label(staff).color_note_heads(color_map)
 
         ..  container:: example
 
@@ -562,48 +349,7 @@ class Label:
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 cs'8 d'8 ds'8 e'8 f'8 fs'8 g'8 gs'8 a'8 as'8 b'8 c''8")
-                >>> abjad.label(staff).color_note_heads()
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    {
-                        \once \override NoteHead.color = #(x11-color 'red)
-                        c'8
-                        \once \override NoteHead.color = #(x11-color 'MediumBlue)
-                        cs'8
-                        \once \override NoteHead.color = #(x11-color 'orange)
-                        d'8
-                        \once \override NoteHead.color = #(x11-color 'LightSlateBlue)
-                        ds'8
-                        \once \override NoteHead.color = #(x11-color 'ForestGreen)
-                        e'8
-                        \once \override NoteHead.color = #(x11-color 'MediumOrchid)
-                        f'8
-                        \once \override NoteHead.color = #(x11-color 'firebrick)
-                        fs'8
-                        \once \override NoteHead.color = #(x11-color 'DeepPink)
-                        g'8
-                        \once \override NoteHead.color = #(x11-color 'DarkOrange)
-                        gs'8
-                        \once \override NoteHead.color = #(x11-color 'IndianRed)
-                        a'8
-                        \once \override NoteHead.color = #(x11-color 'CadetBlue)
-                        as'8
-                        \once \override NoteHead.color = #(x11-color 'SeaGreen)
-                        b'8
-                        \once \override NoteHead.color = #(x11-color 'red)
-                        c''8
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("c'8 cs'8 d'8 ds'8 e'8 f'8 fs'8 g'8 gs'8 a'8 as'8 b'8 c''8")
-                >>> expression = abjad.label().color_note_heads()
-                >>> expression(staff)
+                >>> abjad.Label(staff).color_note_heads()
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 ..  docs::
@@ -642,8 +388,6 @@ class Label:
 
         Returns none.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         color_map = color_map or self._pc_number_to_color
         for leaf in Iteration(self.client).leaves():
             if isinstance(leaf, Chord):
@@ -665,8 +409,6 @@ class Label:
         """
         Colors client by ``selector``.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         if selector._is_singular_get_item():
             colors = colors or ["#green"]
             color = colors[0]
@@ -689,7 +431,7 @@ class Label:
             ..  container:: example
 
                 >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-                >>> abjad.label(staff).with_pitches()
+                >>> abjad.Label(staff).with_pitches()
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 ..  docs::
@@ -708,46 +450,7 @@ class Label:
                         ^ \markup { f' }
                     }
 
-                >>> abjad.label(staff).remove_markup()
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    {
-                        c'8
-                        d'8
-                        e'8
-                        f'8
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-                >>> expression = abjad.label().with_pitches()
-                >>> expression(staff)
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    {
-                        c'8
-                        ^ \markup { c' }
-                        d'8
-                        ^ \markup { d' }
-                        e'8
-                        ^ \markup { e' }
-                        f'8
-                        ^ \markup { f' }
-                    }
-
-                >>> expression = abjad.label().remove_markup()
-                >>> expression(staff)
+                >>> abjad.Label(staff).remove_markup()
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 ..  docs::
@@ -764,8 +467,6 @@ class Label:
 
         Returns none.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         for leaf in Iteration(self.client).leaves():
             detach(Markup, leaf)
 
@@ -786,66 +487,7 @@ class Label:
                 >>> staff_group.append(staff)
                 >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
                 >>> staff_group.append(staff)
-                >>> abjad.label(staff_group).vertical_moments()
-                >>> abjad.show(staff_group) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff_group)
-                    >>> print(string)
-                    \new StaffGroup
-                    <<
-                        \new Staff
-                        {
-                            c'8
-                            ^ \markup {
-                                \tiny
-                                    0
-                                }
-                            d'4
-                            ^ \markup {
-                                \tiny
-                                    1
-                                }
-                            e'16
-                            ^ \markup {
-                                \tiny
-                                    3
-                                }
-                            f'16
-                            ^ \markup {
-                                \tiny
-                                    4
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "alto"
-                            g4
-                            f4
-                            ^ \markup {
-                                \tiny
-                                    2
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "bass"
-                            c,2
-                        }
-                    >>
-
-            ..  container:: example expression
-
-                >>> staff_group = abjad.StaffGroup([])
-                >>> staff = abjad.Staff("c'8 d'4 e'16 f'16")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "alto" g4 f4""")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
-                >>> staff_group.append(staff)
-                >>> expression = abjad.label().vertical_moments()
-                >>> expression(staff_group)
+                >>> abjad.Label(staff_group).vertical_moments()
                 >>> abjad.show(staff_group) # doctest: +SKIP
 
                 ..  docs::
@@ -907,94 +549,9 @@ class Label:
                 >>> staff_group.append(staff)
                 >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
                 >>> staff_group.append(staff)
-                >>> abjad.label(staff_group).vertical_moments(
+                >>> abjad.Label(staff_group).vertical_moments(
                 ...     prototype=abjad.NumberedPitch,
                 ...     )
-                >>> abjad.show(staff_group) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff_group)
-                    >>> print(string)
-                    \new StaffGroup
-                    <<
-                        \new Staff
-                        {
-                            c'8
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            0
-                                            -5
-                                            -24
-                                        }
-                                }
-                            d'4
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            2
-                                            -5
-                                            -24
-                                        }
-                                }
-                            e'16
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            4
-                                            -7
-                                            -24
-                                        }
-                                }
-                            f'16
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            5
-                                            -7
-                                            -24
-                                        }
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "alto"
-                            g4
-                            f4
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            2
-                                            -7
-                                            -24
-                                        }
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "bass"
-                            c,2
-                        }
-                    >>
-
-            ..  container:: example expression
-
-                >>> staff_group = abjad.StaffGroup([])
-                >>> staff = abjad.Staff("c'8 d'4 e'16 f'16")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "alto" g4 f4""")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
-                >>> staff_group.append(staff)
-                >>> prototype = abjad.NumberedPitch
-                >>> expression = abjad.label().vertical_moments(prototype=prototype)
-                >>> expression(staff_group)
                 >>> abjad.show(staff_group) # doctest: +SKIP
 
                 ..  docs::
@@ -1082,90 +639,7 @@ class Label:
                 >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
                 >>> staff_group.append(staff)
                 >>> prototype = abjad.NumberedPitchClass
-                >>> abjad.label(staff_group).vertical_moments(prototype=prototype)
-                >>> abjad.show(staff_group) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff_group)
-                    >>> print(string)
-                    \new StaffGroup
-                    <<
-                        \new Staff
-                        {
-                            c'8
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            7
-                                            0
-                                        }
-                                }
-                            d'4
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            7
-                                            2
-                                            0
-                                        }
-                                }
-                            e'16
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            5
-                                            4
-                                            0
-                                        }
-                                }
-                            f'16
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            5
-                                            0
-                                        }
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "alto"
-                            g4
-                            f4
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            5
-                                            2
-                                            0
-                                        }
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "bass"
-                            c,2
-                        }
-                    >>
-
-            ..  container:: example expression
-
-                >>> staff_group = abjad.StaffGroup([])
-                >>> staff = abjad.Staff("c'8 d'4 e'16 f'16")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "alto" g4 f4""")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
-                >>> staff_group.append(staff)
-                >>> prototype = abjad.NumberedPitchClass
-                >>> expression = abjad.label().vertical_moments(prototype=prototype)
-                >>> expression(staff_group)
+                >>> abjad.Label(staff_group).vertical_moments(prototype=prototype)
                 >>> abjad.show(staff_group) # doctest: +SKIP
 
                 ..  docs::
@@ -1251,87 +725,7 @@ class Label:
                 >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
                 >>> staff_group.append(staff)
                 >>> prototype = abjad.NumberedInterval
-                >>> abjad.label(staff_group).vertical_moments(prototype=prototype)
-                >>> abjad.show(staff_group) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff_group)
-                    >>> print(string)
-                    \new StaffGroup
-                    <<
-                        \new Staff
-                        {
-                            c'8
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            15
-                                            12
-                                        }
-                                }
-                            d'4
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            16
-                                            12
-                                        }
-                                }
-                            e'16
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            17
-                                            11
-                                        }
-                                }
-                            f'16
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            18
-                                            11
-                                        }
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "alto"
-                            g4
-                            f4
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            16
-                                            11
-                                        }
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "bass"
-                            c,2
-                        }
-                    >>
-
-            ..  container:: example expression
-
-                >>> staff_group = abjad.StaffGroup([])
-                >>> staff = abjad.Staff("c'8 d'4 e'16 f'16")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "alto" g4 f4""")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
-                >>> staff_group.append(staff)
-                >>> prototype = abjad.NumberedInterval
-                >>> expression = abjad.label().vertical_moments(prototype=prototype)
-                >>> expression(staff_group)
+                >>> abjad.Label(staff_group).vertical_moments(prototype=prototype)
                 >>> abjad.show(staff_group) # doctest: +SKIP
 
                 ..  docs::
@@ -1414,87 +808,7 @@ class Label:
                 >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
                 >>> staff_group.append(staff)
                 >>> prototype = abjad.NumberedIntervalClass
-                >>> abjad.label(staff_group).vertical_moments(prototype=prototype)
-                >>> abjad.show(staff_group) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff_group)
-                    >>> print(string)
-                    \new StaffGroup
-                    <<
-                        \new Staff
-                        {
-                            c'8
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            12
-                                            7
-                                        }
-                                }
-                            d'4
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            2
-                                            7
-                                        }
-                                }
-                            e'16
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            4
-                                            5
-                                        }
-                                }
-                            f'16
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            5
-                                            5
-                                        }
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "alto"
-                            g4
-                            f4
-                            ^ \markup {
-                                \tiny
-                                    \column
-                                        {
-                                            2
-                                            5
-                                        }
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "bass"
-                            c,2
-                        }
-                    >>
-
-            ..  container:: example expression
-
-                >>> staff_group = abjad.StaffGroup([])
-                >>> staff = abjad.Staff("c'8 d'4 e'16 f'16")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "alto" g4 f4""")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
-                >>> staff_group.append(staff)
-                >>> prototype = abjad.NumberedIntervalClass
-                >>> expression = abjad.label().vertical_moments(prototype=prototype)
-                >>> expression(staff_group)
+                >>> abjad.Label(staff_group).vertical_moments(prototype=prototype)
                 >>> abjad.show(staff_group) # doctest: +SKIP
 
                 ..  docs::
@@ -1577,72 +891,7 @@ class Label:
                 >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
                 >>> staff_group.append(staff)
                 >>> prototype = abjad.IntervalClassVector
-                >>> abjad.label(staff_group).vertical_moments(prototype=prototype)
-                >>> abjad.show(staff_group) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff_group)
-                    >>> print(string)
-                    \new StaffGroup
-                    <<
-                        \new Staff
-                        {
-                            c'8
-                            ^ \markup {
-                                \tiny
-                                    \tiny
-                                        1000020
-                                }
-                            d'4
-                            ^ \markup {
-                                \tiny
-                                    \tiny
-                                        0010020
-                                }
-                            e'16
-                            ^ \markup {
-                                \tiny
-                                    \tiny
-                                        0100110
-                                }
-                            f'16
-                            ^ \markup {
-                                \tiny
-                                    \tiny
-                                        1000020
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "alto"
-                            g4
-                            f4
-                            ^ \markup {
-                                \tiny
-                                    \tiny
-                                        0011010
-                                }
-                        }
-                        \new Staff
-                        {
-                            \clef "bass"
-                            c,2
-                        }
-                    >>
-
-            ..  container:: example expression
-
-                >>> staff_group = abjad.StaffGroup([])
-                >>> staff = abjad.Staff("c'8 d'4 e'16 f'16")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "alto" g4 f4""")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
-                >>> staff_group.append(staff)
-                >>> prototype = abjad.IntervalClassVector
-                >>> expression = abjad.label().vertical_moments(prototype=prototype)
-                >>> expression(staff_group)
+                >>> abjad.Label(staff_group).vertical_moments(prototype=prototype)
                 >>> abjad.show(staff_group) # doctest: +SKIP
 
                 ..  docs::
@@ -1710,52 +959,7 @@ class Label:
                 >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
                 >>> staff_group.append(staff)
                 >>> prototype = abjad.SetClass()
-                >>> abjad.label(staff_group).vertical_moments(prototype=prototype)
-                >>> abjad.show(staff_group) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff_group)
-                    >>> print(string)
-                    \new StaffGroup
-                    <<
-                        \new Staff
-                        {
-                            c'8
-                            ^ \markup \tiny \line { "SC(2-5){0, 5}" }
-                            d'4
-                            ^ \markup \tiny \line { "SC(3-9){0, 2, 7}" }
-                            e'16
-                            ^ \markup \tiny \line { "SC(3-4){0, 1, 5}" }
-                            f'16
-                            ^ \markup \tiny \line { "SC(2-5){0, 5}" }
-                        }
-                        \new Staff
-                        {
-                            \clef "alto"
-                            g4
-                            f4
-                            ^ \markup \tiny \line { "SC(3-7){0, 2, 5}" }
-                        }
-                        \new Staff
-                        {
-                            \clef "bass"
-                            c,2
-                        }
-                    >>
-
-            ..  container:: example expression
-
-                >>> staff_group = abjad.StaffGroup([])
-                >>> staff = abjad.Staff("c'8 d'4 e'16 f'16")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "alto" g4 f4""")
-                >>> staff_group.append(staff)
-                >>> staff = abjad.Staff(r"""\clef "bass" c,2""")
-                >>> staff_group.append(staff)
-                >>> prototype = abjad.SetClass()
-                >>> expression = abjad.label().vertical_moments(prototype=prototype)
-                >>> expression(staff_group)
+                >>> abjad.Label(staff_group).vertical_moments(prototype=prototype)
                 >>> abjad.show(staff_group) # doctest: +SKIP
 
                 ..  docs::
@@ -1793,8 +997,6 @@ class Label:
 
         Returns none.
         '''
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         prototype = prototype or int
         vertical_moments = iterate_vertical_moments(self.client)
         for index, vertical_moment in enumerate(vertical_moments):
@@ -1925,50 +1127,7 @@ class Label:
             ..  container:: example
 
                 >>> staff = abjad.Staff(r"c'4. d'8 ~ d'4. e'16 [ ef'16 ]")
-                >>> abjad.label(staff).with_durations()
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    {
-                        c'4.
-                        ^ \markup {
-                            \fraction
-                                3
-                                8
-                            }
-                        d'8
-                        ^ \markup {
-                            \fraction
-                                4
-                                8
-                            }
-                        ~
-                        d'4.
-                        e'16
-                        ^ \markup {
-                            \fraction
-                                1
-                                16
-                            }
-                        [
-                        ef'16
-                        ^ \markup {
-                            \fraction
-                                1
-                                16
-                            }
-                        ]
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff(r"c'4. d'8 ~ d'4. e'16 [ ef'16 ]")
-                >>> expression = abjad.label().with_durations()
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_durations()
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 ..  docs::
@@ -2014,50 +1173,7 @@ class Label:
             ..  container:: example
 
                 >>> staff = abjad.Staff(r"c'4. d'8 ~ d'4. e'16 [ ef'16 ]")
-                >>> abjad.label(staff).with_durations(denominator=16)
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    {
-                        c'4.
-                        ^ \markup {
-                            \fraction
-                                6
-                                16
-                            }
-                        d'8
-                        ^ \markup {
-                            \fraction
-                                8
-                                16
-                            }
-                        ~
-                        d'4.
-                        e'16
-                        ^ \markup {
-                            \fraction
-                                1
-                                16
-                            }
-                        [
-                        ef'16
-                        ^ \markup {
-                            \fraction
-                                1
-                                16
-                            }
-                        ]
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff(r"c'4. d'8 ~ d'4. e'16 [ ef'16 ]")
-                >>> expression = abjad.label().with_durations(denominator=16)
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_durations(denominator=16)
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 ..  docs::
@@ -2098,8 +1214,6 @@ class Label:
 
         Returns none.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         for logical_tie in Iteration(self.client).logical_ties():
             duration = _inspect._get_duration(logical_tie, in_seconds=in_seconds)
             if denominator is not None:
@@ -2120,39 +1234,7 @@ class Label:
             ..  container:: example
 
                 >>> staff = abjad.Staff("<c' bf'>8 <g' a'>4 af'8 ~ af'8 gf'8 ~ gf'4")
-                >>> abjad.label(staff).with_indices()
-                >>> abjad.override(staff).TextScript.staff_padding = 2
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 2
-                    }
-                    {
-                        <c' bf'>8
-                        ^ \markup { 0 }
-                        <g' a'>4
-                        ^ \markup { 1 }
-                        af'8
-                        ^ \markup { 2 }
-                        ~
-                        af'8
-                        gf'8
-                        ^ \markup { 3 }
-                        ~
-                        gf'4
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("<c' bf'>8 <g' a'>4 af'8 ~ af'8 gf'8 ~ gf'4")
-                >>> expression = abjad.label().with_indices()
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_indices()
                 >>> abjad.override(staff).TextScript.staff_padding = 2
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2187,41 +1269,7 @@ class Label:
             ..  container:: example
 
                 >>> staff = abjad.Staff("<c' bf'>8 <g' a'>4 af'8 ~ af'8 gf'8 ~ gf'4")
-                >>> abjad.label(staff).with_indices(prototype=abjad.Note)
-                >>> abjad.override(staff).TextScript.staff_padding = 2
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 2
-                    }
-                    {
-                        <c' bf'>8
-                        <g' a'>4
-                        af'8
-                        ^ \markup { 0 }
-                        ~
-                        af'8
-                        ^ \markup { 1 }
-                        gf'8
-                        ^ \markup { 2 }
-                        ~
-                        gf'4
-                        ^ \markup { 3 }
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("<c' bf'>8 <g' a'>4 af'8 ~ af'8 gf'8 ~ gf'4")
-                >>> expression = abjad.label().with_indices(
-                ...     prototype=abjad.Note,
-                ...     )
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_indices(prototype=abjad.Note)
                 >>> abjad.override(staff).TextScript.staff_padding = 2
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2256,39 +1304,7 @@ class Label:
             ..  container:: example
 
                 >>> staff = abjad.Staff("<c' bf'>8 <g' a'>4 af'8 ~ af'8 gf'8 ~ gf'4")
-                >>> abjad.label(staff).with_indices(prototype=abjad.Chord)
-                >>> abjad.override(staff).TextScript.staff_padding = 2
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 2
-                    }
-                    {
-                        <c' bf'>8
-                        ^ \markup { 0 }
-                        <g' a'>4
-                        ^ \markup { 1 }
-                        af'8
-                        ~
-                        af'8
-                        gf'8
-                        ~
-                        gf'4
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("<c' bf'>8 <g' a'>4 af'8 ~ af'8 gf'8 ~ gf'4")
-                >>> expression = abjad.label().with_indices(
-                ...     prototype=abjad.Chord,
-                ...     )
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_indices(prototype=abjad.Chord)
                 >>> abjad.override(staff).TextScript.staff_padding = 2
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2321,43 +1337,7 @@ class Label:
             ..  container:: example
 
                 >>> staff = abjad.Staff("<c' bf'>8 <g' a'>4 af'8 ~ af'8 gf'8 ~ gf'4")
-                >>> abjad.label(staff).with_indices(prototype=abjad.Leaf)
-                >>> abjad.override(staff).TextScript.staff_padding = 2
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 2
-                    }
-                    {
-                        <c' bf'>8
-                        ^ \markup { 0 }
-                        <g' a'>4
-                        ^ \markup { 1 }
-                        af'8
-                        ^ \markup { 2 }
-                        ~
-                        af'8
-                        ^ \markup { 3 }
-                        gf'8
-                        ^ \markup { 4 }
-                        ~
-                        gf'4
-                        ^ \markup { 5 }
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("<c' bf'>8 <g' a'>4 af'8 ~ af'8 gf'8 ~ gf'4")
-                >>> expression = abjad.label().with_indices(
-                ...     prototype=abjad.Leaf,
-                ...     )
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_indices(prototype=abjad.Leaf)
                 >>> abjad.override(staff).TextScript.staff_padding = 2
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2396,63 +1376,7 @@ class Label:
                 >>> tuplet = abjad.Tuplet((2, 3), "c'8 [ d'8 e'8 ]")
                 >>> tuplets = abjad.mutate.copy(tuplet, 4)
                 >>> staff = abjad.Staff(tuplets)
-                >>> abjad.label(staff).with_indices(prototype=abjad.Tuplet)
-                >>> abjad.override(staff).TextScript.staff_padding = 2
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 2
-                    }
-                    {
-                        \times 2/3 {
-                            c'8
-                            ^ \markup { 0 }
-                            [
-                            d'8
-                            e'8
-                            ]
-                        }
-                        \times 2/3 {
-                            c'8
-                            ^ \markup { 1 }
-                            [
-                            d'8
-                            e'8
-                            ]
-                        }
-                        \times 2/3 {
-                            c'8
-                            ^ \markup { 2 }
-                            [
-                            d'8
-                            e'8
-                            ]
-                        }
-                        \times 2/3 {
-                            c'8
-                            ^ \markup { 3 }
-                            [
-                            d'8
-                            e'8
-                            ]
-                        }
-                    }
-
-            ..  container:: example expression
-
-                >>> tuplet = abjad.Tuplet((2, 3), "c'8 [ d'8 e'8 ]")
-                >>> tuplets = abjad.mutate.copy(tuplet, 4)
-                >>> staff = abjad.Staff(tuplets)
-                >>> expression = abjad.label().with_indices(
-                ...     prototype=abjad.Tuplet,
-                ...     )
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_indices(prototype=abjad.Tuplet)
                 >>> abjad.override(staff).TextScript.staff_padding = 2
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2502,8 +1426,6 @@ class Label:
 
         Returns none.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         if prototype is None:
             items = Iteration(self.client).logical_ties()
         else:
@@ -2530,45 +1452,7 @@ class Label:
                 >>> pitch_numbers = [0, 25, 11, -4, -14, -13, 9, 10]
                 >>> notes = maker(pitch_numbers, [(1, 4)])
                 >>> staff = abjad.Staff(notes)
-                >>> abjad.label(staff).with_intervals(prototype=None)
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 4
-                    }
-                    {
-                        c'4
-                        ^ \markup { +A15 }
-                        cs'''4
-                        ^ \markup { -M9 }
-                        b'4
-                        ^ \markup { -A9 }
-                        af4
-                        ^ \markup { -m7 }
-                        bf,4
-                        ^ \markup { +A1 }
-                        b,4
-                        ^ \markup { +m14 }
-                        a'4
-                        ^ \markup { +m2 }
-                        bf'4
-                    }
-
-            ..  container:: example expression
-
-                >>> maker = abjad.NoteMaker()
-                >>> pitch_numbers = [0, 25, 11, -4, -14, -13, 9, 10]
-                >>> notes = maker(pitch_numbers, [(1, 4)])
-                >>> staff = abjad.Staff(notes)
-                >>> expression = abjad.label().with_intervals(prototype=None)
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_intervals(prototype=None)
                 >>> abjad.override(staff).TextScript.staff_padding = 4
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2610,46 +1494,7 @@ class Label:
                 >>> notes = maker(pitch_numbers, [(1, 4)])
                 >>> staff = abjad.Staff(notes)
                 >>> prototype = abjad.NamedIntervalClass
-                >>> abjad.label(staff).with_intervals(prototype=prototype)
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 4
-                    }
-                    {
-                        c'4
-                        ^ \markup { +A1 }
-                        cs'''4
-                        ^ \markup { -M2 }
-                        b'4
-                        ^ \markup { -A2 }
-                        af4
-                        ^ \markup { -m7 }
-                        bf,4
-                        ^ \markup { +A1 }
-                        b,4
-                        ^ \markup { +m7 }
-                        a'4
-                        ^ \markup { +m2 }
-                        bf'4
-                    }
-
-            ..  container:: example expression
-
-                >>> maker = abjad.NoteMaker()
-                >>> pitch_numbers = [0, 25, 11, -4, -14, -13, 9, 10]
-                >>> notes = maker(pitch_numbers, [(1, 4)])
-                >>> staff = abjad.Staff(notes)
-                >>> prototype = abjad.NamedIntervalClass
-                >>> expression = abjad.label().with_intervals(prototype=prototype)
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_intervals(prototype=prototype)
                 >>> abjad.override(staff).TextScript.staff_padding = 4
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2691,7 +1536,7 @@ class Label:
                 >>> notes = maker(pitch_numbers, [(1, 4)])
                 >>> staff = abjad.Staff(notes)
                 >>> prototype = abjad.NumberedInterval
-                >>> abjad.label(staff).with_intervals(prototype=prototype)
+                >>> abjad.Label(staff).with_intervals(prototype=prototype)
                 >>> abjad.override(staff).TextScript.staff_padding = 4
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2721,46 +1566,6 @@ class Label:
                         ^ \markup { +1 }
                         bf'4
                     }
-
-            ..  container:: example expression
-
-                >>> maker = abjad.NoteMaker()
-                >>> pitch_numbers = [0, 25, 11, -4, -14, -13, 9, 10]
-                >>> notes = maker(pitch_numbers, [(1, 4)])
-                >>> staff = abjad.Staff(notes)
-                >>> prototype = abjad.NumberedInterval
-                >>> expression = abjad.label().with_intervals(prototype=prototype)
-                >>> expression(staff)
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 4
-                    }
-                    {
-                        c'4
-                        ^ \markup { +25 }
-                        cs'''4
-                        ^ \markup { -14 }
-                        b'4
-                        ^ \markup { -15 }
-                        af4
-                        ^ \markup { -10 }
-                        bf,4
-                        ^ \markup { +1 }
-                        b,4
-                        ^ \markup { +22 }
-                        a'4
-                        ^ \markup { +1 }
-                        bf'4
-                    }
-
 
         ..  container:: example
 
@@ -2773,46 +1578,7 @@ class Label:
                 >>> notes = maker(pitch_numbers, [(1, 4)])
                 >>> staff = abjad.Staff(notes)
                 >>> prototype = abjad.NumberedIntervalClass
-                >>> abjad.label(staff).with_intervals(prototype=prototype)
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 4
-                    }
-                    {
-                        c'4
-                        ^ \markup { +1 }
-                        cs'''4
-                        ^ \markup { -2 }
-                        b'4
-                        ^ \markup { -3 }
-                        af4
-                        ^ \markup { -10 }
-                        bf,4
-                        ^ \markup { +1 }
-                        b,4
-                        ^ \markup { +10 }
-                        a'4
-                        ^ \markup { +1 }
-                        bf'4
-                    }
-
-            ..  container:: example expression
-
-                >>> maker = abjad.NoteMaker()
-                >>> pitch_numbers = [0, 25, 11, -4, -14, -13, 9, 10]
-                >>> notes = maker(pitch_numbers, [(1, 4)])
-                >>> staff = abjad.Staff(notes)
-                >>> prototype = abjad.NumberedIntervalClass
-                >>> expression = abjad.label().with_intervals(prototype=prototype)
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_intervals(prototype=prototype)
                 >>> abjad.override(staff).TextScript.staff_padding = 4
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2855,46 +1621,7 @@ class Label:
                 >>> notes = maker(pitch_numbers, [(1, 4)])
                 >>> staff = abjad.Staff(notes)
                 >>> prototype = abjad.NumberedInversionEquivalentIntervalClass
-                >>> abjad.label(staff).with_intervals(prototype=prototype)
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 4
-                    }
-                    {
-                        c'4
-                        ^ \markup { 1 }
-                        cs'''4
-                        ^ \markup { 2 }
-                        b'4
-                        ^ \markup { 3 }
-                        af4
-                        ^ \markup { 2 }
-                        bf,4
-                        ^ \markup { 1 }
-                        b,4
-                        ^ \markup { 2 }
-                        a'4
-                        ^ \markup { 1 }
-                        bf'4
-                    }
-
-            ..  container:: example expression
-
-                >>> maker = abjad.NoteMaker()
-                >>> pitch_numbers = [0, 25, 11, -4, -14, -13, 9, 10]
-                >>> notes = maker(pitch_numbers, [(1, 4)])
-                >>> staff = abjad.Staff(notes)
-                >>> prototype = abjad.NumberedInversionEquivalentIntervalClass
-                >>> expression = abjad.label().with_intervals(prototype=prototype)
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_intervals(prototype=prototype)
                 >>> abjad.override(staff).TextScript.staff_padding = 4
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2927,8 +1654,6 @@ class Label:
 
         Returns none.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         prototype = prototype or NamedInterval
         for note in Iteration(self.client).leaves(Note):
             label = None
@@ -2963,36 +1688,7 @@ class Label:
             ..  container:: example
 
                 >>> staff = abjad.Staff("<a d' fs'>4 g'4 ~ g'8 r8 fs''4")
-                >>> abjad.label(staff).with_pitches(prototype=None)
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 4
-                    }
-                    {
-                        <a d' fs'>4
-                        ^ \markup \column { "fs'" "d'" "a" }
-                        g'4
-                        ^ \markup { g' }
-                        ~
-                        g'8
-                        r8
-                        fs''4
-                        ^ \markup { fs'' }
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("<a d' fs'>4 g'4 ~ g'8 r8 fs''4")
-                >>> expression = abjad.label().with_pitches(prototype=None)
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_pitches(prototype=None)
                 >>> abjad.override(staff).TextScript.staff_padding = 4
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -3024,36 +1720,7 @@ class Label:
             ..  container:: example
 
                 >>> staff = abjad.Staff("<a d' fs'>4 g'4 ~ g'8 r8 fs''4")
-                >>> abjad.label(staff).with_pitches(locale='us', prototype=None)
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 4
-                    }
-                    {
-                        <a d' fs'>4
-                        ^ \markup \column { "F#4" "D4" "A3" }
-                        g'4
-                        ^ \markup { G4 }
-                        ~
-                        g'8
-                        r8
-                        fs''4
-                        ^ \markup { "F#5" }
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("<a d' fs'>4 g'4 ~ g'8 r8 fs''4")
-                >>> expression = abjad.label().with_pitches(locale='us', prototype=None)
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_pitches(locale='us', prototype=None)
                 >>> abjad.override(staff).TextScript.staff_padding = 4
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -3086,44 +1753,7 @@ class Label:
 
                 >>> staff = abjad.Staff("<a d' fs'>4 g'4 ~ g'8 r8 fs''4")
                 >>> prototype = abjad.NumberedPitch
-                >>> abjad.label(staff).with_pitches(prototype=prototype)
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 4
-                    }
-                    {
-                        <a d' fs'>4
-                        ^ \markup {
-                            \column
-                                {
-                                    6
-                                    2
-                                    -3
-                                }
-                            }
-                        g'4
-                        ^ \markup { 7 }
-                        ~
-                        g'8
-                        r8
-                        fs''4
-                        ^ \markup { 18 }
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("<a d' fs'>4 g'4 ~ g'8 r8 fs''4")
-                >>> prototype = abjad.NumberedPitch
-                >>> expression = abjad.label().with_pitches(prototype=prototype)
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_pitches(prototype=prototype)
                 >>> abjad.override(staff).TextScript.staff_padding = 4
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -3163,44 +1793,7 @@ class Label:
 
                 >>> staff = abjad.Staff("<a d' fs'>4 g'4 ~ g'8 r8 fs''4")
                 >>> prototype = abjad.NumberedPitchClass
-                >>> abjad.label(staff).with_pitches(prototype=prototype)
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 4
-                    }
-                    {
-                        <a d' fs'>4
-                        ^ \markup {
-                            \column
-                                {
-                                    6
-                                    2
-                                    9
-                                }
-                            }
-                        g'4
-                        ^ \markup { 7 }
-                        ~
-                        g'8
-                        r8
-                        fs''4
-                        ^ \markup { 6 }
-                    }
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff("<a d' fs'>4 g'4 ~ g'8 r8 fs''4")
-                >>> prototype = abjad.NumberedPitchClass
-                >>> expression = abjad.label().with_pitches(prototype=prototype)
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_pitches(prototype=prototype)
                 >>> abjad.override(staff).TextScript.staff_padding = 4
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -3245,49 +1838,7 @@ class Label:
                 >>> for selection in selections:
                 ...     abjad.horizontal_bracket(selection)
                 ...
-                >>> abjad.label(selections).with_pitches()
-                >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
-                >>> abjad.override(voice).TextScript.staff_padding = 2
-                >>> abjad.show(voice) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    \with
-                    {
-                        \consists Horizontal_bracket_engraver
-                        \override HorizontalBracket.staff-padding = 3
-                        \override TextScript.staff-padding = 2
-                    }
-                    {
-                        df''4
-                        ^ \markup { df'' }
-                        \startGroup
-                        c''4
-                        ^ \markup { c'' }
-                        \stopGroup
-                        f'4
-                        fs'4
-                        d''4
-                        ^ \markup { d'' }
-                        \startGroup
-                        ds''4
-                        ^ \markup { ds'' }
-                        \stopGroup
-                    }
-
-            ..  container:: example expression
-
-                >>> voice = abjad.Voice("df''4 c''4 f'4 fs'4 d''4 ds''4")
-                >>> voice.consists_commands.append('Horizontal_bracket_engraver')
-                >>> selections = [voice[:2], voice[-2:]]
-                >>> for selection in selections:
-                ...     abjad.horizontal_bracket(selection)
-                ...
-                >>> expression = abjad.label().with_pitches()
-                >>> expression(selections)
+                >>> abjad.Label(selections).with_pitches()
                 >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
                 >>> abjad.override(voice).TextScript.staff_padding = 2
                 >>> abjad.show(voice) # doctest: +SKIP
@@ -3333,50 +1884,7 @@ class Label:
                 ...     abjad.horizontal_bracket(selection)
                 ...
                 >>> prototype = abjad.NumberedPitch
-                >>> abjad.label(selections).with_pitches(prototype=prototype)
-                >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
-                >>> abjad.override(voice).TextScript.staff_padding = 2
-                >>> abjad.show(voice) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    \with
-                    {
-                        \consists Horizontal_bracket_engraver
-                        \override HorizontalBracket.staff-padding = 3
-                        \override TextScript.staff-padding = 2
-                    }
-                    {
-                        df''4
-                        ^ \markup { 13 }
-                        \startGroup
-                        c''4
-                        ^ \markup { 12 }
-                        \stopGroup
-                        f'4
-                        fs'4
-                        d''4
-                        ^ \markup { 14 }
-                        \startGroup
-                        ds''4
-                        ^ \markup { 15 }
-                        \stopGroup
-                    }
-
-            ..  container:: example expression
-
-                >>> voice = abjad.Voice("df''4 c''4 f'4 fs'4 d''4 ds''4")
-                >>> voice.consists_commands.append('Horizontal_bracket_engraver')
-                >>> selections = [voice[:2], voice[-2:]]
-                >>> for selection in selections:
-                ...     abjad.horizontal_bracket(selection)
-                ...
-                >>> prototype = abjad.NumberedPitch
-                >>> expression = abjad.label().with_pitches(prototype=prototype)
-                >>> expression(selections)
+                >>> abjad.Label(selections).with_pitches(prototype=prototype)
                 >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
                 >>> abjad.override(voice).TextScript.staff_padding = 2
                 >>> abjad.show(voice) # doctest: +SKIP
@@ -3423,50 +1931,7 @@ class Label:
                 ...     abjad.horizontal_bracket(selection)
                 ...
                 >>> prototype = abjad.NumberedPitchClass
-                >>> abjad.label(selections).with_pitches(prototype=prototype)
-                >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
-                >>> abjad.override(voice).TextScript.staff_padding = 2
-                >>> abjad.show(voice) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    \with
-                    {
-                        \consists Horizontal_bracket_engraver
-                        \override HorizontalBracket.staff-padding = 3
-                        \override TextScript.staff-padding = 2
-                    }
-                    {
-                        df''4
-                        ^ \markup { 1 }
-                        \startGroup
-                        c''4
-                        ^ \markup { 0 }
-                        \stopGroup
-                        f'4
-                        fs'4
-                        d''4
-                        ^ \markup { 2 }
-                        \startGroup
-                        ds''4
-                        ^ \markup { 3 }
-                        \stopGroup
-                    }
-
-            ..  container:: example expression
-
-                >>> voice = abjad.Voice("df''4 c''4 f'4 fs'4 d''4 ds''4")
-                >>> voice.consists_commands.append('Horizontal_bracket_engraver')
-                >>> selections = [voice[:2], voice[-2:]]
-                >>> for selection in selections:
-                ...     abjad.horizontal_bracket(selection)
-                ...
-                >>> prototype = abjad.NumberedPitchClass
-                >>> expression = abjad.label().with_pitches(prototype=prototype)
-                >>> expression(selections)
+                >>> abjad.Label(selections).with_pitches(prototype=prototype)
                 >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
                 >>> abjad.override(voice).TextScript.staff_padding = 2
                 >>> abjad.show(voice) # doctest: +SKIP
@@ -3501,8 +1966,6 @@ class Label:
 
         Returns none.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         prototype = prototype or NamedPitch
         logical_ties = Iteration(self.client).logical_ties()
         for logical_tie in logical_ties:
@@ -3582,51 +2045,7 @@ class Label:
                 >>> for selection in selections:
                 ...     abjad.horizontal_bracket(selection)
                 ...
-                >>> abjad.label(selections).with_set_classes()
-                >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
-                >>> abjad.override(voice).TextScript.staff_padding = 2
-                >>> abjad.show(voice) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    \with
-                    {
-                        \consists Horizontal_bracket_engraver
-                        \override HorizontalBracket.staff-padding = 3
-                        \override TextScript.staff-padding = 2
-                    }
-                    {
-                        df''8
-                        ^ \markup \tiny \line { "SC(4-3){0, 1, 3, 4}" }
-                        \startGroup
-                        c''8
-                        bf'8
-                        a'8
-                        \stopGroup
-                        f'4.
-                        fs'8
-                        ^ \markup \tiny \line { "SC(4-20){0, 1, 5, 8}" }
-                        \startGroup
-                        g'8
-                        b'8
-                        d''2.
-                        \stopGroup
-                    }
-
-            ..  container:: example expression
-
-                >>> string = "df''8 c''8 bf'8 a'8 f'4. fs'8 g'8 b'8 d''2."
-                >>> voice = abjad.Voice(string)
-                >>> voice.consists_commands.append('Horizontal_bracket_engraver')
-                >>> selections = [voice[:4], voice[-4:]]
-                >>> for selection in selections:
-                ...     abjad.horizontal_bracket(selection)
-                ...
-                >>> expression = abjad.label().with_set_classes()
-                >>> expression(selections)
+                >>> abjad.Label(selections).with_set_classes()
                 >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
                 >>> abjad.override(voice).TextScript.staff_padding = 2
                 >>> abjad.show(voice) # doctest: +SKIP
@@ -3675,52 +2094,7 @@ class Label:
                 ...     abjad.horizontal_bracket(selection)
                 ...
                 >>> prototype = abjad.SetClass(lex_rank=True)
-                >>> abjad.label(selections).with_set_classes(prototype=prototype)
-                >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
-                >>> abjad.override(voice).TextScript.staff_padding = 2
-                >>> abjad.show(voice) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    \with
-                    {
-                        \consists Horizontal_bracket_engraver
-                        \override HorizontalBracket.staff-padding = 3
-                        \override TextScript.staff-padding = 2
-                    }
-                    {
-                        df''8
-                        ^ \markup \tiny \line { "SC(4-6){0, 1, 3, 4}" }
-                        \startGroup
-                        c''8
-                        bf'8
-                        a'8
-                        \stopGroup
-                        f'4.
-                        fs'8
-                        ^ \markup \tiny \line { "SC(4-16){0, 1, 5, 8}" }
-                        \startGroup
-                        g'8
-                        b'8
-                        d''2.
-                        \stopGroup
-                    }
-
-            ..  container:: example expression
-
-                >>> string = "df''8 c''8 bf'8 a'8 f'4. fs'8 g'8 b'8 d''2."
-                >>> voice = abjad.Voice(string)
-                >>> voice.consists_commands.append('Horizontal_bracket_engraver')
-                >>> selections = [voice[:4], voice[-4:]]
-                >>> for selection in selections:
-                ...     abjad.horizontal_bracket(selection)
-                ...
-                >>> prototype = abjad.SetClass(lex_rank=True)
-                >>> expression = abjad.label().with_set_classes(prototype=prototype)
-                >>> expression(selections)
+                >>> abjad.Label(selections).with_set_classes(prototype=prototype)
                 >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
                 >>> abjad.override(voice).TextScript.staff_padding = 2
                 >>> abjad.show(voice) # doctest: +SKIP
@@ -3768,52 +2142,7 @@ class Label:
                 ...     abjad.horizontal_bracket(selection)
                 ...
                 >>> prototype = abjad.SetClass(transposition_only=True)
-                >>> abjad.label(selections).with_set_classes(prototype=prototype)
-                >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
-                >>> abjad.override(voice).TextScript.staff_padding = 2
-                >>> abjad.show(voice) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    \with
-                    {
-                        \consists Horizontal_bracket_engraver
-                        \override HorizontalBracket.staff-padding = 3
-                        \override TextScript.staff-padding = 2
-                    }
-                    {
-                        df''8
-                        ^ \markup \tiny \line { "SC(4-6){0, 1, 3, 4}" }
-                        \startGroup
-                        c''8
-                        bf'8
-                        a'8
-                        \stopGroup
-                        f'4.
-                        fs'8
-                        ^ \markup \tiny \line { "SC(4-16){0, 1, 5, 8}" }
-                        \startGroup
-                        g'8
-                        b'8
-                        d''2.
-                        \stopGroup
-                    }
-
-            ..  container:: example expression
-
-                >>> string = "df''8 c''8 bf'8 a'8 f'4. fs'8 g'8 b'8 d''2."
-                >>> voice = abjad.Voice(string)
-                >>> voice.consists_commands.append('Horizontal_bracket_engraver')
-                >>> selections = [voice[:4], voice[-4:]]
-                >>> for selection in selections:
-                ...     abjad.horizontal_bracket(selection)
-                ...
-                >>> prototype = abjad.SetClass(transposition_only=True)
-                >>> expression = abjad.label().with_set_classes(prototype=prototype)
-                >>> expression(selections)
+                >>> abjad.Label(selections).with_set_classes(prototype=prototype)
                 >>> abjad.override(voice).HorizontalBracket.staff_padding = 3
                 >>> abjad.override(voice).TextScript.staff_padding = 2
                 >>> abjad.show(voice) # doctest: +SKIP
@@ -3849,8 +2178,6 @@ class Label:
 
         Returns none.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         prototype = prototype or SetClass()
         if prototype is SetClass:
             prototype = prototype()
@@ -3889,44 +2216,7 @@ class Label:
 
                 >>> string = r"\times 2/3 { c'4 d'4 e'4 ~ } e'4 ef'4"
                 >>> staff = abjad.Staff(string)
-                >>> abjad.label(staff).with_start_offsets(direction=abjad.Up)
-                Duration(1, 1)
-
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.override(staff).TupletBracket.staff_padding = 0
-                >>> abjad.show(staff) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(staff)
-                    >>> print(string)
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 4
-                        \override TupletBracket.staff-padding = 0
-                    }
-                    {
-                        \times 2/3 {
-                            c'4
-                            ^ \markup { 0 }
-                            d'4
-                            ^ \markup { 1/6 }
-                            e'4
-                            ^ \markup { 1/3 }
-                            ~
-                        }
-                        e'4
-                        ef'4
-                        ^ \markup { 3/4 }
-                    }
-
-            ..  container:: example expression
-
-                >>> string = r"\times 2/3 { c'4 d'4 e'4 ~ } e'4 ef'4"
-                >>> staff = abjad.Staff(string)
-                >>> expression = abjad.label().with_start_offsets()
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_start_offsets(direction=abjad.Up)
                 Duration(1, 1)
 
                 >>> abjad.override(staff).TextScript.staff_padding = 4
@@ -3968,46 +2258,7 @@ class Label:
                 >>> score = abjad.Score([staff])
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
                 >>> abjad.attach(mark, staff[0])
-                >>> abjad.label(staff).with_start_offsets(clock_time=True)
-                Duration(8, 1)
-
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.override(staff).TupletBracket.staff_padding = 0
-                >>> abjad.show(score) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(score)
-                    >>> print(string)
-                    \new Score
-                    <<
-                        \new Staff
-                        \with
-                        {
-                            \override TextScript.staff-padding = 4
-                            \override TupletBracket.staff-padding = 0
-                        }
-                        {
-                            \tempo 4=60
-                            c'2
-                            ^ \markup { 0'00'' }
-                            d'2
-                            ^ \markup { 0'02'' }
-                            e'2
-                            ^ \markup { 0'04'' }
-                            f'2
-                            ^ \markup { 0'06'' }
-                        }
-                    >>
-
-            ..  container:: example
-
-                >>> staff = abjad.Staff(r"c'2 d' e' f'")
-                >>> score = abjad.Score([staff])
-                >>> mark = abjad.MetronomeMark((1, 4), 60)
-                >>> abjad.attach(mark, staff[0])
-                >>> expression = abjad.label().with_start_offsets(clock_time=True)
-                >>> expression(staff)
+                >>> abjad.Label(staff).with_start_offsets(clock_time=True)
                 Duration(8, 1)
 
                 >>> abjad.override(staff).TextScript.staff_padding = 4
@@ -4050,49 +2301,10 @@ class Label:
                 >>> score = abjad.Score([staff])
                 >>> mark = abjad.MetronomeMark((1, 4), 60)
                 >>> abjad.attach(mark, staff[0])
-                >>> abjad.label(staff).with_start_offsets(
+                >>> abjad.Label(staff).with_start_offsets(
                 ...     clock_time=True,
                 ...     markup_command=r'\dark_cyan_markup',
                 ...     )
-                Duration(8, 1)
-
-                >>> abjad.override(staff).TextScript.staff_padding = 4
-                >>> abjad.override(staff).TupletBracket.staff_padding = 0
-
-                >>> string = abjad.lilypond(score)
-                >>> print(string)
-                \new Score
-                <<
-                    \new Staff
-                    \with
-                    {
-                        \override TextScript.staff-padding = 4
-                        \override TupletBracket.staff-padding = 0
-                    }
-                    {
-                        \tempo 4=60
-                        c'2
-                        ^ \dark_cyan_markup "0'00''"
-                        d'2
-                        ^ \dark_cyan_markup "0'02''"
-                        e'2
-                        ^ \dark_cyan_markup "0'04''"
-                        f'2
-                        ^ \dark_cyan_markup "0'06''"
-                    }
-                >>
-
-            ..  container:: example expression
-
-                >>> staff = abjad.Staff(r"c'2 d' e' f'")
-                >>> score = abjad.Score([staff])
-                >>> mark = abjad.MetronomeMark((1, 4), 60)
-                >>> abjad.attach(mark, staff[0])
-                >>> expression = abjad.label().with_start_offsets(
-                ...     clock_time=True,
-                ...     markup_command=r'\dark_cyan_markup',
-                ...     )
-                >>> expression(staff)
                 Duration(8, 1)
 
                 >>> abjad.override(staff).TextScript.staff_padding = 4
@@ -4123,8 +2335,6 @@ class Label:
 
         Returns total duration.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         direction = direction or enums.Up
         if global_offset is not None:
             assert isinstance(global_offset, Duration)
@@ -4419,115 +2629,3 @@ class ColorMap:
             return self[key]
         except (KeyError, TypeError, ValueError):
             return alternative
-
-
-### FUNCTIONS ###
-
-
-def label(client=None, deactivate=None, tag=None):
-    r"""
-    Makes label agent or label expression.
-
-    ..  container:: example
-
-        Labels logical ties with start offsets:
-
-        >>> staff = abjad.Staff(r"\times 2/3 { c'4 d'4 e'4 ~ } e'4 ef'4")
-        >>> abjad.label(staff).with_start_offsets(direction=abjad.Up)
-        Duration(1, 1)
-
-        >>> abjad.override(staff).TextScript.staff_padding = 4
-        >>> abjad.override(staff).TupletBracket.staff_padding = 0
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(staff)
-            >>> print(string)
-            \new Staff
-            \with
-            {
-                \override TextScript.staff-padding = 4
-                \override TupletBracket.staff-padding = 0
-            }
-            {
-                \times 2/3 {
-                    c'4
-                    ^ \markup { 0 }
-                    d'4
-                    ^ \markup { 1/6 }
-                    e'4
-                    ^ \markup { 1/3 }
-                    ~
-                }
-                e'4
-                ef'4
-                ^ \markup { 3/4 }
-            }
-
-        See the ``Label`` API entry for many more examples.
-
-    ..  container:: example expression
-
-        Initializes positionally:
-
-        >>> expression = abjad.label()
-        >>> expression(staff)
-        Label(client=<Staff{3}>)
-
-        Initializes from keyword:
-
-        >>> expression = abjad.label()
-        >>> expression(client=staff)
-        Label(client=<Staff{3}>)
-
-        Makes label expression:
-
-            >>> expression = abjad.label()
-            >>> expression = expression.with_start_offsets()
-
-        >>> staff = abjad.Staff(r"\times 2/3 { c'4 d'4 e'4 ~ } e'4 ef'4")
-        >>> expression(staff)
-        Duration(1, 1)
-
-        >>> abjad.override(staff).TextScript.staff_padding = 4
-        >>> abjad.override(staff).TupletBracket.staff_padding = 0
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(staff)
-            >>> print(string)
-            \new Staff
-            \with
-            {
-                \override TextScript.staff-padding = 4
-                \override TupletBracket.staff-padding = 0
-            }
-            {
-                \times 2/3 {
-                    c'4
-                    ^ \markup { 0 }
-                    d'4
-                    ^ \markup { 1/6 }
-                    e'4
-                    ^ \markup { 1/3 }
-                    ~
-                }
-                e'4
-                ef'4
-                ^ \markup { 3/4 }
-            }
-
-        See the ``Label`` API entry for many more examples.
-
-    Returns label agent when ``client`` is not none.
-
-    Returns label expression when ``client`` is none.
-    """
-    if client is not None:
-        return Label(client=client, deactivate=deactivate, tag=tag)
-    expression = Expression(proxy_class=Label)
-    callback = Expression._make_initializer_callback(Label, tag=tag)
-    expression = expression.append_callback(callback)
-    return expression

--- a/abjad/lilypondfile.py
+++ b/abjad/lilypondfile.py
@@ -2110,9 +2110,9 @@ class LilyPondFile:
             voices = []
             for voice_name in sorted(selections):
                 selections_ = selections[voice_name]
-                selections_ = Sequence(selections_).flatten(depth=-1)
-                selections_ = copy.deepcopy(selections_)
-                voice = Voice(selections_, name=voice_name)
+                selections__ = Sequence(selections_).flatten(depth=-1)
+                selections__ = copy.deepcopy(selections__)
+                voice = Voice(selections__, name=voice_name)
                 if attach_lilypond_voice_commands:
                     voice_name_to_command_string = {
                         "Voice_1": "voiceOne",

--- a/abjad/pattern.py
+++ b/abjad/pattern.py
@@ -1,9 +1,7 @@
 import collections
-import inspect
 import operator
 
 from . import math
-from .expression import Expression
 from .new import new
 from .sequence import Sequence
 from .storage import FormatSpecification, StorageFormatManager
@@ -145,7 +143,6 @@ class Pattern:
         "_patterns",
         "_payload",
         "_period",
-        "_template",
     )
 
     _name_to_operator = {
@@ -165,7 +162,6 @@ class Pattern:
         patterns=None,
         payload=None,
         period=None,
-        template=None,
     ):
         if indices is not None:
             assert all(isinstance(_, int) for _ in indices), repr(indices)
@@ -185,7 +181,6 @@ class Pattern:
         self._patterns = patterns
         self._payload = payload
         self._period = period
-        self._template = template
 
     ### SPECIAL METHODS ###
 
@@ -206,8 +201,12 @@ class Pattern:
             abjad.Pattern(
                 operator='and',
                 patterns=(
-                    abjad.index_first(3),
-                    abjad.index_last(3),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
+                    abjad.Pattern(
+                        indices=[-3, -2, -1],
+                        ),
                     ),
                 )
 
@@ -225,9 +224,16 @@ class Pattern:
             abjad.Pattern(
                 operator='and',
                 patterns=(
-                    abjad.index_first(3),
-                    abjad.index_last(3),
-                    abjad.index([0], period=2),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
+                    abjad.Pattern(
+                        indices=[-3, -2, -1],
+                        ),
+                    abjad.Pattern(
+                        indices=[0],
+                        period=2,
+                        ),
                     ),
                 )
 
@@ -251,11 +257,18 @@ class Pattern:
                     abjad.Pattern(
                         operator='and',
                         patterns=(
-                            abjad.index_first(3),
-                            abjad.index_last(3),
+                            abjad.Pattern(
+                                indices=[0, 1, 2],
+                                ),
+                            abjad.Pattern(
+                                indices=[-3, -2, -1],
+                                ),
                             ),
                         ),
-                    abjad.index([0], period=2),
+                    abjad.Pattern(
+                        indices=[0],
+                        period=2,
+                        ),
                     ),
                 )
 
@@ -274,8 +287,12 @@ class Pattern:
             abjad.Pattern(
                 operator='and',
                 patterns=(
-                    abjad.index_first(3),
-                    abjad.index_last(3),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
+                    abjad.Pattern(
+                        indices=[-3, -2, -1],
+                        ),
                     ),
                 )
 
@@ -301,7 +318,9 @@ class Pattern:
             >>> pattern = abjad.index_first(3)
             >>> string = abjad.storage(pattern)
             >>> print(string)
-            abjad.index_first(3)
+            abjad.Pattern(
+                indices=[0, 1, 2],
+                )
 
             >>> pattern = ~pattern
             >>> string = abjad.storage(pattern)
@@ -335,8 +354,12 @@ class Pattern:
             abjad.Pattern(
                 operator='or',
                 patterns=(
-                    abjad.index_first(3),
-                    abjad.index_last(3),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
+                    abjad.Pattern(
+                        indices=[-3, -2, -1],
+                        ),
                     ),
                 )
 
@@ -355,8 +378,12 @@ class Pattern:
                 inverted=True,
                 operator='or',
                 patterns=(
-                    abjad.index_first(3),
-                    abjad.index_last(3),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
+                    abjad.Pattern(
+                        indices=[-3, -2, -1],
+                        ),
                     ),
                 )
 
@@ -366,7 +393,7 @@ class Pattern:
         Returns new pattern.
         """
         inverted = not self.inverted
-        return new(self, inverted=inverted, template=None)
+        return new(self, inverted=inverted)
 
     def __len__(self):
         """
@@ -447,8 +474,12 @@ class Pattern:
             abjad.Pattern(
                 operator='or',
                 patterns=(
-                    abjad.index_first(3),
-                    abjad.index_last(3),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
+                    abjad.Pattern(
+                        indices=[-3, -2, -1],
+                        ),
                     ),
                 )
 
@@ -466,9 +497,16 @@ class Pattern:
             abjad.Pattern(
                 operator='or',
                 patterns=(
-                    abjad.index_first(3),
-                    abjad.index_last(3),
-                    abjad.index([0], period=2),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
+                    abjad.Pattern(
+                        indices=[-3, -2, -1],
+                        ),
+                    abjad.Pattern(
+                        indices=[0],
+                        period=2,
+                        ),
                     ),
                 )
 
@@ -489,12 +527,19 @@ class Pattern:
             abjad.Pattern(
                 operator='or',
                 patterns=(
-                    abjad.index_first(3),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
                     abjad.Pattern(
                         operator='and',
                         patterns=(
-                            abjad.index_last(3),
-                            abjad.index([0], period=2),
+                            abjad.Pattern(
+                                indices=[-3, -2, -1],
+                                ),
+                            abjad.Pattern(
+                                indices=[0],
+                                period=2,
+                                ),
                             ),
                         ),
                     ),
@@ -515,8 +560,12 @@ class Pattern:
             abjad.Pattern(
                 operator='or',
                 patterns=(
-                    abjad.index_first(3),
-                    abjad.index_last(3),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
+                    abjad.Pattern(
+                        indices=[-3, -2, -1],
+                        ),
                     ),
                 )
 
@@ -554,8 +603,12 @@ class Pattern:
             abjad.Pattern(
                 operator='xor',
                 patterns=(
-                    abjad.index_first(3),
-                    abjad.index_last(3),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
+                    abjad.Pattern(
+                        indices=[-3, -2, -1],
+                        ),
                     ),
                 )
 
@@ -573,9 +626,16 @@ class Pattern:
             abjad.Pattern(
                 operator='xor',
                 patterns=(
-                    abjad.index_first(3),
-                    abjad.index_last(3),
-                    abjad.index([0], period=2),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
+                    abjad.Pattern(
+                        indices=[-3, -2, -1],
+                        ),
+                    abjad.Pattern(
+                        indices=[0],
+                        period=2,
+                        ),
                     ),
                 )
 
@@ -596,12 +656,19 @@ class Pattern:
             abjad.Pattern(
                 operator='xor',
                 patterns=(
-                    abjad.index_first(3),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
                     abjad.Pattern(
                         operator='and',
                         patterns=(
-                            abjad.index_last(3),
-                            abjad.index([0], period=2),
+                            abjad.Pattern(
+                                indices=[-3, -2, -1],
+                                ),
+                            abjad.Pattern(
+                                indices=[0],
+                                period=2,
+                                ),
                             ),
                         ),
                     ),
@@ -622,8 +689,12 @@ class Pattern:
             abjad.Pattern(
                 operator='xor',
                 patterns=(
-                    abjad.index_first(3),
-                    abjad.index_last(3),
+                    abjad.Pattern(
+                        indices=[0, 1, 2],
+                        ),
+                    abjad.Pattern(
+                        indices=[-3, -2, -1],
+                        ),
                     ),
                 )
 
@@ -654,27 +725,7 @@ class Pattern:
         return False
 
     def _get_format_specification(self):
-        if self.template is None:
-            return FormatSpecification(client=self)
-        return FormatSpecification(
-            client=self,
-            repr_is_indented=False,
-            storage_format_is_indented=False,
-            storage_format_args_values=[self.template],
-            storage_format_forced_override=self.template,
-            storage_format_keyword_names=(),
-        )
-
-    @staticmethod
-    def _get_template(frame):
-        try:
-            frame_info = inspect.getframeinfo(frame)
-            function_name = frame_info.function
-            arguments = Expression._wrap_arguments(frame, static_class=Pattern)
-            template = f"abjad.{function_name}({arguments})"
-        finally:
-            del frame
-        return template
+        return FormatSpecification(client=self)
 
     def _make_subscript_string(self):
         return str(self)
@@ -1034,17 +1085,6 @@ class Pattern:
             periods = [_.period for _ in self.patterns]
             if None not in periods:
                 return math.least_common_multiple(*periods)
-
-    @property
-    def template(self):
-        """
-        Get pattern template.
-
-        Set to string or none.
-
-        Returns string or none.
-        """
-        return self._template
 
     @property
     def weight(self):
@@ -1448,7 +1488,9 @@ class Pattern:
 
             >>> string = abjad.storage(pattern)
             >>> print(string)
-            abjad.index([2])
+            abjad.Pattern(
+                indices=[2],
+                )
 
         ..  container:: example
 
@@ -1458,18 +1500,18 @@ class Pattern:
 
             >>> string = abjad.storage(pattern)
             >>> print(string)
-            abjad.index([2, 3, 5])
+            abjad.Pattern(
+                indices=[2, 3, 5],
+                )
 
         Returns pattern.
         """
         assert all(isinstance(_, int) for _ in indices), repr(indices)
         indices = indices or []
-        template = Pattern._get_template(inspect.currentframe())
         return Pattern(
             indices=indices,
             inverted=inverted,
             period=period,
-            template=template,
         )
 
     @staticmethod
@@ -1485,12 +1527,14 @@ class Pattern:
 
             >>> string = abjad.storage(pattern)
             >>> print(string)
-            abjad.index_all()
+            abjad.Pattern(
+                indices=[0],
+                period=1,
+                )
 
         Returns pattern.
         """
-        template = Pattern._get_template(inspect.currentframe())
-        return Pattern(indices=[0], inverted=inverted, period=1, template=template)
+        return Pattern(indices=[0], inverted=inverted, period=1)
 
     @staticmethod
     def index_first(n, inverted=None):
@@ -1505,7 +1549,9 @@ class Pattern:
 
             >>> string = abjad.storage(pattern)
             >>> print(string)
-            abjad.index_first(1)
+            abjad.Pattern(
+                indices=[0],
+                )
 
         ..  container:: example
 
@@ -1515,7 +1561,9 @@ class Pattern:
 
             >>> string = abjad.storage(pattern)
             >>> print(string)
-            abjad.index_first(2)
+            abjad.Pattern(
+                indices=[0, 1],
+                )
 
         ..  container:: example
 
@@ -1525,7 +1573,7 @@ class Pattern:
 
             >>> string = abjad.storage(pattern)
             >>> print(string)
-            abjad.index_first(0)
+            abjad.Pattern()
 
         Returns pattern.
         """
@@ -1534,8 +1582,7 @@ class Pattern:
             indices = list(range(n))
         else:
             indices = None
-        template = Pattern._get_template(inspect.currentframe())
-        return Pattern(indices=indices, inverted=inverted, template=template)
+        return Pattern(indices=indices, inverted=inverted)
 
     @staticmethod
     def index_last(n, inverted=None):
@@ -1550,7 +1597,9 @@ class Pattern:
 
             >>> string = abjad.storage(pattern)
             >>> print(string)
-            abjad.index_last(2)
+            abjad.Pattern(
+                indices=[-2, -1],
+                )
 
         ..  container:: example
 
@@ -1560,7 +1609,7 @@ class Pattern:
 
             >>> string = abjad.storage(pattern)
             >>> print(string)
-            abjad.index_last(0)
+            abjad.Pattern()
 
         Returns pattern.
         """
@@ -1572,8 +1621,7 @@ class Pattern:
             indices = list(reversed(range(start, stop, stride)))
         else:
             indices = None
-        template = Pattern._get_template(inspect.currentframe())
-        return Pattern(indices=indices, inverted=inverted, template=template)
+        return Pattern(indices=indices, inverted=inverted)
 
     def matches_index(self, index, total_length, rotation=None):
         """

--- a/abjad/pitch/operators.py
+++ b/abjad/pitch/operators.py
@@ -1486,7 +1486,7 @@ class Retrograde:
         """
         Gets optional period of retrograde.
 
-        ..  todo:: Deprecated. Use Expression followed by Retrograde instead.
+        ..  todo:: Deprecated.
 
         ..  container:: example
 

--- a/abjad/pitch/segments.py
+++ b/abjad/pitch/segments.py
@@ -1,12 +1,10 @@
 import abc
 import collections
 import importlib
-import inspect
 import types
 
 from .. import math
 from ..duration import Multiplier
-from ..expression import Expression, Signature
 from ..new import new
 from ..sequence import Sequence
 from ..storage import FormatSpecification
@@ -413,110 +411,54 @@ class PitchClassSegment(Segment):
 
         Initializes segment with numbered pitch-classes:
 
-        ..  container:: example
+        >>> items = [-2, -1.5, 6, 7, -1.5, 7]
+        >>> segment = abjad.PitchClassSegment(items=items)
+        >>> lilypond_file = abjad.illustrate(segment)
+        >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-            >>> items = [-2, -1.5, 6, 7, -1.5, 7]
-            >>> segment = abjad.PitchClassSegment(items=items)
-            >>> lilypond_file = abjad.illustrate(segment)
-            >>> abjad.show(lilypond_file) # doctest: +SKIP
+        ..  docs::
 
-            ..  docs::
-
-                >>> voice = lilypond_file[abjad.Score][0][0]
-                >>> string = abjad.lilypond(voice)
-                >>> print(string)
-                \new Voice
-                {
-                    bf'8
-                    bqf'8
-                    fs'8
-                    g'8
-                    bqf'8
-                    g'8
-                    \bar "|."
-                    \override Score.BarLine.transparent = ##f
-                }
-
-        ..  container:: example expression
-
-            >>> expression = abjad.Expression()
-            >>> expression = abjad.pitch_class_segment()
-
-            >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-            >>> lilypond_file = abjad.illustrate(segment)
-            >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> voice = lilypond_file[abjad.Score][0][0]
-                >>> string = abjad.lilypond(voice)
-                >>> print(string)
-                \new Voice
-                {
-                    bf'8
-                    bqf'8
-                    fs'8
-                    g'8
-                    bqf'8
-                    g'8
-                    \bar "|."
-                    \override Score.BarLine.transparent = ##f
-                }
+            >>> voice = lilypond_file[abjad.Score][0][0]
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
+            \new Voice
+            {
+                bf'8
+                bqf'8
+                fs'8
+                g'8
+                bqf'8
+                g'8
+                \bar "|."
+                \override Score.BarLine.transparent = ##f
+            }
 
     ..  container:: example
 
         Initializes segment with named pitch-classes:
 
-        ..  container:: example
+        >>> items = ['c', 'ef', 'bqs,', 'd']
+        >>> segment = abjad.PitchClassSegment(
+        ...     items=items,
+        ...     item_class=abjad.NamedPitchClass,
+        ...     )
+        >>> lilypond_file = abjad.illustrate(segment)
+        >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-            >>> items = ['c', 'ef', 'bqs,', 'd']
-            >>> segment = abjad.PitchClassSegment(
-            ...     items=items,
-            ...     item_class=abjad.NamedPitchClass,
-            ...     )
-            >>> lilypond_file = abjad.illustrate(segment)
-            >>> abjad.show(lilypond_file) # doctest: +SKIP
+        ..  docs::
 
-            ..  docs::
-
-                >>> voice = lilypond_file[abjad.Score][0][0]
-                >>> string = abjad.lilypond(voice)
-                >>> print(string)
-                \new Voice
-                {
-                    c'8
-                    ef'8
-                    bqs'8
-                    d'8
-                    \bar "|."
-                    \override Score.BarLine.transparent = ##f
-                }
-
-        ..  container:: example expression
-
-            >>> expression = abjad.Expression()
-            >>> expression = abjad.pitch_class_segment(
-            ...     item_class=abjad.NamedPitchClass,
-            ...     )
-
-            >>> segment = expression(['c', 'ef', 'bqs,', 'd'])
-            >>> lilypond_file = abjad.illustrate(segment)
-            >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> voice = lilypond_file[abjad.Score][0][0]
-                >>> string = abjad.lilypond(voice)
-                >>> print(string)
-                \new Voice
-                {
-                    c'8
-                    ef'8
-                    bqs'8
-                    d'8
-                    \bar "|."
-                    \override Score.BarLine.transparent = ##f
-                }
+            >>> voice = lilypond_file[abjad.Score][0][0]
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
+            \new Voice
+            {
+                c'8
+                ef'8
+                bqs'8
+                d'8
+                \bar "|."
+                \override Score.BarLine.transparent = ##f
+            }
 
     """
 
@@ -533,10 +475,6 @@ class PitchClassSegment(Segment):
 
     ### SPECIAL METHODS ###
 
-    @Signature(
-        markup_maker_callback="_make___add___markup",
-        string_template_callback="_make___add___string_template",
-    )
     def __add__(self, argument):
         r"""
         Adds ``argument`` to segment.
@@ -565,382 +503,84 @@ class PitchClassSegment(Segment):
 
             Adds J and K:
 
-            ..  container:: example
+            >>> J + K
+            PitchClassSegment([10, 10.5, 6, 7, 10.5, 7, 0, 3, 11.5, 2])
 
-                >>> J + K
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7, 0, 3, 11.5, 2])
+            >>> segment = J + K
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J + K
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        c'8
-                        ef'8
-                        bqs'8
-                        d'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression + pitch_names
-
-                >>> expression(pitch_numbers)
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7, 0, 3, 11.5, 2])
-
-                >>> expression.get_string()
-                "J + ['c', 'ef', 'bqs,', 'd']"
-
-                >>> segment = expression(pitch_names)
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        c'8
-                        ^ \markup {
-                            \line
-                                {
-                                    \bold
-                                        J
-                                    +
-                                    "['c', 'ef', 'bqs,', 'd']"
-                                }
-                            }
-                        ef'8
-                        bqs'8
-                        d'8
-                        c'8
-                        ef'8
-                        bqs'8
-                        d'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    bf'8
+                    bqf'8
+                    fs'8
+                    g'8
+                    bqf'8
+                    g'8
+                    c'8
+                    ef'8
+                    bqs'8
+                    d'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Adds J repeatedly:
 
-            ..  container:: example
-
-                >>> J + J + J
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7, 10, 10.5, 6, 7, 10.5, 7, 10, 10.5, 6, 7, 10.5, 7])
+            >>> J + J + J
+            PitchClassSegment([10, 10.5, 6, 7, 10.5, 7, 10, 10.5, 6, 7, 10.5, 7, 10, 10.5, 6, 7, 10.5, 7])
 
 
-                >>> segment = J + J + J
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            >>> segment = J + J + J
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                ..  docs::
+            ..  docs::
 
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression_J = abjad.pitch_class_segment(name="J")
-                >>> expression = expression_J + expression_J + expression_J
-
-                >>> expression(pitch_numbers)
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7, 10, 10.5, 6, 7, 10.5, 7, 10, 10.5, 6, 7, 10.5, 7])
-
-                >>> expression.get_string()
-                'J + J + J'
-
-                >>> segment = expression(pitch_numbers)
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        ^ \markup {
-                            \line
-                                {
-                                    \line
-                                        {
-                                            \bold
-                                                J
-                                            +
-                                            \bold
-                                                J
-                                        }
-                                    +
-                                    \bold
-                                        J
-                                }
-                            }
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    bf'8
+                    bqf'8
+                    fs'8
+                    g'8
+                    bqf'8
+                    g'8
+                    bf'8
+                    bqf'8
+                    fs'8
+                    g'8
+                    bqf'8
+                    g'8
+                    bf'8
+                    bqf'8
+                    fs'8
+                    g'8
+                    bqf'8
+                    g'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Adds transformed segments:
 
-            ..  container:: example
-
-                >>> J.rotate(n=1) + K.rotate(n=2)
-                PitchClassSegment([7, 10, 10.5, 6, 7, 10.5, 11.5, 2, 0, 3])
-
-                >>> segment = J.rotate(n=1) + K.rotate(n=2)
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        g'8
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        bqs'8
-                        d'8
-                        c'8
-                        ef'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.rotate(n=1)
-                >>> expression = expression + K.rotate(n=2)
-
-                >>> expression(pitch_numbers)
-                PitchClassSegment([7, 10, 10.5, 6, 7, 10.5, 11.5, 2, 0, 3])
-
-                >>> expression.get_string()
-                'r1(J) + PC<bqs d c ef>'
-
-                >>> segment = expression(pitch_numbers)
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        g'8
-                        ^ \markup {
-                            \line
-                                {
-                                    \concat
-                                        {
-                                            r
-                                            \sub
-                                                1
-                                            \bold
-                                                J
-                                        }
-                                    +
-                                    "PC<bqs d c ef>"
-                                }
-                            }
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        bqs'8
-                        d'8
-                        c'8
-                        ef'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-        ..  container:: example
-
-            Reverses result:
-
-            ..  container:: example
-
-                >>> segment = J.rotate(n=1) + K.rotate(n=2)
-                >>> segment.retrograde()
-                PitchClassSegment([3, 0, 2, 11.5, 10.5, 7, 6, 10.5, 10, 7])
-
-                >>> segment = segment.retrograde()
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        ef'8
-                        c'8
-                        d'8
-                        bqs'8
-                        bqf'8
-                        g'8
-                        fs'8
-                        bqf'8
-                        bf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.rotate(n=1)
-                >>> expression = expression + K.rotate(n=2)
-                >>> expression = expression.retrograde()
-
-                >>> expression(pitch_numbers)
-                PitchClassSegment([3, 0, 2, 11.5, 10.5, 7, 6, 10.5, 10, 7])
-
-                >>> expression.get_string()
-                'R(r1(J) + PC<bqs d c ef>)'
-
-                >>> segment = expression(pitch_numbers)
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        ef'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    R
-                                    \line
-                                        {
-                                            \concat
-                                                {
-                                                    r
-                                                    \sub
-                                                        1
-                                                    \bold
-                                                        J
-                                                }
-                                            +
-                                            "PC<bqs d c ef>"
-                                        }
-                                }
-                            }
-                        c'8
-                        d'8
-                        bqs'8
-                        bqf'8
-                        g'8
-                        fs'8
-                        bqf'8
-                        bf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-        ..  container:: example expression
-
-            Establishes equivalence:
-
-            >>> expression = abjad.pitch_class_segment(name="J")
-            >>> expression = expression.rotate(n=1)
-            >>> expression = expression + K.rotate(n=2)
-            >>> expression = expression.establish_equivalence(name='Q')
-
-            >>> expression(pitch_numbers)
+            >>> J.rotate(n=1) + K.rotate(n=2)
             PitchClassSegment([7, 10, 10.5, 6, 7, 10.5, 11.5, 2, 0, 3])
 
-            >>> expression.get_string()
-            'Q = r1(J) + PC<bqs d c ef>'
-
-            >>> segment = expression(pitch_numbers)
-            >>> markup = expression.get_markup()
-            >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
+            >>> segment = J.rotate(n=1) + K.rotate(n=2)
+            >>> lilypond_file = abjad.illustrate(segment)
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -951,27 +591,6 @@ class PitchClassSegment(Segment):
                 \new Voice
                 {
                     g'8
-                    ^ \markup {
-                        \line
-                            {
-                                \bold
-                                    Q
-                                =
-                                \line
-                                    {
-                                        \concat
-                                            {
-                                                r
-                                                \sub
-                                                    1
-                                                \bold
-                                                    J
-                                            }
-                                        +
-                                        "PC<bqs d c ef>"
-                                    }
-                            }
-                        }
                     bf'8
                     bqf'8
                     fs'8
@@ -985,21 +604,16 @@ class PitchClassSegment(Segment):
                     \override Score.BarLine.transparent = ##f
                 }
 
-        ..  container:: example expression
+        ..  container:: example
 
-            Transforms equivalence:
+            Reverses result:
 
-            >>> expression = expression.transpose(n=1)
+            >>> segment = J.rotate(n=1) + K.rotate(n=2)
+            >>> segment.retrograde()
+            PitchClassSegment([3, 0, 2, 11.5, 10.5, 7, 6, 10.5, 10, 7])
 
-            >>> expression(pitch_numbers)
-            PitchClassSegment([8, 11, 11.5, 7, 8, 11.5, 0.5, 3, 1, 4])
-
-            >>> expression.get_string()
-            'T1(Q)'
-
-            >>> segment = expression(pitch_numbers)
-            >>> markup = expression.get_markup()
-            >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
+            >>> segment = segment.retrograde()
+            >>> lilypond_file = abjad.illustrate(segment)
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1009,34 +623,22 @@ class PitchClassSegment(Segment):
                 >>> print(string)
                 \new Voice
                 {
-                    af'8
-                    ^ \markup {
-                        \concat
-                            {
-                                T
-                                \sub
-                                    1
-                                \bold
-                                    Q
-                            }
-                        }
-                    b'8
-                    bqs'8
-                    g'8
-                    af'8
-                    bqs'8
-                    cqs'8
                     ef'8
-                    cs'8
-                    e'8
+                    c'8
+                    d'8
+                    bqs'8
+                    bqf'8
+                    g'8
+                    fs'8
+                    bqf'8
+                    bf'8
+                    g'8
                     \bar "|."
                     \override Score.BarLine.transparent = ##f
                 }
 
         Returns new segment.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         argument = type(self)(items=argument)
         items = self.items + argument.items
         return type(self)(items=items)
@@ -1076,10 +678,6 @@ class PitchClassSegment(Segment):
         """
         return super().__contains__(argument)
 
-    @Signature(
-        markup_maker_callback="_make___getitem___markup",
-        string_template_callback="_make___getitem___string_template",
-    )
     def __getitem__(self, argument):
         r"""
         Gets ``argument`` from segment.
@@ -1100,294 +698,93 @@ class PitchClassSegment(Segment):
 
             Gets item at nonnegative index:
 
-            ..  container:: example
-
-                >>> J[0]
-                NumberedPitchClass(10)
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression[0]
-
-                >>> expression(items=[-2, -1.5, 6, 7, -1.5, 7])
-                NumberedPitchClass(10)
-
-                >>> expression.get_string()
-                'J[0]'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                \bold
-                                    J
-                                \sub
-                                    0
-                            }
-                        }
+            >>> J[0]
+            NumberedPitchClass(10)
 
         ..  container:: example
 
             Gets item at negative index:
 
-            ..  container:: example
-
-                >>> J[-1]
-                NumberedPitchClass(7)
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression[-1]
-
-                >>> expression(items=[-2, -1.5, 6, 7, -1.5, 7])
-                NumberedPitchClass(7)
-
-                >>> expression.get_string()
-                'J[-1]'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                \bold
-                                    J
-                                \sub
-                                    -1
-                            }
-                        }
+            >>> J[-1]
+            NumberedPitchClass(7)
 
         ..  container:: example
 
             Gets slice:
 
-            ..  container:: example
+            >>> J[:4]
+            PitchClassSegment([10, 10.5, 6, 7])
 
-                >>> J[:4]
-                PitchClassSegment([10, 10.5, 6, 7])
+            >>> segment = J[:4]
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J[:4]
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression[:4]
-
-                >>> expression(items=[-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([10, 10.5, 6, 7])
-
-                >>> expression.get_string()
-                'J[:4]'
-
-                >>> segment = expression(items=[-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    \bold
-                                        J
-                                    \sub
-                                        [:4]
-                                }
-                            }
-                        bqf'8
-                        fs'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    bf'8
+                    bqf'8
+                    fs'8
+                    g'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Gets retrograde of slice:
 
-            ..  container:: example
+            >>> J[:4].retrograde()
+            PitchClassSegment([7, 6, 10.5, 10])
 
-                >>> J[:4].retrograde()
-                PitchClassSegment([7, 6, 10.5, 10])
+            >>> segment = J[:4].retrograde()
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J[:4].retrograde()
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        g'8
-                        fs'8
-                        bqf'8
-                        bf'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression[:4]
-                >>> expression = expression.retrograde()
-
-                >>> expression(items=[-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([7, 6, 10.5, 10])
-
-                >>> expression.get_string()
-                'R(J[:4])'
-
-                >>> segment = expression(items=[-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        g'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    R
-                                    \concat
-                                        {
-                                            \bold
-                                                J
-                                            \sub
-                                                [:4]
-                                        }
-                                }
-                            }
-                        fs'8
-                        bqf'8
-                        bf'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    g'8
+                    fs'8
+                    bqf'8
+                    bf'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Gets slice of retrograde:
 
-            ..  container:: example
+            >>> J.retrograde()[:4]
+            PitchClassSegment([7, 10.5, 7, 6])
 
-                >>> J.retrograde()[:4]
-                PitchClassSegment([7, 10.5, 7, 6])
+            >>> segment = J.retrograde()[:4]
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.retrograde()[:4]
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        g'8
-                        bqf'8
-                        g'8
-                        fs'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.retrograde()
-                >>> expression = expression[:4]
-
-                >>> expression(items=[-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([7, 10.5, 7, 6])
-
-                >>> expression.get_string()
-                'R(J)[:4]'
-
-                >>> segment = expression(items=[-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        g'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    \concat
-                                        {
-                                            (
-                                            \concat
-                                                {
-                                                    R
-                                                    \bold
-                                                        J
-                                                }
-                                            )
-                                        }
-                                    \sub
-                                        [:4]
-                                }
-                            }
-                        bqf'8
-                        g'8
-                        fs'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    g'8
+                    bqf'8
+                    g'8
+                    fs'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
@@ -1397,8 +794,6 @@ class PitchClassSegment(Segment):
             True
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe(), precedence=100)
         return super().__getitem__(argument)
 
     def __mul__(self, n):
@@ -1525,10 +920,6 @@ class PitchClassSegment(Segment):
         pcs = [_ % 12 for _ in numbers]
         return type(self)(items=pcs, item_class=self.item_class)
 
-    def _update_expression(self, frame, precedence=None):
-        callback = Expression._frame_to_callback(frame, precedence=precedence)
-        return self._expression.append_callback(callback)
-
     ### PUBLIC PROPERTIES ###
 
     @property
@@ -1549,7 +940,6 @@ class PitchClassSegment(Segment):
             'NumberedPitchClass'
 
         ..  container:: example
-
 
             Gets item class of named segment:
 
@@ -1574,68 +964,32 @@ class PitchClassSegment(Segment):
 
         ..  container:: example
 
-            ..  container:: example
+            Initializes items positionally:
 
-                Initializes items positionally:
+            >>> items = [-2, -1.5, 6, 7, -1.5, 7]
+            >>> segment = abjad.PitchClassSegment(items)
+            >>> for item in segment.items:
+            ...     item
+            ...
+            NumberedPitchClass(10)
+            NumberedPitchClass(10.5)
+            NumberedPitchClass(6)
+            NumberedPitchClass(7)
+            NumberedPitchClass(10.5)
+            NumberedPitchClass(7)
 
-                >>> items = [-2, -1.5, 6, 7, -1.5, 7]
-                >>> segment = abjad.PitchClassSegment(items)
-                >>> for item in segment.items:
-                ...     item
-                ...
-                NumberedPitchClass(10)
-                NumberedPitchClass(10.5)
-                NumberedPitchClass(6)
-                NumberedPitchClass(7)
-                NumberedPitchClass(10.5)
-                NumberedPitchClass(7)
+            Initializes items from keyword:
 
-                Initializes items from keyword:
-
-                >>> items = [-2, -1.5, 6, 7, -1.5, 7]
-                >>> segment = abjad.PitchClassSegment(items=items)
-                >>> for item in segment.items:
-                ...     item
-                NumberedPitchClass(10)
-                NumberedPitchClass(10.5)
-                NumberedPitchClass(6)
-                NumberedPitchClass(7)
-                NumberedPitchClass(10.5)
-                NumberedPitchClass(7)
-
-            ..  container:: example expression
-
-                Initializes items positionally:
-
-                >>> expression = abjad.Expression()
-                >>> expression = abjad.pitch_class_segment()
-
-                >>> items = [-2, -1.5, 6, 7, -1.5, 7]
-                >>> segment = expression(items)
-                >>> for item in segment.items:
-                ...     item
-                NumberedPitchClass(10)
-                NumberedPitchClass(10.5)
-                NumberedPitchClass(6)
-                NumberedPitchClass(7)
-                NumberedPitchClass(10.5)
-                NumberedPitchClass(7)
-
-                Initializes items from keyword:
-
-                >>> expression = abjad.Expression()
-                >>> expression = abjad.pitch_class_segment()
-
-                >>> items = [-2, -1.5, 6, 7, -1.5, 7]
-                >>> segment = expression(items=items)
-                >>> for item in segment.items:
-                ...     item
-                NumberedPitchClass(10)
-                NumberedPitchClass(10.5)
-                NumberedPitchClass(6)
-                NumberedPitchClass(7)
-                NumberedPitchClass(10.5)
-                NumberedPitchClass(7)
+            >>> items = [-2, -1.5, 6, 7, -1.5, 7]
+            >>> segment = abjad.PitchClassSegment(items=items)
+            >>> for item in segment.items:
+            ...     item
+            NumberedPitchClass(10)
+            NumberedPitchClass(10.5)
+            NumberedPitchClass(6)
+            NumberedPitchClass(7)
+            NumberedPitchClass(10.5)
+            NumberedPitchClass(7)
 
         ..  container:: example
 
@@ -1785,7 +1139,6 @@ class PitchClassSegment(Segment):
         """
         return super().index(item)
 
-    @Signature(is_operator=True, method_name="I", subscript="axis")
     def invert(self, axis=None):
         r"""
         Inverts segment.
@@ -1806,151 +1159,60 @@ class PitchClassSegment(Segment):
 
             Inverts segment:
 
-            ..  container:: example
+            >>> J.invert()
+            PitchClassSegment([2, 1.5, 6, 5, 1.5, 5])
 
-                >>> J.invert()
-                PitchClassSegment([2, 1.5, 6, 5, 1.5, 5])
+            >>> segment = J.invert()
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.invert()
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        d'8
-                        dqf'8
-                        fs'8
-                        f'8
-                        dqf'8
-                        f'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.invert()
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([2, 1.5, 6, 5, 1.5, 5])
-
-                >>> expression.get_string()
-                'I(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        d'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    I
-                                    \bold
-                                        J
-                                }
-                            }
-                        dqf'8
-                        fs'8
-                        f'8
-                        dqf'8
-                        f'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    d'8
+                    dqf'8
+                    fs'8
+                    f'8
+                    dqf'8
+                    f'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Inverts inversion of segment:
 
-            ..  container:: example
+            >>> J.invert().invert()
+            PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
 
-                >>> J.invert().invert()
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
+            >>> segment = J.invert().invert()
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.invert().invert()
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    bf'8
+                    bqf'8
+                    fs'8
+                    g'8
+                    bqf'8
+                    g'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-                >>> segment == J
-                True
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.invert()
-                >>> expression = expression.invert()
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
-
-                >>> expression.get_string()
-                'I(I(J))'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    I
-                                    \concat
-                                        {
-                                            I
-                                            \bold
-                                                J
-                                        }
-                                }
-                            }
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+            >>> segment == J
+            True
 
         ..  container:: example
 
@@ -1960,12 +1222,9 @@ class PitchClassSegment(Segment):
             True
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         items = [_.invert(axis=axis) for _ in self]
         return type(self)(items=items)
 
-    @Signature(is_operator=True, method_name="M", subscript="n")
     def multiply(self, n=1):
         r"""
         Multiplies pitch-classes in segment by ``n``.
@@ -1986,293 +1245,113 @@ class PitchClassSegment(Segment):
 
             Multiplies pitch-classes in segment by 1:
 
-            ..  container:: example
+            >>> J.multiply(n=1)
+            PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
 
-                >>> J.multiply(n=1)
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
+            >>> segment = J.multiply(n=1)
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.multiply(n=1)
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.multiply(n=1)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
-
-                >>> expression.get_string()
-                'M1(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    M
-                                    \sub
-                                        1
-                                    \bold
-                                        J
-                                }
-                            }
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    bf'8
+                    bqf'8
+                    fs'8
+                    g'8
+                    bqf'8
+                    g'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Multiplies pitch-classes in segment by 5:
 
-            ..  container:: example
+            >>> J.multiply(n=5)
+            PitchClassSegment([2, 4.5, 6, 11, 4.5, 11])
 
-                >>> J.multiply(n=5)
-                PitchClassSegment([2, 4.5, 6, 11, 4.5, 11])
+            >>> segment = J.multiply(n=5)
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.multiply(n=5)
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        d'8
-                        eqs'8
-                        fs'8
-                        b'8
-                        eqs'8
-                        b'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.multiply(n=5)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([2, 4.5, 6, 11, 4.5, 11])
-
-                >>> expression.get_string()
-                'M5(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        d'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    M
-                                    \sub
-                                        5
-                                    \bold
-                                        J
-                                }
-                            }
-                        eqs'8
-                        fs'8
-                        b'8
-                        eqs'8
-                        b'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    d'8
+                    eqs'8
+                    fs'8
+                    b'8
+                    eqs'8
+                    b'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Multiplies pitch-classes in segment by 7:
 
-            ..  container:: example
+            >>> J.multiply(n=7)
+            PitchClassSegment([10, 1.5, 6, 1, 1.5, 1])
 
-                >>> J.multiply(n=7)
-                PitchClassSegment([10, 1.5, 6, 1, 1.5, 1])
+            >>> segment = J.multiply(n=7)
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.multiply(n=7)
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        dqf'8
-                        fs'8
-                        cs'8
-                        dqf'8
-                        cs'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.multiply(n=7)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([10, 1.5, 6, 1, 1.5, 1])
-
-                >>> expression.get_string()
-                'M7(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    M
-                                    \sub
-                                        7
-                                    \bold
-                                        J
-                                }
-                            }
-                        dqf'8
-                        fs'8
-                        cs'8
-                        dqf'8
-                        cs'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    bf'8
+                    dqf'8
+                    fs'8
+                    cs'8
+                    dqf'8
+                    cs'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Multiplies pitch-classes in segment by 11:
 
-            ..  container:: example
+            >>> segment = J.multiply(n=11)
+            >>> segment
+            PitchClassSegment([2, 7.5, 6, 5, 7.5, 5])
 
-                >>> segment = J.multiply(n=11)
-                >>> segment
-                PitchClassSegment([2, 7.5, 6, 5, 7.5, 5])
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        d'8
-                        gqs'8
-                        fs'8
-                        f'8
-                        gqs'8
-                        f'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.multiply(n=11)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([2, 7.5, 6, 5, 7.5, 5])
-
-                >>> expression.get_string()
-                'M11(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        d'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    M
-                                    \sub
-                                        11
-                                    \bold
-                                        J
-                                }
-                            }
-                        gqs'8
-                        fs'8
-                        f'8
-                        gqs'8
-                        f'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    d'8
+                    gqs'8
+                    fs'8
+                    f'8
+                    gqs'8
+                    f'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
@@ -2282,13 +1361,10 @@ class PitchClassSegment(Segment):
             True
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         items = [NumberedPitchClass(_) for _ in self]
         items = [_.multiply(n) for _ in items]
         return type(self)(items=items)
 
-    @Signature()
     def permute(self, row=None):
         r"""
         Permutes segment by twelve-tone ``row``.
@@ -2343,58 +1419,12 @@ class PitchClassSegment(Segment):
                     \override Score.BarLine.transparent = ##f
                 }
 
-        ..  container:: example expression
-
-            >>> expression = abjad.pitch_class_segment(name="J")
-            >>> row = [10, 0, 2, 6, 8, 7, 5, 3, 1, 9, 4, 11]
-            >>> expression = expression.permute(row)
-
-            >>> expression([-2, -1, 6, 7, -1, 7])
-            PitchClassSegment([4, 11, 5, 3, 11, 3])
-
-            >>> expression.get_string()
-            'permute(J, row=[10, 0, 2, 6, 8, 7, 5, 3, 1, 9, 4, 11])'
-
-            >>> segment = expression([-2, -1, 6, 7, -1, 7])
-            >>> markup = expression.get_markup()
-            >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-            >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-            ..  doctest:
-
-                >>> voice = lilypond_file[abjad.Score][0][0]
-                >>> string = abjad.lilypond(voice)
-                >>> print(string)
-                \new Voice
-                {
-                    e'8
-                    ^ \markup {
-                        \concat
-                            {
-                                permute(
-                                \bold
-                                    J
-                                ", row=[10, 0, 2, 6, 8, 7, 5, 3, 1, 9, 4, 11])"
-                            }
-                        }
-                    b'8
-                    f'8
-                    ef'8
-                    b'8
-                    ef'8
-                    \bar "|."
-                    \override Score.BarLine.transparent = ##f
-                }
-
         Returns new segment.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         row = TwelveToneRow(items=row)
         items = row(self)
         return type(self)(items=items)
 
-    @Signature(is_operator=True, method_name="R")
     def retrograde(self):
         r"""
         Gets retrograde of segment.
@@ -2415,154 +1445,60 @@ class PitchClassSegment(Segment):
 
             Gets retrograde of segment:
 
-            ..  container:: example
+            >>> segment = J.retrograde()
+            >>> segment
+            PitchClassSegment([7, 10.5, 7, 6, 10.5, 10])
 
-                >>> segment = J.retrograde()
-                >>> segment
-                PitchClassSegment([7, 10.5, 7, 6, 10.5, 10])
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        g'8
-                        bqf'8
-                        g'8
-                        fs'8
-                        bqf'8
-                        bf'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.retrograde()
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([7, 10.5, 7, 6, 10.5, 10])
-
-                >>> expression.get_string()
-                'R(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        g'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    R
-                                    \bold
-                                        J
-                                }
-                            }
-                        bqf'8
-                        g'8
-                        fs'8
-                        bqf'8
-                        bf'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    g'8
+                    bqf'8
+                    g'8
+                    fs'8
+                    bqf'8
+                    bf'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Gets retrograde of retrograde of segment:
 
-            ..  container:: example
+            >>> segment = J.retrograde().retrograde()
+            >>> segment
+            PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
 
-                >>> segment = J.retrograde().retrograde()
-                >>> segment
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    bf'8
+                    bqf'8
+                    fs'8
+                    g'8
+                    bqf'8
+                    g'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-                >>> segment == J
-                True
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.retrograde()
-                >>> expression = expression.retrograde()
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
-
-                >>> expression.get_string()
-                'R(R(J))'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    R
-                                    \concat
-                                        {
-                                            R
-                                            \bold
-                                                J
-                                        }
-                                }
-                            }
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-                >>> segment == J
-                True
+            >>> segment == J
+            True
 
         ..  container:: example
 
@@ -2572,15 +1508,8 @@ class PitchClassSegment(Segment):
             True
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         return type(self)(items=reversed(self))
 
-    @Signature(
-        is_operator=True,
-        method_name="r",
-        subscript="n",
-    )
     def rotate(self, n=0):
         r"""
         Rotates segment by index ``n``.
@@ -2601,226 +1530,88 @@ class PitchClassSegment(Segment):
 
             Rotates segment to the right:
 
-            ..  container:: example
+            >>> J.rotate(n=1)
+            PitchClassSegment([7, 10, 10.5, 6, 7, 10.5])
 
-                >>> J.rotate(n=1)
-                PitchClassSegment([7, 10, 10.5, 6, 7, 10.5])
+            >>> segment = J.rotate(n=1)
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.rotate(n=1)
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        g'8
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.rotate(n=1)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([7, 10, 10.5, 6, 7, 10.5])
-
-                >>> expression.get_string()
-                'r1(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        g'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    r
-                                    \sub
-                                        1
-                                    \bold
-                                        J
-                                }
-                            }
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    g'8
+                    bf'8
+                    bqf'8
+                    fs'8
+                    g'8
+                    bqf'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Rotates segment to the left:
 
-            ..  container:: example
+            >>> J.rotate(n=-1)
+            PitchClassSegment([10.5, 6, 7, 10.5, 7, 10])
 
-                >>> J.rotate(n=-1)
-                PitchClassSegment([10.5, 6, 7, 10.5, 7, 10])
+            >>> segment = J.rotate(n=-1)
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.rotate(n=-1)
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        bf'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.rotate(n=-1)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([10.5, 6, 7, 10.5, 7, 10])
-
-                >>> expression.get_string()
-                'r-1(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bqf'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    r
-                                    \sub
-                                        -1
-                                    \bold
-                                        J
-                                }
-                            }
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        bf'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    bqf'8
+                    fs'8
+                    g'8
+                    bqf'8
+                    g'8
+                    bf'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Rotates segment by zero:
 
-            ..  container:: example
+            >>> J.rotate(n=0)
+            PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
 
-                >>> J.rotate(n=0)
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
+            >>> segment = J.rotate(n=0)
+            >>> lilypond_file = abjad.illustrate(J)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.rotate(n=0)
-                >>> lilypond_file = abjad.illustrate(J)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    bf'8
+                    bqf'8
+                    fs'8
+                    g'8
+                    bqf'8
+                    g'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-                >>> segment == J
-                True
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.rotate(n=0)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
-
-                >>> expression.get_string()
-                'r0(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    r
-                                    \sub
-                                        0
-                                    \bold
-                                        J
-                                }
-                            }
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-                >>> segment == J
-                True
+            >>> segment == J
+            True
 
         ..  container:: example
 
@@ -2830,8 +1621,6 @@ class PitchClassSegment(Segment):
             True
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         items = Sequence(self._collection).rotate(n=n)
         return type(self)(items=items)
 
@@ -3095,7 +1884,6 @@ class PitchClassSegment(Segment):
         item_class = class_._to_pitch_item_class(self.item_class)
         return PitchSegment(items=self.items, item_class=item_class)
 
-    @Signature(is_operator=True, method_name="T", subscript="n")
     def transpose(self, n=0):
         r"""
         Transposes segment by index ``n``.
@@ -3116,226 +1904,88 @@ class PitchClassSegment(Segment):
 
             Transposes segment by positive index:
 
-            ..  container:: example
+            >>> J.transpose(n=13)
+            PitchClassSegment([11, 11.5, 7, 8, 11.5, 8])
 
-                >>> J.transpose(n=13)
-                PitchClassSegment([11, 11.5, 7, 8, 11.5, 8])
+            >>> segment = J.transpose(n=13)
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.transpose(n=13)
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        b'8
-                        bqs'8
-                        g'8
-                        af'8
-                        bqs'8
-                        af'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.transpose(n=13)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([11, 11.5, 7, 8, 11.5, 8])
-
-                >>> expression.get_string()
-                'T13(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        b'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    T
-                                    \sub
-                                        13
-                                    \bold
-                                        J
-                                }
-                            }
-                        bqs'8
-                        g'8
-                        af'8
-                        bqs'8
-                        af'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    b'8
+                    bqs'8
+                    g'8
+                    af'8
+                    bqs'8
+                    af'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Transposes segment by negative index:
 
-            ..  container:: example
+            >>> J.transpose(n=-13)
+            PitchClassSegment([9, 9.5, 5, 6, 9.5, 6])
 
-                >>> J.transpose(n=-13)
-                PitchClassSegment([9, 9.5, 5, 6, 9.5, 6])
+            >>> segment = J.transpose(n=-13)
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.transpose(n=-13)
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        a'8
-                        aqs'8
-                        f'8
-                        fs'8
-                        aqs'8
-                        fs'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.transpose(n=-13)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([9, 9.5, 5, 6, 9.5, 6])
-
-                >>> expression.get_string()
-                'T-13(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        a'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    T
-                                    \sub
-                                        -13
-                                    \bold
-                                        J
-                                }
-                            }
-                        aqs'8
-                        f'8
-                        fs'8
-                        aqs'8
-                        fs'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    a'8
+                    aqs'8
+                    f'8
+                    fs'8
+                    aqs'8
+                    fs'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
         ..  container:: example
 
             Transposes segment by zero index:
 
-            ..  container:: example
+            >>> J.transpose(n=0)
+            PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
 
-                >>> J.transpose(n=0)
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
+            >>> segment = J.transpose(n=0)
+            >>> lilypond_file = abjad.illustrate(segment)
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
 
-                >>> segment = J.transpose(n=0)
-                >>> lilypond_file = abjad.illustrate(segment)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
+            ..  docs::
 
-                ..  docs::
+                >>> voice = lilypond_file[abjad.Score][0][0]
+                >>> string = abjad.lilypond(voice)
+                >>> print(string)
+                \new Voice
+                {
+                    bf'8
+                    bqf'8
+                    fs'8
+                    g'8
+                    bqf'8
+                    g'8
+                    \bar "|."
+                    \override Score.BarLine.transparent = ##f
+                }
 
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-                >>> segment == J
-                True
-
-            ..  container:: example expression
-
-                >>> expression = abjad.pitch_class_segment(name="J")
-                >>> expression = expression.transpose(n=0)
-
-                >>> expression([-2, -1.5, 6, 7, -1.5, 7])
-                PitchClassSegment([10, 10.5, 6, 7, 10.5, 7])
-
-                >>> expression.get_string()
-                'T0(J)'
-
-                >>> segment = expression([-2, -1.5, 6, 7, -1.5, 7])
-                >>> markup = expression.get_markup()
-                >>> lilypond_file = abjad.illustrate(segment, figure_name=markup)
-                >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> voice = lilypond_file[abjad.Score][0][0]
-                    >>> string = abjad.lilypond(voice)
-                    >>> print(string)
-                    \new Voice
-                    {
-                        bf'8
-                        ^ \markup {
-                            \concat
-                                {
-                                    T
-                                    \sub
-                                        0
-                                    \bold
-                                        J
-                                }
-                            }
-                        bqf'8
-                        fs'8
-                        g'8
-                        bqf'8
-                        g'8
-                        \bar "|."
-                        \override Score.BarLine.transparent = ##f
-                    }
-
-                >>> segment == J
-                True
+            >>> segment == J
+            True
 
         ..  container:: example
 
@@ -3345,8 +1995,6 @@ class PitchClassSegment(Segment):
             True
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         items = [_.transpose(n=n) for _ in self]
         return type(self)(items=items)
 
@@ -6119,21 +4767,3 @@ class TwelveToneRow(PitchClassSegment):
 
         """
         return super().transpose(n=n)
-
-
-### FUNCTIONS ###
-
-
-def pitch_class_segment(items=None, item_class=None, **keywords):
-    """
-    Makes pitch-class segment or pitch-class segment expression.
-    """
-    if items is not None:
-        return PitchClassSegment(items=items, item_class=item_class)
-    name = keywords.pop("name", None)
-    expression = Expression(name=name, proxy_class=PitchClassSegment)
-    callback = Expression._make_initializer_callback(
-        PitchClassSegment, string_template="{}", **keywords
-    )
-    expression = expression.append_callback(callback)
-    return expression

--- a/abjad/pitch/sets.py
+++ b/abjad/pitch/sets.py
@@ -4,7 +4,6 @@ import copy
 import types
 
 from .. import enumerate
-from ..expression import Expression
 from ..new import new
 from ..sequence import Sequence
 from ..storage import FormatSpecification
@@ -1160,21 +1159,3 @@ class PitchSet(Set):
         """
         items = (pitch.transpose(n=n) for pitch in self)
         return new(self, items=items)
-
-
-### FUNCTIONS ###
-
-
-def pitch_set(items=None, item_class=None, **keywords):
-    """
-    Makes pitch set or pitch set expression.
-    """
-    if items is not None:
-        return PitchSet(items=items, item_class=item_class)
-    name = keywords.pop("name", None)
-    expression = Expression(name=name, proxy_class=PitchSet)
-    callback = Expression._make_initializer_callback(
-        PitchSet, string_template="{}", **keywords
-    )
-    expression = expression.append_callback(callback)
-    return expression

--- a/abjad/select.py
+++ b/abjad/select.py
@@ -422,46 +422,6 @@ class Selection(collections.abc.Sequence):
                 Note("g'8")
                 Note("a'8")
 
-            ..  container:: example expression
-
-                >>> left = abjad.select().leaves()[:2]
-                >>> right = abjad.select().leaves()[-2:]
-                >>> selector = left + right
-                >>> result = selector(staff)
-
-                >>> selector.print(result)
-                Note("c'8")
-                Rest('r8')
-                Note("g'8")
-                Note("a'8")
-
-                >>> abjad.label(result).by_selector(selector)
-                >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(staff)
-                >>> print(string)
-                \new Staff
-                \with
-                {
-                    autoBeaming = ##f
-                }
-                {
-                    \abjad-color-music #'red
-                    c'8
-                    \abjad-color-music #'blue
-                    r8
-                    d'8
-                    e'8
-                    r8
-                    f'8
-                    \abjad-color-music #'red
-                    g'8
-                    \abjad-color-music #'blue
-                    a'8
-                }
-
         """
         assert isinstance(argument, collections.abc.Iterable)
         items = self.items + tuple(argument)
@@ -502,16 +462,9 @@ class Selection(collections.abc.Sequence):
             template = method(argument)
             template = template.format(self._expression.template)
             return self._update_expression(inspect.currentframe(), template=template)
-        if isinstance(argument, Pattern):
-            raise Exception("use abjad.Selection.get() instead.")
-            argument = argument.advance(self._previous)
-            self._previous = None
-            items = Sequence(self.items).retain_pattern(argument)
-            result = type(self)(items, previous=self._previous)
-        else:
-            result = self.items.__getitem__(argument)
-            if isinstance(result, tuple):
-                result = type(self)(result, previous=self._previous)
+        result = self.items.__getitem__(argument)
+        if isinstance(result, tuple):
+            result = type(self)(result, previous=self._previous)
         return result
 
     def __getstate__(self) -> dict:
@@ -1233,7 +1186,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Chord("<fs' gs'>16")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1351,7 +1304,7 @@ class Selection(collections.abc.Sequence):
                 Chord("<fs' gs'>4")
                 Chord("<fs' gs'>16")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1457,7 +1410,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector = abjad.select().components(abjad.Note)
                 >>> result = selector(staff)
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> selector.print(result)
@@ -1569,7 +1522,7 @@ class Selection(collections.abc.Sequence):
                 Note("e'8")
                 Note("f'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -1671,7 +1624,7 @@ class Selection(collections.abc.Sequence):
                 Note("e'8")
                 Note("f'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -1769,7 +1722,7 @@ class Selection(collections.abc.Sequence):
                 Note("af'16")
                 Note("gf'16")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -1846,7 +1799,7 @@ class Selection(collections.abc.Sequence):
                 Note("e'8")
                 Note("f'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -1904,7 +1857,7 @@ class Selection(collections.abc.Sequence):
                 LogicalTie([Note("d'8"), Note("d'8")])
                 LogicalTie([Note("f'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -1967,7 +1920,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("e'8"), Note("e'8")])
                 Selection([Note("f'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -2035,7 +1988,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector = abjad.select().runs().filter(inequality)
                 >>> result = selector(staff)
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
                 >>> selector.print(result)
@@ -2107,7 +2060,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Selection([Note("d'8"), Note("e'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2161,7 +2114,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("c'8")])
                 Selection([Note("d'8"), Note("e'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2226,7 +2179,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("d'8"), Note("e'8")])
                 Selection([Note("f'8"), Note("g'8"), Note("a'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2281,7 +2234,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("c'8")])
                 Selection([Note("d'8"), Note("e'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2350,7 +2303,7 @@ class Selection(collections.abc.Sequence):
                 Chord("<c' e' g'>8")
                 Chord("<c' e' g'>4")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2411,7 +2364,7 @@ class Selection(collections.abc.Sequence):
                 Chord("<c' e' g'>8")
                 Chord("<c' e' g'>4")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2469,7 +2422,7 @@ class Selection(collections.abc.Sequence):
                 LogicalTie([Note("c'8")])
                 LogicalTie([Chord("<c' e' g'>8"), Chord("<c' e' g'>4")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2534,7 +2487,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Selection([Note("d'8"), Note("e'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2588,7 +2541,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("c'8")])
                 Selection([Note("d'8"), Note("e'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2664,7 +2617,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Rest('r16'), Note("bf'16")])
                 Selection([Rest('r16'), Note("bf'16")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2771,7 +2724,7 @@ class Selection(collections.abc.Sequence):
                 Rest('r16')
                 Note("bf'16")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2874,7 +2827,7 @@ class Selection(collections.abc.Sequence):
                 Note("e'8")
                 Rest('r8')
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2932,7 +2885,7 @@ class Selection(collections.abc.Sequence):
                 LogicalTie([Note("c'8")])
                 LogicalTie([Note("e'8"), Note("e'8"), Note("e'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -2996,7 +2949,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("e'8")])
                 Selection(items=())
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -3068,7 +3021,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Selection([Selection([Note("c'8"), Note("c'16"), Note("c'16"), Note("c'16"), Note("c'16"), Note("d'8"), Note("d'16"), Note("d'16"), Note("d'16"), Note("d'16")])])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3145,7 +3098,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Selection([Selection([Note("c'8"), Note("c'16"), Note("c'16"), Note("c'16"), Note("c'16"), Note("d'8"), Note("d'16"), Note("d'16"), Note("d'16"), Note("d'16")])])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3242,7 +3195,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("f'8"), Note("g'8"), Note("a'8")])
                 Selection([Chord("<c' e' g'>8"), Chord("<c' e' g'>4")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3311,7 +3264,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("d'16"), Note("d'16"), Note("d'16"), Note("d'16")])
                 Selection([Note("f'16"), Note("f'16"), Note("f'16"), Note("f'16")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3377,7 +3330,7 @@ class Selection(collections.abc.Sequence):
                 Note("d'8")
                 Note("g'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3445,7 +3398,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("d'8"), Note("d'16"), Note("d'16")])
                 Selection([Note("d'16"), Note("d'16")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3525,7 +3478,7 @@ class Selection(collections.abc.Sequence):
                 Selection([LogicalTie([Note("d'8"), Note("d'16")]), LogicalTie([Note("d'16")])])
                 Selection([LogicalTie([Note("d'16")]), LogicalTie([Note("d'16")])])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3629,7 +3582,7 @@ class Selection(collections.abc.Sequence):
                 Selection([LogicalTie([Note("f'16"), Note("f'16")])])
                 Selection([LogicalTie([Note("f'16")])])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3713,7 +3666,7 @@ class Selection(collections.abc.Sequence):
                 Selection([LogicalTie([Note("e'4"), Note("e'16")]), LogicalTie([Note("f'16"), Note("f'16")])])
                 Selection([LogicalTie([Note("f'16")])])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3803,7 +3756,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("g'8"), Note("a'8"), Note("b'8")])
                 Selection([Note("c''8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3873,7 +3826,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("c'8"), Note("d'8"), Note("e'8"), Note("f'8")])
                 Selection([Note("g'8"), Note("a'8"), Note("b'8"), Note("c''8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -3944,7 +3897,7 @@ class Selection(collections.abc.Sequence):
                 Note("g'8")
                 Note("c''8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4012,7 +3965,7 @@ class Selection(collections.abc.Sequence):
                 Note("b'8")
                 Note("c''8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4074,7 +4027,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("c'4"), Note("d'4"), Note("e'4"), Note("f'4")])
                 Selection([Note("g'4"), Note("a'4"), Note("b'4"), Note("c''4")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4139,7 +4092,7 @@ class Selection(collections.abc.Sequence):
                 Selection([LogicalTie([Note("e'8"), Note("e'8")])])
                 Selection([LogicalTie([Note("f'8")]), LogicalTie([Note("g'8"), Note("g'8")])])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4252,7 +4205,7 @@ class Selection(collections.abc.Sequence):
                 Selection([LogicalTie([Note("e'4"), Note("e'16")])])
                 Selection([LogicalTie([Note("f'16"), Note("f'16")]), LogicalTie([Note("f'16")])])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4351,7 +4304,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Chord("<fs' gs'>16")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4481,7 +4434,7 @@ class Selection(collections.abc.Sequence):
                 Note("d'8")
                 Rest('r8')
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4558,7 +4511,7 @@ class Selection(collections.abc.Sequence):
                 Note("e'8")
                 Note("d'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4639,7 +4592,7 @@ class Selection(collections.abc.Sequence):
 
                 >>> abjad.ottava(result)
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4725,7 +4678,7 @@ class Selection(collections.abc.Sequence):
 
                 >>> abjad.ottava(result)
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4812,7 +4765,7 @@ class Selection(collections.abc.Sequence):
                 Note("d'8")
                 Note("c'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4891,7 +4844,7 @@ class Selection(collections.abc.Sequence):
                 Note("d'8")
                 Rest('r8')
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -4962,7 +4915,7 @@ class Selection(collections.abc.Sequence):
                 Note("e'8")
                 Note("d'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5033,7 +4986,7 @@ class Selection(collections.abc.Sequence):
                 Note("d'8")
                 Note("c'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5107,7 +5060,7 @@ class Selection(collections.abc.Sequence):
                 Note("d'8")
                 Note("c'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5176,7 +5129,7 @@ class Selection(collections.abc.Sequence):
                 Chord("<c' e' g'>8")
                 Chord("<c' d'>8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5253,7 +5206,7 @@ class Selection(collections.abc.Sequence):
                 Note("f'8")
                 Note("e'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5358,7 +5311,7 @@ class Selection(collections.abc.Sequence):
                 Note("e'8")
                 Note("f'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5454,7 +5407,7 @@ class Selection(collections.abc.Sequence):
                 Note("e'8")
                 Note("f'8")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5546,7 +5499,7 @@ class Selection(collections.abc.Sequence):
                 Note("af'16")
                 Note("gf'16")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5672,7 +5625,7 @@ class Selection(collections.abc.Sequence):
                 LogicalTie([Note("f'8"), Note("f'8")])
                 LogicalTie([Rest('r8')])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5738,7 +5691,7 @@ class Selection(collections.abc.Sequence):
                 LogicalTie([Note("e'8")])
                 LogicalTie([Note("f'8"), Note("f'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5803,7 +5756,7 @@ class Selection(collections.abc.Sequence):
                 LogicalTie([Note("d'8"), Note("d'8")])
                 LogicalTie([Note("f'8"), Note("f'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5870,7 +5823,7 @@ class Selection(collections.abc.Sequence):
                 Selection([LogicalTie([Note("g'8")]), LogicalTie([Note("a'8"), Note("a'8")])])
                 Selection([LogicalTie([Note("c''8")]), LogicalTie([Note("d''8")])])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -5952,7 +5905,7 @@ class Selection(collections.abc.Sequence):
                 Selection([LogicalTie([Note("g'8")]), LogicalTie([Note("a'8"), Note("a'8")])])
                 Selection([LogicalTie([Note("c''8")]), LogicalTie([Note("d''8")])])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6063,7 +6016,7 @@ class Selection(collections.abc.Sequence):
                 LogicalTie([Note("e'8")])
                 LogicalTie([Note("f'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6159,7 +6112,7 @@ class Selection(collections.abc.Sequence):
                 LogicalTie([Note("e'8")])
                 LogicalTie([Note("f'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6251,7 +6204,7 @@ class Selection(collections.abc.Sequence):
                 LogicalTie([Note("af'16")])
                 LogicalTie([Note("gf'16")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6315,7 +6268,7 @@ class Selection(collections.abc.Sequence):
                 LogicalTie([Note("f'8"), Note("f'8")])
                 LogicalTie([Rest('r8')])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6379,7 +6332,7 @@ class Selection(collections.abc.Sequence):
                 LogicalTie([Note("c'8")])
                 LogicalTie([Note("d'8"), Note("d'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6462,7 +6415,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Tuplet('3:2', "r8 d'8 e'8")])
                 Selection([Tuplet('3:2', "e'8 d'8 r8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6535,7 +6488,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("f'8")])
                 Selection([Note("e'8"), Note("d'8"), Rest('r8')])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6606,7 +6559,7 @@ class Selection(collections.abc.Sequence):
                 Note("e'8")
                 Note("f'16")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6676,7 +6629,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("d'8"), Note("e'8")])
                 Selection([Note("f'8"), Note("g'8"), Note("a'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -6749,7 +6702,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Note("e'16")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6861,7 +6814,7 @@ class Selection(collections.abc.Sequence):
                 Note("bf'16")
                 Note("e'16")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6975,7 +6928,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Selection([Note("c'8"), Rest('r8'), Note("d'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7037,7 +6990,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("c'8"), Rest('r8'), Note("d'8")])
                 Selection([Note("e'8"), Rest('r8'), Note("f'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7104,7 +7057,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("e'8"), Rest('r8'), Note("f'8")])
                 Selection([Note("g'8"), Note("a'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7173,7 +7126,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("c'8"), Rest('r8'), Note("d'8")])
                 Selection([Note("e'8"), Rest('r8'), Note("f'8"), Note("g'8"), Note("a'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7249,7 +7202,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("a'8"), Note("b'8")])
                 Selection([Rest('r8'), Note("c''8")])
 
-                >>> abjad.label(result).by_selector(selector, ["#red", "#blue", "#cyan"])
+                >>> abjad.Label(result).by_selector(selector, ["#red", "#blue", "#cyan"])
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7323,7 +7276,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("c'8"), Rest('r8')])
                 Selection([Note("f'8"), Note("g'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7393,7 +7346,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("f'8"), Note("g'8")])
                 Selection([Note("c''8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7458,7 +7411,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("c'8"), Rest('r8'), Note("d'8")])
                 Selection([Note("e'8"), Rest('r8'), Note("f'8"), Note("g'8"), Note("a'8"), Note("b'8"), Rest('r8'), Note("c''8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7499,13 +7452,13 @@ class Selection(collections.abc.Sequence):
         if self._expression:
             return self._update_expression(inspect.currentframe())
         result = []
-        groups = Sequence(self).partition_by_counts(
+        groups_ = Sequence(self).partition_by_counts(
             [abs(_) for _ in counts],
             cyclic=cyclic,
             enchain=enchain,
             overhang=overhang,
         )
-        groups = list(groups)
+        groups = list(groups_)
         total = len(groups)
         if overhang and fuse_overhang and 1 < len(groups):
             last_count = counts[(len(groups) - 1) % len(counts)]
@@ -7596,7 +7549,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("f'8"), Note("g'8"), Note("a'8")])
                 Selection([Note("b'8"), Note("c''8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7688,7 +7641,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Selection([Note("c'8"), Note("d'8"), Note("e'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7783,7 +7736,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("a'8")])
                 Selection([Note("b'8"), Note("c''8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7887,7 +7840,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("a'8")])
                 Selection([Note("b'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -7978,7 +7931,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Selection([Note("c'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -8068,7 +8021,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("c'8"), Note("d'8"), Note("e'8")])
                 Selection([Note("f'8"), Note("g'8"), Note("a'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -8165,7 +8118,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("f'8"), Note("g'8"), Note("a'8")])
                 Selection([Note("b'8"), Note("c''8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -8261,7 +8214,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Selection([Note("c'8"), Note("d'8"), Note("e'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -8364,7 +8317,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("a'8")])
                 Selection([Note("b'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -8459,7 +8412,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Selection([Note("c'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -8628,7 +8581,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("c'8"), Note("d'8"), Rest('r8'), Note("e'8"), Rest('r8')])
                 Selection([Note("f'8"), Note("g'8"), Note("a'8"), Rest('r8')])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -8695,7 +8648,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("e'8"), Rest('r8'), Note("f'8")])
                 Selection([Note("g'8"), Note("a'8"), Rest('r8')])
 
-                >>> abjad.label(result).by_selector(selector, ["#red", "#blue", "#cyan"])
+                >>> abjad.Label(result).by_selector(selector, ["#red", "#blue", "#cyan"])
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -8780,7 +8733,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Rest('r16')
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -8886,7 +8839,7 @@ class Selection(collections.abc.Sequence):
                 Rest('r16')
                 Rest('r16')
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -8988,7 +8941,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Selection([Note("e'16"), Note("e'16"), Note("e'16"), Chord("<fs' gs'>4"), Chord("<fs' gs'>16")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -9098,7 +9051,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("d'16"), Note("d'16"), Note("d'16"), Chord("<e' fs'>4"), Chord("<e' fs'>16")])
                 Selection([Note("e'16"), Note("e'16"), Note("e'16"), Chord("<fs' gs'>4"), Chord("<fs' gs'>16")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -9260,7 +9213,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("cs'16"), Note("d'4"), Chord("<e' g'>16"), Note("gs'16"), Note("a'16"), Note("as'16"), Note("e'4")])
                 Selection([Note("f'8"), Note("fs'16")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -9379,7 +9332,7 @@ class Selection(collections.abc.Sequence):
                 Note("a'8")
                 Rest('r8')
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -9467,7 +9420,7 @@ class Selection(collections.abc.Sequence):
                 >>> selector.print(result)
                 Tuplet('9:10', "r16 bf'16 <a'' b''>16 e'16 <fs' gs'>4 <fs' gs'>16")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -9589,7 +9542,7 @@ class Selection(collections.abc.Sequence):
                 Tuplet('3:2', "d'8 e'8 f'8")
                 Tuplet('3:2', "c'4 d'4 e'4")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -9672,7 +9625,7 @@ class Selection(collections.abc.Sequence):
                 Tuplet('3:2', "d'8 e'8 f'8")
                 Tuplet('3:2', "c'4 d'4 e'4")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -9755,7 +9708,7 @@ class Selection(collections.abc.Sequence):
                 Tuplet('3:2', "c'2 { 2/3 d'8 e'8 f'8 }")
                 Tuplet('3:2', "c'4 d'4 e'4")
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -9850,7 +9803,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("d'8"), Note("e'8"), Rest('r8')])
                 Selection([Note("f'8"), Note("g'8"), Note("a'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -9915,7 +9868,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("e'8"), Rest('r8')])
                 Selection([Note("f'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -9988,7 +9941,7 @@ class Selection(collections.abc.Sequence):
                 ...     abjad.piano_pedal(item)
                 ...
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.override(staff).SustainPedalLineSpanner.staff_padding = 6
                 >>> abjad.show(staff) # doctest: +SKIP
 
@@ -10128,7 +10081,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Chord("<e' g'>16"), Note("gs'16"), Note("a'16"), Note("as'16"), Note("e'4")])
                 Selection([Note("fs'16")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -10241,7 +10194,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Rest('r8'), Note("d'8"), Note("e'8")])
                 Selection([Rest('r8'), Note("f'8"), Note("g'8"), Note("a'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -10306,7 +10259,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("d'8"), Note("e'8")])
                 Selection([Rest('r8'), Note("f'8")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
@@ -10434,7 +10387,7 @@ class Selection(collections.abc.Sequence):
                 Selection([Note("d'4"), Chord("<e' g'>16"), Note("gs'16"), Note("a'16"), Note("as'16")])
                 Selection([Note("f'4"), Note("fs'16")])
 
-                >>> abjad.label(result).by_selector(selector)
+                >>> abjad.Label(result).by_selector(selector)
                 >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::

--- a/abjad/sequence.py
+++ b/abjad/sequence.py
@@ -1,6 +1,5 @@
 import collections.abc
 import copy
-import inspect
 import itertools
 import math
 import sys
@@ -11,8 +10,6 @@ import quicktions
 from . import enums
 from . import math as _math
 from .cyclictuple import CyclicTuple
-from .expression import Expression, Signature
-from .markups import Markup
 from .ratio import Ratio
 from .storage import FormatSpecification, StorageFormatManager
 
@@ -27,13 +24,7 @@ class Sequence(collections.abc.Sequence):
 
         ..  container:: example
 
-            >>> abjad.sequence([1, 2, 3, 4, 5, 6])
-            Sequence([1, 2, 3, 4, 5, 6])
-
-        ..  container:: example expression
-
-            >>> expression = abjad.sequence()
-            >>> expression([1, 2, 3, 4, 5, 6])
+            >>> abjad.Sequence([1, 2, 3, 4, 5, 6])
             Sequence([1, 2, 3, 4, 5, 6])
 
     ..  container:: example
@@ -42,15 +33,8 @@ class Sequence(collections.abc.Sequence):
 
         ..  container:: example
 
-            >>> sequence = abjad.sequence([1, 2, 3, 4, 5, 6])
+            >>> sequence = abjad.Sequence([1, 2, 3, 4, 5, 6])
             >>> sequence.reverse()
-            Sequence([6, 5, 4, 3, 2, 1])
-
-        ..  container:: example expression
-
-            >>> expression = abjad.sequence()
-            >>> expression = expression.reverse()
-            >>> expression([1, 2, 3, 4, 5, 6])
             Sequence([6, 5, 4, 3, 2, 1])
 
     ..  container:: example
@@ -59,18 +43,10 @@ class Sequence(collections.abc.Sequence):
 
         ..  container:: example
 
-            >>> sequence = abjad.sequence([1, 2, 3, [4, 5, [6]]])
+            >>> sequence = abjad.Sequence([1, 2, 3, [4, 5, [6]]])
             >>> sequence = sequence.reverse()
             >>> sequence = sequence.flatten(depth=-1)
             >>> sequence
-            Sequence([4, 5, 6, 3, 2, 1])
-
-        ..  container:: example expression
-
-            >>> expression = abjad.sequence()
-            >>> expression = expression.reverse()
-            >>> expression = expression.flatten(depth=-1)
-            >>> expression([1, 2, 3, [4, 5, [6]]])
             Sequence([4, 5, 6, 3, 2, 1])
 
     ..  container:: example
@@ -99,10 +75,6 @@ class Sequence(collections.abc.Sequence):
 
     ### SPECIAL METHODS ###
 
-    @Signature(
-        markup_maker_callback="_make___add___markup",
-        string_template_callback="_make___add___string_template",
-    )
     def __add__(self, argument) -> "Sequence":
         r"""
         Adds ``argument`` to sequence.
@@ -113,36 +85,8 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> abjad.sequence([1, 2, 3]) + (4, 5, 6)
+                >>> abjad.Sequence([1, 2, 3]) + (4, 5, 6)
                 Sequence([1, 2, 3, 4, 5, 6])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression + (4, 5, 6)
-
-                >>> expression([1, 2, 3])
-                Sequence([1, 2, 3, 4, 5, 6])
-
-                >>> expression.get_string()
-                'J + (4, 5, 6)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \line
-                            {
-                                \bold
-                                    J
-                                +
-                                "(4, 5, 6)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -150,36 +94,8 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> abjad.sequence([1, 2, 3]) + [4, 5, 6]
+                >>> abjad.Sequence([1, 2, 3]) + [4, 5, 6]
                 Sequence([1, 2, 3, 4, 5, 6])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression + [4, 5, 6]
-
-                >>> expression([1, 2, 3])
-                Sequence([1, 2, 3, 4, 5, 6])
-
-                >>> expression.get_string()
-                'J + [4, 5, 6]'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \line
-                            {
-                                \bold
-                                    J
-                                +
-                                "[4, 5, 6]"
-                            }
-                        }
 
         ..  container:: example
 
@@ -187,38 +103,10 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence_1 = abjad.sequence([1, 2, 3])
-                >>> sequence_2 = abjad.sequence([4, 5, 6])
+                >>> sequence_1 = abjad.Sequence([1, 2, 3])
+                >>> sequence_2 = abjad.Sequence([4, 5, 6])
                 >>> sequence_1 + sequence_2
                 Sequence([1, 2, 3, 4, 5, 6])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression + [4, 5, 6]
-
-                >>> expression([1, 2, 3])
-                Sequence([1, 2, 3, 4, 5, 6])
-
-                >>> expression.get_string()
-                'J + [4, 5, 6]'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \line
-                            {
-                                \bold
-                                    J
-                                +
-                                "[4, 5, 6]"
-                            }
-                        }
 
         ..  container:: example
 
@@ -226,48 +114,13 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence_1 = abjad.sequence([1, 2, 3])
-                >>> sequence_2 = abjad.sequence([4, 5, 6])
+                >>> sequence_1 = abjad.Sequence([1, 2, 3])
+                >>> sequence_2 = abjad.Sequence([4, 5, 6])
                 >>> sequence = sequence_1 + sequence_2
                 >>> sequence.reverse()
                 Sequence([6, 5, 4, 3, 2, 1])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression + [4, 5, 6]
-                >>> expression = expression.reverse()
-
-                >>> expression([1, 2, 3])
-                Sequence([6, 5, 4, 3, 2, 1])
-
-                >>> expression.get_string()
-                'R(J + [4, 5, 6])'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                R
-                                \line
-                                    {
-                                        \bold
-                                            J
-                                        +
-                                        "[4, 5, 6]"
-                                    }
-                            }
-                        }
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         argument = type(self)(items=argument)
         items = self.items + argument.items
         return type(self)(items)
@@ -282,7 +135,7 @@ class Sequence(collections.abc.Sequence):
             Is true when ``argument`` is a sequence with items equal to those
             of this sequence:
 
-            >>> abjad.sequence([1, 2, 3, 4, 5, 6]) == abjad.sequence([1, 2, 3, 4, 5, 6])
+            >>> abjad.Sequence([1, 2, 3, 4, 5, 6]) == abjad.Sequence([1, 2, 3, 4, 5, 6])
             True
 
         ..  container:: example
@@ -290,16 +143,12 @@ class Sequence(collections.abc.Sequence):
             Is false when ``argument`` is not a sequence with items equal to
             those of this sequence:
 
-            >>> abjad.sequence([1, 2, 3, 4, 5, 6]) == ([1, 2, 3, 4, 5, 6])
+            >>> abjad.Sequence([1, 2, 3, 4, 5, 6]) == ([1, 2, 3, 4, 5, 6])
             False
 
         """
         return StorageFormatManager.compare_objects(self, argument)
 
-    @Signature(
-        markup_maker_callback="_make___getitem___markup",
-        string_template_callback="_make___getitem___string_template",
-    )
     def __getitem__(self, argument) -> typing.Any:
         r"""
         Gets item or slice identified by ``argument``.
@@ -310,38 +159,10 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence([1, 2, 3, 4, 5, 6])
+                >>> sequence = abjad.Sequence([1, 2, 3, 4, 5, 6])
 
                 >>> sequence[0]
                 1
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression[0]
-
-                >>> expression([1, 2, 3, 4, 5, 6])
-                1
-
-                >>> expression.get_string()
-                'J[0]'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                \bold
-                                    J
-                                \sub
-                                    0
-                            }
-                        }
 
         ..  container:: example
 
@@ -349,38 +170,10 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence([1, 2, 3, 4, 5, 6])
+                >>> sequence = abjad.Sequence([1, 2, 3, 4, 5, 6])
 
                 >>> sequence[-1]
                 6
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression[-1]
-
-                >>> expression([1, 2, 3, 4, 5, 6])
-                6
-
-                >>> expression.get_string()
-                'J[-1]'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                \bold
-                                    J
-                                \sub
-                                    -1
-                            }
-                        }
 
         ..  container:: example
 
@@ -388,39 +181,11 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence([1, 2, 3, 4, 5, 6])
+                >>> sequence = abjad.Sequence([1, 2, 3, 4, 5, 6])
                 >>> sequence = sequence[:3]
 
                 >>> sequence
                 Sequence([1, 2, 3])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression[:3]
-
-                >>> expression([1, 2, 3, 4, 5, 6])
-                Sequence([1, 2, 3])
-
-                >>> expression.get_string()
-                'J[:3]'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                \bold
-                                    J
-                                \sub
-                                    [:3]
-                            }
-                        }
 
         ..  container:: example
 
@@ -428,8 +193,8 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence([1, 2, 3, 4, 5, 6])
-                >>> sequence = abjad.sequence(sequence[0])
+                >>> sequence = abjad.Sequence([1, 2, 3, 4, 5, 6])
+                >>> sequence = abjad.Sequence(sequence[0])
 
                 >>> sequence
                 Sequence([1])
@@ -440,51 +205,15 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence([1, 2, [3, [4]], 5])
+                >>> sequence = abjad.Sequence([1, 2, [3, [4]], 5])
                 >>> sequence = sequence[:-1]
                 >>> sequence = sequence.flatten(depth=-1)
 
                 >>> sequence
                 Sequence([1, 2, 3, 4])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression[:-1]
-                >>> expression = expression.flatten(depth=-1)
-
-                >>> expression([1, 2, [3, [4]], 5])
-                Sequence([1, 2, 3, 4])
-
-                >>> expression.get_string()
-                'flatten(J[:-1], depth=-1)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                flatten(
-                                \concat
-                                    {
-                                        \bold
-                                            J
-                                        \sub
-                                            [:-1]
-                                    }
-                                ", depth=-1)"
-                            }
-                        }
-
         Returns item or new sequence.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         result = self._items.__getitem__(argument)
         if isinstance(argument, slice):
             return type(self)(result)
@@ -509,23 +238,19 @@ class Sequence(collections.abc.Sequence):
 
             Gets length of sequence:
 
-            >>> len(abjad.sequence([1, 2, 3, 4, 5, 6]))
+            >>> len(abjad.Sequence([1, 2, 3, 4, 5, 6]))
             6
 
         ..  container:: example
 
             Gets length of sequence:
 
-            >>> len(abjad.sequence('text'))
+            >>> len(abjad.Sequence('text'))
             4
 
         """
         return len(self._items)
 
-    @Signature(
-        markup_maker_callback="_make___radd___markup",
-        string_template_callback="_make___radd___string_template",
-    )
     def __radd__(self, argument) -> "Sequence":
         r"""
         Adds sequence to ``argument``.
@@ -536,36 +261,8 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> (1, 2, 3) + abjad.sequence([4, 5, 6])
+                >>> (1, 2, 3) + abjad.Sequence([4, 5, 6])
                 Sequence([1, 2, 3, 4, 5, 6])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='K')
-                >>> expression = (1, 2, 3) + expression
-
-                >>> expression([4, 5, 6])
-                Sequence([1, 2, 3, 4, 5, 6])
-
-                >>> expression.get_string()
-                '(1, 2, 3) + K'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \line
-                            {
-                                "(1, 2, 3)"
-                                +
-                                \bold
-                                    K
-                            }
-                        }
 
         ..  container:: example
 
@@ -573,36 +270,8 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> [1, 2, 3] + abjad.sequence([4, 5, 6])
+                >>> [1, 2, 3] + abjad.Sequence([4, 5, 6])
                 Sequence([1, 2, 3, 4, 5, 6])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='K')
-                >>> expression = [1, 2, 3] + expression
-
-                >>> expression([4, 5, 6])
-                Sequence([1, 2, 3, 4, 5, 6])
-
-                >>> expression.get_string()
-                '[1, 2, 3] + K'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \line
-                            {
-                                "[1, 2, 3]"
-                                +
-                                \bold
-                                    K
-                            }
-                        }
 
         ..  container:: example
 
@@ -610,40 +279,10 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> abjad.sequence([1, 2, 3]) + abjad.sequence([4, 5, 6])
+                >>> abjad.Sequence([1, 2, 3]) + abjad.Sequence([4, 5, 6])
                 Sequence([1, 2, 3, 4, 5, 6])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = [1, 2, 3] + expression
-
-                >>> expression([4, 5, 6])
-                Sequence([1, 2, 3, 4, 5, 6])
-
-                >>> expression.get_string()
-                '[1, 2, 3] + J'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \line
-                            {
-                                "[1, 2, 3]"
-                                +
-                                \bold
-                                    J
-                            }
-                        }
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         argument = type(self)(items=argument)
         items = argument.items + self.items
         return type(self)(items)
@@ -656,21 +295,19 @@ class Sequence(collections.abc.Sequence):
 
             Gets interpreter representation:
 
-            >>> abjad.sequence([99])
+            >>> abjad.Sequence([99])
             Sequence([99])
 
         ..  container:: example
 
             Gets interpreter representation:
 
-            >>> abjad.sequence([1, 2, 3, 4, 5, 6])
+            >>> abjad.Sequence([1, 2, 3, 4, 5, 6])
             Sequence([1, 2, 3, 4, 5, 6])
 
         """
         items = ", ".join([repr(_) for _ in self.items])
         string = f"{type(self).__name__}([{items}])"
-        if self._expression:
-            string = "*" + string
         return string
 
     ### PRIVATE METHODS ###
@@ -694,62 +331,6 @@ class Sequence(collections.abc.Sequence):
 
     def _get_format_specification(self):
         return FormatSpecification(client=self)
-
-    @staticmethod
-    def _make_map_markup(markup, operand):
-        operand_markup = operand.get_markup(name="X")
-        string = rf"\line {{ {operand_markup.contents[0]} /@ {markup.contents[0]} }}"
-        markup = Markup(string)
-        return markup
-
-    @staticmethod
-    def _make_map_string_template(operand):
-        try:
-            operand = operand.get_string(name="X")
-            string_template = f"{operand} /@ {{}}"
-            return string_template
-        except ValueError:
-            return "unknown string template"
-
-    @staticmethod
-    def _make_partition_indicator(counts, cyclic, enchain, overhang, reversed_):
-        indicator = [str(_) for _ in counts]
-        indicator = ", ".join(indicator)
-        if cyclic:
-            indicator = f"<{indicator}>"
-        else:
-            indicator = f"[{indicator}]"
-        if enchain:
-            indicator = "E" + indicator
-        if reversed_:
-            indicator = "R" + indicator
-        if overhang is True:
-            indicator += "+"
-        elif overhang is enums.Exact:
-            indicator += "!"
-        return indicator
-
-    @staticmethod
-    def _make_partition_ratio_indicator(ratio):
-        return str(ratio)
-
-    @staticmethod
-    def _make_reverse_method_name(recurse=False):
-        if recurse:
-            return "R*"
-        return "R"
-
-    @staticmethod
-    def _make_split_indicator(weights, cyclic, overhang):
-        indicator = [str(_) for _ in weights]
-        indicator = ", ".join(indicator)
-        if cyclic:
-            indicator = f"<{indicator}>"
-        else:
-            indicator = f"[{indicator}]"
-        if overhang:
-            indicator += "+"
-        return indicator
 
     @classmethod
     def _partition_sequence_cyclically_by_weights_at_least(
@@ -881,14 +462,6 @@ class Sequence(collections.abc.Sequence):
         result = [class_(_) for _ in result]
         return class_(items=result)
 
-    def _update_expression(self, frame, evaluation_template=None, map_operand=None):
-        callback = Expression._frame_to_callback(
-            frame,
-            evaluation_template=evaluation_template,
-            map_operand=map_operand,
-        )
-        return self._expression.append_callback(callback)
-
     ### PUBLIC PROPERTIES ###
 
     @property
@@ -902,26 +475,12 @@ class Sequence(collections.abc.Sequence):
 
                 Initializes items positionally:
 
-                >>> abjad.sequence([1, 2, 3, 4, 5, 6]).items
+                >>> abjad.Sequence([1, 2, 3, 4, 5, 6]).items
                 (1, 2, 3, 4, 5, 6)
 
                 Initializes items from keyword:
 
-                >>> abjad.sequence([1, 2, 3, 4, 5, 6]).items
-                (1, 2, 3, 4, 5, 6)
-
-            ..  container:: example expression
-
-                Initializes items positionally:
-
-                >>> expression = abjad.sequence()
-                >>> expression([1, 2, 3, 4, 5, 6]).items
-                (1, 2, 3, 4, 5, 6)
-
-                Initializes items from keyword:
-
-                >>> expression = abjad.sequence()
-                >>> expression([1, 2, 3, 4, 5, 6]).items
+                >>> abjad.Sequence([1, 2, 3, 4, 5, 6]).items
                 (1, 2, 3, 4, 5, 6)
 
         """
@@ -929,7 +488,6 @@ class Sequence(collections.abc.Sequence):
 
     ### PUBLIC METHODS ###
 
-    @Signature()
     def filter(self, predicate=None) -> "Sequence":
         """
         Filters sequence by ``predicate``.
@@ -943,7 +501,7 @@ class Sequence(collections.abc.Sequence):
                 With lambda:
 
                 >>> items = [[1], [2, 3, [4]], [5], [6, 7, [8]]]
-                >>> sequence = abjad.sequence(items)
+                >>> sequence = abjad.Sequence(items)
 
                 >>> sequence.filter(lambda _: len(_) == 1)
                 Sequence([[1], [5]])
@@ -953,20 +511,9 @@ class Sequence(collections.abc.Sequence):
                 With inequality:
 
                 >>> items = [[1], [2, 3, [4]], [5], [6, 7, [8]]]
-                >>> sequence = abjad.sequence(items)
+                >>> sequence = abjad.Sequence(items)
 
                 >>> sequence.filter(abjad.LengthInequality('==', 1))
-                Sequence([[1], [5]])
-
-            ..  container:: example expression
-
-                As expression:
-
-                >>> expression = abjad.sequence(name='J')
-                >>> inequality = abjad.LengthInequality('==', 1)
-                >>> expression = expression.filter(inequality)
-
-                >>> expression([[1], [2, 3, [4]], [5], [6, 7, [8]]])
                 Sequence([[1], [5]])
 
         ..  container:: example
@@ -978,27 +525,12 @@ class Sequence(collections.abc.Sequence):
                 With inequality:
 
                 >>> staff = abjad.Staff("c'4. d'8 e'4. f'8 g'2")
-                >>> sequence = abjad.sequence(staff)
+                >>> sequence = abjad.Sequence(staff)
 
                 >>> sequence.filter(abjad.DurationInequality('==', (1, 8)))
                 Sequence([Note("d'8"), Note("f'8")])
 
-            ..  container:: example expression
-
-                As expression:
-
-                >>> expression = abjad.sequence(name='J')
-                >>> inequality = abjad.DurationInequality('==', (1, 8))
-                >>> expression = expression.filter(inequality)
-
-                >>> expression(staff)
-                Sequence([Note("d'8"), Note("f'8")])
-
-        ..  todo:: supply with clean string and markup templates.
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         if predicate is None:
             return self[:]
         items = []
@@ -1007,7 +539,6 @@ class Sequence(collections.abc.Sequence):
                 items.append(item)
         return type(self)(items)
 
-    @Signature()
     def flatten(self, classes=None, depth=1) -> "Sequence":
         r"""
         Flattens sequence.
@@ -1019,38 +550,10 @@ class Sequence(collections.abc.Sequence):
             ..  container:: example
 
                 >>> items = [1, [2, 3, [4]], 5, [6, 7, [8]]]
-                >>> sequence = abjad.sequence(items)
+                >>> sequence = abjad.Sequence(items)
 
                 >>> sequence.flatten()
                 Sequence([1, 2, 3, [4], 5, 6, 7, [8]])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.flatten()
-
-                >>> expression([1, [2, 3, [4]], 5, [6, 7, [8]]])
-                Sequence([1, 2, 3, [4], 5, 6, 7, [8]])
-
-                >>> expression.get_string()
-                'flatten(J)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                flatten(
-                                \bold
-                                    J
-                                )
-                            }
-                        }
 
         ..  container:: example
 
@@ -1059,38 +562,10 @@ class Sequence(collections.abc.Sequence):
             ..  container:: example
 
                 >>> items = [1, [2, 3, [4]], 5, [6, 7, [8]]]
-                >>> sequence = abjad.sequence(items)
+                >>> sequence = abjad.Sequence(items)
 
                 >>> sequence.flatten(depth=2)
                 Sequence([1, 2, 3, 4, 5, 6, 7, 8])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.flatten(depth=2)
-
-                >>> expression([1, [2, 3, [4]], 5, [6, 7, [8]]])
-                Sequence([1, 2, 3, 4, 5, 6, 7, 8])
-
-                >>> expression.get_string()
-                'flatten(J, depth=2)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                flatten(
-                                \bold
-                                    J
-                                ", depth=2)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -1099,38 +574,10 @@ class Sequence(collections.abc.Sequence):
             ..  container:: example
 
                 >>> items = [1, [2, 3, [4]], 5, [6, 7, [8]]]
-                >>> sequence = abjad.sequence(items)
+                >>> sequence = abjad.Sequence(items)
 
                 >>> sequence.flatten(depth=-1)
                 Sequence([1, 2, 3, 4, 5, 6, 7, 8])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.flatten(depth=-1)
-
-                >>> expression([1, [2, 3, [4]], 5, [6, 7, [8]]])
-                Sequence([1, 2, 3, 4, 5, 6, 7, 8])
-
-                >>> expression.get_string()
-                'flatten(J, depth=-1)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                flatten(
-                                \bold
-                                    J
-                                ", depth=-1)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -1139,42 +586,12 @@ class Sequence(collections.abc.Sequence):
             ..  container:: example
 
                 >>> items = ['ab', 'cd', ('ef', 'gh'), ('ij', 'kl')]
-                >>> sequence = abjad.sequence(items)
+                >>> sequence = abjad.Sequence(items)
 
                 >>> sequence.flatten(classes=(tuple,))
                 Sequence(['ab', 'cd', 'ef', 'gh', 'ij', 'kl'])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.flatten(classes=(tuple,))
-
-                >>> expression(['ab', 'cd', ('ef', 'gh'), ('ij', 'kl')])
-                Sequence(['ab', 'cd', 'ef', 'gh', 'ij', 'kl'])
-
-                >>> expression.get_string()
-                'flatten(J, classes=(tuple,))'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                flatten(
-                                \bold
-                                    J
-                                ", classes=(tuple,))"
-                            }
-                        }
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         if classes is None:
             classes = (collections.abc.Sequence,)
         if Sequence not in classes:
@@ -1189,7 +606,7 @@ class Sequence(collections.abc.Sequence):
         ..  container:: example
 
             >>> items = [0, 0, -1, -1, 2, 3, -5, 1, 1, 5, -5]
-            >>> sequence = abjad.sequence(items)
+            >>> sequence = abjad.Sequence(items)
             >>> for item in sequence.group_by():
             ...     item
             ...
@@ -1206,22 +623,7 @@ class Sequence(collections.abc.Sequence):
 
             >>> staff = abjad.Staff("c'8 d' d' e' e' e'")
             >>> predicate = lambda x: abjad.PitchSet.from_selection(abjad.select(x))
-            >>> for item in abjad.sequence(staff).group_by(predicate):
-            ...     item
-            ...
-            Sequence([Note("c'8")])
-            Sequence([Note("d'8"), Note("d'8")])
-            Sequence([Note("e'8"), Note("e'8"), Note("e'8")])
-
-        ..  container:: expression
-
-            >>> predicate = abjad.select().leaves()
-            >>> callback = abjad.pitch_set()
-            >>> predicate = predicate.append_callback(callback)
-            >>> expression = abjad.sequence().group_by(predicate)
-
-            >>> staff = abjad.Staff("c'8 d' d' e' e' e'")
-            >>> for item in expression(staff):
+            >>> for item in abjad.Sequence(staff).group_by(predicate):
             ...     item
             ...
             Sequence([Note("c'8")])
@@ -1230,12 +632,6 @@ class Sequence(collections.abc.Sequence):
 
         Returns nested sequence.
         """
-        if self._expression:
-            return self._update_expression(
-                inspect.currentframe(),
-                evaluation_template="group_by",
-                map_operand=predicate,
-            )
         items = []
         if predicate is None:
             pairs = itertools.groupby(self, lambda _: _)
@@ -1257,13 +653,13 @@ class Sequence(collections.abc.Sequence):
 
             Is true when sequence is strictly decreasing:
 
-            >>> abjad.sequence([5, 4, 3, 2, 1, 0]).is_decreasing(strict=True)
+            >>> abjad.Sequence([5, 4, 3, 2, 1, 0]).is_decreasing(strict=True)
             True
 
-            >>> abjad.sequence([3, 3, 3, 2, 1, 0]).is_decreasing(strict=True)
+            >>> abjad.Sequence([3, 3, 3, 2, 1, 0]).is_decreasing(strict=True)
             False
 
-            >>> abjad.sequence([3, 3, 3, 3, 3, 3]).is_decreasing(strict=True)
+            >>> abjad.Sequence([3, 3, 3, 3, 3, 3]).is_decreasing(strict=True)
             False
 
             >>> abjad.Sequence().is_decreasing(strict=True)
@@ -1273,13 +669,13 @@ class Sequence(collections.abc.Sequence):
 
             Is true when sequence decreases monotonically:
 
-            >>> abjad.sequence([5, 4, 3, 2, 1, 0]).is_decreasing(strict=False)
+            >>> abjad.Sequence([5, 4, 3, 2, 1, 0]).is_decreasing(strict=False)
             True
 
-            >>> abjad.sequence([3, 3, 3, 2, 1, 0]).is_decreasing(strict=False)
+            >>> abjad.Sequence([3, 3, 3, 2, 1, 0]).is_decreasing(strict=False)
             True
 
-            >>> abjad.sequence([3, 3, 3, 3, 3, 3]).is_decreasing(strict=False)
+            >>> abjad.Sequence([3, 3, 3, 3, 3, 3]).is_decreasing(strict=False)
             True
 
             >>> abjad.Sequence().is_decreasing(strict=False)
@@ -1317,13 +713,13 @@ class Sequence(collections.abc.Sequence):
 
             Is true when sequence is strictly increasing:
 
-            >>> abjad.sequence([0, 1, 2, 3, 4, 5]).is_increasing(strict=True)
+            >>> abjad.Sequence([0, 1, 2, 3, 4, 5]).is_increasing(strict=True)
             True
 
-            >>> abjad.sequence([0, 1, 2, 3, 3, 3]).is_increasing(strict=True)
+            >>> abjad.Sequence([0, 1, 2, 3, 3, 3]).is_increasing(strict=True)
             False
 
-            >>> abjad.sequence([3, 3, 3, 3, 3, 3]).is_increasing(strict=True)
+            >>> abjad.Sequence([3, 3, 3, 3, 3, 3]).is_increasing(strict=True)
             False
 
             >>> abjad.Sequence().is_increasing(strict=True)
@@ -1333,13 +729,13 @@ class Sequence(collections.abc.Sequence):
 
             Is true when sequence increases monotonically:
 
-            >>> abjad.sequence([0, 1, 2, 3, 4, 5]).is_increasing(strict=False)
+            >>> abjad.Sequence([0, 1, 2, 3, 4, 5]).is_increasing(strict=False)
             True
 
-            >>> abjad.sequence([0, 1, 2, 3, 3, 3]).is_increasing(strict=False)
+            >>> abjad.Sequence([0, 1, 2, 3, 3, 3]).is_increasing(strict=False)
             True
 
-            >>> abjad.sequence([3, 3, 3, 3, 3, 3]).is_increasing(strict=False)
+            >>> abjad.Sequence([3, 3, 3, 3, 3, 3]).is_increasing(strict=False)
             True
 
             >>> abjad.Sequence().is_increasing(strict=False)
@@ -1377,14 +773,14 @@ class Sequence(collections.abc.Sequence):
 
             Is true when sequence is a permutation:
 
-            >>> abjad.sequence([4, 5, 0, 3, 2, 1]).is_permutation()
+            >>> abjad.Sequence([4, 5, 0, 3, 2, 1]).is_permutation()
             True
 
         ..  container:: example
 
             Is false when sequence is not a permutation:
 
-            >>> abjad.sequence([1, 1, 5, 3, 2, 1]).is_permutation()
+            >>> abjad.Sequence([1, 1, 5, 3, 2, 1]).is_permutation()
             False
 
         """
@@ -1398,7 +794,7 @@ class Sequence(collections.abc.Sequence):
 
             Is true when sequence is repetition-free:
 
-            >>> abjad.sequence([0, 1, 2, 6, 7, 8]).is_repetition_free()
+            >>> abjad.Sequence([0, 1, 2, 6, 7, 8]).is_repetition_free()
             True
 
         ..  container:: example
@@ -1412,7 +808,7 @@ class Sequence(collections.abc.Sequence):
 
             Is false when sequence contains repetitions:
 
-            >>> abjad.sequence([0, 1, 2, 2, 7, 8]).is_repetition_free()
+            >>> abjad.Sequence([0, 1, 2, 2, 7, 8]).is_repetition_free()
             False
 
         """
@@ -1424,7 +820,6 @@ class Sequence(collections.abc.Sequence):
         except TypeError:
             return False
 
-    @Signature()
     def join(self) -> "Sequence":
         r"""
         Join subsequences in ``sequence``.
@@ -1432,50 +827,14 @@ class Sequence(collections.abc.Sequence):
         ..  container:: example
 
             >>> items = [(1, 2, 3), (), (4, 5), (), (6,)]
-            >>> sequence = abjad.sequence(items)
+            >>> sequence = abjad.Sequence(items)
             >>> sequence
             Sequence([(1, 2, 3), (), (4, 5), (), (6,)])
 
             >>> sequence.join()
             Sequence([(1, 2, 3, 4, 5, 6)])
 
-        ..  container:: example expression
-
-            >>> expression = abjad.sequence(name='J')
-            >>> expression = expression.split([10], cyclic=True)
-            >>> expression = expression.join()
-
-            >>> expression(range(1, 11))
-            Sequence([Sequence([1, 2, 3, 4, 5, 5, 1, 7, 2, 6, 4, 5, 5])])
-
-            >>> expression.get_string()
-            'join(split(J, <10>))'
-
-            >>> markup = expression.get_markup()
-            >>> abjad.show(markup) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(markup)
-                >>> print(string)
-                \markup {
-                    \concat
-                        {
-                            join(
-                            \concat
-                                {
-                                    split(
-                                    \bold
-                                        J
-                                    ", <10>)"
-                                }
-                            )
-                        }
-                    }
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         if not self:
             return type(self)()
         item = self[0]
@@ -1483,10 +842,6 @@ class Sequence(collections.abc.Sequence):
             item += item_
         return type(self)([item])
 
-    @Signature(
-        markup_maker_callback="_make_map_markup",
-        string_template_callback="_make_map_string_template",
-    )
     def map(self, operand=None) -> "Sequence":
         r"""
         Maps ``operand`` to sequence items.
@@ -1497,7 +852,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(1, 10+1))
+                >>> sequence = abjad.Sequence(range(1, 10+1))
                 >>> sequence = sequence.partition_by_counts(
                 ...     [3],
                 ...     cyclic=True,
@@ -1507,70 +862,18 @@ class Sequence(collections.abc.Sequence):
                 >>> sequence
                 Sequence([6, 15, 24])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [3],
-                ...     cyclic=True,
-                ...     )
-                >>> expression = expression.map(abjad.sequence().sum())
-
-                >>> expression(range(1, 10+1))
-                Sequence([6, 15, 24])
-
-                >>> expression.get_string()
-                'sum(X) /@ partition(J, <3>)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \line
-                            {
-                                \concat
-                                    {
-                                        sum(
-                                        \bold
-                                            X
-                                        )
-                                    }
-                                /@
-                                \concat
-                                    {
-                                        partition(
-                                        \bold
-                                            J
-                                        ", <3>)"
-                                    }
-                            }
-                        }
-
         ..  container:: example
 
             Maps identity:
 
-            >>> sequence = abjad.sequence([1, 2, 3, 4, 5, 6])
+            >>> sequence = abjad.Sequence([1, 2, 3, 4, 5, 6])
             >>> sequence.map()
             Sequence([1, 2, 3, 4, 5, 6])
 
         """
-        if self._expression:
-            return self._update_expression(
-                inspect.currentframe(),
-                evaluation_template="map",
-                map_operand=operand,
-            )
         if operand is not None:
-            is_expression = hasattr(operand, "_set_map_index")
             items = []
             for i, item_ in enumerate(self):
-                if is_expression:
-                    operand._set_map_index(i)
                 item_ = operand(item_)
                 items.append(item_)
         else:
@@ -1585,7 +888,7 @@ class Sequence(collections.abc.Sequence):
 
             Iterates iterable by pairs:
 
-            >>> sequence = abjad.sequence(range(10))
+            >>> sequence = abjad.Sequence(range(10))
             >>> for item in sequence.nwise():
             ...     item
             ...
@@ -1603,7 +906,7 @@ class Sequence(collections.abc.Sequence):
 
             Iterates iterable by triples:
 
-            >>> sequence = abjad.sequence(range(10))
+            >>> sequence = abjad.Sequence(range(10))
             >>> for item in sequence.nwise(n=3):
             ...     item
             ...
@@ -1620,7 +923,7 @@ class Sequence(collections.abc.Sequence):
 
             Iterates iterable by pairs. Wraps around at end:
 
-            >>> sequence = abjad.sequence(range(10))
+            >>> sequence = abjad.Sequence(range(10))
             >>> for item in sequence.nwise(n=2, wrapped=True):
             ...     item
             ...
@@ -1639,7 +942,7 @@ class Sequence(collections.abc.Sequence):
 
             Iterates iterable by triples. Wraps around at end:
 
-            >>> sequence = abjad.sequence(range(10))
+            >>> sequence = abjad.Sequence(range(10))
             >>> for item in sequence.nwise(n=3, wrapped=True):
             ...     item
             ...
@@ -1658,7 +961,7 @@ class Sequence(collections.abc.Sequence):
 
             Iterates iterable by pairs. Cycles indefinitely:
 
-            >>> sequence = abjad.sequence(range(10))
+            >>> sequence = abjad.Sequence(range(10))
             >>> pairs = sequence.nwise(n=2, cyclic=True)
             >>> for _ in range(15):
             ...     next(pairs)
@@ -1685,7 +988,7 @@ class Sequence(collections.abc.Sequence):
 
             Iterates iterable by triples. Cycles indefinitely:
 
-            >>> sequence = abjad.sequence(range(10))
+            >>> sequence = abjad.Sequence(range(10))
             >>> triples = sequence.nwise(n=3, cyclic=True)
             >>> for _ in range(15):
             ...     next(triples)
@@ -1712,7 +1015,7 @@ class Sequence(collections.abc.Sequence):
 
             Iterates items one at a time:
 
-            >>> sequence = abjad.sequence(range(10))
+            >>> sequence = abjad.Sequence(range(10))
             >>> for item in sequence.nwise(n=1):
             ...     item
             ...
@@ -1772,10 +1075,6 @@ class Sequence(collections.abc.Sequence):
                     yield type(self)(item_buffer)
                     item_buffer.pop(0)
 
-    @Signature(
-        argument_list_callback="_make_partition_indicator",
-        method_name="partition",
-    )
     def partition_by_counts(
         self,
         counts,
@@ -1793,7 +1092,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> sequence = sequence.partition_by_counts(
                 ...     [3],
                 ...     cyclic=False,
@@ -1807,46 +1106,13 @@ class Sequence(collections.abc.Sequence):
                 ...     part
                 Sequence([0, 1, 2])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [3],
-                ...     cyclic=False,
-                ...     overhang=False,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2])
-
-                >>> expression.get_string()
-                'partition(J, [3])'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", [3])"
-                            }
-                        }
-
         ..  container:: example
 
             Partitions sequence once by counts without overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=False,
@@ -1858,47 +1124,13 @@ class Sequence(collections.abc.Sequence):
                 Sequence([0, 1, 2, 3])
                 Sequence([4, 5, 6])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [4, 3],
-                ...     cyclic=False,
-                ...     overhang=False,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2, 3])
-                Sequence([4, 5, 6])
-
-                >>> expression.get_string()
-                'partition(J, [4, 3])'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", [4, 3])"
-                            }
-                        }
-
         ..  container:: example
 
             Partitions sequence cyclically by counts without overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [3],
                 ...     cyclic=True,
@@ -1913,50 +1145,13 @@ class Sequence(collections.abc.Sequence):
                 Sequence([9, 10, 11])
                 Sequence([12, 13, 14])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [3],
-                ...     cyclic=True,
-                ...     overhang=False,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2])
-                Sequence([3, 4, 5])
-                Sequence([6, 7, 8])
-                Sequence([9, 10, 11])
-                Sequence([12, 13, 14])
-
-                >>> expression.get_string()
-                'partition(J, <3>)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", <3>)"
-                            }
-                        }
-
         ..  container:: example
 
             Partitions sequence cyclically by counts without overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=True,
@@ -1970,49 +1165,13 @@ class Sequence(collections.abc.Sequence):
                 Sequence([7, 8, 9, 10])
                 Sequence([11, 12, 13])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [4, 3],
-                ...     cyclic=True,
-                ...     overhang=False,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2, 3])
-                Sequence([4, 5, 6])
-                Sequence([7, 8, 9, 10])
-                Sequence([11, 12, 13])
-
-                >>> expression.get_string()
-                'partition(J, <4, 3>)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", <4, 3>)"
-                            }
-                        }
-
         ..  container:: example
 
             Partitions sequence once by counts with overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [3],
                 ...     cyclic=False,
@@ -2024,47 +1183,13 @@ class Sequence(collections.abc.Sequence):
                 Sequence([0, 1, 2])
                 Sequence([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [3],
-                ...     cyclic=False,
-                ...     overhang=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2])
-                Sequence([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, [3]+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", [3]+)"
-                            }
-                        }
-
         ..  container:: example
 
             Partitions sequence once by counts with overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=False,
@@ -2076,41 +1201,6 @@ class Sequence(collections.abc.Sequence):
                 Sequence([0, 1, 2, 3])
                 Sequence([4, 5, 6])
                 Sequence([7, 8, 9, 10, 11, 12, 13, 14, 15])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [4, 3],
-                ...     cyclic=False,
-                ...     overhang=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2, 3])
-                Sequence([4, 5, 6])
-                Sequence([7, 8, 9, 10, 11, 12, 13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, [4, 3]+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", [4, 3]+)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -2118,7 +1208,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [3],
                 ...     cyclic=True,
@@ -2134,51 +1224,13 @@ class Sequence(collections.abc.Sequence):
                 Sequence([12, 13, 14])
                 Sequence([15])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [3],
-                ...     cyclic=True,
-                ...     overhang=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2])
-                Sequence([3, 4, 5])
-                Sequence([6, 7, 8])
-                Sequence([9, 10, 11])
-                Sequence([12, 13, 14])
-                Sequence([15])
-
-                >>> expression.get_string()
-                'partition(J, <3>+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", <3>+)"
-                            }
-                        }
-
         ..  container:: example
 
             Partitions sequence cyclically by counts with overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=True,
@@ -2193,50 +1245,13 @@ class Sequence(collections.abc.Sequence):
                 Sequence([11, 12, 13])
                 Sequence([14, 15])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [4, 3],
-                ...     cyclic=True,
-                ...     overhang=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2, 3])
-                Sequence([4, 5, 6])
-                Sequence([7, 8, 9, 10])
-                Sequence([11, 12, 13])
-                Sequence([14, 15])
-
-                >>> expression.get_string()
-                'partition(J, <4, 3>+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", <4, 3>+)"
-                            }
-                        }
-
         ..  container:: example
 
             Reverse-partitions sequence once by counts without overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [3],
                 ...     cyclic=False,
@@ -2248,47 +1263,13 @@ class Sequence(collections.abc.Sequence):
                 ...     part
                 Sequence([13, 14, 15])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [3],
-                ...     cyclic=False,
-                ...     overhang=False,
-                ...     reversed_=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, R[3])'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", R[3])"
-                            }
-                        }
-
         ..  container:: example
 
             Reverse-partitions sequence once by counts without overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=False,
@@ -2300,41 +1281,6 @@ class Sequence(collections.abc.Sequence):
                 ...     part
                 Sequence([9, 10, 11])
                 Sequence([12, 13, 14, 15])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [4, 3],
-                ...     cyclic=False,
-                ...     overhang=False,
-                ...     reversed_=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([9, 10, 11])
-                Sequence([12, 13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, R[4, 3])'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", R[4, 3])"
-                            }
-                        }
 
         ..  container:: example
 
@@ -2342,7 +1288,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [3],
                 ...     cyclic=True,
@@ -2358,51 +1304,13 @@ class Sequence(collections.abc.Sequence):
                 Sequence([10, 11, 12])
                 Sequence([13, 14, 15])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [3],
-                ...     cyclic=True,
-                ...     overhang=False,
-                ...     reversed_=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([1, 2, 3])
-                Sequence([4, 5, 6])
-                Sequence([7, 8, 9])
-                Sequence([10, 11, 12])
-                Sequence([13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, R<3>)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", R<3>)"
-                            }
-                        }
-
         ..  container:: example
 
             Reverse-partitions sequence cyclically by counts without overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=True,
@@ -2417,50 +1325,13 @@ class Sequence(collections.abc.Sequence):
                 Sequence([9, 10, 11])
                 Sequence([12, 13, 14, 15])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [4, 3],
-                ...     cyclic=True,
-                ...     overhang=False,
-                ...     reversed_=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([2, 3, 4])
-                Sequence([5, 6, 7, 8])
-                Sequence([9, 10, 11])
-                Sequence([12, 13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, R<4, 3>)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", R<4, 3>)"
-                            }
-                        }
-
         ..  container:: example
 
             Reverse-partitions sequence once by counts with overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [3],
                 ...     cyclic=False,
@@ -2473,48 +1344,13 @@ class Sequence(collections.abc.Sequence):
                 Sequence([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
                 Sequence([13, 14, 15])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [3],
-                ...     cyclic=False,
-                ...     overhang=True,
-                ...     reversed_=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
-                Sequence([13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, R[3]+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", R[3]+)"
-                            }
-                        }
-
         ..  container:: example
 
             Reverse-partitions sequence once by counts with overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=False,
@@ -2527,42 +1363,6 @@ class Sequence(collections.abc.Sequence):
                 Sequence([0, 1, 2, 3, 4, 5, 6, 7, 8])
                 Sequence([9, 10, 11])
                 Sequence([12, 13, 14, 15])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [4, 3],
-                ...     cyclic=False,
-                ...     overhang=True,
-                ...     reversed_=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2, 3, 4, 5, 6, 7, 8])
-                Sequence([9, 10, 11])
-                Sequence([12, 13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, R[4, 3]+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", R[4, 3]+)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -2570,7 +1370,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [3],
                 ...     cyclic=True,
@@ -2587,52 +1387,13 @@ class Sequence(collections.abc.Sequence):
                 Sequence([10, 11, 12])
                 Sequence([13, 14, 15])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [3],
-                ...     cyclic=True,
-                ...     overhang=True,
-                ...     reversed_=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0])
-                Sequence([1, 2, 3])
-                Sequence([4, 5, 6])
-                Sequence([7, 8, 9])
-                Sequence([10, 11, 12])
-                Sequence([13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, R<3>+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", R<3>+)"
-                            }
-                        }
-
         ..  container:: example
 
             Reverse-partitions sequence cyclically by counts with overhang:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [4, 3],
                 ...     cyclic=True,
@@ -2647,44 +1408,6 @@ class Sequence(collections.abc.Sequence):
                 Sequence([5, 6, 7, 8])
                 Sequence([9, 10, 11])
                 Sequence([12, 13, 14, 15])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [4, 3],
-                ...     cyclic=True,
-                ...     overhang=True,
-                ...     reversed_=True,
-                ...     )
-
-                >>> for part in parts:
-                ...     part
-                Sequence([0, 1])
-                Sequence([2, 3, 4])
-                Sequence([5, 6, 7, 8])
-                Sequence([9, 10, 11])
-                Sequence([12, 13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, R<4, 3>+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", R<4, 3>+)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -2693,7 +1416,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(10))
+                >>> sequence = abjad.Sequence(range(10))
                 >>> parts = sequence.partition_by_counts(
                 ...     [2, 3, 5],
                 ...     cyclic=False,
@@ -2705,41 +1428,6 @@ class Sequence(collections.abc.Sequence):
                 Sequence([0, 1])
                 Sequence([2, 3, 4])
                 Sequence([5, 6, 7, 8, 9])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [2, 3, 5],
-                ...     cyclic=False,
-                ...     overhang=abjad.Exact,
-                ...     )
-
-                >>> for part in expression(range(10)):
-                ...     part
-                Sequence([0, 1])
-                Sequence([2, 3, 4])
-                Sequence([5, 6, 7, 8, 9])
-
-                >>> expression.get_string()
-                'partition(J, [2, 3, 5]!)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", [2, 3, 5]!)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -2749,7 +1437,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(10))
+                >>> sequence = abjad.Sequence(range(10))
                 >>> parts = sequence.partition_by_counts(
                 ...     [2],
                 ...     cyclic=True,
@@ -2763,43 +1451,6 @@ class Sequence(collections.abc.Sequence):
                 Sequence([4, 5])
                 Sequence([6, 7])
                 Sequence([8, 9])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [2],
-                ...     cyclic=True,
-                ...     overhang=abjad.Exact,
-                ...     )
-
-                >>> for part in expression(range(10)):
-                ...     part
-                Sequence([0, 1])
-                Sequence([2, 3])
-                Sequence([4, 5])
-                Sequence([6, 7])
-                Sequence([8, 9])
-
-                >>> expression.get_string()
-                'partition(J, <2>!)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", <2>!)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -2807,7 +1458,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence('some text')
+                >>> sequence = abjad.Sequence('some text')
                 >>> parts = sequence.partition_by_counts(
                 ...     [3],
                 ...     cyclic=False,
@@ -2818,40 +1469,6 @@ class Sequence(collections.abc.Sequence):
                 ...     part
                 Sequence(['s', 'o', 'm'])
                 Sequence(['e', ' ', 't', 'e', 'x', 't'])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [3],
-                ...     cyclic=False,
-                ...     overhang=True,
-                ...     )
-
-                >>> for part in expression('some text'):
-                ...     part
-                Sequence(['s', 'o', 'm'])
-                Sequence(['e', ' ', 't', 'e', 'x', 't'])
-
-                >>> expression.get_string()
-                'partition(J, [3]+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", [3]+)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -2860,7 +1477,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [2, 6],
                 ...     cyclic=True,
@@ -2875,44 +1492,6 @@ class Sequence(collections.abc.Sequence):
                 Sequence([6, 7])
                 Sequence([7, 8, 9, 10, 11, 12])
                 Sequence([12, 13])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [2, 6],
-                ...     cyclic=True,
-                ...     enchain=True,
-                ...     overhang=False,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1])
-                Sequence([1, 2, 3, 4, 5, 6])
-                Sequence([6, 7])
-                Sequence([7, 8, 9, 10, 11, 12])
-                Sequence([12, 13])
-
-                >>> expression.get_string()
-                'partition(J, E<2, 6>)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", E<2, 6>)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -2921,7 +1500,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [2, 6],
                 ...     cyclic=True,
@@ -2937,45 +1516,6 @@ class Sequence(collections.abc.Sequence):
                 Sequence([7, 8, 9, 10, 11, 12])
                 Sequence([12, 13])
                 Sequence([13, 14, 15])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [2, 6],
-                ...     cyclic=True,
-                ...     enchain=True,
-                ...     overhang=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1])
-                Sequence([1, 2, 3, 4, 5, 6])
-                Sequence([6, 7])
-                Sequence([7, 8, 9, 10, 11, 12])
-                Sequence([12, 13])
-                Sequence([13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, E<2, 6>+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", E<2, 6>+)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -2984,7 +1524,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts(
                 ...     [5],
                 ...     cyclic=True,
@@ -2999,89 +1539,21 @@ class Sequence(collections.abc.Sequence):
                 Sequence([8, 9, 10, 11, 12])
                 Sequence([12, 13, 14, 15])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts(
-                ...     [5],
-                ...     cyclic=True,
-                ...     enchain=True,
-                ...     overhang=True,
-                ...     )
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2, 3, 4])
-                Sequence([4, 5, 6, 7, 8])
-                Sequence([8, 9, 10, 11, 12])
-                Sequence([12, 13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, E<5>+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", E<5>+)"
-                            }
-                        }
-
         ..  container:: example
 
             Edge case: empty counts nests sequence and ignores keywords:
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(16))
+                >>> sequence = abjad.Sequence(range(16))
                 >>> parts = sequence.partition_by_counts([])
 
                 >>> for part in parts:
                 ...     part
                 Sequence([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.partition_by_counts([])
-
-                >>> for part in expression(range(16)):
-                ...     part
-                Sequence([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
-
-                >>> expression.get_string()
-                'partition(J, [])'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", [])"
-                            }
-                        }
-
         Returns nested sequence.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         if not all(isinstance(_, int) and 0 <= _ for _ in counts):
             raise Exception(f"must be nonnegative integers: {counts!r}.")
         sequence = self
@@ -3126,10 +1598,6 @@ class Sequence(collections.abc.Sequence):
             result = result_
         return type(self)(result)
 
-    @Signature(
-        argument_list_callback="_make_partition_ratio_indicator",
-        method_name="partition",
-    )
     def partition_by_ratio_of_lengths(self, ratio) -> "Sequence":
         r"""
         Partitions sequence by ``ratio`` of lengths.
@@ -3140,7 +1608,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> numbers = abjad.sequence(range(10))
+                >>> numbers = abjad.Sequence(range(10))
                 >>> ratio = abjad.Ratio((1, 1, 1))
 
                 >>> for part in numbers.partition_by_ratio_of_lengths(ratio):
@@ -3148,38 +1616,6 @@ class Sequence(collections.abc.Sequence):
                 Sequence([0, 1, 2])
                 Sequence([3, 4, 5, 6])
                 Sequence([7, 8, 9])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> ratio = abjad.Ratio((1, 1, 1))
-                >>> expression = expression.partition_by_ratio_of_lengths(ratio)
-
-                >>> for part in expression(range(10)):
-                ...     part
-                Sequence([0, 1, 2])
-                Sequence([3, 4, 5, 6])
-                Sequence([7, 8, 9])
-
-                >>> expression.get_string()
-                'partition(J, 1:1:1)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", 1:1:1)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -3187,7 +1623,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> numbers = abjad.sequence(range(10))
+                >>> numbers = abjad.Sequence(range(10))
                 >>> ratio = abjad.Ratio((1, 1, 2))
 
                 >>> for part in numbers.partition_by_ratio_of_lengths(ratio):
@@ -3196,42 +1632,8 @@ class Sequence(collections.abc.Sequence):
                 Sequence([3, 4])
                 Sequence([5, 6, 7, 8, 9])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> ratio = abjad.Ratio((1, 1, 2))
-                >>> expression = expression.partition_by_ratio_of_lengths(ratio)
-
-                >>> for part in expression(range(10)):
-                ...     part
-                Sequence([0, 1, 2])
-                Sequence([3, 4])
-                Sequence([5, 6, 7, 8, 9])
-
-                >>> expression.get_string()
-                'partition(J, 1:1:2)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                partition(
-                                \bold
-                                    J
-                                ", 1:1:2)"
-                            }
-                        }
-
         Returns nested sequence.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         ratio = Ratio(ratio)
         length = len(self)
         counts = ratio.partition_integer(length)
@@ -3245,7 +1647,7 @@ class Sequence(collections.abc.Sequence):
         ..  container:: example
 
             >>> ratio = abjad.Ratio([1, 1, 1])
-            >>> sequence = abjad.sequence(10 * [1])
+            >>> sequence = abjad.Sequence(10 * [1])
             >>> sequence = sequence.partition_by_ratio_of_weights(ratio)
             >>> for item in sequence:
             ...     item
@@ -3257,7 +1659,7 @@ class Sequence(collections.abc.Sequence):
         ..  container:: example
 
             >>> ratio = abjad.Ratio([1, 1, 1, 1])
-            >>> sequence = abjad.sequence(10 * [1])
+            >>> sequence = abjad.Sequence(10 * [1])
             >>> sequence = sequence.partition_by_ratio_of_weights(ratio)
             >>> for item in sequence:
             ...     item
@@ -3270,7 +1672,7 @@ class Sequence(collections.abc.Sequence):
         ..  container:: example
 
             >>> ratio = abjad.Ratio([2, 2, 3])
-            >>> sequence = abjad.sequence(10 * [1])
+            >>> sequence = abjad.Sequence(10 * [1])
             >>> sequence = sequence.partition_by_ratio_of_weights(ratio)
             >>> for item in sequence:
             ...     item
@@ -3282,7 +1684,7 @@ class Sequence(collections.abc.Sequence):
         ..  container:: example
 
             >>> ratio = abjad.Ratio([3, 2, 2])
-            >>> sequence = abjad.sequence(10 * [1])
+            >>> sequence = abjad.Sequence(10 * [1])
             >>> sequence = sequence.partition_by_ratio_of_weights(ratio)
             >>> for item in sequence:
             ...     item
@@ -3295,7 +1697,7 @@ class Sequence(collections.abc.Sequence):
 
             >>> ratio = abjad.Ratio([1, 1])
             >>> items = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2]
-            >>> sequence = abjad.sequence(items)
+            >>> sequence = abjad.Sequence(items)
             >>> sequence = sequence.partition_by_ratio_of_weights(ratio)
             >>> for item in sequence:
             ...     item
@@ -3307,7 +1709,7 @@ class Sequence(collections.abc.Sequence):
 
             >>> ratio = abjad.Ratio([1, 1, 1])
             >>> items = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2]
-            >>> sequence = abjad.sequence(items)
+            >>> sequence = abjad.Sequence(items)
             >>> sequence = sequence.partition_by_ratio_of_weights(ratio)
             >>> for item in sequence:
             ...     item
@@ -3319,7 +1721,7 @@ class Sequence(collections.abc.Sequence):
         ..  container:: example
 
             >>> ratio = abjad.Ratio([1, 1, 1])
-            >>> sequence = abjad.sequence([5, 5])
+            >>> sequence = abjad.Sequence([5, 5])
             >>> sequence = sequence.partition_by_ratio_of_weights(ratio)
             >>> for item in sequence:
             ...     item
@@ -3331,7 +1733,7 @@ class Sequence(collections.abc.Sequence):
         ..  container:: example
 
             >>> ratio = abjad.Ratio([1, 1, 1, 1])
-            >>> sequence = abjad.sequence([5, 5])
+            >>> sequence = abjad.Sequence([5, 5])
             >>> sequence = sequence.partition_by_ratio_of_weights(ratio)
             >>> for item in sequence:
             ...     item
@@ -3344,7 +1746,7 @@ class Sequence(collections.abc.Sequence):
         ..  container:: example
 
             >>> ratio = abjad.Ratio([2, 2, 3])
-            >>> sequence = abjad.sequence([5, 5])
+            >>> sequence = abjad.Sequence([5, 5])
             >>> sequence = sequence.partition_by_ratio_of_weights(ratio)
             >>> for item in sequence:
             ...     item
@@ -3356,7 +1758,7 @@ class Sequence(collections.abc.Sequence):
         ..  container:: example
 
             >>> ratio = abjad.Ratio([3, 2, 2])
-            >>> sequence = abjad.sequence([5, 5])
+            >>> sequence = abjad.Sequence([5, 5])
             >>> sequence = sequence.partition_by_ratio_of_weights(ratio)
             >>> for item in sequence:
             ...     item
@@ -3404,7 +1806,7 @@ class Sequence(collections.abc.Sequence):
         r"""
         Partitions sequence by ``weights`` exactly.
 
-        >>> sequence = abjad.sequence([3, 3, 3, 3, 4, 4, 4, 4, 5])
+        >>> sequence = abjad.Sequence([3, 3, 3, 3, 4, 4, 4, 4, 5])
 
         ..  container:: example
 
@@ -3464,7 +1866,7 @@ class Sequence(collections.abc.Sequence):
             Sequence([4, 4, 4])
             Sequence([4, 5])
 
-        >>> sequence = abjad.sequence([3, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> sequence = abjad.Sequence([3, 3, 3, 3, 4, 4, 4, 4, 5, 5])
 
         ..  container:: example
 
@@ -3539,7 +1941,7 @@ class Sequence(collections.abc.Sequence):
             Sequence([4, 5])
             Sequence([5])
 
-        >>> sequence = abjad.sequence([3, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> sequence = abjad.Sequence([3, 3, 3, 3, 4, 4, 4, 4, 5, 5])
 
         ..  container:: example
 
@@ -3644,64 +2046,33 @@ class Sequence(collections.abc.Sequence):
             message = message.format(allow_part_weights)
             raise ValueError(message)
 
-    @Signature()
     def permute(self, permutation) -> "Sequence":
         r"""
         Permutes sequence by ``permutation``.
 
         ..  container:: example
 
-            >>> sequence = abjad.sequence([10, 11, 12, 13, 14, 15])
+            >>> sequence = abjad.Sequence([10, 11, 12, 13, 14, 15])
             >>> sequence.permute([5, 4, 0, 1, 2, 3])
             Sequence([15, 14, 10, 11, 12, 13])
 
         ..  container:: example
 
-            >>> sequence = abjad.sequence([11, 12, 13, 14])
+            >>> sequence = abjad.Sequence([11, 12, 13, 14])
             >>> sequence.permute([1, 0, 3, 2])
             Sequence([12, 11, 14, 13])
-
-        ..  container:: example expression
-
-            >>> expression = abjad.sequence(name='J')
-            >>> expression = expression.permute([1, 0, 3, 2])
-
-            >>> expression([11, 12, 13, 14])
-            Sequence([12, 11, 14, 13])
-
-            >>> expression.get_string()
-            'permute(J, [1, 0, 3, 2])'
-
-            >>> markup = expression.get_markup()
-            >>> abjad.show(markup) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(markup)
-                >>> print(string)
-                \markup {
-                    \concat
-                        {
-                            permute(
-                            \bold
-                                J
-                            ", permutation=[1, 0, 3, 2])"
-                        }
-                    }
 
         ..  container:: example
 
             Raises exception when lengths do not match:
 
-            >>> sequence = abjad.sequence([1, 2, 3, 4, 5, 6])
+            >>> sequence = abjad.Sequence([1, 2, 3, 4, 5, 6])
             >>> sequence.permute([3, 0, 1, 2])
             Traceback (most recent call last):
                 ...
             ValueError: permutation Sequence([3, 0, 1, 2]) must match length of Sequence([1, 2, 3, 4, 5, 6]).
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         permutation = type(self)(permutation)
         if not permutation.is_permutation():
             raise ValueError(f"must be permutation: {permutation!r}.")
@@ -3722,7 +2093,7 @@ class Sequence(collections.abc.Sequence):
 
         ..  container:: example
 
-            >>> sequence = abjad.sequence(range(15))
+            >>> sequence = abjad.Sequence(range(15))
 
         ..  container:: example
 
@@ -3796,7 +2167,7 @@ class Sequence(collections.abc.Sequence):
         ..  container:: example
 
             >>> items = [31, 31, 35, 35, 31, 31, 31, 31, 35]
-            >>> sequence = abjad.sequence(items)
+            >>> sequence = abjad.Sequence(items)
             >>> sequence.remove_repeats()
             Sequence([31, 35, 31, 35])
 
@@ -3807,7 +2178,6 @@ class Sequence(collections.abc.Sequence):
                 items.append(item)
         return type(self)(items)
 
-    @Signature()
     def repeat(self, n=1) -> "Sequence":
         r"""
         Repeats sequence.
@@ -3816,111 +2186,25 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> abjad.sequence([1, 2, 3]).repeat(n=0)
+                >>> abjad.Sequence([1, 2, 3]).repeat(n=0)
                 Sequence([])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.repeat(n=0)
-
-                >>> expression([1, 2, 3])
-                Sequence([])
-
-                >>> expression.get_string()
-                'repeat(J, n=0)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                repeat(
-                                \bold
-                                    J
-                                ", n=0)"
-                            }
-                        }
 
         ..  container:: example
 
             ..  container:: example
 
-                >>> abjad.sequence([1, 2, 3]).repeat(n=1)
+                >>> abjad.Sequence([1, 2, 3]).repeat(n=1)
                 Sequence([Sequence([1, 2, 3])])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.repeat(n=1)
-
-                >>> expression([1, 2, 3])
-                Sequence([Sequence([1, 2, 3])])
-
-                >>> expression.get_string()
-                'repeat(J)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                repeat(
-                                \bold
-                                    J
-                                )
-                            }
-                        }
 
         ..  container:: example
 
             ..  container:: example
 
-                >>> abjad.sequence([1, 2, 3]).repeat(n=2)
+                >>> abjad.Sequence([1, 2, 3]).repeat(n=2)
                 Sequence([Sequence([1, 2, 3]), Sequence([1, 2, 3])])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.repeat(n=2)
-
-                >>> expression([1, 2, 3])
-                Sequence([Sequence([1, 2, 3]), Sequence([1, 2, 3])])
-
-                >>> expression.get_string()
-                'repeat(J, n=2)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                repeat(
-                                \bold
-                                    J
-                                ", n=2)"
-                            }
-                        }
 
         Returns nested sequence.
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         items = []
         for i in range(n):
             items.append(self[:])
@@ -3934,17 +2218,17 @@ class Sequence(collections.abc.Sequence):
 
             Repeats list to length 11:
 
-            >>> abjad.sequence(range(5)).repeat_to_length(11)
+            >>> abjad.Sequence(range(5)).repeat_to_length(11)
             Sequence([0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0])
 
         ..  container:: example
 
-            >>> abjad.sequence(range(5)).repeat_to_length(11, start=2)
+            >>> abjad.Sequence(range(5)).repeat_to_length(11, start=2)
             Sequence([2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2])
 
         ..  container:: example
 
-            >>> sequence = abjad.sequence([0, -1, -2, -3, -4])
+            >>> sequence = abjad.Sequence([0, -1, -2, -3, -4])
             >>> sequence.repeat_to_length(11)
             Sequence([0, -1, -2, -3, -4, 0, -1, -2, -3, -4, 0])
 
@@ -3955,7 +2239,7 @@ class Sequence(collections.abc.Sequence):
 
         ..  container:: example
 
-            >>> abjad.sequence([1, 2, 3]).repeat_to_length(10, start=100)
+            >>> abjad.Sequence([1, 2, 3]).repeat_to_length(10, start=100)
             Sequence([2, 3, 1, 2, 3, 1, 2, 3, 1, 2])
 
         """
@@ -3978,14 +2262,14 @@ class Sequence(collections.abc.Sequence):
 
             Repeats sequence to weight of 23 exactly:
 
-            >>> abjad.sequence([5, -5, -5]).repeat_to_weight(23)
+            >>> abjad.Sequence([5, -5, -5]).repeat_to_weight(23)
             Sequence([5, -5, -5, 5, -3])
 
         ..  container:: example
 
             Repeats sequence to weight of 23 more:
 
-            >>> sequence = abjad.sequence([5, -5, -5])
+            >>> sequence = abjad.Sequence([5, -5, -5])
             >>> sequence.repeat_to_weight(23, allow_total=abjad.More)
             Sequence([5, -5, -5, 5, -5])
 
@@ -3993,14 +2277,14 @@ class Sequence(collections.abc.Sequence):
 
             Repeats sequence to weight of 23 or less:
 
-            >>> sequence = abjad.sequence([5, -5, -5])
+            >>> sequence = abjad.Sequence([5, -5, -5])
             >>> sequence.repeat_to_weight(23, allow_total=abjad.Less)
             Sequence([5, -5, -5, 5])
 
         ..  container:: example
 
             >>> items = [abjad.NonreducedFraction(3, 16)]
-            >>> sequence = abjad.sequence(items)
+            >>> sequence = abjad.Sequence(items)
             >>> weight = abjad.NonreducedFraction(5, 4)
             >>> sequence = sequence.repeat_to_weight(weight)
             >>> sum(sequence)
@@ -4062,7 +2346,7 @@ class Sequence(collections.abc.Sequence):
 
         ..  container:: example
 
-            >>> sequence = abjad.sequence([0, 2, 3, 0, 2, 3, 0, 2, 3])
+            >>> sequence = abjad.Sequence([0, 2, 3, 0, 2, 3, 0, 2, 3])
             >>> sequence.replace(0, 1)
             Sequence([1, 2, 3, 1, 2, 3, 1, 2, 3])
 
@@ -4084,7 +2368,7 @@ class Sequence(collections.abc.Sequence):
 
             Replaces items at indices 0, 2, 4, 6:
 
-            >>> sequence = abjad.sequence(range(16))
+            >>> sequence = abjad.Sequence(range(16))
             >>> sequence.replace_at(
             ...     ([0], 2),
             ...     (['A', 'B', 'C', 'D'], None),
@@ -4095,7 +2379,7 @@ class Sequence(collections.abc.Sequence):
 
             Replaces elements at indices 0, 1, 8, 13:
 
-            >>> sequence = abjad.sequence(range(16))
+            >>> sequence = abjad.Sequence(range(16))
             >>> sequence.replace_at(
             ...     ([0, 1, 8, 13], None),
             ...     (['A', 'B', 'C', 'D'], None),
@@ -4106,7 +2390,7 @@ class Sequence(collections.abc.Sequence):
 
             Replaces every item at even index:
 
-            >>> sequence = abjad.sequence(range(16))
+            >>> sequence = abjad.Sequence(range(16))
             >>> sequence.replace_at(
             ...     ([0], 2),
             ...     (['*'], 1),
@@ -4119,7 +2403,7 @@ class Sequence(collections.abc.Sequence):
             ``'A'``; replaces every element at an index congruent to 2 (mod 6)
             with ``'B'``:
 
-            >>> sequence = abjad.sequence(range(16))
+            >>> sequence = abjad.Sequence(range(16))
             >>> sequence.replace_at(
             ...     ([0], 2),
             ...     (['A', 'B'], 3),
@@ -4166,7 +2450,7 @@ class Sequence(collections.abc.Sequence):
 
         ..  container:: example
 
-            >>> sequence = abjad.sequence(range(10))
+            >>> sequence = abjad.Sequence(range(10))
             >>> sequence.retain()
             Sequence([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
@@ -4206,8 +2490,6 @@ class Sequence(collections.abc.Sequence):
             Sequence([])
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         length = len(self)
         period = period or length
         if indices is None:
@@ -4234,7 +2516,7 @@ class Sequence(collections.abc.Sequence):
 
         ..  container:: example
 
-            >>> sequence = abjad.sequence(range(10))
+            >>> sequence = abjad.Sequence(range(10))
             >>> sequence.retain_pattern(abjad.index_all())
             Sequence([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
@@ -4269,8 +2551,6 @@ class Sequence(collections.abc.Sequence):
             Sequence([])
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         length = len(self)
         items = []
         for i, item in enumerate(self):
@@ -4278,7 +2558,6 @@ class Sequence(collections.abc.Sequence):
                 items.append(item)
         return type(self)(items=items)
 
-    @Signature(is_operator=True, method_name_callback="_make_reverse_method_name")
     def reverse(self, recurse=False) -> "Sequence":
         r"""
         Reverses sequence.
@@ -4289,37 +2568,10 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence([[1, 2], 3, [4, 5]])
+                >>> sequence = abjad.Sequence([[1, 2], 3, [4, 5]])
 
                 >>> sequence.reverse()
                 Sequence([[4, 5], 3, [1, 2]])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.reverse()
-
-                >>> expression([[1, 2], 3, [4, 5]])
-                Sequence([[4, 5], 3, [1, 2]])
-
-                >>> expression.get_string()
-                'R(J)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                R
-                                \bold
-                                    J
-                            }
-                        }
 
         ..  container:: example
 
@@ -4330,7 +2582,7 @@ class Sequence(collections.abc.Sequence):
                 >>> segment_1 = abjad.PitchClassSegment([1, 2])
                 >>> pitch = abjad.NumberedPitch(3)
                 >>> segment_2 = abjad.PitchClassSegment([4, 5])
-                >>> sequence = abjad.sequence([segment_1, pitch, segment_2])
+                >>> sequence = abjad.Sequence([segment_1, pitch, segment_2])
 
                 >>> for item in sequence.reverse(recurse=True):
                 ...     item
@@ -4339,40 +2591,7 @@ class Sequence(collections.abc.Sequence):
                 NumberedPitch(3)
                 PitchClassSegment([2, 1])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.reverse(recurse=True)
-
-                >>> for item in expression([segment_1, pitch, segment_2]):
-                ...     item
-                ...
-                PitchClassSegment([5, 4])
-                NumberedPitch(3)
-                PitchClassSegment([2, 1])
-
-                >>> expression.get_string()
-                'R*(J)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                R*
-                                \bold
-                                    J
-                            }
-                        }
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         if not recurse:
             return type(self)(items=reversed(self))
 
@@ -4386,7 +2605,6 @@ class Sequence(collections.abc.Sequence):
         items = _reverse_helper(self.items)
         return type(self)(items=items)
 
-    @Signature(is_operator=True, method_name="r", subscript="n")
     def rotate(self, n=0) -> "Sequence":
         r"""
         Rotates sequence by index ``n``.
@@ -4397,39 +2615,10 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(10))
+                >>> sequence = abjad.Sequence(range(10))
 
                 >>> sequence.rotate(n=4)
                 Sequence([6, 7, 8, 9, 0, 1, 2, 3, 4, 5])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.rotate(n=4)
-
-                >>> expression(range(10))
-                Sequence([6, 7, 8, 9, 0, 1, 2, 3, 4, 5])
-
-                >>> expression.get_string()
-                'r4(J)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                r
-                                \sub
-                                    4
-                                \bold
-                                    J
-                            }
-                        }
 
         ..  container:: example
 
@@ -4437,39 +2626,10 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(10))
+                >>> sequence = abjad.Sequence(range(10))
 
                 >>> sequence.rotate(n=-3)
                 Sequence([3, 4, 5, 6, 7, 8, 9, 0, 1, 2])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.rotate(n=-3)
-
-                >>> expression(range(10))
-                Sequence([3, 4, 5, 6, 7, 8, 9, 0, 1, 2])
-
-                >>> expression.get_string()
-                'r-3(J)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                r
-                                \sub
-                                    -3
-                                \bold
-                                    J
-                            }
-                        }
 
         ..  container:: example
 
@@ -4477,43 +2637,12 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(10))
+                >>> sequence = abjad.Sequence(range(10))
 
                 >>> sequence.rotate(n=0)
                 Sequence([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.rotate(n=0)
-
-                >>> expression(range(10))
-                Sequence([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-
-                >>> expression.get_string()
-                'r0(J)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                r
-                                \sub
-                                    0
-                                \bold
-                                    J
-                            }
-                        }
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         n = n or 0
         items = []
         if len(self):
@@ -4528,7 +2657,7 @@ class Sequence(collections.abc.Sequence):
 
         ..  container:: example
 
-            >>> sequence = abjad.sequence([3, 2, 5, 4, 1, 6])
+            >>> sequence = abjad.Sequence([3, 2, 5, 4, 1, 6])
             >>> sequence.sort()
             Sequence([1, 2, 3, 4, 5, 6])
 
@@ -4540,7 +2669,6 @@ class Sequence(collections.abc.Sequence):
         items.sort(key=key, reverse=reverse)
         return type(self)(items=items)
 
-    @Signature(argument_list_callback="_make_split_indicator")
     def split(self, weights, cyclic=False, overhang=False) -> "Sequence":
         r"""
         Splits sequence by ``weights``.
@@ -4551,7 +2679,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence([10, -10, 10, -10])
+                >>> sequence = abjad.Sequence([10, -10, 10, -10])
 
                 >>> for part in sequence.split(
                 ...     (3, 15, 3),
@@ -4566,45 +2694,6 @@ class Sequence(collections.abc.Sequence):
                 Sequence([3])
                 Sequence([6, -9])
                 Sequence([-1])
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.split(
-                ...     (3, 15, 3),
-                ...     cyclic=True,
-                ...     overhang=True,
-                ...     )
-
-                >>> for part in expression([10, -10, 10, -10]):
-                ...     part
-                ...
-                Sequence([3])
-                Sequence([7, -8])
-                Sequence([-2, 1])
-                Sequence([3])
-                Sequence([6, -9])
-                Sequence([-1])
-
-                >>> expression.get_string()
-                'split(J, <3, 15, 3>+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                split(
-                                \bold
-                                    J
-                                ", <3, 15, 3>+)"
-                            }
-                        }
 
         ..  container:: example
 
@@ -4644,7 +2733,7 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence([
+                >>> sequence = abjad.Sequence([
                 ...     abjad.NonreducedFraction(20, 2),
                 ...     abjad.NonreducedFraction(-20, 2),
                 ...     abjad.NonreducedFraction(20, 2),
@@ -4665,54 +2754,7 @@ class Sequence(collections.abc.Sequence):
                 Sequence([NonreducedFraction(12, 2), NonreducedFraction(-18, 2)])
                 Sequence([NonreducedFraction(-2, 2)])
 
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.split(
-                ...     (3, 15, 3),
-                ...     cyclic=True,
-                ...     overhang=True,
-                ...     )
-
-                >>> for part in expression([
-                ...     abjad.NonreducedFraction(20, 2),
-                ...     abjad.NonreducedFraction(-20, 2),
-                ...     abjad.NonreducedFraction(20, 2),
-                ...     abjad.NonreducedFraction(-20, 2),
-                ... ]):
-                ...     part
-                ...
-                Sequence([NonreducedFraction(6, 2)])
-                Sequence([NonreducedFraction(14, 2), NonreducedFraction(-16, 2)])
-                Sequence([NonreducedFraction(-4, 2), NonreducedFraction(2, 2)])
-                Sequence([NonreducedFraction(6, 2)])
-                Sequence([NonreducedFraction(12, 2), NonreducedFraction(-18, 2)])
-                Sequence([NonreducedFraction(-2, 2)])
-
-                >>> expression.get_string()
-                'split(J, <3, 15, 3>+)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                split(
-                                \bold
-                                    J
-                                ", <3, 15, 3>+)"
-                            }
-                        }
-
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         result = []
         current_index = 0
         current_piece: typing.List[typing.Any] = []
@@ -4748,7 +2790,6 @@ class Sequence(collections.abc.Sequence):
                 result.append(last_piece_)
         return type(self)(items=result)
 
-    @Signature()
     def sum(self) -> typing.Any:
         r"""
         Sums sequence.
@@ -4759,38 +2800,10 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+                >>> sequence = abjad.Sequence([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
                 >>> sequence.sum()
                 55
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.sum()
-
-                >>> expression([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-                55
-
-                >>> expression.get_string()
-                'sum(J)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                sum(
-                                \bold
-                                    J
-                                )
-                            }
-                        }
 
         ..  container:: example
 
@@ -4798,38 +2811,10 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence([-1, 2, -3, 4, -5, 6, -7, 8, -9, 10])
+                >>> sequence = abjad.Sequence([-1, 2, -3, 4, -5, 6, -7, 8, -9, 10])
 
                 >>> sequence.sum()
                 5
-
-            ..  container:: example expression
-
-                >>> expression = abjad.sequence(name='J')
-                >>> expression = expression.sum()
-
-                >>> expression([-1, 2, -3, 4, -5, 6, -7, 8, -9, 10])
-                5
-
-                >>> expression.get_string()
-                'sum(J)'
-
-                >>> markup = expression.get_markup()
-                >>> abjad.show(markup) # doctest: +SKIP
-
-                ..  docs::
-
-                    >>> string = abjad.lilypond(markup)
-                    >>> print(string)
-                    \markup {
-                        \concat
-                            {
-                                sum(
-                                \bold
-                                    J
-                                )
-                            }
-                        }
 
         ..  container:: example
 
@@ -4837,16 +2822,14 @@ class Sequence(collections.abc.Sequence):
 
             ..  container:: example
 
-                >>> sequence = abjad.sequence(range(1, 10+1))
+                >>> sequence = abjad.Sequence(range(1, 10+1))
                 >>> result = sequence.sum()
-                >>> sequence = abjad.sequence(result)
+                >>> sequence = abjad.Sequence(result)
 
                 >>> sequence
                 Sequence([55])
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         if len(self) == 0:
             return 0
         result = self[0]
@@ -4859,7 +2842,7 @@ class Sequence(collections.abc.Sequence):
         Sums consecutive sequence items by ``sign``.
 
         >>> items = [0, 0, -1, -1, 2, 3, -5, 1, 2, 5, -5, -6]
-        >>> sequence = abjad.sequence(items)
+        >>> sequence = abjad.Sequence(items)
 
         ..  container:: example
 
@@ -4921,7 +2904,7 @@ class Sequence(collections.abc.Sequence):
         """
         Truncates sequence.
 
-        >>> sequence = abjad.sequence([-1, 2, -3, 4, -5, 6, -7, 8, -9, 10])
+        >>> sequence = abjad.Sequence([-1, 2, -3, 4, -5, 6, -7, 8, -9, 10])
 
         ..  container:: example
 
@@ -5014,33 +2997,31 @@ class Sequence(collections.abc.Sequence):
 
         ..  container:: example
 
-            >>> abjad.sequence([]).weight()
+            >>> abjad.Sequence([]).weight()
             0
 
-            >>> abjad.sequence([1]).weight()
+            >>> abjad.Sequence([1]).weight()
             1
 
-            >>> abjad.sequence([1, 2, 3]).weight()
+            >>> abjad.Sequence([1, 2, 3]).weight()
             6
 
-            >>> abjad.sequence([1, 2, -3]).weight()
+            >>> abjad.Sequence([1, 2, -3]).weight()
             6
 
-            >>> abjad.sequence([-1, -2, -3]).weight()
+            >>> abjad.Sequence([-1, -2, -3]).weight()
             6
 
-            >>> sequence = abjad.sequence([-1, 2, -3, 4, -5, 6, -7, 8, -9, 10])
+            >>> sequence = abjad.Sequence([-1, 2, -3, 4, -5, 6, -7, 8, -9, 10])
             >>> sequence.weight()
             55
 
         ..  container:: example
 
-            >>> abjad.sequence([[1, -7, -7], [1, -8 -8]]).weight()
+            >>> abjad.Sequence([[1, -7, -7], [1, -8 -8]]).weight()
             32
 
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         weights = []
         for item in self:
             if hasattr(item, "weight"):
@@ -5052,24 +3033,6 @@ class Sequence(collections.abc.Sequence):
                 weights.append(abs(item))
         return sum(weights)
 
-    @Signature()
-    def zebra(self, n, _map_index=None) -> "Sequence":
-        """
-        Test function for mapped index.
-        """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
-        if _map_index is None:
-            addendum = n
-        else:
-            assert isinstance(_map_index, int), repr(_map_index)
-            addendum = n + _map_index
-        items = []
-        for item in self:
-            item = item + addendum
-            items.append(item)
-        return type(self)(items)
-
     def zip(self, cyclic=False, truncate=True) -> "Sequence":
         """
         Zips sequences in sequence.
@@ -5078,7 +3041,7 @@ class Sequence(collections.abc.Sequence):
 
             Zips cyclically:
 
-            >>> sequence = abjad.sequence([[1, 2, 3], ['a', 'b']])
+            >>> sequence = abjad.Sequence([[1, 2, 3], ['a', 'b']])
             >>> for item in sequence.zip(cyclic=True):
             ...     item
             ...
@@ -5087,7 +3050,7 @@ class Sequence(collections.abc.Sequence):
             Sequence([3, 'a'])
 
             >>> items = [[10, 11, 12], [20, 21], [30, 31, 32, 33]]
-            >>> sequence = abjad.sequence(items)
+            >>> sequence = abjad.Sequence(items)
             >>> for item in sequence.zip(cyclic=True):
             ...     item
             ...
@@ -5101,7 +3064,7 @@ class Sequence(collections.abc.Sequence):
             Zips without truncation:
 
             >>> items = [[1, 2, 3, 4], [11, 12, 13], [21, 22, 23]]
-            >>> sequence = abjad.sequence(items)
+            >>> sequence = abjad.Sequence(items)
             >>> for item in sequence.zip(truncate=False):
             ...     item
             ...
@@ -5115,7 +3078,7 @@ class Sequence(collections.abc.Sequence):
             Zips strictly:
 
             >>> items = [[1, 2, 3, 4], [11, 12, 13], [21, 22, 23]]
-            >>> for item in abjad.sequence(items).zip():
+            >>> for item in abjad.Sequence(items).zip():
             ...     item
             ...
             Sequence([1, 11, 21])
@@ -5156,73 +3119,3 @@ class Sequence(collections.abc.Sequence):
                 item = type(self)(items=item)
                 items.append(item)
         return type(self)(items=items)
-
-
-### FUNCTIONS ###
-
-
-def sequence(items=None, **keywords):
-    r"""
-    Makes sequence or sequence expression.
-
-    ..  container:: example
-
-        ..  container:: example
-
-            Makes sequence:
-
-            >>> abjad.sequence([1, 2, [3, [4]], 5])
-            Sequence([1, 2, [3, [4]], 5])
-
-        ..  container:: example expression
-
-            Makes sequence expression:
-
-            >>> expression = abjad.sequence()
-            >>> expression([1, 2, [3, [4]], 5])
-            Sequence([1, 2, [3, [4]], 5])
-
-    ..  container:: example
-
-        Flattens, reverses and slices sequence:
-
-        ..  container:: example
-
-            >>> sequence_ = abjad.sequence([1, 2, [3, [4]], 5])
-            >>> sequence_
-            Sequence([1, 2, [3, [4]], 5])
-
-            >>> sequence_ = sequence_.flatten(depth=-1)
-            >>> sequence_
-            Sequence([1, 2, 3, 4, 5])
-
-            >>> sequence_ = sequence_.reverse()
-            >>> sequence_
-            Sequence([5, 4, 3, 2, 1])
-
-            >>> sequence_ = sequence_[-3:]
-            >>> sequence_
-            Sequence([3, 2, 1])
-
-        ..  container:: example expression
-
-            >>> expression = abjad.sequence()
-            >>> expression = expression.flatten(depth=-1)
-            >>> expression = expression.reverse()
-            >>> expression = expression[-3:]
-            >>> expression([1, 2, [3, [4]], 5])
-            Sequence([3, 2, 1])
-
-    Returns sequence when ``items`` is not none.
-
-    Returns sequence expression when ``items`` is none.
-    """
-    if items is not None:
-        return Sequence(items=items, **keywords)
-    name = keywords.pop("name", None)
-    expression = Expression(name=name, proxy_class=Sequence)
-    callback = Expression._make_initializer_callback(
-        Sequence, string_template="{}", **keywords
-    )
-    expression = expression.append_callback(callback)
-    return expression

--- a/abjad/timespan.py
+++ b/abjad/timespan.py
@@ -3,12 +3,10 @@ Tools for modeling and manipulating timespans.
 """
 import collections
 import copy
-import inspect
 import typing
 
 from . import enums, math
 from .duration import Duration, Multiplier, Offset
-from .expression import Expression, Signature
 from .markups import Markup, Postscript
 from .new import new
 from .ratio import Ratio
@@ -277,7 +275,7 @@ class Timespan:
 
             Works with offsets:
 
-            >>> timespan = abjad.timespan(0, (1, 4))
+            >>> timespan = abjad.Timespan(0, (1, 4))
 
             >>> -1 in timespan
             False
@@ -298,15 +296,15 @@ class Timespan:
 
             Works with other timespans:
 
-            >>> timespan = abjad.timespan(0, (1, 4))
+            >>> timespan = abjad.Timespan(0, (1, 4))
 
-            >>> abjad.timespan(0, (1, 4)) in timespan
+            >>> abjad.Timespan(0, (1, 4)) in timespan
             True
 
-            >>> abjad.timespan((1, 16), (2, 16)) in timespan
+            >>> abjad.Timespan((1, 16), (2, 16)) in timespan
             True
 
-            >>> abjad.timespan(0, (1, 2)) in timespan
+            >>> abjad.Timespan(0, (1, 2)) in timespan
             False
 
         """
@@ -955,14 +953,6 @@ class Timespan:
             return offset
         return Offset(offset)
 
-    def _update_expression(self, frame, evaluation_template=None, map_operand=None):
-        callback = Expression._frame_to_callback(
-            frame,
-            evaluation_template=evaluation_template,
-            map_operand=map_operand,
-        )
-        return self._expression.append_callback(callback)
-
     ### PUBLIC PROPERTIES ###
 
     @property
@@ -1045,7 +1035,6 @@ class Timespan:
 
     ### PUBLIC METHODS ###
 
-    @Signature()
     def contains_timespan_improperly(self, timespan) -> bool:
         """
         Is true when timespan contains ``timespan`` improperly.
@@ -1064,22 +1053,7 @@ class Timespan:
             >>> timespan_2.contains_timespan_improperly(timespan_2)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 5)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.contains_timespan_improperly(timespan)
-
-            >>> expression(-5, 5)
-            True
-            >>> expression(0, 5)
-            True
-            >>> expression(5, 10)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -1087,7 +1061,6 @@ class Timespan:
             and expr_stop_offset <= self_stop_offset
         )
 
-    @Signature()
     def curtails_timespan(self, timespan) -> bool:
         """
         Is true when timespan curtails ``timespan``.
@@ -1106,21 +1079,7 @@ class Timespan:
             >>> timespan_2.curtails_timespan(timespan_2)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan().curtails_timespan(timespan)
-
-            >>> expression(0, 10)
-            False
-            >>> expression(5, 10)
-            True
-            >>> expression(15, 25)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -1129,7 +1088,6 @@ class Timespan:
             and expr_stop_offset <= self_stop_offset
         )
 
-    @Signature()
     def delays_timespan(self, timespan) -> bool:
         """
         Is true when timespan delays ``timespan``.
@@ -1145,21 +1103,7 @@ class Timespan:
             >>> timespan_2.delays_timespan(timespan_3)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(5, 15)
-            >>> expression = abjad.timespan().delays_timespan(timespan)
-
-            >>> expression(0, 10)
-            True
-            >>> expression(5, 15)
-            True
-            >>> expression(10, 20)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -1242,7 +1186,6 @@ class Timespan:
             return result
         return None
 
-    @Signature()
     def happens_during_timespan(self, timespan) -> bool:
         """
         Is true when timespan happens during ``timespan``.
@@ -1261,21 +1204,7 @@ class Timespan:
             >>> timespan_2.happens_during_timespan(timespan_2)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan().happens_during_timespan(timespan)
-
-            >>> expression(0, 10)
-            True
-            >>> expression(5, 10)
-            True
-            >>> expression(5, 15)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -1283,7 +1212,6 @@ class Timespan:
             and self_stop_offset <= expr_stop_offset
         )
 
-    @Signature()
     def intersects_timespan(self, timespan) -> bool:
         """
         Is true when timespan intersects ``timespan``.
@@ -1301,21 +1229,7 @@ class Timespan:
             >>> timespan_1.intersects_timespan(timespan_3)
             False
 
-        ..  container:: example
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan().intersects_timespan(timespan)
-
-            >>> expression(0, 10)
-            True
-            >>> expression(5, 15)
-            True
-            >>> expression(10, 15)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -1326,7 +1240,6 @@ class Timespan:
             and expr_start_offset < self_stop_offset
         )
 
-    @Signature()
     def is_congruent_to_timespan(self, timespan) -> bool:
         """
         Is true when timespan is congruent to ``timespan``.
@@ -1345,19 +1258,7 @@ class Timespan:
             >>> timespan_2.is_congruent_to_timespan(timespan_2)
             True
 
-        ..  container:: example
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan().is_congruent_to_timespan(timespan)
-
-            >>> expression(0, 10)
-            True
-            >>> expression(5, 15)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -1391,7 +1292,6 @@ class Timespan:
             or expr_stop_offset == self_start_offset
         )
 
-    @Signature()
     def overlaps_all_of_timespan(self, timespan) -> bool:
         """
         Is true when timespan overlaps all of ``timespan``.
@@ -1409,22 +1309,7 @@ class Timespan:
             >>> timespan_1.overlaps_all_of_timespan(timespan_3)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(5, 6)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.overlaps_all_of_timespan(timespan)
-
-            >>> expression(0, 10)
-            True
-            >>> expression(5, 6)
-            False
-            >>> expression(5, 10)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -1432,7 +1317,6 @@ class Timespan:
             and expr_stop_offset < self_stop_offset
         )
 
-    @Signature()
     def overlaps_only_start_of_timespan(self, timespan) -> bool:
         """
         Is true when timespan overlaps only start of ``timespan``.
@@ -1453,24 +1337,7 @@ class Timespan:
             >>> timespan_1.overlaps_only_start_of_timespan(timespan_4)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.overlaps_only_start_of_timespan(timespan)
-
-            >>> expression(0, 10)
-            False
-            >>> expression(-5, 5)
-            True
-            >>> expression(4, 6)
-            False
-            >>> expression(5, 15)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -1479,7 +1346,6 @@ class Timespan:
             and self_stop_offset <= expr_stop_offset
         )
 
-    @Signature()
     def overlaps_only_stop_of_timespan(self, timespan) -> bool:
         """
         Is true when timespan overlaps only stop of ``timespan``.
@@ -1500,24 +1366,7 @@ class Timespan:
             >>> timespan_1.overlaps_only_stop_of_timespan(timespan_4)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.overlaps_only_stop_of_timespan(timespan)
-
-            >>> expression(0, 10)
-            False
-            >>> expression(-5, 5)
-            False
-            >>> expression(4, 6)
-            False
-            >>> expression(5, 15)
-            True
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -1526,7 +1375,6 @@ class Timespan:
             and expr_stop_offset < self_stop_offset
         )
 
-    @Signature()
     def overlaps_start_of_timespan(self, timespan) -> bool:
         """
         Is true when timespan overlaps start of ``timespan``.
@@ -1547,24 +1395,7 @@ class Timespan:
             >>> timespan_1.overlaps_start_of_timespan(timespan_4)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.overlaps_start_of_timespan(timespan)
-
-            >>> expression(0, 10)
-            False
-            >>> expression(-5, 5)
-            True
-            >>> expression(4, 6)
-            False
-            >>> expression(5, 15)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -1572,7 +1403,6 @@ class Timespan:
             and expr_start_offset < self_stop_offset
         )
 
-    @Signature()
     def overlaps_stop_of_timespan(self, timespan) -> bool:
         """
         Is true when timespan overlaps start of ``timespan``.
@@ -1593,24 +1423,7 @@ class Timespan:
             >>> timespan_1.overlaps_stop_of_timespan(timespan_4)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.overlaps_stop_of_timespan(timespan)
-
-            >>> expression(0, 10)
-            False
-            >>> expression(-5, 5)
-            False
-            >>> expression(4, 6)
-            False
-            >>> expression(5, 15)
-            True
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -1895,7 +1708,6 @@ class Timespan:
         offset = Offset(offset)
         return offset < self._start_offset
 
-    @Signature()
     def starts_after_timespan_starts(self, timespan) -> bool:
         """
         Is true when timespan starts after ``timespan`` starts.
@@ -1914,25 +1726,11 @@ class Timespan:
             >>> timespan_2.starts_after_timespan_starts(timespan_2)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.starts_after_timespan_starts(timespan)
-
-            >>> expression(0, 10)
-            False
-            >>> expression(5, 15)
-            True
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return expr_start_offset < self_start_offset
 
-    @Signature()
     def starts_after_timespan_stops(self, timespan) -> bool:
         """
         Is true when timespan starts after ``timespan`` stops.
@@ -1953,25 +1751,7 @@ class Timespan:
             >>> timespan_4.starts_after_timespan_stops(timespan_1)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.starts_after_timespan_stops(timespan)
-
-            >>> expression(0, 10)
-            False
-            >>> expression(5, 15)
-            False
-
-        ..  todo:: Is this wrong?
-
-            >>> expression(10, 20)
-            True
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return expr_stop_offset <= self_start_offset
@@ -2052,7 +1832,6 @@ class Timespan:
         offset = Offset(offset)
         return self._start_offset <= offset
 
-    @Signature()
     def starts_before_timespan_starts(self, timespan) -> bool:
         """
         Is true when timespan starts before ``timespan`` starts.
@@ -2071,27 +1850,11 @@ class Timespan:
             >>> timespan_2.starts_before_timespan_starts(timespan_2)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.starts_before_timespan_starts(timespan)
-
-            >>> expression(-5, 10)
-            True
-            >>> expression(0, 10)
-            False
-            >>> expression(5, 15)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return self_start_offset < expr_start_offset
 
-    @Signature()
     def starts_before_timespan_stops(self, timespan) -> bool:
         """
         Is true when timespan starts before ``timespan`` stops.
@@ -2110,29 +1873,11 @@ class Timespan:
             >>> timespan_2.starts_before_timespan_stops(timespan_2)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.starts_before_timespan_stops(timespan)
-
-            >>> expression(-5, 10)
-            True
-            >>> expression(0, 10)
-            True
-            >>> expression(5, 15)
-            True
-            >>> expression(10, 20)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return self_start_offset < expr_stop_offset
 
-    @Signature()
     def starts_during_timespan(self, timespan) -> bool:
         """
         Is true when timespan starts during ``timespan``.
@@ -2151,24 +1896,7 @@ class Timespan:
             >>> timespan_2.starts_during_timespan(timespan_2)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.starts_during_timespan(timespan)
-
-            >>> expression(-5, 10)
-            False
-            >>> expression(0, 10)
-            True
-            >>> expression(5, 15)
-            True
-            >>> expression(10, 20)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -2176,7 +1904,6 @@ class Timespan:
             and self_start_offset < expr_stop_offset
         )
 
-    @Signature()
     def starts_when_timespan_starts(self, timespan) -> bool:
         """
         Is true when timespan starts when ``timespan`` starts.
@@ -2195,29 +1922,11 @@ class Timespan:
             >>> timespan_2.starts_when_timespan_starts(timespan_2)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.starts_when_timespan_starts(timespan)
-
-            >>> expression(-5, 10)
-            False
-            >>> expression(0, 10)
-            True
-            >>> expression(5, 15)
-            False
-            >>> expression(10, 20)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return expr_start_offset == self_start_offset
 
-    @Signature()
     def starts_when_timespan_stops(self, timespan) -> bool:
         """
         Is true when timespan starts when ``timespan`` stops.
@@ -2236,24 +1945,7 @@ class Timespan:
             >>> timespan_2.starts_when_timespan_stops(timespan_2)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.starts_when_timespan_stops(timespan)
-
-            >>> expression(-5, 10)
-            False
-            >>> expression(0, 10)
-            False
-            >>> expression(5, 15)
-            False
-            >>> expression(10, 20)
-            True
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return self_start_offset == expr_stop_offset
@@ -2277,7 +1969,6 @@ class Timespan:
         offset = Offset(offset)
         return offset < self._stop_offset
 
-    @Signature()
     def stops_after_timespan_starts(self, timespan) -> bool:
         """
         Is true when timespan stops when ``timespan`` starts.
@@ -2296,31 +1987,11 @@ class Timespan:
             >>> timespan_2.stops_after_timespan_starts(timespan_2)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.stops_after_timespan_starts(timespan)
-
-            >>> expression(-10, 0)
-            False
-            >>> expression(-5, 5)
-            True
-            >>> expression(0, 10)
-            True
-            >>> expression(5, 15)
-            True
-            >>> expression(10, 20)
-            True
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return expr_start_offset < self_stop_offset
 
-    @Signature()
     def stops_after_timespan_stops(self, timespan) -> bool:
         """
         Is true when timespan stops when ``timespan`` stops.
@@ -2339,26 +2010,7 @@ class Timespan:
             >>> timespan_2.stops_after_timespan_stops(timespan_2)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.stops_after_timespan_stops(timespan)
-
-            >>> expression(-10, 0)
-            False
-            >>> expression(-5, 5)
-            False
-            >>> expression(0, 10)
-            False
-            >>> expression(5, 15)
-            True
-            >>> expression(10, 20)
-            True
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return expr_stop_offset < self_stop_offset
@@ -2439,7 +2091,6 @@ class Timespan:
         offset = Offset(offset)
         return self._stop_offset <= offset
 
-    @Signature()
     def stops_before_timespan_starts(self, timespan) -> bool:
         """
         Is true when timespan stops before ``timespan`` starts.
@@ -2458,33 +2109,11 @@ class Timespan:
             >>> timespan_2.stops_before_timespan_starts(timespan_2)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.stops_before_timespan_starts(timespan)
-
-            >>> expression(-15, -5)
-            True
-            >>> expression(-10, 0)
-            False
-            >>> expression(-5, 5)
-            False
-            >>> expression(0, 10)
-            False
-            >>> expression(5, 15)
-            False
-            >>> expression(10, 20)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return self_stop_offset < expr_start_offset
 
-    @Signature()
     def stops_before_timespan_stops(self, timespan) -> bool:
         """
         Is true when timespan stops before ``timespan`` stops.
@@ -2503,33 +2132,11 @@ class Timespan:
             >>> timespan_2.stops_before_timespan_stops(timespan_2)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.stops_before_timespan_stops(timespan)
-
-            >>> expression(-15, -5)
-            True
-            >>> expression(-10, 0)
-            True
-            >>> expression(-5, 5)
-            True
-            >>> expression(0, 10)
-            False
-            >>> expression(5, 15)
-            False
-            >>> expression(10, 20)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return self_stop_offset < expr_stop_offset
 
-    @Signature()
     def stops_during_timespan(self, timespan) -> bool:
         """
         Is true when timespan stops during ``timespan``.
@@ -2548,32 +2155,7 @@ class Timespan:
             >>> timespan_2.stops_during_timespan(timespan_2)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.stops_during_timespan(timespan)
-
-            >>> expression(-15, -5)
-            False
-            >>> expression(-10, 0)
-            False
-            >>> expression(-5, 5)
-            True
-
-            TODO: is this one wrong:
-
-            >>> expression(0, 10)
-            True
-
-            >>> expression(5, 15)
-            False
-            >>> expression(10, 20)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -2581,7 +2163,6 @@ class Timespan:
             and self_stop_offset <= expr_stop_offset
         )
 
-    @Signature()
     def stops_when_timespan_starts(self, timespan) -> bool:
         """
         Is true when timespan stops when ``timespan`` starts.
@@ -2600,33 +2181,11 @@ class Timespan:
             >>> timespan_2.stops_when_timespan_starts(timespan_2)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.stops_when_timespan_starts(timespan)
-
-            >>> expression(-15, -5)
-            False
-            >>> expression(-10, 0)
-            True
-            >>> expression(-5, 5)
-            False
-            >>> expression(0, 10)
-            False
-            >>> expression(5, 15)
-            False
-            >>> expression(10, 20)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return self_stop_offset == expr_start_offset
 
-    @Signature()
     def stops_when_timespan_stops(self, timespan) -> bool:
         """
         Is true when timespan stops when ``timespan`` stops.
@@ -2645,28 +2204,7 @@ class Timespan:
             >>> timespan_2.stops_when_timespan_stops(timespan_2)
             True
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.stops_when_timespan_stops(timespan)
-
-            >>> expression(-15, -5)
-            False
-            >>> expression(-10, 0)
-            False
-            >>> expression(-5, 5)
-            False
-            >>> expression(0, 10)
-            True
-            >>> expression(5, 15)
-            False
-            >>> expression(10, 20)
-            False
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return self_stop_offset == expr_stop_offset
@@ -2765,7 +2303,6 @@ class Timespan:
         new_stop_offset = self._stop_offset + stop_offset_translation
         return new(self, start_offset=new_start_offset, stop_offset=new_stop_offset)
 
-    @Signature()
     def trisects_timespan(self, timespan) -> bool:
         """
         Is true when timespan trisects ``timespan``.
@@ -2784,31 +2321,7 @@ class Timespan:
             >>> timespan_2.trisects_timespan(timespan_2)
             False
 
-        ..  container:: example expression
-
-            >>> timespan = abjad.timespan(0, 10)
-            >>> expression = abjad.timespan()
-            >>> expression = expression.trisects_timespan(timespan)
-
-            >>> expression(-15, -5)
-            False
-            >>> expression(-10, 0)
-            False
-            >>> expression(-5, 5)
-            False
-            >>> expression(0, 10)
-            False
-            >>> expression(5, 15)
-            False
-            >>> expression(10, 20)
-            False
-
-            >>> expression(4, 6)
-            True
-
         """
-        if self._expression:
-            return self._update_expression(inspect.currentframe())
         self_start_offset, self_stop_offset = self.offsets
         expr_start_offset, expr_stop_offset = self._get_offsets(timespan)
         return (
@@ -4711,8 +4224,9 @@ class TimespanList(TypedList):
         """
         if timespan is None:
             timespan = self.timespan
-        expression = _timespan_constructor().intersects_timespan(timespan)
-        timespans = self.get_timespans_that_satisfy_time_relation(expression)
+        timespans = self.get_timespans_that_satisfy_time_relation(
+            lambda _: _.intersects_timespan(timespan)
+        )
         total_overlap = Duration(
             sum(x.get_overlap_with_timespan(timespan) for x in timespans)
         )
@@ -5133,11 +4647,10 @@ class TimespanList(TypedList):
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
             >>> timespan = abjad.Timespan(2, 5)
-            >>> time_relation = abjad.timespan()
-            >>> time_relation = time_relation.starts_during_timespan(timespan)
-
+            >>> time_relation = lambda _: _.starts_during_timespan(timespan)
             >>> timespan = timespans.get_timespan_that_satisfies_time_relation(
-            ...     time_relation)
+            ...     time_relation
+            ... )
             >>> abjad.show(timespan, range_=(0, 10), scale=0.5) # doctest: +SKIP
 
             >>> timespan
@@ -5176,8 +4689,7 @@ class TimespanList(TypedList):
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
             >>> timespan = abjad.Timespan(2, 8)
-            >>> time_relation = abjad.timespan()
-            >>> time_relation = time_relation.starts_during_timespan(timespan)
+            >>> time_relation = lambda _: _.starts_during_timespan(timespan)
             >>> result = timespans.get_timespans_that_satisfy_time_relation(
             ...     time_relation)
             >>> abjad.show(result, range_=(0, 10), scale=0.5) # doctest: +SKIP
@@ -5200,11 +4712,8 @@ class TimespanList(TypedList):
         """
         result = []
         for timespan in self:
-            if isinstance(time_relation, Expression):
-                if time_relation(*timespan.offsets):
-                    result.append(timespan)
-            else:
-                raise ValueError(f"unknown time relation: {time_relation!r}.")
+            if time_relation(timespan):
+                result.append(timespan)
         return type(self)(result)
 
     def has_timespan_that_satisfies_time_relation(self, time_relation) -> bool:
@@ -5223,8 +4732,7 @@ class TimespanList(TypedList):
             >>> abjad.show(timespans, scale=0.5) # doctest: +SKIP
 
             >>> timespan = abjad.Timespan(2, 8)
-            >>> time_relation = abjad.timespan()
-            >>> time_relation = time_relation.starts_during_timespan(timespan)
+            >>> time_relation = lambda _: _.starts_during_timespan(timespan)
             >>> timespans.has_timespan_that_satisfies_time_relation(
             ...     time_relation)
             True
@@ -5234,8 +4742,7 @@ class TimespanList(TypedList):
             Is false when list does not have matching timespan:
 
             >>> timespan = abjad.Timespan(10, 20)
-            >>> time_relation = abjad.timespan()
-            >>> time_relation = time_relation.starts_during_timespan(timespan)
+            >>> time_relation = lambda _: _.starts_during_timespan(timespan)
 
             >>> timespans.has_timespan_that_satisfies_time_relation(
             ...     time_relation)
@@ -6355,36 +5862,3 @@ class TimespanList(TypedList):
             timespans.append(timespan)
         self[:] = timespans
         return self
-
-
-### EXPRESSION CONSTRUCTOR ###
-
-
-def timespan(start_offset=None, stop_offset=None, **keywords):
-    """
-    Makes timespan or timespan expression.
-
-    ..  container:: example
-
-        >>> abjad.timespan(0, (1, 4))
-        Timespan(Offset((0, 1)), Offset((1, 4)))
-
-    ..  container:: example expression
-
-        >>> expression = abjad.timespan()
-        >>> expression(0, (1, 4))
-        Timespan(Offset((0, 1)), Offset((1, 4)))
-
-    """
-    if start_offset is not None or stop_offset is not None:
-        return Timespan(start_offset=start_offset, stop_offset=stop_offset)
-    name = keywords.pop("name", None)
-    expression = Expression(name=name, proxy_class=Timespan)
-    callback = Expression._make_initializer_callback(
-        Timespan, string_template="{}", **keywords
-    )
-    expression = expression.append_callback(callback)
-    return expression
-
-
-_timespan_constructor = timespan

--- a/docs/source/_mothballed/score-fragment-strings.rst
+++ b/docs/source/_mothballed/score-fragment-strings.rst
@@ -164,7 +164,7 @@ Let's see what a few of these look like. Here are the first ten violin 1 descent
     ...     abjad.attach(markup, descent[0])
     ...
 
-    >>> leaves = abjad.sequence(descents).flatten()
+    >>> leaves = abjad.Sequence(descents).flatten()
     >>> staff = abjad.Staff(leaves)
     >>> time_signature = abjad.TimeSignature((6, 4))
     >>> leaf = abjad.select(staff).leaf(0)
@@ -182,7 +182,7 @@ Here are the first ten violin 2 descents:
     ...     abjad.attach(markup, descent[0])
     ...
 
-    >>> leaves = abjad.sequence(descents).flatten()
+    >>> leaves = abjad.Sequence(descents).flatten()
     >>> staff = abjad.Staff(leaves)
     >>> time_signature = abjad.TimeSignature((6, 4))
     >>> leaf = abjad.select(staff).leaf(0)
@@ -204,7 +204,7 @@ too:
     ...     abjad.attach(markup, descent[0])
     ...
 
-    >>> notes = abjad.sequence(descents).flatten()
+    >>> notes = abjad.Sequence(descents).flatten()
     >>> staff = abjad.Staff(notes)
     >>> selections = abjad.mutate.split(staff[:], [(3, 2)], cyclic=True)
     >>> time_signature = abjad.TimeSignature((6, 4))

--- a/docs/source/_pending/scale-derivation-by-sieve.rst
+++ b/docs/source/_pending/scale-derivation-by-sieve.rst
@@ -12,7 +12,7 @@ First we define a function to illustrate the examples that follow:
 ::
 
     >>> def illustrate_scale(pattern, length, transposition):
-    ...     pitches = abjad.sequence(range(length))
+    ...     pitches = abjad.Sequence(range(length))
     ...     pitches = pitches.retain_pattern(pattern)
     ...     notes = [abjad.Note(_ + transposition, (1, 16)) for _ in pitches]
     ...     containers = abjad.illustrators.make_piano_score(notes)

--- a/etc/performance.txt
+++ b/etc/performance.txt
@@ -31,7 +31,7 @@ def make_score_with_indicators_01(self):
 
     """
     staff = abjad.Staff(200 * abjad.Note("c'16"))
-    for part in abjad.sequence(staff[:]).partition_by_counts([20], cyclic=True):
+    for part in abjad.Sequence(staff[:]).partition_by_counts([20], cyclic=True):
         dynamic = abjad.Dynamic("f")
         abjad.attach(dynamic, part[0])
     return staff
@@ -51,7 +51,7 @@ def make_score_with_indicators_02(self):
 
     """
     staff = abjad.Staff(200 * abjad.Note("c'16"))
-    for part in abjad.sequence(staff[:]).partition_by_counts([4], cyclic=True):
+    for part in abjad.Sequence(staff[:]).partition_by_counts([4], cyclic=True):
         dynamic = abjad.Dynamic("f")
         abjad.attach(dynamic, part[0])
     return staff

--- a/tests/test_abjad___slots__.py
+++ b/tests/test_abjad___slots__.py
@@ -5,7 +5,6 @@ import pytest
 import abjad
 
 ignored_classes = (
-    abjad.Expression,
     abjad.FormatSpecification,
     abjad.MetricModulation,
     abjad.StorageFormatManager,


### PR DESCRIPTION
Removed abjad.pitch_class_segment() constructor.

Use abjad.PitchClassSegment instead.

Cleaned up abjad.PitchClassSegment doctests.

Removed expression infrastructure from timespans.

Removed label expressions. Just use labels instead.

CHANGE: removed abjad.sequence(); use abjad.Sequence() instead.

Removed abjad.Signature.

Removed abjad.pitch_set(). Use abjad.PitchSet instead.

Removed expression from abjad.Pattern.

Gutted abjad.Expression.

Removed a comment.

Removed abjad.Expression.__add__().