### PR TITLE
BREAKING CHANGE: abjad.Markup now initializes from only a string.

### DIFF
--- a/abjad/__init__.py
+++ b/abjad/__init__.py
@@ -184,7 +184,7 @@ from .lyproxy import (
     LilyPondGrobInterface,
 )
 from .makers import LeafMaker, NoteMaker
-from .markups import Markup, Postscript, PostscriptOperator
+from .markups import Markup
 from .math import Infinity, NegativeInfinity
 from .meter import Meter, MeterList, MetricAccentKernel, OffsetCounter
 from .metricmodulation import MetricModulation
@@ -529,8 +529,6 @@ __all__ = [
     "PitchSet",
     "PitchTyping",
     "PitchVector",
-    "Postscript",
-    "PostscriptOperator",
     "ProgressIndicator",
     "Prototype",
     "Ratio",

--- a/abjad/bind.py
+++ b/abjad/bind.py
@@ -341,8 +341,7 @@ class Wrapper:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -1082,13 +1081,9 @@ def detach(argument, target=None, by_id=False):
 
         Consider the three document-specifier markups below:
 
-        >>> markup_1 = abjad.Markup(r'\markup tutti', direction=abjad.Up, literal=True)
-        >>> markup_2 = abjad.Markup(
-        ...     r'\markup { with the others }', direction=abjad.Up, literal=True,
-        ... )
-        >>> markup_3 = abjad.Markup(
-        ...     r'\markup { with the others }', direction=abjad.Up, literal=True,
-        ... )
+        >>> markup_1 = abjad.Markup(r'\markup tutti', direction=abjad.Up)
+        >>> markup_2 = abjad.Markup(r'\markup { with the others }', direction=abjad.Up)
+        >>> markup_3 = abjad.Markup(r'\markup { with the others }', direction=abjad.Up)
 
         Markups two and three compare equal:
 
@@ -1136,8 +1131,11 @@ def detach(argument, target=None, by_id=False):
         Passing in one of the markup objects directory doesn't work. This is
         because detach tests for equality to input argument:
 
-        >>> abjad.detach(markup_2, staff[0])
-        (Markup(contents=['\\markup { with the others }'], direction=Up, literal=True), Markup(contents=['\\markup { with the others }'], direction=Up, literal=True))
+        >>> markups = abjad.detach(markup_2, staff[0])
+        >>> for markup in markups:
+        ...     markup
+        Markup('\\markup { with the others }', direction=Up)
+        Markup('\\markup { with the others }', direction=Up)
 
         >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1187,12 +1185,13 @@ def detach(argument, target=None, by_id=False):
             f'4
         }
 
-        This time we set ``by_id`` to true. Now detach checks the exact id of
-        its input argument (rather than just testing for equality). This gives
-        us what we want:
+        This time we set ``by_id`` to true. Now detach checks the exact id of its input
+        argument (rather than just testing for equality). This gives us what we want:
 
-        >>> abjad.detach(markup_2, staff[0], by_id=True)
-        (Markup(contents=['\\markup { with the others }'], direction=Up, literal=True),)
+        >>> markups = abjad.detach(markup_2, staff[0], by_id=True)
+        >>> for markup in markups:
+        ...     markup
+        Markup('\\markup { with the others }', direction=Up)
 
         >>> abjad.show(staff) # doctest: +SKIP
 

--- a/abjad/deprecated.py
+++ b/abjad/deprecated.py
@@ -80,7 +80,7 @@ def add_final_markup(score, markup, extra_offset=None) -> None:
         >>> place = "Bremen - Boston - LA."
         >>> date = "July 2010 - May 2011."
         >>> string = rf'\markup \italic \right-column {{ "{place}" "{date}" }}'
-        >>> markup = abjad.Markup(string, direction=abjad.Down, literal=True)
+        >>> markup = abjad.Markup(string, direction=abjad.Down)
         >>> markup = abjad.deprecated.add_final_markup(
         ...     score,
         ...     markup,
@@ -115,7 +115,7 @@ def add_final_markup(score, markup, extra_offset=None) -> None:
         >>> place = "Bremen - Boston - LA."
         >>> date = "July 2010 - May 2011."
         >>> string = rf'\markup \italic \right-column {{ "{place}" "{date}" }}'
-        >>> markup = abjad.Markup(string, direction=abjad.Down, literal=True)
+        >>> markup = abjad.Markup(string, direction=abjad.Down)
         >>> markup = abjad.deprecated.add_final_markup(
         ...     score,
         ...     markup,

--- a/abjad/duration.py
+++ b/abjad/duration.py
@@ -1116,7 +1116,7 @@ class Duration(quicktions.Fraction):
             "1'57''"
 
             >>> string = rf"\markup {{ {clock_string} }}"
-            >>> markup = abjad.Markup(string, direction=abjad.Up, literal=True)
+            >>> markup = abjad.Markup(string, direction=abjad.Up)
             >>> abjad.attach(markup, note)
             >>> abjad.show(note) # doctest: +SKIP
 

--- a/abjad/get.py
+++ b/abjad/get.py
@@ -214,8 +214,7 @@ def annotation_wrappers(argument):
                 name='cello',
                 short_name='vc.',
                 markup=abjad.Markup(
-                    contents=['\\markup Cello'],
-                    literal=True,
+                    '\\markup Cello'
                     ),
                 allowable_clefs=('bass', 'tenor', 'treble'),
                 context='Staff',
@@ -1407,9 +1406,9 @@ def effective(
         ...     bar_line = abjad.get.effective(leaf, abjad.BarLine)
         ...     leaf, bar_line
         (Note("c'2"), None)
-        (Note("d'2"), BarLine('||', format_slot='after'))
-        (Note("e'2"), BarLine('||', format_slot='after'))
-        (Note("f'2"), BarLine('||', format_slot='after'))
+        (Note("d'2"), BarLine(abbreviation='||', format_slot='after'))
+        (Note("e'2"), BarLine(abbreviation='||', format_slot='after'))
+        (Note("f'2"), BarLine(abbreviation='||', format_slot='after'))
 
     """
     if not isinstance(argument, Component):

--- a/abjad/illustrators.py
+++ b/abjad/illustrators.py
@@ -43,15 +43,6 @@ def _illustrate_markup_maker(argument, **keywords):
     return _illustrate_markup(markup)
 
 
-def _illustrate_postscript(postscript):
-    if isinstance(postscript, _markups.Postscript):
-        postscript = str(postscript)
-    assert isinstance(postscript, str)
-    string = "\n".join([r"\markup", r"\postscript", '#"', postscript, '"'])
-    markup = _markups.Markup(string, literal=True)
-    return _illustrate_markup(markup)
-
-
 def _illustrate_metric_modulation(metric_modulation):
     lilypond_file = LilyPondFile()
     markup = metric_modulation._get_markup()
@@ -161,7 +152,7 @@ def _illustrate_pitch_class_segment(
         notes.append(note)
     markup = None
     if isinstance(figure_name, str):
-        figure_name = _markups.Markup(rf"\markup {figure_name}", literal=True)
+        figure_name = _markups.Markup(rf"\markup {figure_name}")
     if figure_name is not None:
         markup = figure_name
     if markup is not None:
@@ -211,7 +202,6 @@ _class_to_method = dict(
         (_markups.Markup, _illustrate_markup),
         (MetricModulation, _illustrate_metric_modulation),
         (_timespan.OffsetCounter, _illustrate_markup_maker),
-        (_markups.Postscript, _illustrate_postscript),
         (PitchRange, _illustrate_pitch_range),
         (PitchClassSet, _illustrate_pitch_class_set),
         (PitchSegment, _illustrate_pitch_segment),
@@ -233,14 +223,14 @@ def attach_markup_struts(lilypond_file):
     """
     rhythmic_staff = lilypond_file[_score.Score][-1]
     first_leaf = get.leaf(rhythmic_staff, 0)
-    markup = _markups.Markup(r"\markup I", direction=enums.Up, literal=True)
+    markup = _markups.Markup(r"\markup I", direction=enums.Up)
     attach(markup, first_leaf)
     overrides.tweak(markup).staff_padding = 11
     overrides.tweak(markup).transparent = "##t"
     duration = get.duration(rhythmic_staff)
     if Duration(6, 4) < duration:
         last_leaf = get.leaf(rhythmic_staff, -1)
-        markup = _markups.Markup(r"\markup I", direction=enums.Up, literal=True)
+        markup = _markups.Markup(r"\markup I", direction=enums.Up)
         attach(markup, last_leaf)
         overrides.tweak(markup).staff_padding = 18
         overrides.tweak(markup).transparent = "##t"
@@ -339,9 +329,9 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
         REGRESSION. Function preserves markup:
 
         >>> note = abjad.Chord("<c bf'>4")
-        >>> markup = abjad.Markup(r"\markup loco", direction=abjad.Up, literal=True)
+        >>> markup = abjad.Markup(r"\markup loco", direction=abjad.Up)
         >>> abjad.attach(markup, chord)
-        >>> markup = abjad.Markup(r"\markup ped.", direction=abjad.Down, literal=True)
+        >>> markup = abjad.Markup(r"\markup ped.", direction=abjad.Down)
         >>> abjad.attach(markup, chord)
         >>> score = abjad.illustrators.make_piano_score([chord])
         >>> abjad.show(score) # doctest: +SKIP

--- a/abjad/indicators/BarLine.py
+++ b/abjad/indicators/BarLine.py
@@ -1,7 +1,10 @@
+import dataclasses
+
 from .. import format as _format
 from ..bundle import LilyPondFormatBundle
 
 
+@dataclasses.dataclass
 class BarLine:
     r"""
     Bar line.
@@ -16,7 +19,7 @@ class BarLine:
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> bar_line
-        BarLine('|.', format_slot='after')
+        BarLine(abbreviation='|.', format_slot='after')
 
         ..  docs::
 
@@ -62,9 +65,8 @@ class BarLine:
 
     """
 
-    ### CLASS VARIABLES ###
-
-    __slots__ = ("_abbreviation", "_format_slot")
+    abbreviation: str = "|"
+    format_slot: str = "after"
 
     _context = "Score"
 
@@ -93,27 +95,6 @@ class BarLine:
         "'",
     )
 
-    ### INITIALIZER ##
-
-    def __init__(self, abbreviation: str = "|", *, format_slot: str = "after") -> None:
-        if abbreviation not in self._known_abbreviations:
-            message = f"unknown bar line abbreviation: {repr(abbreviation)}\n"
-            message += "Abbreviation must be one of these:\n"
-            string = "\n    ".join([repr(_) for _ in self._known_abbreviations])
-            message += string
-            raise Exception(message)
-        self._abbreviation = abbreviation
-        assert isinstance(format_slot, str), repr(format_slot)
-        self._format_slot = format_slot
-
-    ### SPECIAL METHODS ###
-
-    def __repr__(self):
-        """
-        Delegates to storage format manager.
-        """
-        return _format.get_repr(self)
-
     ### PRIVATE METHODS ###
 
     def _get_format_specification(self):
@@ -131,52 +112,6 @@ class BarLine:
         slot.commands.append(self._get_lilypond_format())
         return bundle
 
-    ## PUBLIC PROPERTIES ##
-
-    @property
-    def abbreviation(self) -> str:
-        r"""
-        Gets abbreviation.
-
-        ..  container:: example
-
-            >>> bar_line = abjad.BarLine('|.')
-            >>> bar_line.abbreviation
-            '|.'
-
-        ..  container:: example exception:
-
-            Abbreviation error-checking looks like this:
-
-            >>> abjad.BarLine("text")
-            Traceback (most recent call last):
-            ...
-            Exception: unknown bar line abbreviation: 'text'
-            Abbreviation must be one of these:
-            ''
-                '|'
-                '.'
-                '||'
-                '.|'
-                '..'
-                '|.|'
-                '|.'
-                ';'
-                '!'
-                '.|:'
-                ':..:'
-                ':|.|:'
-                ':|.:'
-                ':.|.:'
-                '[|:'
-                ':|][|:'
-                ':|]'
-                ':|.'
-                "'"
-
-        """
-        return self._abbreviation
-
     @property
     def context(self) -> str:
         r"""
@@ -191,55 +126,3 @@ class BarLine:
         Override with ``abjad.attach(..., context='...')``.
         """
         return self._context
-
-    @property
-    def format_slot(self) -> str:
-        r"""
-        Gets format slot.
-
-        ..  container:: example
-
-            >>> abjad.BarLine("|").format_slot
-            'after'
-
-            >>> abjad.BarLine("|", format_slot="before").format_slot
-            'before'
-
-        ..  container:: example
-
-            REGRESSION. You can attach a before barline and after barline to
-            the same leaf:
-
-            >>> staff = abjad.Staff("c'1 d'1")
-            >>> bar_line_1 = abjad.BarLine(".|:", format_slot="before")
-            >>> bar_line_2 = abjad.BarLine(":|.", format_slot="after")
-            >>> assert bar_line_1.format_slot != bar_line_2.format_slot
-            >>> abjad.attach(bar_line_1, staff[-1])
-            >>> abjad.attach(bar_line_2, staff[-1])
-            >>> abjad.show(staff) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(staff)
-                >>> print(string)
-                \new Staff
-                {
-                    c'1
-                    \bar ".|:"
-                    d'1
-                    \bar ":|."
-                }
-
-        """
-        return self._format_slot
-
-    @property
-    def tweaks(self) -> None:
-        r"""
-        Are not implemented on bar line.
-
-        The LilyPond ``\bar`` command refuses tweaks.
-
-        Use overrides instead.
-        """
-        pass

--- a/abjad/indicators/BowContactPoint.py
+++ b/abjad/indicators/BowContactPoint.py
@@ -156,7 +156,7 @@ class BowContactPoint:
             contact_point = self.contact_point
         fraction = fr"\fraction {contact_point.numerator} {contact_point.denominator}"
         string = rf"\markup \center-align \vcenter {fraction}"
-        markup = Markup(string, literal=True)
+        markup = Markup(string)
         return markup
 
     @property

--- a/abjad/indicators/BowPressure.py
+++ b/abjad/indicators/BowPressure.py
@@ -42,8 +42,7 @@ class BowPressure:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/BreathMark.py
+++ b/abjad/indicators/BreathMark.py
@@ -100,8 +100,7 @@ class BreathMark:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/Clef.py
+++ b/abjad/indicators/Clef.py
@@ -221,8 +221,7 @@ class Clef:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -685,9 +684,7 @@ class StaffPosition:
             ...         note.written_pitch,
             ...         "alto",
             ...     )
-            ...     markup = abjad.Markup(
-            ...         rf"\markup {staff_position.number}", literal=True
-            ...     )
+            ...     markup = abjad.Markup(rf"\markup {staff_position.number}")
             ...     abjad.attach(markup, note)
             ...
             >>> abjad.override(staff).TextScript.staff_padding = 5
@@ -748,9 +745,7 @@ class StaffPosition:
             ...         note.written_pitch,
             ...         "bass",
             ...     )
-            ...     markup = abjad.Markup(
-            ...         rf"\markup {staff_position.number}", literal=True
-            ...     )
+            ...     markup = abjad.Markup(rf"\markup {staff_position.number}")
             ...     abjad.attach(markup, note)
             ...
             >>> abjad.attach(abjad.Clef("bass"), staff[0])

--- a/abjad/indicators/ColorFingering.py
+++ b/abjad/indicators/ColorFingering.py
@@ -73,8 +73,7 @@ class ColorFingering:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -173,7 +172,7 @@ class ColorFingering:
             return None
         string = rf"\override #'(circle-padding . 0.25) \circle \finger {self.number}"
         string = rf"\markup {{ {string} }}"
-        markup = Markup(string, literal=True)
+        markup = Markup(string)
         return markup
 
     @property

--- a/abjad/indicators/Fermata.py
+++ b/abjad/indicators/Fermata.py
@@ -129,8 +129,7 @@ class Fermata:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/Glissando.py
+++ b/abjad/indicators/Glissando.py
@@ -93,8 +93,7 @@ class Glissando:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/KeyCluster.py
+++ b/abjad/indicators/KeyCluster.py
@@ -68,8 +68,7 @@ class KeyCluster:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -104,11 +103,7 @@ class KeyCluster:
                 string = r"\center-align \flat"
             else:
                 string = r"\center-align \natural"
-            markup = Markup(
-                rf"\markup {string}",
-                direction=self.markup_direction,
-                literal=True,
-            )
+            markup = Markup(rf"\markup {string}", direction=self.markup_direction)
             markup_format_pieces = markup._get_format_pieces()
             bundle.after.markup.extend(markup_format_pieces)
         return bundle

