### PR TITLE
moved a doctest to docs from container

### DIFF
--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -1689,62 +1689,64 @@ def split(argument, durations, cyclic=False):
         ...     )
         >>> abjad.show(staff) # doctest: +SKIP
 
-        >>> string = abjad.lilypond(staff)
-        >>> print(string)
-        \new Staff
-        {
-            <<
-                \context Voice = "Voice_1"
-                \with
-                {
-                    \override Slur.direction = #up
-                    \override Stem.direction = #up
-                }
-                {
-                    e''4
-                    (
-                    es''8
-                    ~
-                }
-                \context Voice = "Voice_2"
-                \with
-                {
-                    \override Stem.direction = #down
-                }
-                {
-                    c'4
-                    \p
-                    \<
-                    cs'8
-                    ~
-                }
-            >>
-            <<
-                \context Voice = "Voice_1"
-                \with
-                {
-                    \override Slur.direction = #up
-                    \override Stem.direction = #up
-                }
-                {
-                    es''8
-                    f''4
-                    fs''4
-                    )
-                }
-                \context Voice = "Voice_2"
-                \with
-                {
-                    \override Stem.direction = #down
-                }
-                {
-                    cs'8
-                    d'4
-                    ds'4
-                    \f
-                }
-            >>
-        }
+        ..  docs::
+
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
+            \new Staff
+            {
+                <<
+                    \context Voice = "Voice_1"
+                    \with
+                    {
+                        \override Slur.direction = #up
+                        \override Stem.direction = #up
+                    }
+                    {
+                        e''4
+                        (
+                        es''8
+                        ~
+                    }
+                    \context Voice = "Voice_2"
+                    \with
+                    {
+                        \override Stem.direction = #down
+                    }
+                    {
+                        c'4
+                        \p
+                        \<
+                        cs'8
+                        ~
+                    }
+                >>
+                <<
+                    \context Voice = "Voice_1"
+                    \with
+                    {
+                        \override Slur.direction = #up
+                        \override Stem.direction = #up
+                    }
+                    {
+                        es''8
+                        f''4
+                        fs''4
+                        )
+                    }
+                    \context Voice = "Voice_2"
+                    \with
+                    {
+                        \override Stem.direction = #down
+                    }
+                    {
+                        cs'8
+                        d'4
+                        ds'4
+                        \f
+                    }
+                >>
+            }
 
     ..  container:: example
 


### PR DESCRIPTION
Moving a doctest in `abjad.mutate.split` from `..  container::` to `..  docs::`.