--- a/abjad/indicators/KeySignature.py
+++ b/abjad/indicators/KeySignature.py
@@ -84,8 +84,7 @@ class KeySignature:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/LaissezVibrer.py
+++ b/abjad/indicators/LaissezVibrer.py
@@ -45,8 +45,7 @@ class LaissezVibrer:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/LilyPondComment.py
+++ b/abjad/indicators/LilyPondComment.py
@@ -67,8 +67,7 @@ class LilyPondComment:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/MarginMarkup.py
+++ b/abjad/indicators/MarginMarkup.py
@@ -14,7 +14,7 @@ class MarginMarkup:
 
         >>> staff = abjad.Staff("c'4 d'4 e'4 f'4")
         >>> margin_markup = abjad.MarginMarkup(
-        ...     markup=abjad.Markup(r"\markup Vc.", literal=True),
+        ...     markup=abjad.Markup(r"\markup Vc.")
         ... )
         >>> abjad.attach(margin_markup, staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
@@ -98,15 +98,15 @@ class MarginMarkup:
 
             >>> margin_markup_1 = abjad.MarginMarkup(
             ...     context="PianoStaff",
-            ...     markup=abjad.Markup(r"\markup Hp.", literal=True),
+            ...     markup=abjad.Markup(r"\markup Hp."),
             ... )
             >>> margin_markup_2 = abjad.MarginMarkup(
             ...     context="PianoStaff",
-            ...     markup=abjad.Markup(r"\markup Hp.", literal=True),
+            ...     markup=abjad.Markup(r"\markup Hp."),
             ... )
             >>> margin_markup_3 = abjad.MarginMarkup(
             ...     context="Staff",
-            ...     markup=abjad.Markup(r"\markup Hp.", literal=True),
+            ...     markup=abjad.Markup(r"\markup Hp."),
             ... )
 
             >>> margin_markup_1 == margin_markup_1
@@ -145,7 +145,7 @@ class MarginMarkup:
 
             >>> margin_markup = abjad.MarginMarkup(
             ...     context="PianoStaff",
-            ...     markup=abjad.Markup(r"\markup Hp.", literal=True),
+            ...     markup=abjad.Markup(r"\markup Hp."),
             ... )
 
             >>> hash_ = hash(margin_markup)
@@ -236,7 +236,7 @@ class MarginMarkup:
         ..  container::
 
             >>> margin_markup = abjad.MarginMarkup(
-            ...     markup=abjad.Markup(r"\markup Hp.", literal=True),
+            ...     markup=abjad.Markup(r"\markup Hp.")
             ... )
             >>> margin_markup.latent
             True
@@ -260,7 +260,7 @@ class MarginMarkup:
         ..  container:: example
 
             >>> margin_markup = abjad.MarginMarkup(
-            ...     markup=abjad.Markup(r"\markup Hp.", literal=True),
+            ...     markup=abjad.Markup(r"\markup Hp.")
             ... )
             >>> margin_markup.persistent
             True
@@ -277,7 +277,7 @@ class MarginMarkup:
         ..  container:: example
 
             >>> margin_markup = abjad.MarginMarkup(
-            ...     markup=abjad.Markup(r"\markup Hp.", literal=True),
+            ...     markup=abjad.Markup(r"\markup Hp.")
             ... )
             >>> margin_markup.redraw
             True

--- a/abjad/indicators/MetronomeMark.py
+++ b/abjad/indicators/MetronomeMark.py
@@ -756,7 +756,7 @@ class MetronomeMark:
         string += f" #{self.reference_duration.dot_count}"
         string += f" #{stem_height}"
         string += f' #"{self.units_per_minute}"'
-        markup = markups.Markup(rf"\markup {string}", literal=True)
+        markup = markups.Markup(rf"\markup {string}")
         return markup
 
     # TODO: refactor to return dict
@@ -1263,8 +1263,7 @@ class MetronomeMark:
                     decimal_ = decimal
                 markup = markups.Markup(
                     r"\markup \abjad-metronome-mark-markup"
-                    f' #{log} #{dots} #{stem} #"{decimal_}"',
-                    literal=True,
+                    f' #{log} #{dots} #{stem} #"{decimal_}"'
                 )
             else:
                 nonreduced = NonreducedFraction(units_per_minute)
@@ -1274,14 +1273,12 @@ class MetronomeMark:
                 markup = markups.Markup(
                     r"\markup \abjad-metronome-mark-mixed-number-markup"
                     f" #{log} #{dots} #{stem}"
-                    f' #"{base}" #"{n}" #"{d}"',
-                    literal=True,
+                    f' #"{base}" #"{n}" #"{d}"'
                 )
         else:
             markup = markups.Markup(
                 r"\markup \abjad-metronome-mark-markup"
-                f' #{log} #{dots} #{stem} #"{units_per_minute}"',
-                literal=True,
+                f' #{log} #{dots} #{stem} #"{units_per_minute}"'
             )
         return markup
 

--- a/abjad/indicators/Ottava.py
+++ b/abjad/indicators/Ottava.py
@@ -53,8 +53,7 @@ class Ottava:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/RehearsalMark.py
+++ b/abjad/indicators/RehearsalMark.py
@@ -124,8 +124,7 @@ class RehearsalMark:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -212,7 +211,7 @@ class RehearsalMark:
 
         ..  container:: example
 
-            >>> markup = abjad.Markup(r'\markup \bold { \italic { A } }', literal=True)
+            >>> markup = abjad.Markup(r'\markup \bold { \italic { A } }')
             >>> mark = abjad.RehearsalMark(markup=markup)
             >>> staff = abjad.Staff("c'4 d' e' f'")
             >>> abjad.attach(mark, staff[0])

--- a/abjad/indicators/Repeat.py
+++ b/abjad/indicators/Repeat.py
@@ -91,8 +91,7 @@ class Repeat:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/RepeatTie.py
+++ b/abjad/indicators/RepeatTie.py
@@ -69,8 +69,7 @@ class RepeatTie:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/StaffChange.py
+++ b/abjad/indicators/StaffChange.py
@@ -65,8 +65,7 @@ class StaffChange:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/StartBeam.py
+++ b/abjad/indicators/StartBeam.py
@@ -65,8 +65,7 @@ class StartBeam:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/StartGroup.py
+++ b/abjad/indicators/StartGroup.py
@@ -58,8 +58,7 @@ class StartGroup:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/StartHairpin.py
+++ b/abjad/indicators/StartHairpin.py
@@ -83,8 +83,7 @@ class StartHairpin:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/StartMarkup.py
+++ b/abjad/indicators/StartMarkup.py
@@ -13,7 +13,7 @@ class StartMarkup:
     ..  container:: example
 
         >>> staff = abjad.Staff("c'4 d'4 e'4 f'4")
-        >>> markup = abjad.Markup(r"\markup Cellos", literal=True)
+        >>> markup = abjad.Markup(r"\markup Cellos")
         >>> start_markup = abjad.StartMarkup(markup=markup)
         >>> abjad.attach(start_markup, staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
@@ -85,15 +85,15 @@ class StartMarkup:
 
             >>> start_markup_1 = abjad.StartMarkup(
             ...     context='PianoStaff',
-            ...     markup=abjad.Markup(r"\markup Harp", literal=True),
+            ...     markup=abjad.Markup(r"\markup Harp"),
             ...     )
             >>> start_markup_2 = abjad.StartMarkup(
             ...     context="PianoStaff",
-            ...     markup=abjad.Markup(r"\markup Harp", literal=True),
+            ...     markup=abjad.Markup(r"\markup Harp"),
             ...     )
             >>> start_markup_3 = abjad.StartMarkup(
             ...     context="Staff",
-            ...     markup=abjad.Markup(r"\markup Harp", literal=True),
+            ...     markup=abjad.Markup(r"\markup Harp"),
             ...     )
 
             >>> start_markup_1 == start_markup_1
@@ -132,7 +132,7 @@ class StartMarkup:
 
             >>> start_markup = abjad.StartMarkup(
             ...     context="PianoStaff",
-            ...     markup=abjad.Markup(r"\markup Harp", literal=True),
+            ...     markup=abjad.Markup(r"\markup Harp"),
             ...     )
 
             >>> hash_ = hash(start_markup)
@@ -197,7 +197,7 @@ class StartMarkup:
 
         ..  container:: example
 
-            >>> markup = abjad.Markup(r"\markup Cellos", literal=True)
+            >>> markup = abjad.Markup(r"\markup Cellos")
             >>> start_markup = abjad.StartMarkup(markup=markup)
             >>> start_markup.context
             'Staff'
@@ -212,7 +212,7 @@ class StartMarkup:
 
         ..  container:: example
 
-            >>> markup = abjad.Markup(r"\markup Cellos", literal=True)
+            >>> markup = abjad.Markup(r"\markup Cellos")
             >>> start_markup = abjad.StartMarkup(markup=markup)
             >>> start_markup.format_slot
             'before'
@@ -227,10 +227,10 @@ class StartMarkup:
 
         ..  container:: example
 
-            >>> markup = abjad.Markup(r"\markup Cellos", literal=True)
+            >>> markup = abjad.Markup(r"\markup Cellos")
             >>> start_markup = abjad.StartMarkup(markup=markup)
             >>> start_markup.markup
-            Markup(contents=['\\markup Cellos'], literal=True)
+            Markup('\\markup Cellos')
 
         """
         return self._markup

--- a/abjad/indicators/StartPhrasingSlur.py
+++ b/abjad/indicators/StartPhrasingSlur.py
@@ -69,8 +69,7 @@ class StartPhrasingSlur:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/StartPianoPedal.py
+++ b/abjad/indicators/StartPianoPedal.py
@@ -88,8 +88,7 @@ class StartPianoPedal:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/StartSlur.py
+++ b/abjad/indicators/StartSlur.py
@@ -71,8 +71,7 @@ class StartSlur:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/StartTextSpan.py
+++ b/abjad/indicators/StartTextSpan.py
@@ -16,8 +16,8 @@ class StartTextSpan:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> start_text_span = abjad.StartTextSpan(
-        ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
-        ...     right_text=abjad.Markup(r"\markup \upright tasto", literal=True),
+        ...     left_text=abjad.Markup(r"\upright pont."),
+        ...     right_text=abjad.Markup(r"\markup \upright tasto"),
         ...     style="solid-line-with-arrow",
         ... )
         >>> abjad.tweak(start_text_span).staff_padding = 2.5
@@ -135,8 +135,7 @@ class StartTextSpan:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal the
-        initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -171,13 +170,11 @@ class StartTextSpan:
     def _get_left_text_directive(self):
         if isinstance(self.left_text, str):
             return self.left_text
-        assert len(self.left_text.contents) == 1, repr(self.left_text)
-        left_text_string = self.left_text.contents[0]
+        left_text_string = self.left_text.string
         left_text_string = left_text_string.removeprefix(r"\markup").strip()
         hspace_string = fr"\hspace #{self.concat_hspace_left}"
         markup = markups.Markup(
-            rf"\markup \concat {{ {left_text_string} {hspace_string} }}",
-            literal=True,
+            rf"\markup \concat {{ {left_text_string} {hspace_string} }}"
         )
         override = LilyPondOverride(
             grob_name="TextSpanner",
@@ -227,11 +224,9 @@ class StartTextSpan:
             return self.right_text
         if self.concat_hspace_right is not None:
             number = self.concat_hspace_right
-            assert len(self.right_text.contents) == 1
-            right_text = self.right_text.contents[0]
+            right_text = self.right_text.string
             markup = markups.Markup(
-                rf"\markup \concat {{ {right_text} \hspace #{number} }}",
-                literal=True,
+                rf"\markup \concat {{ {right_text} \hspace #{number} }}"
             )
         else:
             markup = self.right_text
@@ -259,8 +254,8 @@ class StartTextSpan:
             >>> staff = abjad.Staff("c'4 d' e' f'")
 
             >>> start_text_span = abjad.StartTextSpan(
-            ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
-            ...     right_text=abjad.Markup(r"\markup \upright tasto", literal=True),
+            ...     left_text=abjad.Markup(r"\upright pont."),
+            ...     right_text=abjad.Markup(r"\markup \upright tasto"),
             ...     style="dashed-line-with-arrow",
             ... )
             >>> abjad.tweak(start_text_span).color = "#blue"
@@ -271,8 +266,8 @@ class StartTextSpan:
 
             >>> start_text_span = abjad.StartTextSpan(
             ...     command=r"\startTextSpanOne",
-            ...     left_text=abjad.Markup(r"\upright A", literal=True),
-            ...     right_text=abjad.Markup(r"\markup \upright B", literal=True),
+            ...     left_text=abjad.Markup(r"\upright A"),
+            ...     right_text=abjad.Markup(r"\markup \upright B"),
             ...     style="dashed-line-with-arrow",
             ... )
             >>> abjad.tweak(start_text_span).color = "#red"
@@ -281,9 +276,7 @@ class StartTextSpan:
             >>> stop_text_span = abjad.StopTextSpan(command=r"\stopTextSpanOne")
             >>> abjad.attach(stop_text_span, staff[-1])
 
-            >>> markup = abjad.Markup(
-            ...     r"\markup SPACER", direction=abjad.Up, literal=True
-            ... )
+            >>> markup = abjad.Markup(r"\markup SPACER", direction=abjad.Up)
             >>> abjad.tweak(markup).transparent = True
             >>> abjad.attach(markup, staff[0])
             >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
@@ -488,8 +481,8 @@ class StartTextSpan:
 
             >>> staff = abjad.Staff("c'4 d' e' fs'")
             >>> start_text_span = abjad.StartTextSpan(
-            ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
-            ...     right_text=abjad.Markup(r"\markup \upright tasto", literal=True),
+            ...     left_text=abjad.Markup(r"\upright pont."),
+            ...     right_text=abjad.Markup(r"\markup \upright tasto"),
             ...     style="dashed-line-with-arrow",
             ... )
             >>> abjad.tweak(start_text_span).staff_padding = 2.5
@@ -521,7 +514,7 @@ class StartTextSpan:
 
             >>> staff = abjad.Staff("c'4 d' e' f'")
             >>> start_text_span = abjad.StartTextSpan(
-            ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
+            ...     left_text=abjad.Markup(r"\upright pont."),
             ...     style="dashed-line-with-hook",
             ... )
             >>> abjad.tweak(start_text_span).staff_padding = 2.5
@@ -552,8 +545,8 @@ class StartTextSpan:
 
             >>> staff = abjad.Staff("c'4 d' e' f'")
             >>> start_text_span = abjad.StartTextSpan(
-            ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
-            ...     right_text=abjad.Markup(r"\markup \upright tasto", literal=True),
+            ...     left_text=abjad.Markup(r"\upright pont."),
+            ...     right_text=abjad.Markup(r"\markup \upright tasto"),
             ...     style="invisible-line",
             ... )
             >>> abjad.tweak(start_text_span).staff_padding = 2.5
@@ -585,8 +578,8 @@ class StartTextSpan:
 
             >>> staff = abjad.Staff("c'4 d' e' f'")
             >>> start_text_span = abjad.StartTextSpan(
-            ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
-            ...     right_text=abjad.Markup(r"\markup \upright tasto", literal=True),
+            ...     left_text=abjad.Markup(r"\upright pont."),
+            ...     right_text=abjad.Markup(r"\markup \upright tasto"),
             ...     style="solid-line-with-arrow",
             ... )
             >>> abjad.tweak(start_text_span).staff_padding = 2.5
@@ -618,7 +611,7 @@ class StartTextSpan:
 
             >>> staff = abjad.Staff("c'4 d' e' f'")
             >>> start_text_span = abjad.StartTextSpan(
-            ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
+            ...     left_text=abjad.Markup(r"\upright pont."),
             ...     style="solid-line-with-hook",
             ... )
             >>> abjad.tweak(start_text_span).staff_padding = 2.5

--- a/abjad/indicators/StartTrillSpan.py
+++ b/abjad/indicators/StartTrillSpan.py
@@ -71,8 +71,7 @@ class StartTrillSpan:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/StemTremolo.py
+++ b/abjad/indicators/StemTremolo.py
@@ -102,8 +102,7 @@ class StemTremolo:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/indicators/StopTextSpan.py
+++ b/abjad/indicators/StopTextSpan.py
@@ -98,8 +98,8 @@ class StopTextSpan:
 
             >>> staff = abjad.Staff("c'4 d' e' r")
             >>> command = abjad.StartTextSpan(
-            ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
-            ...     right_text=abjad.Markup(r"\markup \upright tasto", literal=True),
+            ...     left_text=abjad.Markup(r"\upright pont."),
+            ...     right_text=abjad.Markup(r"\markup \upright tasto"),
             ...     style="dashed-line-with-arrow",
             ... )
             >>> abjad.tweak(command).staff_padding = 2.5
@@ -131,8 +131,8 @@ class StopTextSpan:
 
             >>> staff = abjad.Staff("c'4 d' e' r")
             >>> command = abjad.StartTextSpan(
-            ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
-            ...     right_text=abjad.Markup(r"\markup \upright tasto", literal=True),
+            ...     left_text=abjad.Markup(r"\upright pont."),
+            ...     right_text=abjad.Markup(r"\markup \upright tasto"),
             ...     style="dashed-line-with-arrow",
             ... )
             >>> abjad.tweak(command).staff_padding = 2.5

--- a/abjad/indicators/StringContactPoint.py
+++ b/abjad/indicators/StringContactPoint.py
@@ -71,8 +71,7 @@ class StringContactPoint:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -149,7 +148,7 @@ class StringContactPoint:
         """
         string = self._contact_point_abbreviations[self.contact_point]
         string = rf"\markup \caps {string.title()}"
-        markup = Markup(string, literal=True)
+        markup = Markup(string)
         return markup
 
     @property

--- a/abjad/indicators/Tie.py
+++ b/abjad/indicators/Tie.py
@@ -69,8 +69,7 @@ class Tie:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/instruments.py
+++ b/abjad/instruments.py
@@ -25,18 +25,14 @@ class Instrument:
         >>> voice_1 = abjad.Voice("e'8 g'8 f'8 a'8")
         >>> flute = abjad.Flute()
         >>> abjad.attach(flute, voice_1[0], context='Voice')
-        >>> flute_markup = abjad.Markup(
-        ...     r'\markup (flute)', direction=abjad.Up, literal=True,
-        ... )
+        >>> flute_markup = abjad.Markup(r'\markup (flute)', direction=abjad.Up)
         >>> abjad.attach(flute_markup, voice_1[0])
         >>> abjad.attach(abjad.LilyPondLiteral(r'\voiceOne'), voice_1)
         >>> voice_2 = abjad.Voice("c'2")
         >>> abjad.attach(abjad.LilyPondLiteral(r'\voiceTwo'), voice_2)
         >>> viola = abjad.Viola()
         >>> abjad.attach(viola, voice_2[0], context='Voice')
-        >>> viola_markup = abjad.Markup(
-        ...     r'\markup (viola)', direction=abjad.Down, literal=True,
-        ... )
+        >>> viola_markup = abjad.Markup(r'\markup (viola)', direction=abjad.Down)
         >>> abjad.attach(viola_markup, voice_2[0])
         >>> staff = abjad.Staff([voice_1, voice_2], simultaneous=True)
         >>> abjad.show(staff) # doctest: +SKIP
@@ -124,13 +120,13 @@ class Instrument:
             name = str(name)
         self._name = name
         if markup is not None:
-            markup = _markups.Markup(markup, literal=True)
+            markup = _markups.Markup(str(markup))
         self._name_markup = markup
         if short_name is not None:
             short_name = str(short_name)
         self._short_name = short_name
         if short_markup is not None:
-            short_markup = _markups.Markup(short_markup, literal=True)
+            short_markup = _markups.Markup(str(short_markup))
         self._short_name_markup = short_markup
         allowable_clefs = allowable_clefs or ("treble",)
         self._allowable_clefs = allowable_clefs
@@ -156,8 +152,7 @@ class Instrument:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -207,7 +202,7 @@ class Instrument:
             if self.name:
                 string = self.name
                 string = String(string).capitalize_start()
-                markup = _markups.Markup(rf"\markup {string}", literal=True)
+                markup = _markups.Markup(rf"\markup {string}")
                 self._name_markup = markup
             else:
                 self._name_markup = None
@@ -215,7 +210,7 @@ class Instrument:
             if self.short_name:
                 string = self.short_name
                 string = String(string).capitalize_start()
-                markup = _markups.Markup(rf"\markup {string}", literal=True)
+                markup = _markups.Markup(rf"\markup {string}")
             else:
                 self._short_name_markup = None
 
@@ -269,9 +264,9 @@ class Instrument:
             return
         if not isinstance(self._name_markup, _markups.Markup):
             assert isinstance(self._name_markup, str), repr(self._name_markup)
-            markup = _markups.Markup(rf"\markup {self._name_markup}", literal=True)
+            markup = _markups.Markup(rf"\markup {self._name_markup}")
             self._name_markup = markup
-        if self._name_markup.contents != ("",):
+        if self._name_markup.string:
             return self._name_markup
 
     @property
@@ -344,11 +339,9 @@ class Instrument:
             assert isinstance(self._short_name_markup, str), repr(
                 self._short_name_markup
             )
-            markup = _markups.Markup(
-                rf"\markup {self._short_name_markup}", literal=True
-            )
+            markup = _markups.Markup(rf"\markup {self._short_name_markup}")
             self._short_name_markup = markup
-        if self._short_name_markup.contents != ("",):
+        if self._short_name_markup.string:
             return self._short_name_markup
 
     @property
@@ -411,8 +404,7 @@ class StringNumber:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -523,8 +515,7 @@ class Tuning:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/label.py
+++ b/abjad/label.py
@@ -795,9 +795,7 @@ def vertical_moments(
         else:
             raise TypeError(f"unknown prototype {prototype!r}.")
         assert string is not None
-        label = _markups.Markup(
-            rf"\markup \tiny {string}", direction=direction, literal=True
-        )
+        label = _markups.Markup(rf"\markup \tiny {string}", direction=direction)
         if direction is _enums.Up:
             leaf = vertical_moment.start_leaves[0]
         else:
@@ -883,7 +881,6 @@ def with_durations(
         label = _markups.Markup(
             rf"\markup \fraction {numerator} {denominator}",
             direction=direction,
-            literal=True,
         )
         _attach(label, logical_tie.head)
 
@@ -1101,7 +1098,7 @@ def with_indices(argument, direction=_enums.Up, prototype=None):
         items = iterate_.components(argument, prototype=prototype)
     items = list(items)
     for index, item in enumerate(items):
-        label = _markups.Markup(rf"\markup {index}", direction=direction, literal=True)
+        label = _markups.Markup(rf"\markup {index}", direction=direction)
         leaves = _selection.Selection(item).leaves()
         first_leaf = leaves[0]
         _attach(label, first_leaf)
@@ -1330,34 +1327,26 @@ def with_intervals(argument, direction=_enums.Up, prototype=None):
         if isinstance(next_leaf, _score.Note):
             interval = NamedInterval.from_pitch_carriers(note, next_leaf)
             if prototype is NamedInterval:
-                label = _markups.Markup(
-                    rf"\markup {interval}",
-                    direction=direction,
-                    literal=True,
-                )
+                label = _markups.Markup(rf"\markup {interval}", direction=direction)
             elif prototype is NamedIntervalClass:
                 label = _markups.Markup(
                     rf"\markup {NamedIntervalClass(interval)}",
                     direction=direction,
-                    literal=True,
                 )
             elif prototype is NumberedInterval:
                 label = _markups.Markup(
                     rf"\markup {NumberedInterval(interval)}",
                     direction=direction,
-                    literal=True,
                 )
             elif prototype is NumberedIntervalClass:
                 label = _markups.Markup(
                     rf"\markup {NumberedIntervalClass(interval)}",
                     direction=direction,
-                    literal=True,
                 )
             elif prototype is NumberedInversionEquivalentIntervalClass:
                 label = _markups.Markup(
                     rf"\markup {NumberedInversionEquivalentIntervalClass(interval)}",
                     direction=direction,
-                    literal=True,
                 )
             if label is not None:
                 _attach(label, note)
@@ -1647,11 +1636,7 @@ def with_pitches(argument, direction=_enums.Up, locale=None, prototype=None):
                 string = leaf.written_pitch.get_name(locale=locale)
                 if "#" in string:
                     string = '"' + string + '"'
-                label = _markups.Markup(
-                    rf"\markup {{ {string} }}",
-                    direction=direction,
-                    literal=True,
-                )
+                label = _markups.Markup(rf"\markup {{ {string} }}", direction=direction)
             elif isinstance(leaf, _score.Chord):
                 pitches = leaf.written_pitches
                 pitches = reversed(pitches)
@@ -1664,16 +1649,11 @@ def with_pitches(argument, direction=_enums.Up, locale=None, prototype=None):
                 label = _markups.Markup(
                     rf"\markup \column {{ {string} }}",
                     direction=direction,
-                    literal=True,
                 )
         elif prototype is NumberedPitch:
             if isinstance(leaf, _score.Note):
                 pitch = leaf.written_pitch.number
-                label = _markups.Markup(
-                    rf"\markup {pitch}",
-                    direction=direction,
-                    literal=True,
-                )
+                label = _markups.Markup(rf"\markup {pitch}", direction=direction)
             elif isinstance(leaf, _score.Chord):
                 pitches = leaf.written_pitches
                 pitches = reversed(pitches)
@@ -1682,16 +1662,11 @@ def with_pitches(argument, direction=_enums.Up, locale=None, prototype=None):
                 label = _markups.Markup(
                     rf"\markup \column {{ {string} }}",
                     direction=direction,
-                    literal=True,
                 )
         elif prototype is NumberedPitchClass:
             if isinstance(leaf, _score.Note):
                 pitch = leaf.written_pitch.pitch_class.number
-                label = _markups.Markup(
-                    rf"\markup {pitch}",
-                    direction=direction,
-                    literal=True,
-                )
+                label = _markups.Markup(rf"\markup {pitch}", direction=direction)
             elif isinstance(leaf, _score.Chord):
                 pitches = leaf.written_pitches
                 pitches = reversed(pitches)
@@ -1700,7 +1675,6 @@ def with_pitches(argument, direction=_enums.Up, locale=None, prototype=None):
                 label = _markups.Markup(
                     rf"\markup \column {{ {string} }}",
                     direction=direction,
-                    literal=True,
                 )
         if label is not None:
             label = _new.new(label, direction=direction)
@@ -1872,7 +1846,7 @@ def with_set_classes(argument, direction=_enums.Up, prototype=None):
         )
         string = str(set_class)
         string = rf'\markup \tiny \line {{ "{string}" }}'
-        label = _markups.Markup(string, direction=direction, literal=True)
+        label = _markups.Markup(string, direction=direction)
         leaf = selection[0]
         _attach(label, leaf)
 
@@ -2037,10 +2011,10 @@ def with_start_offsets(
             string = f"[{string}]"
         if markup_command is not None:
             string = rf"{markup_command} {{ {string} }}"
-            label = _markups.Markup(string, direction=direction, literal=True)
+            label = _markups.Markup(string, direction=direction)
         else:
             string = rf"\markup {{ {string} }}"
-            label = _markups.Markup(string, direction=direction, literal=True)
+            label = _markups.Markup(string, direction=direction)
         _attach(label, logical_tie.head)
     total_duration = _duration.Duration(timespan.stop_offset)
     if global_offset is not None:
@@ -2097,8 +2071,7 @@ class ColorMap:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/lilypondfile.py
+++ b/abjad/lilypondfile.py
@@ -50,7 +50,7 @@ class Block:
     ..  container:: example
 
         >>> block = abjad.Block(name='score')
-        >>> markup = abjad.Markup(r"\markup foo", literal=True)
+        >>> markup = abjad.Markup(r"\markup foo")
         >>> block.items.append(markup)
         >>> block
         <Block(name='score')>
@@ -267,11 +267,11 @@ class Block:
         ..  container:: example
 
             >>> block = abjad.Block(name="score")
-            >>> markup = abjad.Markup(r"\markup foo", literal=True)
+            >>> markup = abjad.Markup(r"\markup foo")
             >>> block.items.append(markup)
 
             >>> block.items
-            [Markup(contents=['\\markup foo'], literal=True)]
+            [Markup('\\markup foo')]
 
         ..  container:: example
 

--- a/abjad/markups.py
+++ b/abjad/markups.py
@@ -4,15 +4,12 @@ Tools for modeling LilyPond's markup and postscript.
 import collections
 import typing
 
-from . import enums
+from . import enums as _enums
 from . import format as _format
-from . import math
-from . import tag as _tag
-from .bundle import LilyPondFormatBundle
-from .fsv import format_scheme_value
-from .new import new
-from .overrides import TweakInterface
-from .string import String
+from . import math as _math
+from . import new as _new
+from . import overrides as _overrides
+from . import string as _string
 
 
 class Markup:
@@ -24,21 +21,15 @@ class Markup:
         Initializes from string:
 
         >>> string = r'\markup \italic "Allegro assai"'
-        >>> markup = abjad.Markup(string, literal=True)
+        >>> markup = abjad.Markup(string)
         >>> string = abjad.lilypond(markup)
         >>> print(string)
         \markup \italic "Allegro assai"
 
         >>> abjad.show(markup) # doctest: +SKIP
 
-    ..  container:: example
-
-        Initializes from other markup:
-
-        >>> markup = abjad.Markup(
-        ...     r'\markup \italic "Allegro assai"', direction=abjad.Up, literal=True
-        ... )
-        >>> markup = abjad.Markup(markup, direction=abjad.Down, literal=True)
+        >>> markup = abjad.Markup(r'\markup \italic "Allegro assai"', direction=abjad.Up)
+        >>> markup = abjad.Markup(markup.string, direction=abjad.Down)
         >>> string = abjad.lilypond(markup)
         >>> print(string)
         _ \markup \italic "Allegro assai"
@@ -51,7 +42,7 @@ class Markup:
 
         >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
         >>> string = r'\markup \italic "Allegro assai"'
-        >>> markup = abjad.Markup(string, direction=abjad.Up, literal=True)
+        >>> markup = abjad.Markup(string, direction=abjad.Up)
         >>> string = abjad.lilypond(markup)
         >>> print(string)
         ^ \markup \italic "Allegro assai"
@@ -72,20 +63,15 @@ class Markup:
                 f'8
             }
 
-    ..  note:: Make sure all markup methods implement a direction
-        keyword when extending this class.
-
-    Set ``direction`` to ``Up``, ``Down``, ``"neutral"``, ``"^"``, ``"_"``,
-    ``"-"`` or None.
+    Set ``direction`` to ``Up``, ``Down``, ``"neutral"``, ``"^"``, ``"_"``, ``"-"`` or
+    None.
 
     ..  container:: example
 
         Markup can be tagged:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> markup = abjad.Markup(
-        ...     r"\markup \italic Allegro", direction=abjad.Up, literal=True
-        ... )
+        >>> markup = abjad.Markup(r"\markup \italic Allegro", direction=abjad.Up)
         >>> abjad.attach(markup, staff[0], tag=abjad.Tag("RED:M1"))
         >>> abjad.show(staff) # doctest: +SKIP
 
@@ -107,15 +93,13 @@ class Markup:
         Markup can be deactively tagged:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> markup = abjad.Markup(
-        ...     r"\markup \italic Allegro", direction=abjad.Up, literal=True
-        ... )
+        >>> markup = abjad.Markup(r"\markup \italic Allegro", direction=abjad.Up)
         >>> abjad.attach(
         ...     markup,
         ...     staff[0],
         ...     deactivate=True,
         ...     tag=abjad.Tag("RED:M1"),
-        ...     )
+        ... )
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> string = abjad.lilypond(staff, tags=True)
@@ -133,16 +117,12 @@ class Markup:
 
     ..  container:: example
 
-        REGRESSION: make sure the first italic markup doesn't disappear after
-        the second italic markup is attached:
+        REGRESSION: make sure the first italic markup doesn't disappear after the second
+        italic markup is attached:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> markup_1 = abjad.Markup(
-        ...     r"\markup \italic Allegro", direction=abjad.Up, literal=True
-        ... )
-        >>> markup_2 = abjad.Markup(
-        ...     r'\markup \italic "non troppo"', direction=abjad.Up, literal=True
-        ... )
+        >>> markup_1 = abjad.Markup(r"\markup \italic Allegro", direction=abjad.Up)
+        >>> markup_2 = abjad.Markup(r'\markup \italic "non troppo"', direction=abjad.Up)
         >>> abjad.attach(markup_1, staff[0])
         >>> abjad.attach(markup_2, staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
@@ -165,9 +145,8 @@ class Markup:
 
     __slots__ = (
         "_annotation",
-        "_contents",
+        "_string",
         "_direction",
-        "_literal",
         "_tweaks",
     )
 
@@ -177,51 +156,21 @@ class Markup:
 
     def __init__(
         self,
-        contents=None,
+        string,
         *,
-        direction: typing.Union[int, enums.VerticalAlignment] = None,
-        literal: bool = None,
-        tweaks: TweakInterface = None,
+        direction: typing.Union[int, _enums.VerticalAlignment] = None,
+        tweaks: _overrides.TweakInterface = None,
     ) -> None:
-        assert literal is True, repr(literal)
         self._annotation = None
-        new_contents: typing.Tuple[typing.Union[str, MarkupCommand], ...]
-        if contents is None:
-            new_contents = ("",)
-        elif isinstance(contents, str):
-            new_contents = (contents,)
-        elif isinstance(contents, MarkupCommand):
-            new_contents = (contents,)
-        elif isinstance(contents, type(self)):
-            direction = direction or contents.direction
-            literal = literal or contents.literal
-            new_contents = tuple(contents.contents)
-        elif isinstance(contents, collections.abc.Sequence) and 0 < len(contents):
-            new_contents_ = []
-            for argument in contents:
-                if isinstance(argument, (str, MarkupCommand)):
-                    new_contents_.append(argument)
-                elif isinstance(argument, type(self)):
-                    new_contents_.extend(argument.contents)
-                else:
-                    new_contents_.append(str(argument))
-            new_contents = tuple(new_contents_)
-        else:
-            new_contents = (str(contents),)
-        assert isinstance(new_contents, tuple), repr(new_contents)
-        item = (str, MarkupCommand)
-        assert all(isinstance(_, item) for _ in new_contents), repr(new_contents)
-        self._contents = new_contents
-        direction_ = String.to_tridirectional_ordinal_constant(direction)
+        assert isinstance(string, str), repr(string)
+        self._string = string
+        direction_ = _string.String.to_tridirectional_ordinal_constant(direction)
         if direction_ is not None:
-            assert isinstance(direction_, enums.VerticalAlignment), repr(direction_)
+            assert isinstance(direction_, _enums.VerticalAlignment), repr(direction_)
         self._direction = direction_
-        if literal is not None:
-            assert isinstance(literal, bool), repr(literal)
-        self._literal = literal
         if tweaks is not None:
-            assert isinstance(tweaks, TweakInterface), repr(tweaks)
-        self._tweaks = TweakInterface.set_tweaks(self, tweaks)
+            assert isinstance(tweaks, _overrides.TweakInterface), repr(tweaks)
+        self._tweaks = _overrides.TweakInterface.set_tweaks(self, tweaks)
 
     ### SPECIAL METHODS ###
 
@@ -233,16 +182,14 @@ class Markup:
 
         ..  container:: example
 
-            >>> markup_1 = abjad.Markup(
-            ...     r"\markup Allegro assai", direction=abjad.Up, literal=True
-            ... )
+            >>> markup_1 = abjad.Markup(r"\markup Allegro assai", direction=abjad.Up)
             >>> markup_2 = copy.copy(markup_1)
 
             >>> markup_1
-            Markup(contents=['\\markup Allegro assai'], direction=Up, literal=True)
+            Markup('\\markup Allegro assai', direction=Up)
 
             >>> markup_2
-            Markup(contents=['\\markup Allegro assai'], direction=Up, literal=True)
+            Markup('\\markup Allegro assai', direction=Up)
 
             >>> markup_1 == markup_2
             True
@@ -252,7 +199,7 @@ class Markup:
 
         Returns new markup.
         """
-        return new(self)
+        return _new.new(self)
 
     def __eq__(self, argument):
         r"""
@@ -262,9 +209,9 @@ class Markup:
 
             Without keywords:
 
-            >>> markup_1 = abjad.Markup(r"\markup Allegro", literal=True)
-            >>> markup_2 = abjad.Markup(r"\markup Allegro", literal=True)
-            >>> markup_3 = abjad.Markup(r'\markup "Allegro assai"', literal=True)
+            >>> markup_1 = abjad.Markup(r"\markup Allegro")
+            >>> markup_2 = abjad.Markup(r"\markup Allegro")
+            >>> markup_3 = abjad.Markup(r'\markup "Allegro assai"')
 
             >>> markup_1 == markup_1
             True
@@ -289,10 +236,8 @@ class Markup:
 
             With keywords:
 
-            >>> markup_1 = abjad.Markup(r"\markup Allegro", literal=True)
-            >>> markup_2 = abjad.Markup(
-            ...     r"\markup Allegro", direction=abjad.Up, literal=True
-            ... )
+            >>> markup_1 = abjad.Markup(r"\markup Allegro")
+            >>> markup_2 = abjad.Markup(r"\markup Allegro", direction=abjad.Up)
 
             >>> markup_1 == markup_1
             True
@@ -315,9 +260,9 @@ class Markup:
 
             Without keywords:
 
-            >>> hash_1 = hash(abjad.Markup(r"\markup Allegro", literal=True))
-            >>> hash_2 = hash(abjad.Markup(r"\markup Allegro", literal=True))
-            >>> hash_3 = hash(abjad.Markup(r'\markup "Allegro assai"', literal=True))
+            >>> hash_1 = hash(abjad.Markup(r"\markup Allegro"))
+            >>> hash_2 = hash(abjad.Markup(r"\markup Allegro"))
+            >>> hash_3 = hash(abjad.Markup(r'\markup "Allegro assai"'))
 
             >>> hash_1 == hash_1
             True
@@ -342,9 +287,9 @@ class Markup:
 
             With keywords:
 
-            >>> hash_1 = hash(abjad.Markup(r"\markup Allegro", literal=True))
+            >>> hash_1 = hash(abjad.Markup(r"\markup Allegro"))
             >>> string = r"\markup Allegro"
-            >>> hash_2 = hash(abjad.Markup(string, direction=abjad.Up, literal=True))
+            >>> hash_2 = hash(abjad.Markup(string, direction=abjad.Up))
 
             >>> hash_1 == hash_1
             True
@@ -360,12 +305,12 @@ class Markup:
 
     def __lt__(self, argument):
         r"""
-        Is true when markup contents compare less than ``argument`` contents.
+        Is true when markup string compare less than ``argument`` string.
 
         ..  container:: example
 
-            >>> markup_1 = abjad.Markup(r"\markup Allegro", literal=True)
-            >>> markup_2 = abjad.Markup(r"\markup assai", literal=True)
+            >>> markup_1 = abjad.Markup(r"\markup Allegro")
+            >>> markup_2 = abjad.Markup(r"\markup assai")
 
             >>> markup_1 < markup_2
             True
@@ -378,7 +323,7 @@ class Markup:
         """
         if not isinstance(argument, type(self)):
             raise TypeError(f"can only compare markup to markup: {argument!r}.")
-        return self.contents < argument.contents
+        return self.string < argument.string
 
     def __repr__(self) -> str:
         """
@@ -392,7 +337,7 @@ class Markup:
 
         ..  container:: example
 
-            >>> markup = abjad.Markup(rf'\markup \italic "Allegro assai"', literal=True)
+            >>> markup = abjad.Markup(rf'\markup \italic "Allegro assai"')
             >>> print(str(markup))
             \markup \italic "Allegro assai"
 
@@ -408,35 +353,14 @@ class Markup:
         tweaks = []
         if self.tweaks:
             tweaks = self.tweaks._list_format_contributions()
-        indent = LilyPondFormatBundle.indent
         direction = ""
         if self.direction is not None:
-            direction = String.to_tridirectional_lilypond_symbol(self.direction)
-        if len(self.contents) == 1 and isinstance(self.contents[0], str):
-            content = self.contents[0]
-            if not self.literal:
-                if content:
-                    content = rf"\markup {{ {content} }}"
-                else:
-                    content = r"\markup {}"
-            if direction:
-                string = rf"{direction} {content}"
-            else:
-                string = content
-            return tweaks + [string]
+            direction = _string.String.to_tridirectional_lilypond_symbol(self.direction)
         if direction:
-            string = rf"{direction} \markup {{"
-            pieces = [string]
+            string = rf"{direction} {self.string}"
         else:
-            pieces = [r"\markup {"]
-        for content in self.contents:
-            if isinstance(content, str):
-                pieces.append(f"{indent}{content}")
-            else:
-                pieces_ = content._get_format_pieces()
-                pieces.extend([f"{indent}{_}" for _ in pieces_])
-        pieces.append(f"{indent}}}")
-        return tweaks + pieces
+            string = self.string
+        return tweaks + [string]
 
     def _get_format_specification(self):
         result = _format._inspect_signature(self)
@@ -448,43 +372,31 @@ class Markup:
     def _get_lilypond_format(self):
         return "\n".join(self._get_format_pieces())
 
-    @staticmethod
-    def _parse_markup_command_argument(argument):
-        if isinstance(argument, Markup):
-            if len(argument.contents) == 1:
-                contents = argument.contents[0]
-            else:
-                contents = list(argument.contents)
-        elif isinstance(argument, (str, MarkupCommand)):
-            contents = argument
-        else:
-            raise TypeError(f"must be markup, markup command or string: {argument!r}.")
-        return contents
-
     ### PUBLIC PROPERTIES ###
 
     @property
-    def contents(self) -> typing.List[typing.Union[str, "MarkupCommand"]]:
+    def string(self) -> str:
         r"""
-        Gets contents of markup.
+        Gets string of markup.
 
         ..  container:: example
 
-            Initializes contents positionally:
+            Initializes string positionally:
 
-            >>> abjad.Markup(r"\markup Allegro", literal=True)
-            Markup(contents=['\\markup Allegro'], literal=True)
+            >>> abjad.Markup(r"\markup Allegro")
+            Markup('\\markup Allegro')
 
-            Initializes contents from keyword:
+            Initializes string from keyword:
 
-            >>> abjad.Markup(contents=r"\markup Allegro", literal=True)
-            Markup(contents=['\\markup Allegro'], literal=True)
+            >>> abjad.Markup(r"\markup Allegro")
+            Markup('\\markup Allegro')
 
         """
-        return list(self._contents)
+        assert isinstance(self._string, str), repr(self._string)
+        return self._string
 
     @property
-    def direction(self) -> typing.Optional[enums.VerticalAlignment]:
+    def direction(self) -> typing.Optional[_enums.VerticalAlignment]:
         r"""
         Gets direction of markup.
 
@@ -492,7 +404,7 @@ class Markup:
 
             With ``direction`` unset:
 
-            >>> markup = abjad.Markup(r"\markup Allegro", literal=True)
+            >>> markup = abjad.Markup(r"\markup Allegro")
             >>> note = abjad.Note("c'4")
             >>> abjad.attach(markup, note)
             >>> abjad.show(note) # doctest: +SKIP
@@ -507,7 +419,7 @@ class Markup:
             With ``direction=abjad.Up``:
 
             >>> string = r"\markup Allegro"
-            >>> markup = abjad.Markup(string, direction=abjad.Up, literal=True)
+            >>> markup = abjad.Markup(string, direction=abjad.Up)
             >>> note = abjad.Note("c'4")
             >>> abjad.attach(markup, note)
             >>> abjad.show(note) # doctest: +SKIP
@@ -523,7 +435,7 @@ class Markup:
             With ``direction=abjad.Down``:
 
             >>> string = r"\markup Allegro"
-            >>> markup = abjad.Markup(string, direction=abjad.Down, literal=True)
+            >>> markup = abjad.Markup(string, direction=abjad.Down)
             >>> note = abjad.Note("c'4")
             >>> abjad.attach(markup, note)
             >>> abjad.show(note) # doctest: +SKIP
@@ -539,7 +451,7 @@ class Markup:
 
             REGRESSSION #806. Markup preserves tweaks when ``direction=None``:
 
-            >>> markup = abjad.Markup(r"\markup Allegro", literal=True)
+            >>> markup = abjad.Markup(r"\markup Allegro")
             >>> abjad.tweak(markup).color = "#red"
             >>> note = abjad.Note("c'4")
             >>> abjad.attach(markup, note)
@@ -557,1580 +469,76 @@ class Markup:
         return self._direction
 
     @property
-    def literal(self) -> typing.Optional[bool]:
-        r"""
-        Is true when markup formats contents literally.
-
-        ..  container:: example
-
-            Adds neither quotes nor braces:
-
-            >>> string = r"\custom-function #1 #4"
-            >>> markup = abjad.Markup(string, literal=True)
-            >>> string = abjad.lilypond(markup)
-            >>> print(string)
-            \custom-function #1 #4
-
-            Works with normal initializer, too:
-
-            >>> string = r"\custom-function #1 #4"
-            >>> markup = abjad.Markup(string, literal=True)
-            >>> string = abjad.lilypond(markup)
-            >>> print(string)
-            \custom-function #1 #4
-
-        ..  container:: example
-
-            Works with direction:
-
-            >>> string = r"\custom-function #1 #4"
-            >>> markup = abjad.Markup(
-            ...     string,
-            ...     direction=abjad.Up,
-            ...     literal=True,
-            ... )
-            >>> string = abjad.lilypond(markup)
-            >>> print(string)
-            ^ \custom-function #1 #4
-
-            Works with normal initialier, too:
-
-            >>> string = r"\custom-function #1 #4"
-            >>> markup = abjad.Markup(
-            ...     string,
-            ...     direction=abjad.Up,
-            ...     literal=True,
-            ... )
-            >>> string = abjad.lilypond(markup)
-            >>> print(string)
-            ^ \custom-function #1 #4
-
-        ..  container:: example
-
-            REGRESSION. Input string accepts LilyPond \markup command:
-
-            >>> string = r'\markup { \note {4} #1 }'
-            >>> markup = abjad.Markup(
-            ...     string,
-            ...     direction=abjad.Up,
-            ...     literal=True,
-            ... )
-            >>> string = abjad.lilypond(markup)
-            >>> print(string)
-            ^ \markup { \note {4} #1 }
-
-            >>> note = abjad.Note("c'4")
-            >>> abjad.attach(markup, note)
-            >>> abjad.show(note) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(note)
-                >>> print(string)
-                c'4
-                ^ \markup { \note {4} #1 }
-
-        """
-        return self._literal
-
-    # TODO: Tweaks do not appear on markup without direction!
-    @property
-    def tweaks(self) -> typing.Optional[TweakInterface]:
+    def tweaks(self) -> typing.Optional[_overrides.TweakInterface]:
         r"""
         Gets tweaks.
 
         ..  container:: example
 
             >>> string = r'\markup \bold "Allegro assai"'
-            >>> markup = abjad.Markup(string, direction=abjad.Up, literal=True)
+            >>> markup = abjad.Markup(string, direction=abjad.Up)
             >>> abjad.tweak(markup).color = "#blue"
             >>> staff = abjad.Staff("c'4 d' e' f'")
             >>> abjad.attach(markup, staff[0])
-            >>> string = abjad.lilypond(staff)
-            >>> print(string)
-            \new Staff
-            {
-                c'4
-                - \tweak color #blue
-                ^ \markup \bold "Allegro assai"
-                d'4
-                e'4
-                f'4
-            }
-
             >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
+                \new Staff
+                {
+                    c'4
+                    - \tweak color #blue
+                    ^ \markup \bold "Allegro assai"
+                    d'4
+                    e'4
+                    f'4
+                }
+
+            REGRESSION: tweaks format even markup has no direction:
+
+            >>> string = r'\markup \bold "Allegro assai"'
+            >>> markup = abjad.Markup(string)
+            >>> abjad.tweak(markup).color = "#blue"
+            >>> staff = abjad.Staff("c'4 d' e' f'")
+            >>> abjad.attach(markup, staff[0])
+            >>> abjad.show(staff) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
+                \new Staff
+                {
+                    c'4
+                    - \tweak color #blue
+                    - \markup \bold "Allegro assai"
+                    d'4
+                    e'4
+                    f'4
+                }
 
         """
         return self._tweaks
 
 
-class MarkupCommand:
-    r"""
-    LilyPond markup command.
-
-    ..  container:: example
-
-        Initializes a complex LilyPond markup command:
-
-        >>> circle = abjad.markups.MarkupCommand("draw-circle", 2.5, 0.1, False)
-        >>> square = abjad.markups.MarkupCommand("rounded-box", "hello?")
-        >>> line = abjad.markups.MarkupCommand("line", [square, "wow!"])
-        >>> rotate = abjad.markups.MarkupCommand("rotate", 60, line)
-        >>> combine = abjad.markups.MarkupCommand("combine", rotate, circle)
-
-        >>> string = abjad.lilypond(combine)
-        >>> print(string)
-        \combine
-            \rotate
-                #60
-                \line
-                    {
-                        \rounded-box
-                            hello?
-                        wow!
-                    }
-            \draw-circle
-                #2.5
-                #0.1
-                ##f
-
-        >>> note = abjad.Note("c'4")
-        >>> markup = abjad.Markup(rf"\markup {combine}", literal=True)
-        >>> abjad.attach(markup, note)
-        >>> abjad.show(note) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(note)
-            >>> print(string)
-            c'4
-            - \markup \combine
-                \rotate
-                    #60
-                    \line
-                        {
-                            \rounded-box
-                                hello?
-                            wow!
-                        }
-                \draw-circle
-                    #2.5
-                    #0.1
-                    ##f
-
-    ..  container:: example
-
-        Works with the LilyPond ``\score`` markup command:
-
-        >>> small_staff = abjad.Staff("fs'16 gs'16 as'16 b'16")
-        >>> small_staff.remove_commands.append("Clef_engraver")
-        >>> small_staff.remove_commands.append("Time_signature_engraver")
-        >>> abjad.setting(small_staff).fontSize = -3
-        >>> layout_block = abjad.Block(name="layout")
-        >>> layout_block.indent = 0
-        >>> layout_block.ragged_right = "##t"
-        >>> command = abjad.markups.MarkupCommand(
-        ...     "score",
-        ...     [small_staff, layout_block],
-        ... )
-
-        >>> string = abjad.lilypond(command)
-        >>> print(string)
-        \score
-            {
-                \new Staff
-                \with
-                {
-                    \remove Clef_engraver
-                    \remove Time_signature_engraver
-                    fontSize = -3
-                }
-                {
-                    fs'16
-                    gs'16
-                    as'16
-                    b'16
-                }
-                \layout
-                {
-                    indent = 0
-                    ragged-right = ##t
-                }
-            }
-
-        >>> string = rf"\markup {command}"
-        >>> markup = abjad.Markup(string, direction=abjad.Up, literal=True)
-        >>> staff = abjad.Staff("c'4 d'4 e'4 f'4")
-        >>> abjad.attach(markup, staff[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(staff)
-            >>> print(string)
-            \new Staff
-            {
-                c'4
-                ^ \markup \score
-                    {
-                        \new Staff
-                        \with
-                        {
-                            \remove Clef_engraver
-                            \remove Time_signature_engraver
-                            fontSize = -3
-                        }
-                        {
-                            fs'16
-                            gs'16
-                            as'16
-                            b'16
-                        }
-                        \layout
-                        {
-                            indent = 0
-                            ragged-right = ##t
-                        }
-                    }
-                d'4
-                e'4
-                f'4
-            }
-
-    """
-
-    ### CLASS VARIABLES ###
-
-    __slots__ = ("_arguments", "_deactivate", "_name", "_tag")
-
-    ### INITIALIZER ###
-
-    def __init__(self, name=None, *arguments):
-        if name is None:
-            # TODO: Generalize these arbitrary default arguments away.
-            name = "draw-circle"
-            assert len(arguments) == 0
-        self._arguments = tuple(arguments)
-        self._deactivate = None
-        assert isinstance(name, str) and len(name)
-        self._name = name
-        self._tag = None
-
-    ### SPECIAL METHODS ###
-
-    def __eq__(self, argument):
-        """
-        Is true when ``argument`` is a markup command with name and
-        arguments equal to those of this markup command.
-
-        ..  container:: example
-
-            >>> command_1 = abjad.markups.MarkupCommand("bold", "foo")
-            >>> command_2 = abjad.markups.MarkupCommand("bold", "foo")
-            >>> command_3 = abjad.markups.MarkupCommand("bold", "bar")
-
-            >>> command_1 == command_1
-            True
-            >>> command_1 == command_2
-            True
-            >>> command_1 == command_3
-            False
-            >>> command_2 == command_1
-            True
-            >>> command_2 == command_2
-            True
-            >>> command_2 == command_3
-            False
-            >>> command_3 == command_1
-            False
-            >>> command_3 == command_2
-            False
-            >>> command_3 == command_3
-            True
-
-        Returns true or false.
-        """
-        # defined explicitly because of initializer *arguments
-        if isinstance(argument, type(self)):
-            if self.name == argument.name:
-                if self.arguments == argument.arguments:
-                    return True
-        return False
-
-    def __hash__(self):
-        """
-        Hashes markup command.
-        """
-        return hash(self.__class__.__name__ + str(self))
-
-    def __repr__(self):
-        r"""
-        Gets markup command interpreter representation.
-
-        ..  container:: example
-
-            Interpreter representation is evaluable.
-
-            >>> command = abjad.markups.MarkupCommand("hspace", 0)
-            >>> command
-            MarkupCommand('hspace', 0)
-
-        Returns string.
-        """
-        return _format.get_repr(self)
-
-    def __str__(self):
-        r"""
-        Gets string representation of markup command.
-
-        ..  container:: example
-
-            >>> circle = abjad.markups.MarkupCommand("draw-circle", 2.5, 0.1, False)
-            >>> square = abjad.markups.MarkupCommand("rounded-box", "hello?")
-            >>> line = abjad.markups.MarkupCommand("line", [square, "wow!"])
-            >>> rotate = abjad.markups.MarkupCommand("rotate", 60, line)
-            >>> combine = abjad.markups.MarkupCommand("combine", rotate, circle)
-            >>> print(str(combine))
-            \combine
-                \rotate
-                    #60
-                    \line
-                        {
-                            \rounded-box
-                                hello?
-                            wow!
-                        }
-                \draw-circle
-                    #2.5
-                    #0.1
-                    ##f
-
-        Returns string.
-        """
-        return self._get_lilypond_format()
-
-    ### PRIVATE METHODS ###
-
-    def _get_format_pieces(self):
-        def recurse(iterable):
-            result = []
-            for item in iterable:
-                if isinstance(item, (list, tuple)):
-                    result.append("{")
-                    result.extend(recurse(item))
-                    result.append("}")
-                elif hasattr(item, "_get_format_pieces"):
-                    result.extend(item._get_format_pieces())
-                elif isinstance(item, str) and "\n" in item:
-                    result.append('#"')
-                    result.extend(item.splitlines())
-                    result.append('"')
-                else:
-                    formatted = format_scheme_value(item)
-                    if isinstance(item, str):
-                        result.append(formatted)
-                        # result.append(item)
-                    else:
-                        result.append(f"#{formatted}")
-                        # result.append(f"#{item}")
-            return [f"{indent}{item}" for item in result]
-
-        indent = LilyPondFormatBundle.indent
-        parts = [rf"\{self.name}"]
-        parts.extend(recurse(self.arguments))
-        parts = _tag.double_tag(parts, self.tag, deactivate=self.deactivate)
-        return parts
-
-    def _get_format_specification(self):
-        return _format.FormatSpecification(
-            storage_format_args_values=(self.name,) + self.arguments,
-            storage_format_keyword_names=[],
-        )
-
-    def _get_lilypond_format(self):
-        return "\n".join(self._get_format_pieces())
-
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def arguments(self):
-        """
-        Gets markup command arguments.
-
-        ..  container:: example
-
-            >>> arguments = ("draw-circle", 1, 0.1, False)
-            >>> command = abjad.markups.MarkupCommand(*arguments)
-            >>> command.arguments
-            (1, 0.1, False)
-
-        Returns tuple.
-        """
-        return self._arguments
-
-    @property
-    def deactivate(self):
-        """
-        Is true when markup command deactivates tag.
-
-        Returns true, false or none.
-        """
-        return self._deactivate
-
-    @deactivate.setter
-    def deactivate(self, argument):
-        if argument is not None:
-            argument = bool(argument)
-        self._deactivate = argument
-
-    @property
-    def name(self):
-        """
-        Gets markup command name.
-
-        ..  container:: example
-
-            >>> arguments = ("draw-circle", 1, 0.1, False)
-            >>> command = abjad.markups.MarkupCommand(*arguments)
-            >>> command.name
-            'draw-circle'
-
-        Returns string.
-        """
-        return self._name
-
-    @property
-    def tag(self):
-        """
-        Gets tag.
-        """
-        return self._tag
-
-    @tag.setter
-    def tag(self, argument):
-        if argument is not None:
-            tag = _tag.Tag(argument)
-        else:
-            tag = None
-        self._tag = tag
-
-
-class Postscript:
-    r"""
-    Postscript session.
-
-    ..  note::
-
-        The markup resulting from the ``\postscript`` markup command is both 0-height and
-        0-width. Make sure to wrap the ``\postscript`` command with a ``\pad-to-box`` or
-        ``\with-dimensions`` markup command to give it explicit height and width.
-        Likewise, use only positive coordinates in your postscript markup if at all
-        possible. When specifying explicit extents with ``\pad-to-box`` or
-        ``\with-dimensions``, negative extents will *not* be interpreted by LilyPond as
-        resulting in positive height or width, and may have unexpected behavior.
-
-    ..  note::
-
-        LilyPond will fail to render if *any* of the font commands are used. To create
-        text, use ``.show("text")`` preceded by ``.scale()`` or ``.rotate()`` to provide
-        the appropriate transformation. ``.charpath()`` is also useable. However,
-        ``.findfont()``, ``.scalefont()``, ``.setfont()`` will cause LilyPond to error.
-
-    ..  container:: example
-
-        >>> postscript = abjad.Postscript()
-        >>> postscript = postscript.moveto(1, 1)
-        >>> postscript = postscript.setlinewidth(2.5)
-        >>> postscript = postscript.setdash((2, 1))
-        >>> postscript = postscript.lineto(3, -4)
-        >>> postscript = postscript.stroke()
-        >>> print(abjad.storage(postscript))
-        abjad.Postscript(
-            operators=(
-                abjad.PostscriptOperator('moveto', 1.0, 1.0),
-                abjad.PostscriptOperator('setlinewidth', 2.5),
-                abjad.PostscriptOperator('setdash', (2.0, 1.0), 0.0),
-                abjad.PostscriptOperator('lineto', 3.0, -4.0),
-                abjad.PostscriptOperator('stroke'),
-                ),
-            )
-
-        >>> print(str(postscript))
-        1 1 moveto
-        2.5 setlinewidth
-        [ 2 1 ] 0 setdash
-        3 -4 lineto
-        stroke
-
-        >>> postscript = abjad.Postscript()
-        >>> postscript = postscript.newpath()
-        >>> postscript = postscript.moveto(0, 0)
-        >>> postscript = postscript.rlineto(0, -10)
-        >>> postscript = postscript.rlineto(10, 0)
-        >>> postscript = postscript.rlineto(0, 10)
-        >>> postscript = postscript.rlineto(-10, 0)
-        >>> postscript = postscript.closepath()
-        >>> postscript = postscript.gsave()
-        >>> postscript = postscript.setrgbcolor(0.5, 1, 0.5)
-        >>> postscript = postscript.fill()
-        >>> postscript = postscript.grestore()
-        >>> postscript = postscript.setrgbcolor(1, 0, 0)
-        >>> postscript = postscript.setlinewidth(1)
-        >>> postscript = postscript.stroke()
-        >>> abjad.show(postscript) # doctest: +SKIP
-
-    """
-
-    ### CLASS VARIABLES ###
-
-    __slots__ = ("_operators",)
-
-    ### INITIALIZER ###
-
-    def __init__(self, operators=None):
-        prototype = PostscriptOperator
-        if operators is not None:
-            assert all(isinstance(_, prototype) for _ in operators)
-            operators = tuple(operators)
-        self._operators = operators
-
-    ### SPECIAL METHODS ###
-
-    def __add__(self, argument):
-        """
-        Adds postscript to ``argument``.
-
-        Returns new postscript.
-        """
-        assert isinstance(argument, type(self))
-        self_operators = self.operators or ()
-        argument_operators = argument.operators or ()
-        operators = self_operators + argument_operators
-        operators = operators or None
-        return type(self)(operators)
-
-    def __eq__(self, argument) -> bool:
-        """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
-        """
-        return _format.compare_objects(self, argument)
-
-    def __hash__(self) -> int:
-        """
-        Hashes postscript.
-        """
-        return hash(self.__class__.__name__ + str(self))
-
-    def __radd__(self, argument):
-        """
-        Adds ``argument`` to postscript.
-
-        Returns new postscript.
-        """
-        assert isinstance(argument, type(self))
-        self_operators = self.operators or ()
-        argument_operators = argument.operators or ()
-        operators = argument_operators + self_operators
-        operators = operators or None
-        return type(self)(operators)
-
-    def __repr__(self) -> str:
-        """
-        Gets interpreter representation.
-        """
-        return _format.get_repr(self)
-
-    def __str__(self):
-        """
-        Gets string representation of Postscript.
-
-        Return string.
-        """
-        if not self.operators:
-            return ""
-        return "\n".join(str(_) for _ in self.operators)
-
-    ### PRIVATE METHODS ###
-
-    @staticmethod
-    def _format_argument(argument):
-        if isinstance(argument, str):
-            if argument.startswith("/"):
-                return argument
-            return f"({argument})"
-        elif isinstance(argument, collections.abc.Sequence):
-            if not argument:
-                return "[ ]"
-            contents = " ".join(Postscript._format_argument(_) for _ in argument)
-            return f"[ {contents} ]"
-        elif isinstance(argument, bool):
-            return str(argument).lower()
-        elif isinstance(argument, (int, float)):
-            argument = math.integer_equivalent_number_to_integer(argument)
-            return str(argument)
+def _format_postscript_argument(argument):
+    if isinstance(argument, str):
+        if argument.startswith("/"):
+            return argument
+        return f"({argument})"
+    elif isinstance(argument, collections.abc.Sequence):
+        if not argument:
+            return "[ ]"
+        string = " ".join(_format_postscript_argument(_) for _ in argument)
+        return f"[ {string} ]"
+    elif isinstance(argument, bool):
+        return str(argument).lower()
+    elif isinstance(argument, (int, float)):
+        argument = _math.integer_equivalent_number_to_integer(argument)
         return str(argument)
+    return str(argument)
 
-    def _with_operator(self, operator):
-        operators = self.operators or ()
-        operators = operators + (operator,)
-        return type(self)(operators)
 
-    ### PUBLIC METHODS ###
-
-    def as_markup(self):
-        r"""
-        Converts postscript to markup.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 200)
-            >>> postscript = postscript.lineto(200, 250)
-            >>> postscript = postscript.lineto(100, 300)
-            >>> postscript = postscript.closepath()
-            >>> postscript = postscript.gsave()
-            >>> postscript = postscript.setgray(0.5)
-            >>> postscript = postscript.fill()
-            >>> postscript = postscript.grestore()
-            >>> postscript = postscript.setlinewidth(4)
-            >>> postscript = postscript.setgray(0.75)
-            >>> postscript = postscript.stroke()
-
-            >>> markup = postscript.as_markup()
-            >>> string = abjad.lilypond(markup)
-            >>> print(string)
-            \markup \postscript
-                #"
-                newpath
-                100 200 moveto
-                200 250 lineto
-                100 300 lineto
-                closepath
-                gsave
-                0.5 setgray
-                fill
-                grestore
-                4 setlinewidth
-                0.75 setgray
-                stroke
-                "
-
-        Returns new markup.
-        """
-        return Markup(f'\\markup \\postscript\n#"\n{self}\n"', literal=True)
-
-    def charpath(self, text, modify_font=True):
-        """
-        Postscript ``charpath`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.findfont("Times Roman")
-            >>> postscript = postscript.scalefont(32)
-            >>> postscript = postscript.setfont()
-            >>> postscript = postscript.translate(100, 200)
-            >>> postscript = postscript.rotate(45)
-            >>> postscript = postscript.scale(2, 1)
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(0, 0)
-            >>> postscript = postscript.charpath("This is text.", True)
-            >>> postscript = postscript.setlinewidth(0.5)
-            >>> postscript = postscript.setgray(0.25)
-            >>> postscript = postscript.stroke()
-            >>> print(str(postscript))
-            /Times-Roman findfont
-            32 scalefont
-            setfont
-            100 200 translate
-            45 rotate
-            2 1 scale
-            newpath
-            0 0 moveto
-            (This is text.) true charpath
-            0.5 setlinewidth
-            0.25 setgray
-            stroke
-
-        Returns new Postscript.
-        """
-        text = str(text)
-        modify_font = bool(modify_font)
-        operator = PostscriptOperator("charpath", text, modify_font)
-        return self._with_operator(operator)
-
-    def closepath(self):
-        """
-        Postscript ``closepath`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 200)
-            >>> postscript = postscript.lineto(200, 250)
-            >>> postscript = postscript.lineto(100, 300)
-            >>> postscript = postscript.closepath()
-            >>> postscript = postscript.gsave()
-            >>> postscript = postscript.setgray(0.5)
-            >>> postscript = postscript.fill()
-            >>> postscript = postscript.grestore()
-            >>> postscript = postscript.setlinewidth(4)
-            >>> postscript = postscript.setgray(0.75)
-            >>> postscript = postscript.stroke()
-            >>> print(str(postscript))
-            newpath
-            100 200 moveto
-            200 250 lineto
-            100 300 lineto
-            closepath
-            gsave
-            0.5 setgray
-            fill
-            grestore
-            4 setlinewidth
-            0.75 setgray
-            stroke
-
-        Returns new Postscript.
-        """
-        operator = PostscriptOperator("closepath")
-        return self._with_operator(operator)
-
-    def curveto(self, x1, y1, x2, y2, x3, y3):
-        """
-        Postscript ``curveto`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.curveto(0, 1, 1.5, 2, 3, 6)
-            >>> print(str(postscript))
-            0 1 1.5 2 3 6 curveto
-
-        Returns new Postscript.
-        """
-        x1 = float(x1)
-        x2 = float(x2)
-        x3 = float(x3)
-        y1 = float(y1)
-        y2 = float(y2)
-        y3 = float(y3)
-        operator = PostscriptOperator("curveto", x1, y1, x2, y2, x3, y3)
-        return self._with_operator(operator)
-
-    def fill(self):
-        """
-        Postscript ``fill`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 200)
-            >>> postscript = postscript.lineto(200, 250)
-            >>> postscript = postscript.lineto(100, 300)
-            >>> postscript = postscript.closepath()
-            >>> postscript = postscript.gsave()
-            >>> postscript = postscript.setgray(0.5)
-            >>> postscript = postscript.fill()
-            >>> postscript = postscript.grestore()
-            >>> postscript = postscript.setlinewidth(4)
-            >>> postscript = postscript.setgray(0.75)
-            >>> postscript = postscript.stroke()
-            >>> print(str(postscript))
-            newpath
-            100 200 moveto
-            200 250 lineto
-            100 300 lineto
-            closepath
-            gsave
-            0.5 setgray
-            fill
-            grestore
-            4 setlinewidth
-            0.75 setgray
-            stroke
-
-        Returns new Postscript.
-        """
-        operator = PostscriptOperator("fill")
-        return self._with_operator(operator)
-
-    def findfont(self, font_name):
-        """
-        Postscript ``findfont`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.findfont("Times Roman")
-            >>> postscript = postscript.scalefont(12)
-            >>> postscript = postscript.setfont()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 200)
-            >>> postscript = postscript.show("This is text.")
-            >>> print(str(postscript))
-            /Times-Roman findfont
-            12 scalefont
-            setfont
-            newpath
-            100 200 moveto
-            (This is text.) show
-
-        Returns new Postscript.
-        """
-        font_name = str(font_name)
-        font_name = font_name.replace(" ", "-")
-        font_name = f"/{font_name}"
-        operator = PostscriptOperator("findfont", font_name)
-        return self._with_operator(operator)
-
-    def grestore(self):
-        """
-        Postscript ``grestore`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 200)
-            >>> postscript = postscript.lineto(200, 250)
-            >>> postscript = postscript.lineto(100, 300)
-            >>> postscript = postscript.closepath()
-            >>> postscript = postscript.gsave()
-            >>> postscript = postscript.setgray(0.5)
-            >>> postscript = postscript.fill()
-            >>> postscript = postscript.grestore()
-            >>> postscript = postscript.setlinewidth(4)
-            >>> postscript = postscript.setgray(0.75)
-            >>> postscript = postscript.stroke()
-            >>> print(str(postscript))
-            newpath
-            100 200 moveto
-            200 250 lineto
-            100 300 lineto
-            closepath
-            gsave
-            0.5 setgray
-            fill
-            grestore
-            4 setlinewidth
-            0.75 setgray
-            stroke
-
-        Returns new Postscript.
-        """
-        operator = PostscriptOperator("grestore")
-        return self._with_operator(operator)
-
-    def gsave(self):
-        """
-        Postscript ``gsave`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 200)
-            >>> postscript = postscript.lineto(200, 250)
-            >>> postscript = postscript.lineto(100, 300)
-            >>> postscript = postscript.closepath()
-            >>> postscript = postscript.gsave()
-            >>> postscript = postscript.setgray(0.5)
-            >>> postscript = postscript.fill()
-            >>> postscript = postscript.grestore()
-            >>> postscript = postscript.setlinewidth(4)
-            >>> postscript = postscript.setgray(0.75)
-            >>> postscript = postscript.stroke()
-            >>> print(str(postscript))
-            newpath
-            100 200 moveto
-            200 250 lineto
-            100 300 lineto
-            closepath
-            gsave
-            0.5 setgray
-            fill
-            grestore
-            4 setlinewidth
-            0.75 setgray
-            stroke
-
-        Returns new Postscript.
-        """
-        operator = PostscriptOperator("gsave")
-        return self._with_operator(operator)
-
-    def lineto(self, x, y):
-        """
-        Postscript ``lineto`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.moveto(1, 1)
-            >>> postscript = postscript.lineto(3, -4)
-            >>> postscript = postscript.stroke()
-            >>> print(str(postscript))
-            1 1 moveto
-            3 -4 lineto
-            stroke
-
-        Returns new Postscript.
-        """
-        x = float(x)
-        y = float(y)
-        operator = PostscriptOperator("lineto", x, y)
-        return self._with_operator(operator)
-
-    def moveto(self, x, y):
-        """
-        Postscript ``moveto`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.moveto(1, 1)
-            >>> postscript = postscript.lineto(3, -4)
-            >>> postscript = postscript.stroke()
-            >>> print(abjad.storage(postscript))
-            abjad.Postscript(
-                operators=(
-                    abjad.PostscriptOperator('moveto', 1.0, 1.0),
-                    abjad.PostscriptOperator('lineto', 3.0, -4.0),
-                    abjad.PostscriptOperator('stroke'),
-                    ),
-                )
-
-            >>> print(str(postscript))
-            1 1 moveto
-            3 -4 lineto
-            stroke
-
-        Returns new Postscript.
-        """
-        x = float(x)
-        y = float(y)
-        operator = PostscriptOperator("moveto", x, y)
-        return self._with_operator(operator)
-
-    def newpath(self):
-        """
-        Postscript ``newpath`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 200)
-            >>> postscript = postscript.lineto(200, 250)
-            >>> postscript = postscript.lineto(100, 300)
-            >>> postscript = postscript.closepath()
-            >>> postscript = postscript.gsave()
-            >>> postscript = postscript.setgray(0.5)
-            >>> postscript = postscript.fill()
-            >>> postscript = postscript.grestore()
-            >>> postscript = postscript.setlinewidth(4)
-            >>> postscript = postscript.setgray(0.75)
-            >>> postscript = postscript.stroke()
-            >>> print(str(postscript))
-            newpath
-            100 200 moveto
-            200 250 lineto
-            100 300 lineto
-            closepath
-            gsave
-            0.5 setgray
-            fill
-            grestore
-            4 setlinewidth
-            0.75 setgray
-            stroke
-
-        Returns new Postscript.
-        """
-        operator = PostscriptOperator("newpath")
-        return self._with_operator(operator)
-
-    def rcurveto(self, dx1, dy1, dx2, dy2, dx3, dy3):
-        """
-        Postscript ``rcurveto`` operator.
-
-        ..  container:: edxample
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.rcurveto(0, 1, 1.5, 2, 3, 6)
-            >>> print(str(postscript))
-            0 1 1.5 2 3 6 rcurveto
-
-        Returns new Postscript.
-        """
-        dx1 = float(dx1)
-        dx2 = float(dx2)
-        dx3 = float(dx3)
-        dy1 = float(dy1)
-        dy2 = float(dy2)
-        dy3 = float(dy3)
-        operator = PostscriptOperator("rcurveto", dx1, dy1, dx2, dy2, dx3, dy3)
-        return self._with_operator(operator)
-
-    def rlineto(self, dx, dy):
-        """
-        Postscript ``rlineto`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.rmoveto(1, 1)
-            >>> postscript = postscript.rlineto(3, -4)
-            >>> postscript = postscript.stroke()
-            >>> print(abjad.storage(postscript))
-            abjad.Postscript(
-                operators=(
-                    abjad.PostscriptOperator('rmoveto', 1.0, 1.0),
-                    abjad.PostscriptOperator('rlineto', 3.0, -4.0),
-                    abjad.PostscriptOperator('stroke'),
-                    ),
-                )
-
-            >>> print(str(postscript))
-            1 1 rmoveto
-            3 -4 rlineto
-            stroke
-
-        Returns new Postscript.
-        """
-        dx = float(dx)
-        dy = float(dy)
-        operator = PostscriptOperator("rlineto", dx, dy)
-        return self._with_operator(operator)
-
-    def rmoveto(self, dx, dy):
-        """
-        Postscript ``rmoveto`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.rmoveto(1, 1)
-            >>> postscript = postscript.rlineto(3, -4)
-            >>> postscript = postscript.stroke()
-            >>> print(abjad.storage(postscript))
-            abjad.Postscript(
-                operators=(
-                    abjad.PostscriptOperator('rmoveto', 1.0, 1.0),
-                    abjad.PostscriptOperator('rlineto', 3.0, -4.0),
-                    abjad.PostscriptOperator('stroke'),
-                    ),
-                )
-
-            >>> print(str(postscript))
-            1 1 rmoveto
-            3 -4 rlineto
-            stroke
-
-        Returns new Postscript.
-        """
-        dx = float(dx)
-        dy = float(dy)
-        operator = PostscriptOperator("rmoveto", dx, dy)
-        return self._with_operator(operator)
-
-    def rotate(self, degrees):
-        """
-        Postscript ``restore`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.findfont("Times Roman")
-            >>> postscript = postscript.scalefont(32)
-            >>> postscript = postscript.setfont()
-            >>> postscript = postscript.translate(100, 200)
-            >>> postscript = postscript.rotate(45)
-            >>> postscript = postscript.scale(2, 1)
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(0, 0)
-            >>> postscript = postscript.charpath("This is text.", True)
-            >>> postscript = postscript.setlinewidth(0.5)
-            >>> postscript = postscript.setgray(0.25)
-            >>> postscript = postscript.stroke()
-            >>> print(str(postscript))
-            /Times-Roman findfont
-            32 scalefont
-            setfont
-            100 200 translate
-            45 rotate
-            2 1 scale
-            newpath
-            0 0 moveto
-            (This is text.) true charpath
-            0.5 setlinewidth
-            0.25 setgray
-            stroke
-
-        Returns new Postscript.
-        """
-        degrees = float(degrees)
-        operator = PostscriptOperator("rotate", degrees)
-        return self._with_operator(operator)
-
-    def scale(self, dx, dy):
-        """
-        Postscript ``scale`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.findfont("Times Roman")
-            >>> postscript = postscript.scalefont(32)
-            >>> postscript = postscript.setfont()
-            >>> postscript = postscript.translate(100, 200)
-            >>> postscript = postscript.rotate(45)
-            >>> postscript = postscript.scale(2, 1)
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(0, 0)
-            >>> postscript = postscript.charpath("This is text.", True)
-            >>> postscript = postscript.setlinewidth(0.5)
-            >>> postscript = postscript.setgray(0.25)
-            >>> postscript = postscript.stroke()
-            >>> print(str(postscript))
-            /Times-Roman findfont
-            32 scalefont
-            setfont
-            100 200 translate
-            45 rotate
-            2 1 scale
-            newpath
-            0 0 moveto
-            (This is text.) true charpath
-            0.5 setlinewidth
-            0.25 setgray
-            stroke
-
-        Returns new Postscript.
-        """
-        dx = float(dx)
-        dy = float(dy)
-        operator = PostscriptOperator("scale", dx, dy)
-        return self._with_operator(operator)
-
-    def scalefont(self, font_size):
-        """
-        Postscript ``scalefont`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.findfont("Times Roman")
-            >>> postscript = postscript.scalefont(12)
-            >>> postscript = postscript.setfont()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 200)
-            >>> postscript = postscript.show("This is text.")
-            >>> print(str(postscript))
-            /Times-Roman findfont
-            12 scalefont
-            setfont
-            newpath
-            100 200 moveto
-            (This is text.) show
-
-        Returns new Postscript.
-        """
-        font_size = float(font_size)
-        operator = PostscriptOperator("scalefont", font_size)
-        return self._with_operator(operator)
-
-    def setdash(self, array=None, offset=0):
-        """
-        Postscript ``setdash`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript().setdash([2, 1], 3)
-            >>> print(abjad.storage(postscript))
-            abjad.Postscript(
-                operators=(
-                    abjad.PostscriptOperator('setdash', (2.0, 1.0), 3.0),
-                    ),
-                )
-
-            >>> print(str(postscript))
-            [ 2 1 ] 3 setdash
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript().setdash()
-            >>> print(abjad.storage(postscript))
-            abjad.Postscript(
-                operators=(
-                    abjad.PostscriptOperator('setdash', (), 0.0),
-                    ),
-                )
-
-            >>> print(str(postscript))
-            [ ] 0 setdash
-
-        Returns new Postscript.
-        """
-        if array is None:
-            array = ()
-        else:
-            array = tuple(float(_) for _ in array)
-        offset = float(offset)
-        operator = PostscriptOperator("setdash", array, offset)
-        return self._with_operator(operator)
-
-    def setfont(self):
-        """
-        Postscript ``setfont`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.findfont("Times Roman")
-            >>> postscript = postscript.scalefont(12)
-            >>> postscript = postscript.setfont()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 200)
-            >>> postscript = postscript.show("This is text.")
-            >>> print(str(postscript))
-            /Times-Roman findfont
-            12 scalefont
-            setfont
-            newpath
-            100 200 moveto
-            (This is text.) show
-
-        Returns new Postscript.
-        """
-        operator = PostscriptOperator("setfont")
-        return self._with_operator(operator)
-
-    def setgray(self, gray_value):
-        """
-        Postscript ``setgray`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 200)
-            >>> postscript = postscript.lineto(200, 250)
-            >>> postscript = postscript.lineto(100, 300)
-            >>> postscript = postscript.closepath()
-            >>> postscript = postscript.gsave()
-            >>> postscript = postscript.setgray(0.5)
-            >>> postscript = postscript.fill()
-            >>> postscript = postscript.grestore()
-            >>> postscript = postscript.setlinewidth(4)
-            >>> postscript = postscript.setgray(0.75)
-            >>> postscript = postscript.stroke()
-            >>> print(str(postscript))
-            newpath
-            100 200 moveto
-            200 250 lineto
-            100 300 lineto
-            closepath
-            gsave
-            0.5 setgray
-            fill
-            grestore
-            4 setlinewidth
-            0.75 setgray
-            stroke
-
-        Returns new Postscript.
-        """
-        gray_value = float(gray_value)
-        assert 0 <= gray_value <= 1
-        operator = PostscriptOperator("setgray", gray_value)
-        return self._with_operator(operator)
-
-    def setlinewidth(self, width):
-        """
-        Postscript ``setlinewidth`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.moveto(1, 1)
-            >>> postscript = postscript.setlinewidth(2.5)
-            >>> postscript = postscript.lineto(3, -4)
-            >>> postscript = postscript.stroke()
-            >>> print(abjad.storage(postscript))
-            abjad.Postscript(
-                operators=(
-                    abjad.PostscriptOperator('moveto', 1.0, 1.0),
-                    abjad.PostscriptOperator('setlinewidth', 2.5),
-                    abjad.PostscriptOperator('lineto', 3.0, -4.0),
-                    abjad.PostscriptOperator('stroke'),
-                    ),
-                )
-
-            >>> print(str(postscript))
-            1 1 moveto
-            2.5 setlinewidth
-            3 -4 lineto
-            stroke
-
-        Returns new Postscript.
-        """
-        width = float(width)
-        operator = PostscriptOperator("setlinewidth", width)
-        return self._with_operator(operator)
-
-    def setrgbcolor(self, red, green, blue):
-        """
-        Postscript ``setrgb`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 100)
-            >>> postscript = postscript.rlineto(0, 100)
-            >>> postscript = postscript.rlineto(100, 0)
-            >>> postscript = postscript.rlineto(0, -100)
-            >>> postscript = postscript.rlineto(-100, 0)
-            >>> postscript = postscript.closepath()
-            >>> postscript = postscript.gsave()
-            >>> postscript = postscript.setrgbcolor(0.5, 1, 0.5)
-            >>> postscript = postscript.fill()
-            >>> postscript = postscript.grestore()
-            >>> postscript = postscript.setrgbcolor(1, 0, 0)
-            >>> postscript = postscript.setlinewidth(4)
-            >>> postscript = postscript.stroke()
-
-            >>> print(str(postscript))
-            newpath
-            100 100 moveto
-            0 100 rlineto
-            100 0 rlineto
-            0 -100 rlineto
-            -100 0 rlineto
-            closepath
-            gsave
-            0.5 1 0.5 setrgbcolor
-            fill
-            grestore
-            1 0 0 setrgbcolor
-            4 setlinewidth
-            stroke
-
-        Returns new Postscript.
-        """
-        red = float(red)
-        green = float(green)
-        blue = float(blue)
-        assert 0 <= red <= 1
-        assert 0 <= green <= 1
-        assert 0 <= blue <= 1
-        operator = PostscriptOperator("setrgbcolor", red, green, blue)
-        return self._with_operator(operator)
-
-    def show(self, text):
-        """
-        Postscript ``show`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.findfont("Times Roman")
-            >>> postscript = postscript.scalefont(12)
-            >>> postscript = postscript.setfont()
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(100, 200)
-            >>> postscript = postscript.show("This is text.")
-            >>> print(str(postscript))
-            /Times-Roman findfont
-            12 scalefont
-            setfont
-            newpath
-            100 200 moveto
-            (This is text.) show
-
-        Returns new Postscript.
-        """
-        text = str(text)
-        operator = PostscriptOperator("show", text)
-        return self._with_operator(operator)
-
-    def stroke(self):
-        """
-        Postscript ``stroke`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.lineto(3, -4)
-            >>> postscript = postscript.stroke()
-            >>> print(abjad.storage(postscript))
-            abjad.Postscript(
-                operators=(
-                    abjad.PostscriptOperator('lineto', 3.0, -4.0),
-                    abjad.PostscriptOperator('stroke'),
-                    ),
-                )
-
-            >>> print(str(postscript))
-            3 -4 lineto
-            stroke
-
-        Returns new Postscript.
-        """
-        operator = PostscriptOperator("stroke")
-        return self._with_operator(operator)
-
-    def translate(self, dx, dy):
-        """
-        Postscript ``translate`` operator.
-
-        ..  container:: example
-
-            >>> postscript = abjad.Postscript()
-            >>> postscript = postscript.findfont("Times Roman")
-            >>> postscript = postscript.scalefont(32)
-            >>> postscript = postscript.setfont()
-            >>> postscript = postscript.translate(100, 200)
-            >>> postscript = postscript.rotate(45)
-            >>> postscript = postscript.scale(2, 1)
-            >>> postscript = postscript.newpath()
-            >>> postscript = postscript.moveto(0, 0)
-            >>> postscript = postscript.charpath("This is text.", True)
-            >>> postscript = postscript.setlinewidth(0.5)
-            >>> postscript = postscript.setgray(0.25)
-            >>> postscript = postscript.stroke()
-            >>> print(str(postscript))
-            /Times-Roman findfont
-            32 scalefont
-            setfont
-            100 200 translate
-            45 rotate
-            2 1 scale
-            newpath
-            0 0 moveto
-            (This is text.) true charpath
-            0.5 setlinewidth
-            0.25 setgray
-            stroke
-
-        Returns new Postscript.
-        """
-        dx = float(dx)
-        dy = float(dy)
-        operator = PostscriptOperator("translate", dx, dy)
-        return self._with_operator(operator)
-
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def operators(self):
-        """
-        Gets Postscript operators.
-
-        Returns tuple or none.
-        """
-        return self._operators
-
-
-class PostscriptOperator:
-    """
-    Postscript operator.
-
-    ..  container:: example
-
-        >>> operator = abjad.PostscriptOperator("rmoveto", 1, 1.5)
-        >>> abjad.storage(operator)
-        "abjad.PostscriptOperator('rmoveto', 1, 1.5)"
-
-    """
-
-    ### CLASS VARIABLES ###
-
-    __slots__ = ("_name", "_arguments")
-
-    ### INITIALIZER ###
-
-    def __init__(self, name="stroke", *arguments):
-        name = str(name)
-        self._name = name
-        if arguments:
-            self._arguments = tuple(arguments)
-        else:
-            self._arguments = None
-
-    ### SPECIAL METHODS ###
-
-    def __eq__(self, argument) -> bool:
-        """
-        Is true when all initialization values of Abjad value object equal the
-        initialization values of ``argument``.
-        """
-        return _format.compare_objects(self, argument)
-
-    def __hash__(self) -> int:
-        """
-        Hashes postscript operator.
-        """
-        return hash(self.__class__.__name__ + str(self))
-
-    def __repr__(self) -> str:
-        """
-        Gets interpreter representation.
-        """
-        return _format.get_repr(self)
-
-    def __str__(self):
-        """
-        Gets string representation of Postscript operator.
-
-        ..  container:: example
-
-            >>> operator = abjad.PostscriptOperator("rmoveto", 1, 1.5)
-            >>> str(operator)
-            '1 1.5 rmoveto'
-
-        Returns string.
-        """
-        parts = []
-        if self.arguments:
-            for argument in self.arguments:
-                parts.append(Postscript._format_argument(argument))
-        parts.append(self.name)
-        string = " ".join(parts)
-        return string
-
-    ### PRIVATE METHODS ###
-
-    def _get_format_specification(self):
-        values = [self.name] + list(self.arguments or ())
-        return _format.FormatSpecification(
-            storage_format_args_values=values,
-            storage_format_is_not_indented=True,
-            storage_format_keyword_names=[],
-        )
-
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def arguments(self):
-        """
-        Gets Postscript operator arguments.
-
-        Returns tuple or none.
-        """
-        return self._arguments
-
-    @property
-    def name(self):
-        """
-        Gets Postscript operator name.
-
-        Returns string.
-        """
-        return self._name
+_fpa = _format_postscript_argument

--- a/abjad/meter.py
+++ b/abjad/meter.py
@@ -10,6 +10,7 @@ import uqbar.graphs
 from . import _inspect, _iterate
 from . import format as _format
 from . import markups, math, mutate, rhythmtrees
+from . import timespan as _timespan
 from .duration import Duration, Multiplier, NonreducedFraction, Offset
 from .indicators.TimeSignature import TimeSignature
 from .lilypondfile import LilyPondFile
@@ -26,11 +27,10 @@ class Meter:
     """
     Meter.
 
-    Meter models a common practice understanding of beats and other levels of
-    rhythmic organization structured as a tree. Meter structure corresponds to
-    the monotonically increasing sequence of factors in the numerator of a
-    given time signature. Successively deeper levels of the tree divide time by
-    successive factors.
+    Meter models a common practice understanding of beats and other levels of rhythmic
+    organization structured as a tree. Meter structure corresponds to the monotonically
+    increasing sequence of factors in the numerator of a given time signature.
+    Successively deeper levels of the tree divide time by successive factors.
 
     ..  container:: example
 
@@ -244,10 +244,9 @@ class Meter:
 
         >>> abjad.graph(meter) # doctest: +SKIP
 
-    Prime divisions greater than ``3`` are converted to sequences of ``2``
-    and ``3`` summing to that prime. Summands are arranged from greatest
-    to least by default. This means that ``5`` becomes ``3+2`` and ``7``
-    becomes ``3+2+2`` in the examples above.
+    Prime divisions greater than ``3`` are converted to sequences of ``2`` and ``3``
+    summing to that prime. Summands are arranged from greatest to least by default. This
+    means that ``5`` becomes ``3+2`` and ``7`` becomes ``3+2+2`` in the examples above.
     """
 
     ### CLASS VARIABLES ###
@@ -861,8 +860,8 @@ class Meter:
             11/8
             12/8    True
 
-        Compound meters defined equal to those meters with a numerator
-        divisible by ``3`` (but not equal to ``3``).
+        Compound meters defined equal to those meters with a numerator divisible by ``3``
+        (but not equal to ``3``).
 
         Returns true or false.
         """
@@ -920,8 +919,8 @@ class Meter:
             11/8    True
             12/8
 
-        Simple meters defined equal to those meters with a numerator
-        not divisible by ``3``.
+        Simple meters defined equal to those meters with a numerator not divisible by
+        ``3``.
 
         Meters with numerator equal to ``3`` are also defined as simple.
 
@@ -1106,8 +1105,8 @@ class Meter:
         starting_offset=None,
     ):
         """
-        Finds the best-matching sequence of meters for the offsets
-        contained in ``argument``.
+        Finds the best-matching sequence of meters for the offsets contained in
+        ``argument``.
 
         ..  container:: example
 
@@ -1141,8 +1140,7 @@ class Meter:
             5/4
             5/4
 
-        Coerces offsets from ``argument`` via
-        ``MetricAccentKernel.count_offsets()``.
+        Coerces offsets from ``argument`` via ``MetricAccentKernel.count_offsets()``.
 
         Coerces Meters from ``meters`` via ``MeterList``.
 
@@ -1159,11 +1157,9 @@ class Meter:
 
     def generate_offset_kernel_to_denominator(self, denominator, normalize=True):
         r"""
-        Generates a dictionary of all offsets in a meter up
-        to ``denominator``.
+        Generates a dictionary of all offsets in a meter up to ``denominator``.
 
-        Keys are the offsets and the values are the normalized weights of
-        those offsets.
+        Keys are the offsets and the values are the normalized weights of those offsets.
 
         ..  container:: example
 
@@ -1182,8 +1178,8 @@ class Meter:
             7/8     1/16
             1       3/16
 
-        This is useful for testing how strongly a collection of offsets
-        responds to a given meter.
+        This is useful for testing how strongly a collection of offsets responds to a
+        given meter.
 
         Returns dictionary.
         """
@@ -1226,8 +1222,8 @@ class Meter:
 
         ..  container:: example
 
-            Rewrites the contents of a measure in a staff using the default
-            meter for that measure's time signature:
+            Rewrites the contents of a measure in a staff using the default meter for
+            that measure's time signature:
 
             >>> lily_string = "| 2/4 c'2 ~ |"
             >>> lily_string += "| 4/4 c'32 d'2.. ~ d'16 e'32 ~ |"
@@ -1379,8 +1375,7 @@ class Meter:
 
         ..  container:: example
 
-            Limit the maximum number of dots per leaf using
-            ``maximum_dot_count``:
+            Limit the maximum number of dots per leaf using ``maximum_dot_count``:
 
             >>> lily_string = "| 3/4 c'32 d'8 e'8 fs'4... |"
             >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
@@ -1561,9 +1556,9 @@ class Meter:
 
         ..  container:: example
 
-            Split logical ties at different depths of the ``Meter``, if those
-            logical ties cross any offsets at that depth, but do not also both
-            begin and end at any of those offsets.
+            Split logical ties at different depths of the ``Meter``, if those logical
+            ties cross any offsets at that depth, but do not also both begin and end at
+            any of those offsets.
 
             Consider the default meter for ``9/8``:
 
@@ -1583,8 +1578,7 @@ class Meter:
                     1/8
                     1/8))))
 
-            We can establish that meter without specifying
-            a ``boundary_depth``:
+            We can establish that meter without specifying a ``boundary_depth``:
 
             >>> lily_string = "| 9/8 c'2 d'2 e'8 |"
             >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
@@ -1630,10 +1624,10 @@ class Meter:
                     }
                 }
 
-            With a ``boundary_depth`` of ``1`` logical ties which cross any
-            offsets created by nodes with a depth of ``1`` in this Meter's rhythm
-            tree - i.e.  ``0/8`` ``3/8`` ``6/8`` and ``9/8`` - which do not also
-            begin and end at any of those offsets, will be split:
+            With a ``boundary_depth`` of ``1`` logical ties which cross any offsets
+            created by nodes with a depth of ``1`` in this Meter's rhythm tree - i.e.
+            ``0/8`` ``3/8`` ``6/8`` and ``9/8`` - which do not also begin and end at any
+            of those offsets, will be split:
 
             >>> lily_string = "| 9/8 c'2 d'2 e'8 |"
             >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
@@ -1669,9 +1663,9 @@ class Meter:
                     }
                 }
 
-            For this ``9/8`` meter, and this input notation, A ``boundary_depth``
-            of ``2`` causes no change, as all logical ties already align to
-            multiples of ``1/8``
+            For this ``9/8`` meter, and this input notation, A ``boundary_depth`` of
+            ``2`` causes no change, as all logical ties already align to multiples of
+            ``1/8``
 
             >>> lily_string = "| 9/8 c'2 d'2 e'8 |"
             >>> container = abjad.parsers.reduced.parse_reduced_ly_syntax(lily_string)
@@ -1721,9 +1715,8 @@ class Meter:
             >>> staff_2[:] = container
             >>> score = abjad.Score([staff_1, staff_2])
 
-            In order to see the different time signatures on each staff,
-            we need to move some engravers from the Score context to the
-            Staff context:
+            In order to see the different time signatures on each staff, we need to move
+            some engravers from the Score context to the Staff context:
 
             >>> engravers = [
             ...     'Timing_translator',
@@ -2043,8 +2036,7 @@ class Meter:
                     }
                 >>
 
-            Note that the two time signatures are much more clearly
-            disambiguated above.
+            Note that the two time signatures are much more clearly disambiguated above.
 
         ..  container:: example
 
@@ -2086,11 +2078,10 @@ class Meter:
                     }
                 }
 
-            When establishing a meter on a selection of components which
-            contain containers, like tuplets or containers, ``rewrite_meter()``
-            will recurse into those containers, treating them as measures whose
-            time signature is derived from the preprolated preprolated_duration
-            of the container's contents:
+            When establishing a meter on a selection of components which contain
+            containers, like tuplets or containers, ``rewrite_meter()`` will recurse into
+            those containers, treating them as measures whose time signature is derived
+            from the preprolated preprolated_duration of the container's contents:
 
             >>> measure = staff[0]
             >>> time_signature = abjad.get.indicator(
@@ -2138,9 +2129,9 @@ class Meter:
 
         ..  container:: example
 
-            Default rewrite behavior doesn't subdivide the first note in this
-            measure because the first note in the measure starts at the
-            beginning of a level-0 beat in meter:
+            Default rewrite behavior doesn't subdivide the first note in this measure
+            because the first note in the measure starts at the beginning of a level-0
+            beat in meter:
 
             >>> staff = abjad.Staff("c'4.. c'16 ~ c'4")
             >>> abjad.attach(abjad.TimeSignature((6, 8)), staff[0])
@@ -2161,8 +2152,7 @@ class Meter:
                     c'4
                 }
 
-            Setting boundary depth to 1 subdivides the first note in this
-            measure:
+            Setting boundary depth to 1 subdivides the first note in this measure:
 
             >>> staff = abjad.Staff("c'4.. c'16 ~ c'4")
             >>> abjad.attach(abjad.TimeSignature((6, 8)), staff[0])
@@ -2185,8 +2175,8 @@ class Meter:
                     c'4
                 }
 
-            Another way of doing this is by setting preferred boundary depth on
-            the meter itself:
+            Another way of doing this is by setting preferred boundary depth on the meter
+            itself:
 
             >>> staff = abjad.Staff("c'4.. c'16 ~ c'4")
             >>> abjad.attach(abjad.TimeSignature((6, 8)), staff[0])
@@ -2212,8 +2202,7 @@ class Meter:
                     c'4
                 }
 
-            This makes it possible to divide different meters in different
-            ways.
+            This makes it possible to divide different meters in different ways.
 
         ..  container:: example
 
@@ -2289,8 +2278,8 @@ class Meter:
                     c'4.
                 }
 
-            The tied note rewriting is good while the tuplet rewriting
-            could use some adjustment.
+            The tied note rewriting is good while the tuplet rewriting could use some
+            adjustment.
 
             Rewrites notes but not tuplets:
 
@@ -2556,13 +2545,27 @@ class MeterList(TypedList):
             >>> meters = abjad.MeterList([(3, 4), (5, 16), (7, 8)])
             >>> abjad.show(meters, scale=0.5) # doctest: +SKIP
 
-            ..  doctest
+            ..  docs::
 
                 >>> lilypond_file = meters.__illustrate__()
                 >>> markup = lilypond_file.items[0]
                 >>> string = abjad.lilypond(markup)
                 >>> print(string)
-                \markup { \column { \combine \combine \translate #'(1.0 . 1) \sans \fontsize #-3 \center-align \fraction 3 4 \translate #'(49.38709677419355 . 1) \sans \fontsize #-3 \center-align \fraction 5 16 \translate #'(69.54838709677419 . 1) \sans \fontsize #-3 \center-align \fraction 7 8 \combine \postscript #"0.2 setlinewidth
+                \markup
+                \column
+                {
+                \combine
+                \combine
+                \translate #'(1.0 . 1)
+                \sans \fontsize #-3 \center-align \fraction 3 4
+                \translate #'(49.38709677419355 . 1)
+                \sans \fontsize #-3 \center-align \fraction 5 16
+                \translate #'(69.54838709677419 . 1)
+                \sans \fontsize #-3 \center-align \fraction 7 8
+                \combine
+                \postscript
+                #"
+                0.2 setlinewidth
                 1 0.5 moveto
                 49.38709677419355 0.5 lineto
                 stroke
@@ -2589,7 +2592,11 @@ class MeterList(TypedList):
                 stroke
                 126 1.25 moveto
                 126 -0.25 lineto
-                stroke" \postscript #"1 -2 moveto
+                stroke
+                "
+                \postscript
+                #"
+                1 -2 moveto
                 0 -6.153846153846154 rlineto
                 stroke
                 5.032258064516129 -2 moveto
@@ -2690,7 +2697,9 @@ class MeterList(TypedList):
                 stroke
                 126 -2 moveto
                 0 -5.517241379310345 rlineto
-                stroke" } }
+                stroke
+                "
+                }
 
         Returns LilyPond file.
         """
@@ -2713,14 +2722,13 @@ class MeterList(TypedList):
         postscript_scale = 125.0 / (maximum - minimum)
         postscript_scale *= float(scale)
         postscript_x_offset = (minimum * postscript_scale) - 1
-        timespan_markup = timespans._make_timespan_list_markup(
+        timespan_markup = _timespan._make_timespan_list_markup(
             timespans,
             postscript_x_offset,
             postscript_scale,
             draw_offsets=False,
         )
-        timespan_string = timespan_markup.contents[0]
-        ps = markups.Postscript()
+        postscript_strings = []
         rational_x_offset = Offset(0)
         for meter in self:
             kernel_denominator = denominator or meter.denominator
@@ -2730,26 +2738,41 @@ class MeterList(TypedList):
                 ps_x_offset = float(rational_x_offset + offset)
                 ps_x_offset *= postscript_scale
                 ps_x_offset += 1
-                ps = ps.moveto(ps_x_offset, -2)
-                ps = ps.rlineto(0, weight)
-                ps = ps.stroke()
+                postscript_strings.append(f"{markups._fpa(ps_x_offset)} -2 moveto")
+                postscript_strings.append(f"0 {markups._fpa(weight)} rlineto")
+                postscript_strings.append("stroke")
             rational_x_offset += meter.duration
-        ps_markup = rf'\postscript #"{ps}"'
-        lines_string = rf"\combine {timespan_string} {ps_markup}"
-        fraction_markups = []
+        fraction_pairs = []
         for meter, offset in zip(self, offsets):
             numerator, denominator = meter.numerator, meter.denominator
             x_translation = float(offset) * postscript_scale
             x_translation -= postscript_x_offset
-            string = rf"\translate #'({x_translation} . 1) \sans \fontsize #-3"
-            string += rf" \center-align \fraction {numerator} {denominator}"
-            fraction = markups.Markup(string, literal=True)
-            fraction_markups.append(fraction)
-        fraction_markup = str(fraction_markups[0].contents[0])
-        for markup in fraction_markups[1:]:
-            fraction_markup = rf"\combine {fraction_markup} {markup.contents[0]}"
-        string = rf"\markup {{ \column {{ {fraction_markup} {lines_string} }} }}"
-        markup = markups.Markup(string, literal=True)
+            top_string = rf"\translate #'({x_translation} . 1)"
+            bottom_string = r"\sans \fontsize #-3 \center-align"
+            bottom_string = bottom_string + rf" \fraction {numerator} {denominator}"
+            pair = (top_string, bottom_string)
+            fraction_pairs.append(pair)
+        fraction_strings = []
+        fraction_strings.append(fraction_pairs[0][0])
+        fraction_strings.append(fraction_pairs[0][1])
+        for pair in fraction_pairs[1:]:
+            fraction_strings.insert(0, r"\combine")
+            fraction_strings.append(pair[0])
+            fraction_strings.append(pair[1])
+        strings = []
+        strings.append(r"\markup")
+        strings.append(r"\column")
+        strings.append("{")
+        strings.extend(fraction_strings)
+        strings.append(r"\combine")
+        strings.append(str(timespan_markup))
+        strings.append(r"\postscript")
+        strings.append('#"')
+        strings.extend(postscript_strings)
+        strings.append('"')
+        strings.append("}")
+        string = "\n".join(strings)
+        markup = markups.Markup(string)
         lilypond_file = LilyPondFile()
         markup = new(markup, direction=None)
         lilypond_file.items.append(markup)
@@ -2783,8 +2806,8 @@ class MetricAccentKernel:
                 }
             )
 
-    Call the kernel against an expression from which offsets can be counted
-    to receive an impulse-response:
+    Call the kernel against an expression from which offsets can be counted to receive an
+    impulse-response:
 
     ..  container:: example
 
@@ -2836,8 +2859,8 @@ class MetricAccentKernel:
 
     def __eq__(self, argument):
         """
-        Is true when ``argument`` is a metrical accent kernal with a kernal
-        equal to that of this metrical accent kernel.
+        Is true when ``argument`` is a metrical accent kernal with a kernal equal to that
+        of this metrical accent kernel.
 
         Returns true or false.
         """
@@ -3260,8 +3283,8 @@ class _MeterManager:
     @staticmethod
     def iterate_rewrite_inputs(argument):
         r"""
-        Iterates topmost masked logical ties, rest groups and containers
-        in ``argument``, masked by ``argument``.
+        Iterates topmost masked logical ties, rest groups and containers in ``argument``,
+        masked by ``argument``.
 
         >>> string = "! 2/4 c'4 d'4 ~ !"
         >>> string += "! 4/4 d'8. r16 r8. e'16 ~ "

--- a/abjad/metricmodulation.py
+++ b/abjad/metricmodulation.py
@@ -509,7 +509,7 @@ class MetricModulation:
     def _get_markup(self):
         string = self._get_lilypond_command_string()
         if string is not None:
-            markup = Markup(rf"\markup {string}", literal=True)
+            markup = Markup(rf"\markup {string}")
             return markup
         strings = []
         string = illustrators.selection_to_score_markup_string(self.left_rhythm)
@@ -520,7 +520,7 @@ class MetricModulation:
         strings.extend(string.split("\n"))
         string = "\n".join(strings)
         string = rf"\markup {{ {string} }}"
-        markup = Markup(string, literal=True)
+        markup = Markup(string)
         return markup
 
     def _get_markup_arguments(self):

--- a/abjad/new.py
+++ b/abjad/new.py
@@ -11,9 +11,7 @@ def new(argument, *arguments, **keywords):
 
         Makes markup with new direction:
 
-        >>> markup = abjad.Markup(
-        ...     r'\markup \italic "Andante assai"', direction=abjad.Up, literal=True,
-        ... )
+        >>> markup = abjad.Markup(r'\markup \italic "Andante assai"', direction=abjad.Up)
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> abjad.attach(markup, staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
@@ -54,9 +52,7 @@ def new(argument, *arguments, **keywords):
 
         REGRESSION. Can be used to set existing properties to none:
 
-        >>> markup = abjad.Markup(
-        ...     r'\markup \italic "Andante assai"', direction=abjad.Up, literal=True,
-        ... )
+        >>> markup = abjad.Markup(r'\markup \italic "Andante assai"', direction=abjad.Up)
         >>> string = abjad.lilypond(markup)
         >>> print(string)
         ^ \markup \italic "Andante assai"

--- a/abjad/overrides.py
+++ b/abjad/overrides.py
@@ -314,8 +314,7 @@ class LilyPondLiteral:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -637,7 +636,7 @@ class LilyPondOverride:
         ...        "left",
         ...        "text",
         ...        ),
-        ...    value=abjad.Markup(r"\markup \bold { over pressure }", literal=True),
+        ...    value=abjad.Markup(r"\markup \bold { over pressure }"),
         ...    )
 
         >>> print(override.override_string)
@@ -797,7 +796,7 @@ class LilyPondOverride:
             ...        "left",
             ...        "text",
             ...        ),
-            ...    value=abjad.Markup(r"\markup \bold { over pressure }", literal=True),
+            ...    value=abjad.Markup(r"\markup \bold { over pressure }"),
             ...    )
             >>> override.lilypond_type
             'Staff'
@@ -829,7 +828,7 @@ class LilyPondOverride:
             ...        "left",
             ...        "text",
             ...        ),
-            ...    value=abjad.Markup(r"\markup \bold { over pressure }", literal=True),
+            ...    value=abjad.Markup(r"\markup \bold { over pressure }"),
             ...    )
             >>> bool(override.once)
             True
@@ -861,7 +860,7 @@ class LilyPondOverride:
             ...        "left",
             ...        "text",
             ...        ),
-            ...    value=abjad.Markup(r"\markup \bold { over pressure }", literal=True),
+            ...    value=abjad.Markup(r"\markup \bold { over pressure }"),
             ...    )
             >>> for line in override.override_format_pieces:
             ...     line
@@ -917,7 +916,7 @@ class LilyPondOverride:
             ...        "left",
             ...        "text",
             ...        ),
-            ...    value=abjad.Markup(r"\markup \bold { over pressure }", literal=True),
+            ...    value=abjad.Markup(r"\markup \bold { over pressure }"),
             ...    )
             >>> override.property_path
             ('bound-details', 'left', 'text')
@@ -978,10 +977,10 @@ class LilyPondOverride:
             ...        "left",
             ...        "text",
             ...        ),
-            ...    value=abjad.Markup(r"\markup \bold { over pressure }", literal=True),
+            ...    value=abjad.Markup(r"\markup \bold { over pressure }"),
             ...    )
             >>> override.value
-            Markup(contents=['\\markup \\bold { over pressure }'], literal=True)
+            Markup('\\markup \\bold { over pressure }')
 
         """
         return self._value
@@ -1384,7 +1383,7 @@ class SettingInterface(Interface):
         ..  container:: example
 
             >>> staff = abjad.Staff("c'4 d' e' f'")
-            >>> markup = abjad.Markup(r'\markup "Vn. I"', literal=True)
+            >>> markup = abjad.Markup(r'\markup "Vn. I"')
             >>> abjad.setting(staff).instrumentName = markup
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1409,7 +1408,7 @@ class SettingInterface(Interface):
             Returns arbitrary object keyed to ``name``:
 
             >>> abjad.setting(staff).instrumentName
-            Markup(contents=['\\markup "Vn. I"'], literal=True)
+            Markup('\\markup "Vn. I"')
 
         """
         camel_name = String(name).to_upper_camel_case()
@@ -1522,7 +1521,7 @@ def setting(argument):
         Sets instrument name:
 
         >>> staff = abjad.Staff("c'4 e'4 d'4 f'4")
-        >>> markup = abjad.Markup(r'\markup "Vn. I"', literal=True)
+        >>> markup = abjad.Markup(r'\markup "Vn. I"')
         >>> abjad.setting(staff).instrumentName = markup
         >>> abjad.show(staff) # doctest: +SKIP
 
@@ -1548,7 +1547,7 @@ def setting(argument):
         Returns LilyPond setting name manager:
 
         >>> abjad.setting(staff)
-        SettingInterface(('instrumentName', Markup(contents=['\\markup "Vn. I"'], literal=True)))
+        SettingInterface(('instrumentName', Markup('\\markup "Vn. I"')))
 
     """
     if getattr(argument, "_lilypond_setting_name_manager", None) is None:
@@ -1564,7 +1563,7 @@ class TweakInterface(Interface):
 
         Tweak managers are created by the ``abjad.tweak()`` factory function:
 
-        >>> markup = abjad.Markup(r"\markup Allegro", direction=abjad.Up, literal=True)
+        >>> markup = abjad.Markup(r"\markup Allegro", direction=abjad.Up)
         >>> abjad.tweak(markup)
         TweakInterface(('_literal', None))
 
@@ -1616,9 +1615,7 @@ class TweakInterface(Interface):
             Tweaks may be tagged:
 
             >>> staff = abjad.Staff("c'4 d' e' f'")
-            >>> markup = abjad.Markup(
-            ...     r"\markup \italic Allegro", direction=abjad.Up, literal=True
-            ... )
+            >>> markup = abjad.Markup(r"\markup \italic Allegro", direction=abjad.Up)
             >>> abjad.tweak(markup, tag=abjad.Tag("+PARTS")).color = "#red"
             >>> abjad.attach(markup, staff[0])
             >>> abjad.show(staff) # doctest: +SKIP
@@ -1639,9 +1636,7 @@ class TweakInterface(Interface):
             Tweaks may be tagged with ``deactivate=True``:
 
             >>> staff = abjad.Staff("c'4 d' e' f'")
-            >>> markup = abjad.Markup(
-            ...     r"\markup \italic Allegro", direction=abjad.Up, literal=True
-            ... )
+            >>> markup = abjad.Markup(r"\markup \italic Allegro", direction=abjad.Up)
             >>> abjad.tweak(
             ...     markup, deactivate=True, tag=abjad.Tag("+PARTS")
             ... ).color = "#red"
@@ -1664,9 +1659,7 @@ class TweakInterface(Interface):
             Tweak tags and indicator tags may be set together:
 
             >>> staff = abjad.Staff("c'4 d' e' f'")
-            >>> markup = abjad.Markup(
-            ...     r"\markup \italic Allegro", direction=abjad.Up, literal=True
-            ... )
+            >>> markup = abjad.Markup(r"\markup \italic Allegro", direction=abjad.Up)
             >>> abjad.tweak(markup, tag=abjad.Tag("+PARTS")).color = "#red"
             >>> abjad.attach(markup, staff[0], tag=abjad.Tag("RED:M1"))
             >>> abjad.show(staff) # doctest: +SKIP
@@ -1911,9 +1904,7 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
         Tweaks markup:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> markup = abjad.Markup(
-        ...     r'\markup "Allegro assai"', direction=abjad.Up, literal=True
-        ... )
+        >>> markup = abjad.Markup(r'\markup "Allegro assai"', direction=abjad.Up)
         >>> abjad.tweak(markup).color = "#red"
         >>> abjad.attach(markup, staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
@@ -1936,9 +1927,7 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
 
         >>> import copy
         >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> markup_1 = abjad.Markup(
-        ...     r'\markup "Allegro assai"', direction=abjad.Up, literal=True
-        ... )
+        >>> markup_1 = abjad.Markup(r'\markup "Allegro assai"', direction=abjad.Up)
         >>> abjad.tweak(markup_1).color = "#red"
         >>> markup_2 = copy.copy(markup_1)
         >>> abjad.attach(markup_2, staff[0])
@@ -1961,9 +1950,7 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
         Survives dot-chaining:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> markup = abjad.Markup(
-        ...     r'\markup \italic "Allegro assai"', direction=abjad.Up, literal=True
-        ... )
+        >>> markup = abjad.Markup(r'\markup \italic "Allegro assai"', direction=abjad.Up)
         >>> abjad.tweak(markup).color = "#red"
         >>> abjad.attach(markup, staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
@@ -1985,14 +1972,10 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
         Works for opposite-directed coincident markup:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> markup_1 = abjad.Markup(
-        ...     r'\markup "Allegro assai ..."', direction=abjad.Up, literal=True
-        ... )
+        >>> markup_1 = abjad.Markup(r'\markup "Allegro assai ..."', direction=abjad.Up)
         >>> abjad.tweak(markup_1).color = "#red"
         >>> abjad.attach(markup_1, staff[0])
-        >>> markup_2 = abjad.Markup(
-        ...     r'\markup "... ma non troppo"', direction=abjad.Down, literal=True
-        ... )
+        >>> markup_2 = abjad.Markup(r'\markup "... ma non troppo"', direction=abjad.Down)
         >>> abjad.tweak(markup_2).color = "#blue"
         >>> abjad.tweak(markup_2).staff_padding = 4
         >>> abjad.attach(markup_2, staff[0])
@@ -2018,14 +2001,10 @@ def tweak(argument, *, deactivate=None, expression=None, literal=None, tag=None)
         Ignored for same-directed coincident markup:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> markup_1 = abjad.Markup(
-        ...     r'\markup "Allegro assai ..."', direction=abjad.Up, literal=True
-        ... )
+        >>> markup_1 = abjad.Markup(r'\markup "Allegro assai ..."', direction=abjad.Up)
         >>> abjad.tweak(markup_1).color = "#red"
         >>> abjad.attach(markup_1, staff[0])
-        >>> markup_2 = abjad.Markup(
-        ...     r'\markup "... ma non troppo"', direction=abjad.Up, literal=True
-        ... )
+        >>> markup_2 = abjad.Markup(r'\markup "... ma non troppo"', direction=abjad.Up)
         >>> abjad.tweak(markup_2).color = "#blue"
         >>> abjad.tweak(markup_2).staff_padding = 4
         >>> abjad.attach(markup_2, staff[0])

--- a/abjad/parsers/scheme.py
+++ b/abjad/parsers/scheme.py
@@ -28,10 +28,9 @@ class Scheme:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal the
-        initialization values of ``argument``.
 
         Returns true or false.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/pitch/Accidental.py
+++ b/abjad/pitch/Accidental.py
@@ -173,8 +173,7 @@ class Accidental:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/pitch/SetClass.py
+++ b/abjad/pitch/SetClass.py
@@ -986,8 +986,7 @@ class SetClass:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/pitch/intervalclasses.py
+++ b/abjad/pitch/intervalclasses.py
@@ -88,8 +88,7 @@ class IntervalClass:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/pitch/intervals.py
+++ b/abjad/pitch/intervals.py
@@ -78,8 +78,7 @@ class Interval:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/pitch/operators.py
+++ b/abjad/pitch/operators.py
@@ -136,8 +136,7 @@ class CompoundOperator:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -640,8 +639,7 @@ class Duplication:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -903,8 +901,7 @@ class Inversion:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -1121,8 +1118,7 @@ class Multiplication:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -1369,8 +1365,7 @@ class Retrograde:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -1611,8 +1606,7 @@ class Rotation:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 
@@ -1861,8 +1855,7 @@ class Transposition:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/pitch/pitchclasses.py
+++ b/abjad/pitch/pitchclasses.py
@@ -54,8 +54,7 @@ class PitchClass:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/pitch/pitches.py
+++ b/abjad/pitch/pitches.py
@@ -77,8 +77,7 @@ class Pitch:
 
     def __eq__(self, argument) -> bool:
         """
-        Is true when all initialization values of Abjad value object equal
-        the initialization values of ``argument``.
+        Delegates to ``abjad.format.compare_objects()``.
         """
         return _format.compare_objects(self, argument)
 

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -870,7 +870,7 @@ class Container(Component):
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> abjad.attach(abjad.Articulation('^'), staff[0])
-        >>> markup = abjad.Markup(r'\markup Allegro', direction=abjad.Up, literal=True)
+        >>> markup = abjad.Markup(r'\markup Allegro', direction=abjad.Up)
         >>> abjad.attach(markup, staff[0])
         >>> abjad.attach(abjad.StemTremolo(), staff[0])
         >>> abjad.show(staff) # doctest: +SKIP
@@ -2006,7 +2006,7 @@ class AfterGraceContainer(Container):
         >>> after_grace_container = abjad.AfterGraceContainer("c'16 d'16")
         >>> abjad.attach(after_grace_container, voice[1])
         >>> leaves = abjad.select(voice).leaves(grace=None)
-        >>> markup = abjad.Markup(r'\markup Allegro', direction=abjad.Up, literal=True)
+        >>> markup = abjad.Markup(r'\markup Allegro', direction=abjad.Up)
         >>> abjad.attach(markup, leaves[1])
         >>> abjad.attach(abjad.Articulation("."), leaves[1])
         >>> abjad.show(voice) # doctest: +SKIP
@@ -5690,7 +5690,7 @@ class Tuplet(Container):
             >>> duration = abjad.get.duration(tuplet)
             >>> note = abjad.Note.from_pitch_and_duration(0, duration)
             >>> string = abjad.illustrators.selection_to_score_markup_string([note])
-            >>> markup = abjad.Markup(rf"\markup {{ {string} }}", literal=True)
+            >>> markup = abjad.Markup(rf"\markup {{ {string} }}")
             >>> abjad.override(tuplet).TupletNumber.text = markup
             >>> staff = abjad.Staff([tuplet])
             >>> abjad.show(staff) # doctest: +SKIP

--- a/abjad/spanners.py
+++ b/abjad/spanners.py
@@ -1953,8 +1953,8 @@ def text_spanner(
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> start_text_span = abjad.StartTextSpan(
-        ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
-        ...     right_text=abjad.Markup(r"\markup \upright tasto", literal=True),
+        ...     left_text=abjad.Markup(r"\upright pont."),
+        ...     right_text=abjad.Markup(r"\markup \upright tasto"),
         ...     style="solid-line-with-arrow",
         ... )
         >>> abjad.text_spanner(staff[:], start_text_span=start_text_span)
@@ -1986,13 +1986,13 @@ def text_spanner(
 
         >>> staff = abjad.Staff("c'4 d' e' f' r")
         >>> start_text_span = abjad.StartTextSpan(
-        ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
+        ...     left_text=abjad.Markup(r"\upright pont."),
         ...     style="dashed-line-with-arrow",
         ... )
         >>> abjad.text_spanner(staff[:3], start_text_span=start_text_span)
         >>> start_text_span = abjad.StartTextSpan(
-        ...     left_text=abjad.Markup(r"\upright tasto", literal=True),
-        ...     right_text=abjad.Markup(r"\markup \upright pont.", literal=True),
+        ...     left_text=abjad.Markup(r"\upright tasto"),
+        ...     right_text=abjad.Markup(r"\markup \upright pont."),
         ...     style="dashed-line-with-arrow",
         ... )
         >>> abjad.text_spanner(staff[-3:], start_text_span=start_text_span)
@@ -2028,12 +2028,12 @@ def text_spanner(
 
         >>> staff = abjad.Staff("c'4 d' e' f' r")
         >>> start_text_span = abjad.StartTextSpan(
-        ...     left_text=abjad.Markup(r"\upright pont.", literal=True),
+        ...     left_text=abjad.Markup(r"\upright pont."),
         ...     style="dashed-line-with-arrow",
         ... )
         >>> abjad.text_spanner(staff[:3], start_text_span=start_text_span)
         >>> start_text_span = abjad.StartTextSpan(
-        ...     left_text=abjad.Markup(r"\upright tasto", literal=True),
+        ...     left_text=abjad.Markup(r"\upright tasto"),
         ...     style="solid-line-with-hook",
         ... )
         >>> abjad.text_spanner(staff[-3:], start_text_span=start_text_span)

--- a/abjad/tag.py
+++ b/abjad/tag.py
@@ -644,7 +644,7 @@ def activate(text, tag, skipped=False):
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> string = r"\markup { \with-color #red Allegro }"
-        >>> markup = abjad.Markup(string, literal=True)
+        >>> markup = abjad.Markup(string)
         >>> abjad.attach(
         ...     markup,
         ...     staff[0],
@@ -790,7 +790,7 @@ def deactivate(text, tag, prepend_empty_chord=False, skipped=False):
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> string = r"\markup { \with-color #red Allegro }"
-        >>> markup = abjad.Markup(string, literal=True)
+        >>> markup = abjad.Markup(string)
         >>> abjad.attach(
         ...     markup,
         ...     staff[0],

--- a/docs/source/_mothballed/pitch-conventions.rst
+++ b/docs/source/_mothballed/pitch-conventions.rst
@@ -25,7 +25,7 @@ Abjad numbers pitches like this:
     ...         bass_staff.append(note)
     ...     number = note.written_pitch.number
     ...     string = rf"\markup {number}"
-    ...     markup = abjad.Markup(string, direction=abjad.Down, literal=True)
+    ...     markup = abjad.Markup(string, direction=abjad.Down)
     ...     abjad.attach(markup, bass_staff[-1])
     ...
     >>> clef = abjad.Clef("bass")
@@ -80,7 +80,7 @@ Abjad numbers diatonic pitches like this:
     ...         bass_staff.append(note)
     ...     number = note.written_pitch._get_diatonic_pitch_number()
     ...     string = rf"\markup {number}"
-    ...     markup = abjad.Markup(string, direction=abjad.Down, literal=True)
+    ...     markup = abjad.Markup(string, direction=abjad.Down)
     ...     abjad.attach(markup, bass_staff[-1])
     ...
     >>> clef = abjad.Clef("bass")

--- a/docs/source/_mothballed/score-fragment-strings.rst
+++ b/docs/source/_mothballed/score-fragment-strings.rst
@@ -160,7 +160,7 @@ Let's see what a few of these look like. Here are the first ten violin 1 descent
     >>> descents = voice_to_descents["Violin_1"][:10]
     >>> for i, descent in enumerate(descents):
     ...     string = rf"\markup \rounded-box \bold {i}"
-    ...     markup = abjad.Markup(string, direction=abjad.Up, literal=True)
+    ...     markup = abjad.Markup(string, direction=abjad.Up)
     ...     abjad.attach(markup, descent[0])
     ...
 
@@ -178,7 +178,7 @@ Here are the first ten violin 2 descents:
     >>> descents = voice_to_descents["Violin_2"][:10]
     >>> for i, descent in enumerate(descents):
     ...     string = rf"\markup \rounded-box \bold {i}"
-    ...     markup = abjad.Markup(string, direction=abjad.Up, literal=True)
+    ...     markup = abjad.Markup(string, direction=abjad.Up)
     ...     abjad.attach(markup, descent[0])
     ...
 
@@ -197,7 +197,7 @@ too:
     >>> descents = voice_to_descents["Viola"][:10]
     >>> for i, descent in enumerate(descents):
     ...     string = rf"\markup \rounded-box \bold {i}"
-    ...     markup = abjad.Markup(string, direction=abjad.Up, literal=True)
+    ...     markup = abjad.Markup(string, direction=abjad.Up)
     ...     abjad.attach(markup, descent[0])
     ...
 
@@ -464,11 +464,11 @@ We define more functions:
     ...             abjad.attach(articulation, chord)
     ...     string = r'''\markup \concat { \musicglyph "scripts.downbow"'''
     ...     string += r''' \hspace #1 \musicglyph "scripts.upbow" }'''
-    ...     markup = abjad.Markup(string, literal=True)
+    ...     markup = abjad.Markup(string)
     ...     abjad.attach(markup, score["Violin_1_Voice"][65 - 1][0])
-    ...     markup = abjad.Markup(string, literal=True)
+    ...     markup = abjad.Markup(string)
     ...     abjad.attach(markup, score["Violin_2_Voice"][76 - 1][0])
-    ...     markup = abjad.Markup(string, literal=True)
+    ...     markup = abjad.Markup(string)
     ...     abjad.attach(markup, score["Viola_Voice"][87 - 1][0])
 
     >>> def handle_dynamic_commands(score, commands):
@@ -491,7 +491,7 @@ We define more functions:
     ...         voice = score[voice_name]
     ...         leaf = voice[measure_index][leaf_index]
     ...         string = r"\markup " + string
-    ...         markup = abjad.Markup(string, direction=direction, literal=True)
+    ...         markup = abjad.Markup(string, direction=direction)
     ...         abjad.attach(markup, leaf)
 
     >>> def attach_rehearsal_marks(score, measure_indices):

--- a/docs/source/_pending/rotation-by-row-index.rst
+++ b/docs/source/_pending/rotation-by-row-index.rst
@@ -12,7 +12,7 @@ Rotation, by row index
     >>> def make_rotation_chart(permutation, label):
     ...     rotations = [0, -1, -2, -3, -4, -5]
     ...     source_staff = abjad.Staff([abjad.Note(_, (1, 16)) for _ in permutation])
-    ...     markup = abjad.Markup(rf'\markup "{label}"', direction=abjad.Up, literal=True)
+    ...     markup = abjad.Markup(rf'\markup "{label}"', direction=abjad.Up)
     ...     abjad.attach(markup, source_staff[0])
     ...     score = abjad.Score([source_staff], name="Score")
     ...     group = abjad.StaffGroup(name="Staff_Group")
@@ -20,7 +20,7 @@ Rotation, by row index
     ...         [_.number for _ in permutation[:6]],
     ...         [_.number for _ in permutation[6:]],
     ...     ]
-    ...     markup = abjad.Markup(rf'\markup \box "{label}"', literal=True)
+    ...     markup = abjad.Markup(rf'\markup \box "{label}"')
     ...     margin_markups = [
     ...         abjad.StartMarkup(markup=markup),
     ...         abjad.StartMarkup(markup="I"),
@@ -42,10 +42,10 @@ Rotation, by row index
     ...             .transpose(hexachords[1][0]),
     ...         ]
     ...         names = [
-    ...             abjad.Markup(r"\markup \box α", direction=abjad.Up, literal=True),
-    ...             abjad.Markup(r"\markup \box β", direction=abjad.Up, literal=True),
-    ...             abjad.Markup(r"\markup \box γ", direction=abjad.Up, literal=True),
-    ...             abjad.Markup(r"\markup \box δ", direction=abjad.Up, literal=True),
+    ...             abjad.Markup(r"\markup \box α", direction=abjad.Up),
+    ...             abjad.Markup(r"\markup \box β", direction=abjad.Up),
+    ...             abjad.Markup(r"\markup \box γ", direction=abjad.Up),
+    ...             abjad.Markup(r"\markup \box δ", direction=abjad.Up),
     ...         ]
     ...         for set, name in zip(sets, names):
     ...             voice = abjad.Voice([abjad.Note(_, (1, 16)) for _ in set])
@@ -53,7 +53,6 @@ Rotation, by row index
     ...                 markup = abjad.Markup(
     ...                     rf"\markup {abjad.NumberedPitchClass(leaf.written_pitch)}",
     ...                     direction=abjad.Up,
-    ...                     literal=True,
     ...                 )
     ...                 abjad.tweak(markup).staff_padding = "3"
     ...                 abjad.attach(markup, leaf)

--- a/docs/source/_pending/trichord-definition-by-ratio.rst
+++ b/docs/source/_pending/trichord-definition-by-ratio.rst
@@ -84,7 +84,7 @@ Define helper functions:
     ...     else:
     ...         cent_string = f"+{remainder}"
     ...     string = rf"\markup {cent_string}"
-    ...     markup = abjad.Markup(string, direction=direction, literal=True)
+    ...     markup = abjad.Markup(string, direction=direction)
     ...     abjad.tweak(markup).parent_alignment_X = 0 
     ...     abjad.tweak(markup).self_alignment_X = 0.25 
     ...     if pitch <= -8:
@@ -115,7 +115,7 @@ Define helper functions:
     ...             staff.append(note)
     ...     for measure_number in (1, 11, 21, 31):
     ...         note = abjad.select(staff_1).note(measure_number - 1)
-    ...         markup = abjad.Markup(r"\markup A", direction=abjad.Up, literal=True)
+    ...         markup = abjad.Markup(r"\markup A", direction=abjad.Up)
     ...         abjad.tweak(markup).staff_padding = 8
     ...         abjad.tweak(markup).transparent = True
     ...         abjad.attach(markup, note)

--- a/docs/source/appendices/best-practices.rst
+++ b/docs/source/appendices/best-practices.rst
@@ -72,11 +72,11 @@ Abjad.
 
     Not so good: ::
 
-        abjad.Markup(r'\bold italic \font-size #4 "Allegro con moto"')
+        abjad.Markup(r'\markup \bold italic \font-size #4 "Allegro con moto"')
 
     Good: ::
 
-        abjad.Markup(r"\my-score-allegro-con-moto", literal=True) 
+        abjad.Markup(r"\my-score-allegro-con-moto")
 
 **8. Externalize LilyPond context, layout, paper settings in a separate file.** Rather
 than defining them with Abjad.

--- a/docs/source/examples/corpus-selection.rst
+++ b/docs/source/examples/corpus-selection.rst
@@ -373,11 +373,11 @@ can start building our score.
     ...     clef = abjad.Clef("bass")
     ...     abjad.attach(clef, leaf)
     ...     groups = abjad.select(score["RH_Voice"]).leaves().group_by_measure()
-    ...     strut = abjad.Markup(r"\markup A", direction=abjad.Up, literal=True)
+    ...     strut = abjad.Markup(r"\markup A", direction=abjad.Up)
     ...     abjad.tweak(strut).staff_padding = 10
     ...     abjad.tweak(strut).transparent = True
     ...     abjad.attach(strut, groups[0][0])
-    ...     strut = abjad.Markup(r"\markup A", direction=abjad.Up, literal=True)
+    ...     strut = abjad.Markup(r"\markup A", direction=abjad.Up)
     ...     abjad.tweak(strut).staff_padding = 10
     ...     abjad.tweak(strut).transparent = True
     ...     abjad.attach(strut, groups[-1][0])

--- a/docs/source/examples/enumeration.rst
+++ b/docs/source/examples/enumeration.rst
@@ -41,7 +41,7 @@ The following functions recreate Malt's results in Abjad:
     ...         label = f'"1 : ({outer} | {inner})"'
     ...         contents = [lone_note, inner_tuplet]
     ...     outer_tuplet = abjad.Tuplet(outer_string, contents)
-    ...     markup = abjad.Markup(rf"\markup {label}", direction=abjad.Up, literal=True)
+    ...     markup = abjad.Markup(rf"\markup {label}", direction=abjad.Up)
     ...     note = abjad.select(outer_tuplet).note(0)
     ...     abjad.attach(markup, note)
     ...     outer_tuplet.hide = outer_tuplet.trivial()

--- a/docs/source/examples/magic-square-from-twelve-tone-row.rst
+++ b/docs/source/examples/magic-square-from-twelve-tone-row.rst
@@ -33,7 +33,7 @@ example:
     ...         number = notes[0].written_pitch.number
     ...         string = r"\markup \larger \with-color #blue"
     ...         string = string + r" { T \hspace #-0.75 \sub" + str(number) + "}"
-    ...         markup = abjad.Markup(string, literal=True)
+    ...         markup = abjad.Markup(string)
     ...         start_markup = abjad.StartMarkup(markup)
     ...         abjad.attach(start_markup, notes[0])
     ...     for note in score["Voice_0"]:
@@ -41,7 +41,7 @@ example:
     ...         string = r"\markup \larger { IT \hspace #-0.75 \sub "
     ...         string += str(number)
     ...         string += " }"
-    ...         markup = abjad.Markup(string, direction=abjad.Up, literal=True)
+    ...         markup = abjad.Markup(string, direction=abjad.Up)
     ...         abjad.attach(markup, note)
     ...     note = abjad.select(score).note(0)
     ...     time_signature = abjad.TimeSignature((12, 4))

--- a/docs/source/examples/scales-diatonic.rst
+++ b/docs/source/examples/scales-diatonic.rst
@@ -160,12 +160,12 @@ This function enumerates scales in any mode:
     ...         name = notes[0].written_pitch.get_name(locale="us")
     ...         name = name[:-1]
     ...         string = fr'\markup {{ "{name} {mode_name}" }}'
-    ...         markup = abjad.Markup(string, direction=abjad.Up, literal=True)
+    ...         markup = abjad.Markup(string, direction=abjad.Up)
     ...         abjad.attach(markup, notes[0])
     ...         bar_line = abjad.BarLine("||")
     ...         abjad.attach(bar_line, notes[-1])
     ...         string = r"\markup \transparent A"
-    ...         strut = abjad.Markup(string, direction=abjad.Up, literal=True)
+    ...         strut = abjad.Markup(string, direction=abjad.Up)
     ...         abjad.tweak(strut).staff_padding = 8 
     ...         abjad.attach(strut, notes[-1])
     ...         voice.extend(notes)

--- a/tests/test_Chord___copy__.py
+++ b/tests/test_Chord___copy__.py
@@ -96,7 +96,7 @@ def test_Chord___copy___05():
     chord_1 = abjad.Chord("<ef' cs'' f''>4")
     articulation_1 = abjad.Articulation("staccato")
     abjad.attach(articulation_1, chord_1)
-    markup_1 = abjad.Markup(r"\markup foo", direction=abjad.Up, literal=True)
+    markup_1 = abjad.Markup(r"\markup foo", direction=abjad.Up)
     abjad.attach(markup_1, chord_1)
 
     chord_2 = copy.copy(chord_1)

--- a/tests/test_LilyPondParser__indicators__Markup.py
+++ b/tests/test_LilyPondParser__indicators__Markup.py
@@ -4,7 +4,7 @@ import abjad
 def test_LilyPondParser__indicators__Markup_01():
 
     target = abjad.Staff([abjad.Note(0, 1)])
-    markup = abjad.Markup(r"\markup { hello! }", direction=abjad.Up, literal=True)
+    markup = abjad.Markup(r"\markup { hello! }", direction=abjad.Up)
     abjad.attach(markup, target[0])
 
     assert abjad.lilypond(target) == abjad.String.normalize(
@@ -28,9 +28,7 @@ def test_LilyPondParser__indicators__Markup_01():
 def test_LilyPondParser__indicators__Markup_02():
 
     target = abjad.Staff([abjad.Note(0, (1, 4))])
-    markup = abjad.Markup(
-        r'\markup { X Y Z "a b c" }', direction=abjad.Down, literal=True
-    )
+    markup = abjad.Markup(r'\markup { X Y Z "a b c" }', direction=abjad.Down)
     abjad.attach(markup, target[0])
 
     assert abjad.lilypond(target) == abjad.String.normalize(
@@ -51,7 +49,7 @@ def test_LilyPondParser__indicators__Markup_03():
     """
 
     target = abjad.Staff([abjad.Note(0, (1, 4)), abjad.Note(2, (1, 4))])
-    markup = abjad.Markup(r"\markup { hello }", direction=abjad.Up, literal=True)
+    markup = abjad.Markup(r"\markup { hello }", direction=abjad.Up)
     abjad.attach(markup, target[0])
     articulation = abjad.Articulation(".")
     abjad.attach(articulation, target[0])

--- a/tests/test_LilyPondParser__misc__chord_repetition.py
+++ b/tests/test_LilyPondParser__misc__chord_repetition.py
@@ -46,7 +46,7 @@ def test_LilyPondParser__misc__chord_repetition_02():
     abjad.attach(dynamic, target[0])
     articulation = abjad.Articulation("staccatissimo")
     abjad.attach(articulation, target[2])
-    markup = abjad.Markup(r"\markup { text }", direction=abjad.Up, literal=True)
+    markup = abjad.Markup(r"\markup { text }", direction=abjad.Up)
     abjad.attach(markup, target[3])
     articulation = abjad.Articulation("staccatissimo")
     abjad.attach(articulation, target[-1])

--- a/tests/test_abjad___doc__.py
+++ b/tests/test_abjad___doc__.py
@@ -27,6 +27,7 @@ ignored_classes = (
     abjad.parsers.reduced.ReducedLyParser,
     abjad.parsers.scheme.SchemeParser,
     abjad.rhythmtrees.RhythmTreeParser,
+    abjad.BarLine,  # TODO: exclude dataclasses programatically
     abjad.FormatSpecification,
 )
 
@@ -63,6 +64,6 @@ if functions:
     @pytest.mark.parametrize("function", functions)
     def test_abjad___doc___02(function):
         """
-        All old functions had a docstring.
+        All functions have a docstring.
         """
         assert function.__doc__ is not None

--- a/tests/test_abjad___str__.py
+++ b/tests/test_abjad___str__.py
@@ -9,7 +9,6 @@ _allowed_to_be_empty_string = (
     abjad.Articulation,
     abjad.CompoundOperator,
     abjad.Line,
-    abjad.Postscript,
     abjad.String,
     abjad.Tag,
 )
@@ -27,8 +26,8 @@ def test_abjad___str___01(class_):
     """
     All concrete classes have a string representation.
 
-    With the exception of the exception classes. And those classes listed
-    explicitly here.
+    With the exception of the exception classes. And those classes listed explicitly
+    here.
     """
     if inspect.isabstract(class_):
         return

--- a/tests/test_get_markup.py
+++ b/tests/test_get_markup.py
@@ -4,9 +4,9 @@ import abjad
 def test_get_markup_01():
 
     chord = abjad.Chord([-11, 2, 5], (1, 4))
-    up_markup = abjad.Markup(r"\markup UP", direction=abjad.Up, literal=True)
+    up_markup = abjad.Markup(r"\markup UP", direction=abjad.Up)
     abjad.attach(up_markup, chord)
-    down_markup = abjad.Markup(r"\markup DOWN", direction=abjad.Down, literal=True)
+    down_markup = abjad.Markup(r"\markup DOWN", direction=abjad.Down)
     abjad.attach(down_markup, chord)
     found_markup = abjad.get.markup(chord, direction=abjad.Down)
     assert found_markup == [down_markup]
@@ -15,9 +15,9 @@ def test_get_markup_01():
 def test_get_markup_02():
 
     chord = abjad.Chord([-11, 2, 5], (1, 4))
-    up_markup = abjad.Markup(r"\markup UP", direction=abjad.Up, literal=True)
+    up_markup = abjad.Markup(r"\markup UP", direction=abjad.Up)
     abjad.attach(up_markup, chord)
-    down_markup = abjad.Markup(r"\markup DOWN", direction=abjad.Down, literal=True)
+    down_markup = abjad.Markup(r"\markup DOWN", direction=abjad.Down)
     abjad.attach(down_markup, chord)
     found_markup = abjad.get.markup(chord, direction=abjad.Up)
     assert found_markup == [up_markup]


### PR DESCRIPTION
    * Removed abjad.Markup.literal property
    * All markup now behaves as literal

    OLD: abjad.Markup.contents returned a list
    NEW: abjad.Markup.contents returns a string

    * Removed abjad.Postscript; use strings instead
    * Removed abjad.PostscriptOperator; use strings instead

Closes #1368.