### PR TITLE
Gutted abjad.LilyPondFile

### DIFF
--- a/abjad/__init__.py
+++ b/abjad/__init__.py
@@ -166,16 +166,7 @@ from .instruments import (
 )
 from .io import graph, play, show
 from .label import ColorMap
-from .lilypondfile import (
-    Block,
-    ContextBlock,
-    DateTimeToken,
-    LilyPondDimension,
-    LilyPondFile,
-    LilyPondLanguageToken,
-    LilyPondVersionToken,
-    PackageGitCommitToken,
-)
+from .lilypondfile import Block, LilyPondFile
 from .lilypondformat import lilypond
 from .lyproxy import (
     LilyPondContext,
@@ -306,7 +297,7 @@ from .templates import (
     StringOrchestraScoreTemplate,
     StringQuartetScoreTemplate,
 )
-from .timespan import AnnotatedTimespan, Timespan, TimespanList
+from .timespan import Timespan, TimespanList
 from .typedcollections import (
     TypedCollection,
     TypedCounter,
@@ -348,7 +339,6 @@ __all__ = [
     "AltoSaxophone",
     "AltoTrombone",
     "AltoVoice",
-    "AnnotatedTimespan",
     "Arpeggio",
     "Articulation",
     "AssignabilityError",
@@ -385,7 +375,6 @@ __all__ = [
     "Configuration",
     "Container",
     "Context",
-    "ContextBlock",
     "ContextManager",
     "Contrabass",
     "ContrabassClarinet",
@@ -393,7 +382,6 @@ __all__ = [
     "ContrabassSaxophone",
     "Contrabassoon",
     "CyclicTuple",
-    "DateTimeToken",
     "Descendants",
     "Down",
     "DrumNoteHead",
@@ -449,18 +437,15 @@ __all__ = [
     "Less",
     "LilyPondComment",
     "LilyPondContext",
-    "LilyPondDimension",
     "LilyPondEngraver",
     "LilyPondFile",
     "LilyPondFormatBundle",
     "LilyPondGrob",
     "LilyPondGrobInterface",
-    "LilyPondLanguageToken",
     "LilyPondLiteral",
     "LilyPondOverride",
     "LilyPondParserError",
     "LilyPondSetting",
-    "LilyPondVersionToken",
     "Line",
     "Lineage",
     "LogicalTie",
@@ -507,7 +492,6 @@ __all__ = [
     "OnBeatGraceContainer",
     "Ottava",
     "OverrideInterface",
-    "PackageGitCommitToken",
     "Parentage",
     "ParentageError",
     "Parser",

--- a/abjad/_update.py
+++ b/abjad/_update.py
@@ -1,16 +1,16 @@
 """
 Updates start offsets, stop offsets and indicators everywhere in score.
 
-..  note:: This is probably the most important part of Abjad to optimize.
-    Use the profiler to figure out how many unnecessary updates are
-    happening. Then reimplement. As a hint, the update manager implements
-    a weird version of the "observer pattern." It may make sense to revisit
-    a textbook example of the observer pattern and review the
-    implementation of the update manager.
+..  note:: This is probably the most important part of Abjad to optimize. Use the
+    profiler to figure out how many unnecessary updates are happening. Then reimplement.
+    As a hint, the update manager implements a weird version of the "observer pattern."
+    It may make sense to revisit a textbook example of the observer pattern and review
+    the implementation of the update manager.
 
 """
 from . import iterate as iterate_
 from . import math
+from . import timespan as _timespan
 from .duration import Duration, Multiplier, Offset
 from .indicators.MetronomeMark import MetronomeMark
 from .indicators.TimeSignature import TimeSignature
@@ -18,7 +18,6 @@ from .obgc import OnBeatGraceContainer
 from .parentage import Parentage
 from .score import AfterGraceContainer, BeforeGraceContainer
 from .sequence import Sequence
-from .timespan import AnnotatedTimespan, TimespanList
 
 
 def _get_after_grace_leaf_offsets(leaf):
@@ -176,7 +175,7 @@ def _make_metronome_mark_map(root):
     if pairs[0][0] != 0:
         return
     score_stop_offset = max(all_stop_offsets)
-    timespans = TimespanList()
+    timespans = _timespan.TimespanList()
     clocktime_start_offset = Offset(0)
     for left, right in Sequence(pairs).nwise(wrapped=True):
         metronome_mark = left[-1]
@@ -189,7 +188,7 @@ def _make_metronome_mark_map(root):
         multiplier = Multiplier(60, metronome_mark.units_per_minute)
         clocktime_duration = duration / metronome_mark.reference_duration
         clocktime_duration *= multiplier
-        timespan = AnnotatedTimespan(
+        timespan = _timespan.Timespan(
             start_offset=start_offset,
             stop_offset=stop_offset,
             annotation=(clocktime_start_offset, clocktime_duration),

--- a/abjad/bundle.py
+++ b/abjad/bundle.py
@@ -28,8 +28,6 @@ class LilyPondFormatBundle:
         "_opening",
     )
 
-    indent = 4 * " "
-
     ### INITIALIZER ###
 
     def __init__(self):

--- a/abjad/ext/sphinx.py
+++ b/abjad/ext/sphinx.py
@@ -24,11 +24,11 @@ from sphinx.util.osutil import copyfile, ensuredir
 from uqbar.book.extensions import Extension
 from uqbar.strings import normalize
 
+from .. import lilypondfile as _lilypondfile
 from ..configuration import Configuration
 from ..contextmanagers import TemporaryDirectoryChange
 from ..illustrators import illustrate
 from ..io import Illustrator, LilyPondIO, Player
-from ..lilypondfile import Block, LilyPondVersionToken
 from ..lilypondformat import remove_tags
 
 configuration = Configuration()
@@ -235,61 +235,39 @@ class LilyPondExtension(Extension):
             latex=[cls.visit_block_latex, None],
             text=[cls.visit_block_text, cls.depart_block_text],
         )
-        cls.add_option("lilypond/no-stylesheet", directives.flag)
         cls.add_option("lilypond/no-trim", directives.flag)
         cls.add_option("lilypond/pages", directives.unchanged)
-        cls.add_option("lilypond/stylesheet", directives.unchanged)
         cls.add_option("lilypond/with-columns", int)
 
     def __init__(
         self,
         illustrable,
         kind,
-        no_stylesheet=None,
         no_trim=None,
         pages=None,
-        stylesheet=None,
         with_columns=None,
         **keywords,
     ):
         self.illustrable = copy.deepcopy(illustrable)
         self.keywords = keywords
         self.kind = kind
-        self.no_stylesheet = no_stylesheet
         self.no_trim = no_trim
         self.pages = pages
-        self.stylesheet = stylesheet
         self.with_columns = with_columns
 
     def to_docutils(self):
-        if hasattr(self.illustrable, "__illustrate__"):
-            illustration = self.illustrable.__illustrate__(**self.keywords)
+        if isinstance(self.illustrable, _lilypondfile.LilyPondFile):
+            illustration = self.illustrable
         else:
             illustration = illustrate(self.illustrable, **self.keywords)
         if self.kind == self.Kind.AUDIO:
-            block = Block(name="midi")
-            illustration.score_block.items.append(block)
-        if illustration.header_block:
-            if illustration.header_block.empty():
-                illustration.items.remove(illustration.header_block)
-        if illustration.layout_block and illustration.layout_block.empty():
-            illustration.items.remove(illustration.layout_block)
-        if illustration.paper_block and illustration.paper_block.empty():
-            illustration.items.remove(illustration.paper_block)
-        token = LilyPondVersionToken("2.19.83")
-        illustration._lilypond_version_token = token
-        stylesheet = self.stylesheet
-        if self.no_stylesheet:
-            stylesheet = None
-        if stylesheet and not illustration.includes:
-            illustration._use_relative_includes = True
-            includes = [stylesheet]
-            illustration._includes = tuple(includes)
+            block = _lilypondfile.Block("midi")
+            illustration["score"].items.append(block)
+        illustration.lilypond_version_token = r'\version "2.19.83"'
         code = illustration._get_lilypond_format()
         code = remove_tags(code)
         node = self.lilypond_block(code, code)
         node["kind"] = self.kind.name.lower()
-        node["no-stylesheet"] = self.no_stylesheet
         node["no-trim"] = self.no_trim
         node["pages"] = self.pages
         node["with-columns"] = self.with_columns

--- a/abjad/format.py
+++ b/abjad/format.py
@@ -8,6 +8,8 @@ import typing
 import quicktions
 import uqbar
 
+INDENT = 4 * " "
+
 
 @dataclasses.dataclass
 class FormatSpecification:

--- a/abjad/get.py
+++ b/abjad/get.py
@@ -36,7 +36,7 @@ def after_grace_container(argument):
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -313,7 +313,7 @@ def before_grace_container(argument):
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -408,7 +408,7 @@ def contents(argument) -> typing.Optional["Selection"]:
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -602,7 +602,7 @@ def descendants(argument) -> typing.Union["Descendants", "Selection"]:
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -771,7 +771,7 @@ def duration(argument, in_seconds: bool = None) -> Duration:
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -940,7 +940,7 @@ def effective(
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -1441,7 +1441,7 @@ def effective_staff(argument) -> typing.Optional["Staff"]:
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -1555,7 +1555,7 @@ def effective_wrapper(
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -1674,7 +1674,7 @@ def grace(argument) -> bool:
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -1776,7 +1776,7 @@ def has_effective_indicator(
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -1929,7 +1929,7 @@ def has_indicator(
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -2127,7 +2127,7 @@ def indicator(
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -2281,7 +2281,7 @@ def indicators(
         >>> for note in abjad.select(staff).notes():
         ...     abjad.attach(abjad.Articulation("."), note)
 
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -2511,7 +2511,7 @@ def leaf(argument, n: int = 0) -> typing.Optional["Leaf"]:
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -2695,7 +2695,7 @@ def lineage(argument) -> "Lineage":
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -2901,7 +2901,7 @@ def logical_tie(argument) -> "LogicalTie":
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -3094,7 +3094,7 @@ def measure_number(argument) -> int:
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -3269,7 +3269,7 @@ def parentage(argument) -> "Parentage":
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -3484,7 +3484,7 @@ def pitches(argument) -> typing.Optional[PitchSet]:
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -3795,7 +3795,7 @@ def timespan(argument, in_seconds: bool = False) -> Timespan:
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -3961,7 +3961,7 @@ def wrapper(
         >>> for note in abjad.select(staff).notes():
         ...     abjad.attach(abjad.Articulation("."), note)
 
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -4081,7 +4081,7 @@ def wrappers(
         >>> for note in abjad.select(staff).notes():
         ...     abjad.attach(abjad.Articulation("."), note)
 
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::

--- a/abjad/grace_corner_cases.py
+++ b/abjad/grace_corner_cases.py
@@ -14,7 +14,7 @@ r"""
     ... )
     >>> abjad.attach(abjad.Articulation(">"), container[0])
     >>> staff = abjad.Staff([music_voice])
-    >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+    >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
     >>> abjad.show(lilypond_file) # doctest: +SKIP
 
     ..  docs::
@@ -73,7 +73,7 @@ r"""
     >>> container = abjad.BeforeGraceContainer("gs'16")
     >>> abjad.attach(container, music_voice[1][1][0])
     >>> staff = abjad.Staff([music_voice])
-    >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+    >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
     >>> abjad.show(lilypond_file) # doctest: +SKIP
 
     ..  docs::
@@ -133,7 +133,7 @@ r"""
     ... )
     >>> abjad.attach(abjad.Articulation(">"), container[0])
     >>> staff = abjad.Staff([music_voice])
-    >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+    >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
     >>> abjad.show(lilypond_file) # doctest: +SKIP
 
     ..  docs::
@@ -242,7 +242,7 @@ r"""
     ... )
     >>> abjad.attach(abjad.Articulation(">"), container[0])
     >>> staff = abjad.Staff([music_voice])
-    >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+    >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
     >>> abjad.show(lilypond_file) # doctest: +SKIP
 
     ..  docs::

--- a/abjad/illustrators.py
+++ b/abjad/illustrators.py
@@ -446,16 +446,22 @@ def selection(selection, time_signatures=None, *, includes=None):
             attach(time_signature, _selection.Selection(part).leaf(0))
     staff = _score.Staff(selection, name="Staff")
     score = _score.Score([staff], name="Score")
-    preamble = r"""\include "abjad.ily"
-
-\layout {
-    \context {
+    items = []
+    items.append(r'\include "abjad.ily"')
+    for include in includes or []:
+        items.append(rf'\include "{include}"')
+    string = r"""\layout
+{
+    \context
+    {
         \Score
         proportionalNotationDuration = #(ly:make-moment 1 24)
     }
 }
 """
-    lilypond_file = LilyPondFile([preamble, score], includes=includes)
+    items.append(string)
+    items.append(score)
+    lilypond_file = LilyPondFile(items)
     return lilypond_file
 
 
@@ -481,9 +487,9 @@ def selection_to_score_markup_string(selection):
     scheme = "#tuplet-number::calc-fraction-text"
     overrides.override(staff).TupletNumber.text = scheme
     overrides.setting(staff).tupletFullLength = True
-    layout_block = Block(name="layout")
-    layout_block.indent = 0
-    layout_block.ragged_right = "##t"
+    layout_block = Block("layout")
+    layout_block.items.append("indent = 0")
+    layout_block.items.append("ragged-right = ##t")
     score = _score.Score([staff], name="Score")
     overrides.override(score).SpacingSpanner.spacing_increment = 0.5
     overrides.setting(score).proportionalNotationDuration = False

--- a/abjad/indicators/Arpeggio.py
+++ b/abjad/indicators/Arpeggio.py
@@ -16,14 +16,18 @@ class Arpeggio:
         >>> chord = abjad.Chord("<c' e' g' c''>4")
         >>> arpeggio = abjad.Arpeggio()
         >>> abjad.attach(arpeggio, chord)
-        >>> abjad.show(chord) # doctest: +SKIP
+        >>> staff = abjad.Staff([chord])
+        >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(chord)
+            >>> string = abjad.lilypond(staff)
             >>> print(string)
-            <c' e' g' c''>4
-            \arpeggio
+            \new Staff
+            {
+                <c' e' g' c''>4
+                \arpeggio
+            }
 
     ..  container:: example
 
@@ -32,15 +36,19 @@ class Arpeggio:
         >>> chord = abjad.Chord("<c' e' g' c''>4")
         >>> arpeggio = abjad.Arpeggio(direction=abjad.Down)
         >>> abjad.attach(arpeggio, chord)
-        >>> abjad.show(chord) # doctest: +SKIP
+        >>> staff = abjad.Staff([chord])
+        >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(chord)
+            >>> string = abjad.lilypond(staff)
             >>> print(string)
-            \arpeggioArrowDown
-            <c' e' g' c''>4
-            \arpeggio
+            \new Staff
+            {
+                \arpeggioArrowDown
+                <c' e' g' c''>4
+                \arpeggio
+            }
 
     """
 
@@ -114,15 +122,19 @@ class Arpeggio:
             >>> arpeggio = abjad.Arpeggio()
             >>> abjad.tweak(arpeggio).color = "#blue"
             >>> abjad.attach(arpeggio, chord)
-            >>> abjad.show(chord) # doctest: +SKIP
+            >>> staff = abjad.Staff([chord])
+            >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(chord)
+                >>> string = abjad.lilypond(staff)
                 >>> print(string)
-                <c' e' g' c''>4
-                - \tweak color #blue
-                \arpeggio
+                \new Staff
+                {
+                    <c' e' g' c''>4
+                    - \tweak color #blue
+                    \arpeggio
+                }
 
         """
         return self._tweaks

--- a/abjad/indicators/BreathMark.py
+++ b/abjad/indicators/BreathMark.py
@@ -17,14 +17,18 @@ class BreathMark:
         >>> note = abjad.Note("c'4")
         >>> breath_mark = abjad.BreathMark()
         >>> abjad.attach(breath_mark, note)
-        >>> abjad.show(note) # doctest: +SKIP
+        >>> staff = abjad.Staff([note])
+        >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(note)
+            >>> string = abjad.lilypond(staff)
             >>> print(string)
-            c'4
-            \breathe
+            \new Staff
+            {
+                c'4
+                \breathe
+            }
 
     ..  container:: example
 
@@ -76,6 +80,26 @@ class BreathMark:
                 d'4
                 e'4
                 f'4
+                \breathe
+            }
+
+    ..  container:: example
+
+        >>> note = abjad.Note("c'4")
+        >>> breath = abjad.BreathMark()
+        >>> abjad.tweak(breath).color = "#blue"
+        >>> abjad.attach(breath, note)
+        >>> staff = abjad.Staff([note])
+        >>> abjad.show(staff) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> string = abjad.lilypond(staff)
+            >>> print(string)
+            \new Staff
+            {
+                c'4
+                \tweak color #blue
                 \breathe
             }
 
@@ -131,7 +155,7 @@ class BreathMark:
     ### PRIVATE METHODS ###
 
     def _get_lilypond_format(self):
-        return str(self)
+        return r"\breathe"
 
     def _get_lilypond_format_bundle(self, component=None):
         bundle = LilyPondFormatBundle()
@@ -141,28 +165,9 @@ class BreathMark:
         bundle.after.commands.append(self._get_lilypond_format())
         return bundle
 
-    ### PUBLIC PROPERTIES ###
-
     @property
     def tweaks(self) -> typing.Optional[TweakInterface]:
-        r"""
+        """
         Gets tweaks
-
-        ..  container:: example
-
-            >>> note = abjad.Note("c'4")
-            >>> breath = abjad.BreathMark()
-            >>> abjad.tweak(breath).color = "#blue"
-            >>> abjad.attach(breath, note)
-            >>> abjad.show(note) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(note)
-                >>> print(string)
-                c'4
-                \tweak color #blue
-                \breathe
-
         """
         return self._tweaks

--- a/abjad/indicators/Glissando.py
+++ b/abjad/indicators/Glissando.py
@@ -203,7 +203,7 @@ class Glissando:
             ...     abjad.override(note).NoteHead.transparent = True
             ...     abjad.override(note).NoteHead.X_extent = "#'(0 . 0)"
             ...
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -241,7 +241,7 @@ class Glissando:
             ...     abjad.override(note).NoteHead.transparent = True
             ...     abjad.override(note).NoteHead.X_extent = "#'(0 . 0)"
             ...
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::

--- a/abjad/indicators/KeyCluster.py
+++ b/abjad/indicators/KeyCluster.py
@@ -15,20 +15,24 @@ class KeyCluster:
         >>> chord = abjad.Chord("<c' e' g' b' d'' f''>8")
         >>> key_cluster = abjad.KeyCluster()
         >>> abjad.attach(key_cluster, chord)
-        >>> abjad.show(chord) # doctest: +SKIP
+        >>> staff = abjad.Staff([chord])
+        >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(chord)
+            >>> string = abjad.lilypond(staff)
             >>> print(string)
-            \once \override Accidental.stencil = ##f
-            \once \override AccidentalCautionary.stencil = ##f
-            \once \override Arpeggio.X-offset = #-2
-            \once \override NoteHead.stencil = #ly:text-interface::print
-            \once \override NoteHead.text =
-            \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
-            <c' e' g' b' d'' f''>8
-            ^ \markup \center-align \concat { \natural \flat }
+            \new Staff
+            {
+                \once \override Accidental.stencil = ##f
+                \once \override AccidentalCautionary.stencil = ##f
+                \once \override Arpeggio.X-offset = #-2
+                \once \override NoteHead.stencil = #ly:text-interface::print
+                \once \override NoteHead.text =
+                \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
+                <c' e' g' b' d'' f''>8
+                ^ \markup \center-align \concat { \natural \flat }
+            }
 
     """
 
@@ -122,20 +126,24 @@ class KeyCluster:
             >>> chord = abjad.Chord("<c' e' g' b' d'' f''>8")
             >>> key_cluster = abjad.KeyCluster(hide=False)
             >>> abjad.attach(key_cluster, chord)
-            >>> abjad.show(chord) # doctest: +SKIP
+            >>> staff = abjad.Staff([chord])
+            >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(chord)
+                >>> string = abjad.lilypond(staff)
                 >>> print(string)
-                \once \override Accidental.stencil = ##f
-                \once \override AccidentalCautionary.stencil = ##f
-                \once \override Arpeggio.X-offset = #-2
-                \once \override NoteHead.stencil = #ly:text-interface::print
-                \once \override NoteHead.text =
-                \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
-                <c' e' g' b' d'' f''>8
-                ^ \markup \center-align \concat { \natural \flat }
+                \new Staff
+                {
+                    \once \override Accidental.stencil = ##f
+                    \once \override AccidentalCautionary.stencil = ##f
+                    \once \override Arpeggio.X-offset = #-2
+                    \once \override NoteHead.stencil = #ly:text-interface::print
+                    \once \override NoteHead.text =
+                    \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
+                    <c' e' g' b' d'' f''>8
+                    ^ \markup \center-align \concat { \natural \flat }
+                }
 
             Default behavior.
 
@@ -146,19 +154,23 @@ class KeyCluster:
             >>> chord = abjad.Chord("<c' e' g' b' d'' f''>8")
             >>> key_cluster = abjad.KeyCluster(hide=True)
             >>> abjad.attach(key_cluster, chord)
-            >>> abjad.show(chord) # doctest: +SKIP
+            >>> staff = abjad.Staff([chord])
+            >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(chord)
+                >>> string = abjad.lilypond(staff)
                 >>> print(string)
-                \once \override Accidental.stencil = ##f
-                \once \override AccidentalCautionary.stencil = ##f
-                \once \override Arpeggio.X-offset = #-2
-                \once \override NoteHead.stencil = #ly:text-interface::print
-                \once \override NoteHead.text =
-                \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
-                <c' e' g' b' d'' f''>8
+                \new Staff
+                {
+                    \once \override Accidental.stencil = ##f
+                    \once \override AccidentalCautionary.stencil = ##f
+                    \once \override Arpeggio.X-offset = #-2
+                    \once \override NoteHead.stencil = #ly:text-interface::print
+                    \once \override NoteHead.text =
+                    \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
+                    <c' e' g' b' d'' f''>8
+                }
 
         ..  todo:: Remove?
 
@@ -179,20 +191,24 @@ class KeyCluster:
             ...     include_black_keys=True,
             ...     )
             >>> abjad.attach(key_cluster, chord)
-            >>> abjad.show(chord) # doctest: +SKIP
+            >>> staff = abjad.Staff([chord])
+            >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(chord)
+                >>> string = abjad.lilypond(staff)
                 >>> print(string)
-                \once \override Accidental.stencil = ##f
-                \once \override AccidentalCautionary.stencil = ##f
-                \once \override Arpeggio.X-offset = #-2
-                \once \override NoteHead.stencil = #ly:text-interface::print
-                \once \override NoteHead.text =
-                \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
-                <c' e' g' b' d'' f''>8
-                ^ \markup \center-align \concat { \natural \flat }
+                \new Staff
+                {
+                    \once \override Accidental.stencil = ##f
+                    \once \override AccidentalCautionary.stencil = ##f
+                    \once \override Arpeggio.X-offset = #-2
+                    \once \override NoteHead.stencil = #ly:text-interface::print
+                    \once \override NoteHead.text =
+                    \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
+                    <c' e' g' b' d'' f''>8
+                    ^ \markup \center-align \concat { \natural \flat }
+                }
 
             Default behavior.
 
@@ -205,20 +221,24 @@ class KeyCluster:
             ...     include_black_keys=False,
             ...     )
             >>> abjad.attach(key_cluster, chord)
-            >>> abjad.show(chord) # doctest: +SKIP
+            >>> staff = abjad.Staff([chord])
+            >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(chord)
+                >>> string = abjad.lilypond(staff)
                 >>> print(string)
-                \once \override Accidental.stencil = ##f
-                \once \override AccidentalCautionary.stencil = ##f
-                \once \override Arpeggio.X-offset = #-2
-                \once \override NoteHead.stencil = #ly:text-interface::print
-                \once \override NoteHead.text =
-                \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
-                <c' e' g' b' d'' f''>8
-                ^ \markup \center-align \natural
+                \new Staff
+                {
+                    \once \override Accidental.stencil = ##f
+                    \once \override AccidentalCautionary.stencil = ##f
+                    \once \override Arpeggio.X-offset = #-2
+                    \once \override NoteHead.stencil = #ly:text-interface::print
+                    \once \override NoteHead.text =
+                    \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
+                    <c' e' g' b' d'' f''>8
+                    ^ \markup \center-align \natural
+                }
 
         ..  todo:: Rename to ``include_flat_markup``.
 
@@ -239,20 +259,24 @@ class KeyCluster:
             ...     include_white_keys=True,
             ...     )
             >>> abjad.attach(key_cluster, chord)
-            >>> abjad.show(chord) # doctest: +SKIP
+            >>> staff = abjad.Staff([chord])
+            >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(chord)
+                >>> string = abjad.lilypond(staff)
                 >>> print(string)
-                \once \override Accidental.stencil = ##f
-                \once \override AccidentalCautionary.stencil = ##f
-                \once \override Arpeggio.X-offset = #-2
-                \once \override NoteHead.stencil = #ly:text-interface::print
-                \once \override NoteHead.text =
-                \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
-                <c' e' g' b' d'' f''>8
-                ^ \markup \center-align \concat { \natural \flat }
+                \new Staff
+                {
+                    \once \override Accidental.stencil = ##f
+                    \once \override AccidentalCautionary.stencil = ##f
+                    \once \override Arpeggio.X-offset = #-2
+                    \once \override NoteHead.stencil = #ly:text-interface::print
+                    \once \override NoteHead.text =
+                    \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
+                    <c' e' g' b' d'' f''>8
+                    ^ \markup \center-align \concat { \natural \flat }
+                }
 
             Default behavior.
 
@@ -265,20 +289,24 @@ class KeyCluster:
             ...     include_white_keys=False,
             ...     )
             >>> abjad.attach(key_cluster, chord)
-            >>> abjad.show(chord) # doctest: +SKIP
+            >>> staff = abjad.Staff([chord])
+            >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(chord)
+                >>> string = abjad.lilypond(staff)
                 >>> print(string)
-                \once \override Accidental.stencil = ##f
-                \once \override AccidentalCautionary.stencil = ##f
-                \once \override Arpeggio.X-offset = #-2
-                \once \override NoteHead.stencil = #ly:text-interface::print
-                \once \override NoteHead.text =
-                \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
-                <c' e' g' b' d'' f''>8
-                ^ \markup \center-align \flat
+                \new Staff
+                {
+                    \once \override Accidental.stencil = ##f
+                    \once \override AccidentalCautionary.stencil = ##f
+                    \once \override Arpeggio.X-offset = #-2
+                    \once \override NoteHead.stencil = #ly:text-interface::print
+                    \once \override NoteHead.text =
+                    \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
+                    <c' e' g' b' d'' f''>8
+                    ^ \markup \center-align \flat
+                }
 
         ..  todo:: Rename to ``include_natural_markup``.
 
@@ -299,20 +327,24 @@ class KeyCluster:
             ...     markup_direction=abjad.Up,
             ...     )
             >>> abjad.attach(key_cluster, chord)
-            >>> abjad.show(chord) # doctest: +SKIP
+            >>> staff = abjad.Staff([chord])
+            >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(chord)
+                >>> string = abjad.lilypond(staff)
                 >>> print(string)
-                \once \override Accidental.stencil = ##f
-                \once \override AccidentalCautionary.stencil = ##f
-                \once \override Arpeggio.X-offset = #-2
-                \once \override NoteHead.stencil = #ly:text-interface::print
-                \once \override NoteHead.text =
-                \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
-                <c' e' g' b' d'' f''>8
-                ^ \markup \center-align \concat { \natural \flat }
+                \new Staff
+                {
+                    \once \override Accidental.stencil = ##f
+                    \once \override AccidentalCautionary.stencil = ##f
+                    \once \override Arpeggio.X-offset = #-2
+                    \once \override NoteHead.stencil = #ly:text-interface::print
+                    \once \override NoteHead.text =
+                    \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
+                    <c' e' g' b' d'' f''>8
+                    ^ \markup \center-align \concat { \natural \flat }
+                }
 
             Default behavior.
 
@@ -325,20 +357,24 @@ class KeyCluster:
             ...     markup_direction=abjad.Down,
             ...     )
             >>> abjad.attach(key_cluster, chord)
-            >>> abjad.show(chord) # doctest: +SKIP
+            >>> staff = abjad.Staff([chord])
+            >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(chord)
+                >>> string = abjad.lilypond(staff)
                 >>> print(string)
-                \once \override Accidental.stencil = ##f
-                \once \override AccidentalCautionary.stencil = ##f
-                \once \override Arpeggio.X-offset = #-2
-                \once \override NoteHead.stencil = #ly:text-interface::print
-                \once \override NoteHead.text =
-                \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
-                <c' e' g' b' d'' f''>8
-                _ \markup \center-align \concat { \natural \flat }
+                \new Staff
+                {
+                    \once \override Accidental.stencil = ##f
+                    \once \override AccidentalCautionary.stencil = ##f
+                    \once \override Arpeggio.X-offset = #-2
+                    \once \override NoteHead.stencil = #ly:text-interface::print
+                    \once \override NoteHead.text =
+                    \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
+                    <c' e' g' b' d'' f''>8
+                    _ \markup \center-align \concat { \natural \flat }
+                }
 
         """
         return self._markup_direction
@@ -366,10 +402,9 @@ class KeyCluster:
             <c' e' g' b' d'' f''>8
             ^ \markup \center-align \concat { \natural \flat }
 
-            The reason for this is that chords contain multiple note-heads: if
-            key cluster formatted tweaks instead of overrides, the five format
-            commands shown above would need to be duplicated immediately before
-            each note-head.
+            The reason for this is that chords contain multiple note-heads: if key
+            cluster formatted tweaks instead of overrides, the five format commands shown
+            above would need to be duplicated immediately before each note-head.
 
         """
         pass

--- a/abjad/indicators/MetronomeMark.py
+++ b/abjad/indicators/MetronomeMark.py
@@ -60,7 +60,7 @@ class MetronomeMark:
         >>> score.append(staff)
         >>> mark = abjad.MetronomeMark((1, 4), quicktions.Fraction(272, 3))
         >>> abjad.attach(mark, staff[0])
-        >>> lilypond_file = abjad.LilyPondFile([score], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', score])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -90,7 +90,7 @@ class MetronomeMark:
         ...     decimal="90.66",
         ... )
         >>> abjad.attach(mark, staff[0])
-        >>> lilypond_file = abjad.LilyPondFile([score], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', score])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -120,7 +120,7 @@ class MetronomeMark:
         ...     decimal=True,
         ... )
         >>> abjad.attach(mark, staff[0])
-        >>> lilypond_file = abjad.LilyPondFile([score], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', score])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -821,7 +821,7 @@ class MetronomeMark:
             >>> staff = abjad.Staff("c'4 d'4 e'4 f'4")
             >>> score = abjad.Score([staff])
             >>> abjad.attach(mark, staff[0])
-            >>> lilypond_file = abjad.LilyPondFile([score], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', score])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1205,7 +1205,7 @@ class MetronomeMark:
             Integer-valued metronome mark:
 
             >>> markup = abjad.MetronomeMark.make_tempo_equation_markup((1, 4),  90)
-            >>> lilypond_file = abjad.LilyPondFile([markup], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', markup])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1219,7 +1219,7 @@ class MetronomeMark:
             Float-valued metronome mark:
 
             >>> markup = abjad.MetronomeMark.make_tempo_equation_markup((1, 4), 90.1)
-            >>> lilypond_file = abjad.LilyPondFile([markup], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', markup])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1237,7 +1237,7 @@ class MetronomeMark:
             ...     abjad.Duration(1, 4),
             ...     quicktions.Fraction(272, 3),
             ... )
-            >>> lilypond_file = abjad.LilyPondFile([markup], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', markup])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::

--- a/abjad/indicators/RehearsalMark.py
+++ b/abjad/indicators/RehearsalMark.py
@@ -257,15 +257,19 @@ class RehearsalMark:
             >>> mark = abjad.RehearsalMark(markup='A')
             >>> abjad.tweak(mark).color = "#blue"
             >>> abjad.attach(mark, note)
-            >>> abjad.show(note) # doctest: +SKIP
+            >>> staff = abjad.Staff([note])
+            >>> abjad.show(staff) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(note)
+                >>> string = abjad.lilypond(staff)
                 >>> print(string)
-                \tweak color #blue
-                \mark A
-                c'4
+                \new Staff
+                {
+                    \tweak color #blue
+                    \mark A
+                    c'4
+                }
 
         """
         return self._tweaks

--- a/abjad/indicators/StartTextSpan.py
+++ b/abjad/indicators/StartTextSpan.py
@@ -24,7 +24,7 @@ class StartTextSpan:
         >>> abjad.attach(start_text_span, staff[0])
         >>> stop_text_span = abjad.StopTextSpan()
         >>> abjad.attach(stop_text_span, staff[-1])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -279,7 +279,7 @@ class StartTextSpan:
             >>> markup = abjad.Markup(r"\markup SPACER", direction=abjad.Up)
             >>> abjad.tweak(markup).transparent = True
             >>> abjad.attach(markup, staff[0])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -393,7 +393,7 @@ class StartTextSpan:
             >>> abjad.attach(start_text_span, staff[0])
             >>> stop_text_span = abjad.StopTextSpan()
             >>> abjad.attach(stop_text_span, staff[-1])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -489,7 +489,7 @@ class StartTextSpan:
             >>> abjad.attach(start_text_span, staff[0])
             >>> stop_text_span = abjad.StopTextSpan()
             >>> abjad.attach(stop_text_span, staff[-1])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -521,7 +521,7 @@ class StartTextSpan:
             >>> abjad.attach(start_text_span, staff[0])
             >>> stop_text_span = abjad.StopTextSpan()
             >>> abjad.attach(stop_text_span, staff[-1])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -553,7 +553,7 @@ class StartTextSpan:
             >>> abjad.attach(start_text_span, staff[0])
             >>> stop_text_span = abjad.StopTextSpan()
             >>> abjad.attach(stop_text_span, staff[-1])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -586,7 +586,7 @@ class StartTextSpan:
             >>> abjad.attach(start_text_span, staff[0])
             >>> stop_text_span = abjad.StopTextSpan()
             >>> abjad.attach(stop_text_span, staff[-1])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -618,7 +618,7 @@ class StartTextSpan:
             >>> abjad.attach(start_text_span, staff[0])
             >>> stop_text_span = abjad.StopTextSpan()
             >>> abjad.attach(stop_text_span, staff[-1])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::

--- a/abjad/indicators/StopTextSpan.py
+++ b/abjad/indicators/StopTextSpan.py
@@ -106,7 +106,7 @@ class StopTextSpan:
             >>> abjad.attach(command, staff[0])
             >>> command = abjad.StopTextSpan()
             >>> abjad.attach(command, staff[-2])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -139,7 +139,7 @@ class StopTextSpan:
             >>> abjad.attach(command, staff[0])
             >>> command = abjad.StopTextSpan(leak=True)
             >>> abjad.attach(command, staff[-2])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::

--- a/abjad/iterate.py
+++ b/abjad/iterate.py
@@ -24,7 +24,7 @@ def components(argument, prototype=None, *, exclude=None, grace=None, reverse=No
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -246,7 +246,7 @@ def leaves(
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -485,7 +485,7 @@ def logical_ties(
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -960,7 +960,7 @@ def timeline(argument, prototype=None, *, exclude=None, reverse=None):
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
         >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::

--- a/abjad/label.py
+++ b/abjad/label.py
@@ -143,7 +143,7 @@ def color_leaves(argument, color="#red", *, deactivate=False, tag=None) -> None:
             >>> staff = abjad.Staff("cs'8. r8. s8. <c' cs' a'>8.")
             >>> abjad.beam(staff[:])
             >>> abjad.label.color_leaves(staff, "#red")
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::

--- a/abjad/lilypondfile.py
+++ b/abjad/lilypondfile.py
@@ -1,44 +1,27 @@
-import importlib
-import inspect
-import numbers
-import os
-import pathlib
-import subprocess
-import time
+import dataclasses
 import typing
 
-from . import bundle as _bundle
 from . import configuration as _configuration
-from . import contextmanagers as _contextmanagers
 from . import format as _format
 from . import iterate as iterate_
-from . import lilypondformat as _lilypondformat
-from . import markups as _markups
-from . import overrides as _overrides
 from . import score as _score
 from . import tag as _tag
-from .indicators.LilyPondComment import LilyPondComment
 
 configuration = _configuration.Configuration()
 
 
+@dataclasses.dataclass
 class Block:
-    r"""
+    r'''
     LilyPond file block.
 
     ..  container:: example
 
-        REGRESSION. Blocks remember attribute assignment order.
+        Use strings to add contents to a block:
 
-        Here right margin precedes left margin even though left margin alphabetizes
-        before right margin:
-
-        >>> block = abjad.Block(name="paper")
-        >>> block.right_margin = abjad.LilyPondDimension(2, "cm")
-        >>> block.left_margin = abjad.LilyPondDimension(2, "cm")
-        >>> block
-        <Block(name='paper')>
-
+        >>> string = r"""right-margin = 2\cm
+        ...     left-margin = 2\cm"""
+        >>> block = abjad.Block("paper", items=[string])
         >>> string = abjad.lilypond(block)
         >>> print(string)
         \paper
@@ -49,316 +32,22 @@ class Block:
 
     ..  container:: example
 
-        >>> block = abjad.Block(name='score')
-        >>> markup = abjad.Markup(r"\markup foo")
-        >>> block.items.append(markup)
-        >>> block
-        <Block(name='score')>
+        Define a context block like this:
 
-        >>> string = abjad.lilypond(block)
-        >>> print(string)
-        \score
-        {
-            {
-                \markup foo
-            }
-        }
-
-    """
-
-    ### INITIALIZER ###
-
-    def __init__(self, name="score"):
-        assert isinstance(name, str), repr(name)
-        self._name = name
-        escaped_name = rf"\{name}"
-        self._escaped_name = escaped_name
-        self._items = []
-        self._public_attribute_names = []
-
-    ### SPECIAL METHODS ###
-
-    def __delattr__(self, name) -> None:
-        """
-        Deletes block attribute with ``name``.
-
-        ..  container:: example
-
-            >>> header_block = abjad.Block(name="header")
-            >>> header_block.tagline = False
-            >>> header_block.tagline
-            False
-
-            >>> delattr(header_block, "tagline")
-            >>> hasattr(header_block, "tagline")
-            False
-
-        """
-        self._public_attribute_names.remove(name)
-        object.__delattr__(self, name)
-
-    def __getitem__(self, name):
-        """
-        Gets item with ``name``.
-
-        ..  container:: example
-
-            Gets score with name ``'Red Example Score'`` in score block:
-
-            >>> block = abjad.Block(name="score")
-            >>> score = abjad.Score(name="Red_Example_Score")
-            >>> block.items.append(score)
-
-            >>> block["Red_Example_Score"]
-            Score(simultaneous=True, name='Red_Example_Score')
-
-        Returns item.
-
-        Raises key error when no item with ``name`` is found.
-        """
-        for item in self.items:
-            if getattr(item, "name", None) == name:
-                return item
-        raise KeyError
-
-    def __repr__(self) -> str:
-        """
-        Gets interpreter representation.
-        """
-        return _format.get_repr(self)
-
-    def __setattr__(self, name, value):
-        """
-        Sets block ``name`` to ``value``.
-
-        Returns none.
-        """
-        if not name.startswith("_") and name not in self._public_attribute_names:
-            self._public_attribute_names.append(name)
-        object.__setattr__(self, name, value)
-
-    def __setstate__(self, state):
-        """
-        Sets state of block.
-
-        Returns none.
-        """
-        if not hasattr(self, "_public_attribute_names"):
-            self._public_attribute_names = []
-        for key, value in state.items():
-            setattr(self, key, value)
-
-    ### PRIVATE METHODS ###
-
-    def _format_item(self, item, depth=1):
-        indent = _bundle.LilyPondFormatBundle.indent * depth
-        result = []
-        if isinstance(item, (list, tuple)):
-            result.append(indent + "{")
-            depth_ = depth + 1
-            for x in item:
-                pieces = self._format_item(x, depth=depth_)
-                result.extend(pieces)
-            result.append(indent + "}")
-        elif isinstance(item, str):
-            if item.isspace():
-                string = ""
-            else:
-                string = indent + item
-            result.append(string)
-        elif "_get_format_pieces" in dir(item):
-            try:
-                pieces = item._get_format_pieces()
-            except TypeError:
-                pieces = item._get_format_pieces()
-            for piece in pieces:
-                if piece.isspace():
-                    piece = ""
-                else:
-                    piece = indent + piece
-                result.append(piece)
-        return result
-
-    def _formatted_context_blocks(self):
-        result = []
-        context_blocks = []
-        for item in self.items:
-            if isinstance(item, ContextBlock):
-                context_blocks.append(item)
-        for context_block in context_blocks:
-            result.extend(context_block._get_format_pieces())
-        return result
-
-    def _get_format_pieces(self, tag=None):
-        indent = _bundle.LilyPondFormatBundle.indent
-        result = []
-        if (
-            not self._get_formatted_user_attributes()
-            and not getattr(self, "contexts", None)
-            and not getattr(self, "context_blocks", None)
-            and not len(self.items)
-        ):
-            string = f"{self._escaped_name} {{}}"
-            result.append(string)
-            return result
-        strings = [f"{self._escaped_name}", "{"]
-        if tag is not None:
-            strings = _tag.double_tag(strings, tag)
-        result.extend(strings)
-        for item in self.items:
-            if isinstance(item, ContextBlock):
-                continue
-            if isinstance(item, (_score.Leaf, _markups.Markup)):
-                item = [item]
-            result.extend(self._format_item(item))
-        formatted_attributes = self._get_formatted_user_attributes()
-        formatted_attributes = [indent + _ for _ in formatted_attributes]
-        result.extend(formatted_attributes)
-        formatted_context_blocks = self._formatted_context_blocks()
-        formatted_context_blocks = [indent + _ for _ in formatted_context_blocks]
-        result.extend(formatted_context_blocks)
-        string = "}"
-        strings = [string]
-        if tag is not None:
-            strings = _tag.double_tag(strings, tag)
-        result.extend(strings)
-
-        return result
-
-    def _get_format_specification(self):
-        return _format.FormatSpecification(
-            repr_is_bracketed=True,
-        )
-
-    def _get_formatted_user_attributes(self):
-        result = []
-        for key in self._public_attribute_names:
-            assert not key.startswith("_"), repr(key)
-            value = getattr(self, key)
-            formatted_key = key.split("__")
-            for i, k in enumerate(formatted_key):
-                formatted_key[i] = k.replace("_", "-")
-                if 0 < i:
-                    string = f"#'{formatted_key[i]}"
-                    formatted_key[i] = string
-            formatted_key = " ".join(formatted_key)
-            if isinstance(value, _markups.Markup):
-                formatted_value = value._get_format_pieces()
-            elif isinstance(value, LilyPondDimension):
-                formatted_value = [_lilypondformat.lilypond(value)]
-            else:
-                assert isinstance(value, (int, str, float)), repr((self, key, value))
-                formatted_value = [str(value)]
-            setting = f"{formatted_key!s} = {formatted_value[0]!s}"
-            result.append(setting)
-            result.extend(formatted_value[1:])
-        return result
-
-    def _get_lilypond_format(self, tag=None):
-        return "\n".join(self._get_format_pieces(tag=tag))
-
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def items(self):
-        r"""
-        Gets items in block.
-
-        ..  container:: example
-
-            >>> block = abjad.Block(name="score")
-            >>> markup = abjad.Markup(r"\markup foo")
-            >>> block.items.append(markup)
-
-            >>> block.items
-            [Markup('\\markup foo')]
-
-        ..  container:: example
-
-            Accepts strings:
-
-            >>> staff = abjad.Staff("c'4 d' e' f'")
-            >>> score_block = abjad.Block(name="score")
-            >>> score_block.items.append("<<")
-            >>> score_block.items.append(r'{ \include "layout.ly" }')
-            >>> score_block.items.append(staff)
-            >>> score_block.items.append(">>")
-            >>> lilypond_file = abjad.LilyPondFile(
-            ...     lilypond_language_token=False,
-            ...     lilypond_version_token=False,
-            ... )
-            >>> lilypond_file.items.append(score_block)
-
-            >>> string = abjad.lilypond(lilypond_file)
-            >>> print(string)
-            <BLANKLINE>
-            \score
-            {
-                <<
-                { \include "layout.ly" }
-                \new Staff
-                {
-                    c'4
-                    d'4
-                    e'4
-                    f'4
-                }
-                >>
-            }
-
-        Returns list.
-        """
-        return self._items
-
-    @property
-    def name(self) -> typing.Optional[str]:
-        """
-        Gets name of block.
-
-        ..  container:: example
-
-            >>> block = abjad.Block(name="score")
-            >>> block.name
-            'score'
-
-        """
-        return self._name
-
-    ### PUBLIC METHODS ###
-
-    def empty(self) -> bool:
-        """
-        Is true when block contains no items and has no user attributes.
-        """
-        if not self.items and not self._get_formatted_user_attributes():
-            return True
-        return False
-
-
-class ContextBlock(Block):
-    r"""
-    LilyPond file ``\context`` block.
-
-    ..  container:: example
-
-        >>> block = abjad.ContextBlock(
-        ...     source_lilypond_type="Staff",
-        ...     name="FluteStaff",
-        ...     type_="Engraver_group",
-        ...     alias="Staff",
-        ... )
-        >>> block.remove_commands.append("Forbid_line_break_engraver")
-        >>> block.consists_commands.append("Horizontal_bracket_engraver")
-        >>> block.accepts_commands.append("FluteUpperVoice")
-        >>> block.accepts_commands.append("FluteLowerVoice")
-        >>> block.items.append(r"\accidentalStyle dodecaphonic")
-        >>> abjad.override(block).Beam.positions = "#'(-4 . -4)"
-        >>> abjad.override(block).Stem.stem_end_position = -6
-        >>> abjad.setting(block).autoBeaming = False
-        >>> abjad.setting(block).tupletFullLength = True
-        >>> block
-        <ContextBlock(source_lilypond_type='Staff', name='FluteStaff', type_='Engraver_group', alias='Staff')>
-
+        >>> string = r"""\Staff
+        ...     \name FluteStaff
+        ...     \type Engraver_group
+        ...     \alias Staff
+        ...     \remove Forbid_line_break_engraver
+        ...     \consists Horizontal_bracket_engraver
+        ...     \accepts FluteUpperVoice
+        ...     \accepts FluteLowerVoice
+        ...     \override Beam.positions = #'(-4 . -4)
+        ...     \override Stem.stem-end-position = -6
+        ...     autoBeaming = ##f
+        ...     tupletFullLength = ##t
+        ...     \accidentalStyle dodecaphonic"""
+        >>> block = abjad.Block("context", items=[string])
         >>> string = abjad.lilypond(block)
         >>> print(string)
         \context
@@ -378,639 +67,121 @@ class ContextBlock(Block):
             \accidentalStyle dodecaphonic
         }
 
-    """
+    ..  container:: example
 
-    ### INITIALIZER ###
+        Define an anonymous block like this:
 
-    def __init__(self, source_lilypond_type=None, name=None, type_=None, alias=None):
-        Block.__init__(self, name="context")
-        self._source_lilypond_type = source_lilypond_type
-        self._name = name
-        self._type_ = type_
-        self._alias = alias
-        self._accepts_commands = []
-        self._consists_commands = []
-        self._remove_commands = []
+        >>> string = r"""command-1
+        ...     command-2
+        ...     command-3"""
+        >>> block = abjad.Block("", items=[string])
+        >>> string = abjad.lilypond(block)
+        >>> print(string)
+        {
+            command-1
+            command-2
+            command-3
+        }
 
-    ### PRIVATE METHODS ###
+    ..  container:: example
 
-    def _get_format_pieces(self, tag=None):
-        indent = _bundle.LilyPondFormatBundle.indent
+        Markup formats like this:
+
+        >>> block = abjad.Block("score", items=[abjad.Markup(r"\markup foo")])
+        >>> string = abjad.lilypond(block)
+        >>> print(string)
+        \score
+        {
+            \markup foo
+        }
+
+    ..  container:: example
+
+        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> block = abjad.Block("score")
+        >>> block.items.append("<<")
+        >>> block.items.append(r'{ \include "layout.ly" }')
+        >>> block.items.append(staff)
+        >>> block.items.append(">>")
+        >>> lilypond_file = abjad.LilyPondFile(
+        ...     lilypond_language_token=False,
+        ...     lilypond_version_token=False,
+        ... )
+        >>> lilypond_file.items.append(block)
+        >>> string = abjad.lilypond(lilypond_file)
+        >>> print(string)
+        \score
+        {
+            <<
+            { \include "layout.ly" }
+            \new Staff
+            {
+                c'4
+                d'4
+                e'4
+                f'4
+            }
+            >>
+        }
+
+    '''
+
+    name: str
+    items: list = dataclasses.field(default_factory=list)
+
+    def __post_init__(self):
+        self.items = list(self.items or [])
+
+    @staticmethod
+    def _format_item(item, depth=1):
+        indent = depth * _format.INDENT
         result = []
-        result.extend([f"{self._escaped_name}", "{"])
-        # CAUTION: source context name must come before type_ to allow
-        # context redefinition.
-        if self.source_lilypond_type is not None:
-            string = indent + rf"\{self.source_lilypond_type}"
-            result.append(string)
-        if self.name is not None:
-            string = indent + rf"\name {self.name}"
-            result.append(string)
-        if self.type_ is not None:
-            string = indent + rf"\type {self.type_}"
-            result.append(string)
-        if self.alias is not None:
-            string = indent + rf"\alias {self.alias}"
-            result.append(string)
-        for statement in self.remove_commands:
-            string = indent + rf"\remove {statement}"
-            result.append(string)
-        # CAUTION: LilyPond \consists statements are order-significant!
-        for statement in self.consists_commands:
-            string = indent + rf"\consists {statement}"
-            result.append(string)
-        for statement in self.accepts_commands:
-            string = indent + rf"\accepts {statement}"
-            result.append(string)
-        overrides = _overrides.override(self)._list_format_contributions("override")
-        for statement in overrides:
-            string = indent + statement
-            result.append(string)
-        setting_contributions = _overrides.setting(self)._format_in_with_block()
-        for setting_contribution in sorted(setting_contributions):
-            string = indent + setting_contribution
-            result.append(string)
-        for item in self.items:
-            if isinstance(item, str):
-                string = indent + f"{item}"
-                result.append(string)
-            elif "_get_format_pieces" in dir(item):
-                for piece in item._get_format_pieces():
-                    if piece.isspace():
-                        piece = ""
-                    else:
-                        piece = indent + piece
-                    result.append(piece)
+        if isinstance(item, str):
+            if item.isspace():
+                string = ""
             else:
-                pass
-        result.append("}")
+                string = indent + item
+            result.append(string)
+        else:
+            pieces = item._get_format_pieces()
+            for piece in pieces:
+                if piece.isspace():
+                    piece = ""
+                else:
+                    piece = indent + piece
+                result.append(piece)
         return result
-
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def accepts_commands(self) -> typing.List[str]:
-        r"""
-        Gets arguments of LilyPond ``\accepts`` commands.
-
-        ..  container:: example
-
-            >>> block = abjad.ContextBlock(
-            ...     source_lilypond_type="Staff",
-            ...     name="FluteStaff",
-            ...     type_="Engraver_group",
-            ...     alias="Staff",
-            ... )
-            >>> block.remove_commands.append("Forbid_line_break_engraver")
-            >>> block.consists_commands.append("Horizontal_bracket_engraver")
-            >>> block.accepts_commands.append("FluteUpperVoice")
-            >>> block.accepts_commands.append("FluteLowerVoice")
-            >>> block.items.append(r"\accidentalStyle dodecaphonic")
-            >>> abjad.override(block).Beam.positions = "#'(-4 . -4)"
-            >>> abjad.override(block).Stem.stem_end_position = -6
-            >>> abjad.setting(block).autoBeaming = False
-            >>> abjad.setting(block).tupletFullLength = True
-
-            >>> block.accepts_commands
-            ['FluteUpperVoice', 'FluteLowerVoice']
-
-        """
-        return self._accepts_commands
-
-    @property
-    def alias(self) -> typing.Optional[str]:
-        r"""
-        Gets and sets argument of LilyPond ``\alias`` command.
-
-        ..  container:: example
-
-            >>> block = abjad.ContextBlock(
-            ...     source_lilypond_type="Staff",
-            ...     name="FluteStaff",
-            ...     type_="Engraver_group",
-            ...     alias="Staff",
-            ... )
-            >>> block.remove_commands.append("Forbid_line_break_engraver")
-            >>> block.consists_commands.append("Horizontal_bracket_engraver")
-            >>> block.accepts_commands.append("FluteUpperVoice")
-            >>> block.accepts_commands.append("FluteLowerVoice")
-            >>> block.items.append(r"\accidentalStyle dodecaphonic")
-            >>> abjad.override(block).Beam.positions = "#'(-4 . -4)"
-            >>> abjad.override(block).Stem.stem_end_position = -6
-            >>> abjad.setting(block).autoBeaming = False
-            >>> abjad.setting(block).tupletFullLength = True
-
-            >>> block.alias
-            'Staff'
-
-        """
-        return self._alias
-
-    @property
-    def consists_commands(self) -> typing.List[str]:
-        r"""
-        Gets arguments of LilyPond ``\consists`` commands.
-
-        ..  container:: example
-
-            >>> block = abjad.ContextBlock(
-            ...     source_lilypond_type="Staff",
-            ...     name="FluteStaff",
-            ...     type_="Engraver_group",
-            ...     alias="Staff",
-            ... )
-            >>> block.remove_commands.append("Forbid_line_break_engraver")
-            >>> block.consists_commands.append("Horizontal_bracket_engraver")
-            >>> block.accepts_commands.append("FluteUpperVoice")
-            >>> block.accepts_commands.append("FluteLowerVoice")
-            >>> block.items.append(r"\accidentalStyle dodecaphonic")
-            >>> abjad.override(block).Beam.positions = "#'(-4 . -4)"
-            >>> abjad.override(block).Stem.stem_end_position = -6
-            >>> abjad.setting(block).autoBeaming = False
-            >>> abjad.setting(block).tupletFullLength = True
-
-            >>> block.consists_commands
-            ['Horizontal_bracket_engraver']
-
-        """
-        return self._consists_commands
-
-    @property
-    def items(self) -> typing.List[str]:
-        r"""
-        Gets items in context block.
-
-        ..  container:: example
-
-            >>> block = abjad.ContextBlock(
-            ...     source_lilypond_type="Staff",
-            ...     name="FluteStaff",
-            ...     type_="Engraver_group",
-            ...     alias="Staff",
-            ... )
-            >>> block.remove_commands.append("Forbid_line_break_engraver")
-            >>> block.consists_commands.append("Horizontal_bracket_engraver")
-            >>> block.accepts_commands.append("FluteUpperVoice")
-            >>> block.accepts_commands.append("FluteLowerVoice")
-            >>> block.items.append(r"\accidentalStyle dodecaphonic")
-            >>> abjad.override(block).Beam.positions = "#'(-4 . -4)"
-            >>> abjad.override(block).Stem.stem_end_position = -6
-            >>> abjad.setting(block).autoBeaming = False
-            >>> abjad.setting(block).tupletFullLength = True
-
-            >>> block.items
-            ['\\accidentalStyle dodecaphonic']
-
-        """
-        return self._items
-
-    @property
-    def name(self) -> typing.Optional[str]:
-        r"""
-        Gets and sets argument of LilyPond ``\name`` command.
-
-        ..  container:: example
-
-            >>> block = abjad.ContextBlock(
-            ...     source_lilypond_type="Staff",
-            ...     name="FluteStaff",
-            ...     type_="Engraver_group",
-            ...     alias="Staff",
-            ... )
-            >>> block.remove_commands.append("Forbid_line_break_engraver")
-            >>> block.consists_commands.append("Horizontal_bracket_engraver")
-            >>> block.accepts_commands.append("FluteUpperVoice")
-            >>> block.accepts_commands.append("FluteLowerVoice")
-            >>> block.items.append(r"\accidentalStyle dodecaphonic")
-            >>> abjad.override(block).Beam.positions = "#'(-4 . -4)"
-            >>> abjad.override(block).Stem.stem_end_position = -6
-            >>> abjad.setting(block).autoBeaming = False
-            >>> abjad.setting(block).tupletFullLength = True
-
-            >>> block.name
-            'FluteStaff'
-
-        """
-        return self._name
-
-    @property
-    def remove_commands(self) -> typing.List[str]:
-        r"""
-        Gets arguments of LilyPond ``\remove`` commands.
-
-        ..  container:: example
-
-            >>> block = abjad.ContextBlock(
-            ...     source_lilypond_type="Staff",
-            ...     name="FluteStaff",
-            ...     type_="Engraver_group",
-            ...     alias="Staff",
-            ... )
-            >>> block.remove_commands.append("Forbid_line_break_engraver")
-            >>> block.consists_commands.append("Horizontal_bracket_engraver")
-            >>> block.accepts_commands.append("FluteUpperVoice")
-            >>> block.accepts_commands.append("FluteLowerVoice")
-            >>> block.items.append(r"\accidentalStyle dodecaphonic")
-            >>> abjad.override(block).Beam.positions = "#'(-4 . -4)"
-            >>> abjad.override(block).Stem.stem_end_position = -6
-            >>> abjad.setting(block).autoBeaming = False
-            >>> abjad.setting(block).tupletFullLength = True
-
-            >>> block.remove_commands
-            ['Forbid_line_break_engraver']
-
-        """
-        return self._remove_commands
-
-    @property
-    def source_lilypond_type(self) -> typing.Optional[str]:
-        r"""
-        Gets and sets source context name.
-
-        ..  container:: example
-
-            >>> block = abjad.ContextBlock(
-            ...     source_lilypond_type="Staff",
-            ...     name="FluteStaff",
-            ...     type_="Engraver_group",
-            ...     alias="Staff",
-            ... )
-            >>> block.remove_commands.append("Forbid_line_break_engraver")
-            >>> block.consists_commands.append("Horizontal_bracket_engraver")
-            >>> block.accepts_commands.append("FluteUpperVoice")
-            >>> block.accepts_commands.append("FluteLowerVoice")
-            >>> block.items.append(r"\accidentalStyle dodecaphonic")
-            >>> abjad.override(block).Beam.positions = "#'(-4 . -4)"
-            >>> abjad.override(block).Stem.stem_end_position = -6
-            >>> abjad.setting(block).autoBeaming = False
-            >>> abjad.setting(block).tupletFullLength = True
-
-            >>> block.source_lilypond_type
-            'Staff'
-
-        """
-        return self._source_lilypond_type
-
-    @property
-    def type_(self) -> typing.Optional[str]:
-        r"""
-        Gets and sets argument of LilyPond ``\type`` command.
-
-        ..  container:: example
-
-            >>> block = abjad.ContextBlock(
-            ...     source_lilypond_type="Staff",
-            ...     name="FluteStaff",
-            ...     type_="Engraver_group",
-            ...     alias="Staff",
-            ... )
-            >>> block.remove_commands.append("Forbid_line_break_engraver")
-            >>> block.consists_commands.append("Horizontal_bracket_engraver")
-            >>> block.accepts_commands.append("FluteUpperVoice")
-            >>> block.accepts_commands.append("FluteLowerVoice")
-            >>> block.items.append(r"\accidentalStyle dodecaphonic")
-            >>> abjad.override(block).Beam.positions = "#'(-4 . -4)"
-            >>> abjad.override(block).Stem.stem_end_position = -6
-            >>> abjad.setting(block).autoBeaming = False
-            >>> abjad.setting(block).tupletFullLength = True
-
-            >>> block.type_
-            'Engraver_group'
-
-        """
-        return self._type_
-
-
-class DateTimeToken:
-    """
-    LilyPond file date / time token.
-
-    ..  container:: example
-
-        >>> abjad.DateTimeToken()
-        DateTimeToken()
-
-    """
-
-    ### CLASS VARIABLES ###
-
-    __slots__ = ("_date_string",)
-
-    ### INITIALIZER ###
-
-    def __init__(self, date_string=None):
-        assert isinstance(date_string, (str, type(None)))
-        self._date_string = date_string
-
-    ### SPECIAL METHODS ###
-
-    def __repr__(self) -> str:
-        """
-        Gets interpreter representation of date / time token.
-
-        ..  container:: example
-
-            >>> abjad.DateTimeToken()
-            DateTimeToken()
-
-        """
-        date_string = self._date_string or ""
-        return f"{type(self).__name__}({date_string})"
-
-    ### PRIVATE METHODS ###
-
-    def _get_lilypond_format(self):
-        return self.date_string
-
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def date_string(self) -> str:
-        """
-        Gets date string of date / time token.
-
-        ..  container:: example
-
-            >>> token = abjad.DateTimeToken()
-            >>> token.date_string # doctest: +SKIP
-            '2014-01-23 12:21'
-
-        """
-        date_string = self._date_string or time.strftime("%Y-%m-%d %H:%M")
-        return date_string
-
-
-class LilyPondDimension:
-    r"""
-    LilyPond file ``\paper`` block dimension.
-
-    ..  container:: example
-
-        >>> abjad.LilyPondDimension(2, "in")
-        LilyPondDimension(value=2, unit='in')
-
-    Use for LilyPond file ``\paper`` block attributes.
-    """
-
-    ### CLASS VARIABLES ###
-
-    __slots__ = ("_unit", "_value")
-
-    ### INITIALIZER ###
-
-    def __init__(self, value=0, unit="cm"):
-        assert isinstance(value, numbers.Number) and 0 <= value
-        assert unit in ("cm", "in", "mm", "pt")
-        self._value = value
-        self._unit = unit
-
-    ### SPECIAL METHODS ###
-
-    def __repr__(self) -> str:
-        """
-        Gets interpreter representation.
-        """
-        return _format.get_repr(self)
-
-    ### PRIVATE METHODS ###
 
     def _get_format_pieces(self, tag=None):
-        return [rf"{self.value}\{self.unit}"]
-
-    def _get_lilypond_format(self):
-        return "\n".join(self._get_format_pieces())
-
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def unit(self) -> str:
-        """
-        Gets unit of LilyPond dimension.
-
-        ..  container:: example
-
-            >>> dimension = abjad.LilyPondDimension(2, "in")
-            >>> dimension.unit
-            'in'
-
-        Returns ``'cm'``, ``'in'``, ``'mm'`` or ``'pt'``.
-        """
-        return self._unit
-
-    @property
-    def value(self) -> typing.Union[int, float]:
-        """
-        Gets value of LilyPond dimension.
-
-        ..  container:: example
-
-            >>> dimension = abjad.LilyPondDimension(2, "in")
-            >>> dimension.value
-            2
-
-        """
-        return self._value
-
-
-class LilyPondLanguageToken:
-    r"""
-    LilyPond file ``\language`` token.
-
-    ..  container:: example
-
-        >>> abjad.LilyPondLanguageToken()
-        LilyPondLanguageToken()
-
-    """
-
-    ### CLASS VARIABLES ###
-
-    __slots__ = ()
-
-    ### SPECIAL METHODS ###
-
-    def __repr__(self) -> str:
-        """
-        Gets interpreter representation of LilyPond language token.
-
-        ..  container:: example
-
-            >>> token = abjad.LilyPondLanguageToken()
-            >>> token
-            LilyPondLanguageToken()
-
-        """
-        return f"{type(self).__name__}()"
-
-    ### PRIVATE METHODS ###
-
-    def _get_lilypond_format(self):
-        string = r'\language "english"'
-        return string
-
-
-class LilyPondVersionToken:
-    r"""
-    LilyPond file ``\version`` token.
-    """
-
-    ### CLASS VARIABLES ###
-
-    __slots__ = ("_version_string",)
-
-    ### INITIALIZER ###
-
-    def __init__(self, version_string=None):
-        assert isinstance(version_string, (str, type(None)))
-        if version_string is None:
-            version_string = configuration.get_lilypond_version_string()
-        self._version_string = version_string
-
-    ### SPECIAL METHODS ###
-
-    def __repr__(self) -> str:
-        """
-        Gets interpreter representation of LilyPond version_string token.
-
-        ..  container:: example
-
-            >>> token = abjad.LilyPondVersionToken()
-            >>> token # doctest: +SKIP
-            LilyPondVersionToken('2.19.84')
-
-        """
-        return f"{type(self).__name__}({self.version_string!r})"
-
-    ### PRIVATE METHODS ###
-
-    def _get_lilypond_format(self):
-        return rf'\version "{self.version_string}"'
-
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def version_string(self) -> str:
-        """
-        Gets version string of LilyPond version token.
-
-        ..  container:: example
-
-            Gets version string from install environment:
-
-            >>> token = abjad.LilyPondVersionToken(
-            ...     version_string=None,
-            ...     )
-            >>> token.version_string # doctest: +SKIP
-            '2.19.84'
-
-        ..  container:: example
-
-            Gets version string from explicit input:
-
-            >>> token = abjad.LilyPondVersionToken(
-            ...     version_string="2.19.84",
-            ...     )
-            >>> token.version_string
-            '2.19.84'
-
-        """
-        return self._version_string
-
-
-class PackageGitCommitToken:
-    """
-    Python package git commit token.
-
-    ..  container:: example
-
-        >>> token = abjad.PackageGitCommitToken("abjad")
-        >>> token
-        PackageGitCommitToken(package_name='abjad')
-
-        >>> string = abjad.lilypond(token)
-        >>> print(string)  # doctest: +SKIP
-        package "abjad" @ b6a48a7 [implement-lpf-git-token] (2016-02-02 13:36:25)
-
-    """
-
-    ### CLASS VARIABLES ###
-
-    __slots__ = ("_package_name",)
-
-    ### INITIALIZER ###
-
-    def __init__(self, package_name=None):
-        self._package_name = package_name
-
-    ### SPECIAL METHODS ###
-
-    def __repr__(self) -> str:
-        """
-        Gets interpreter representation.
-        """
-        return _format.get_repr(self)
-
-    ### PRIVATE METHODS ###
-
-    def _get_commit_timestamp(self, commit_hash):
-        command = f"git show -s --format=%ci {commit_hash}"
-        return self._run_command(command)
-
-    def _get_git_branch(self):
-        command = "git rev-parse --abbrev-ref HEAD"
-        return self._run_command(command)
-
-    def _get_git_hash(self):
-        command = "git rev-parse HEAD"
-        return self._run_command(command)
-
-    def _get_lilypond_format(self):
-        path = self._get_package_path()
-        with _contextmanagers.TemporaryDirectoryChange(path):
-            git_branch = self._get_git_branch()
-            git_hash = self._get_git_hash()
-            timestamp = self._get_commit_timestamp(git_hash)
-        date, time, _ = timestamp.split()
-        return 'package "{}" @ {} [{}] ({} {})'.format(
-            self._package_name, git_hash[:7], git_branch, date, time
-        )
-
-    def _get_package_path(self):
-        module = importlib.import_module(self._package_name)
-        path = module.__path__[0]
-        if not os.path.isdir(path):
-            path = os.path.dirname(path)
-        path = os.path.abspath(path)
-        return path
-
-    def _run_command(self, command):
-        process = subprocess.Popen(
-            command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        process.wait()
-        if process.returncode:
-            return None
-        result = process.stdout.read().splitlines()[0]
-        result = result.decode("utf-8")
+        result = []
+        if not len(self.items):
+            if self.name:
+                string = rf"\{self.name} {{}}"
+            else:
+                string = "{}"
+            result.append(string)
+            return result
+        strings = []
+        if self.name:
+            strings.append(rf"\{self.name}")
+        strings.append("{")
+        if tag is not None:
+            strings = _tag.double_tag(strings, tag)
+        result.extend(strings)
+        for item in self.items:
+            result.extend(self._format_item(item))
+        string = "}"
+        strings = [string]
+        if tag is not None:
+            strings = _tag.double_tag(strings, tag)
+        result.extend(strings)
         return result
 
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def package_name(self) -> str:
-        """
-        Gets package name of package git commit token.
-
-        ..  container:: example
-
-            >>> token = abjad.PackageGitCommitToken("abjad")
-            >>> token.package_name
-            'abjad'
-
-        """
-        return self._package_name
+    def _get_lilypond_format(self, tag=None):
+        return "\n".join(self._get_format_pieces(tag=tag))
 
 
+@dataclasses.dataclass
 class LilyPondFile:
     r"""
     LilyPond file.
@@ -1018,16 +189,13 @@ class LilyPondFile:
     ..  container:: example
 
         >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-        >>> comments = [
-        ...     "File construct as an example.",
-        ...     "Parts shown here for positioning.",
-        ... ]
         >>> lilypond_file = abjad.LilyPondFile(
-        ...     items=[staff],
-        ...     default_paper_size=("a5", "portrait"),
-        ...     comments=comments,
-        ...     includes=["abjad.ily"],
-        ...     global_staff_size=16,
+        ...     items=[
+        ...         r'\include "abjad.ily"',
+        ...         '''#(set-default-paper-size "a5" 'portrait)''',
+        ...         "#(set-global-staff-size 16)",
+        ...         staff,
+        ...     ],
         ... )
 
         >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -1035,18 +203,12 @@ class LilyPondFile:
         ::
 
             >>> string = abjad.lilypond(lilypond_file)
-            >>> print(string) # doctest: +SKIP
-            % File construct as an example.
-            % Parts shown here for positioning.
-            <BLANKLINE>
-            \version "2.23.1"
+            >>> print(string)
+            \version "..."
             \language "english"
-            <BLANKLINE>
             \include "abjad.ily"
-            <BLANKLINE>
             #(set-default-paper-size "a5" 'portrait)
             #(set-global-staff-size 16)
-            <BLANKLINE>
             \new Staff
             {
                 c'8
@@ -1057,62 +219,10 @@ class LilyPondFile:
 
     """
 
-    ### CLASS VARIABLES ###
-
-    __slots__ = (
-        "_comments",
-        "_date_time_token",
-        "_default_paper_size",
-        "_global_staff_size",
-        "_includes",
-        "_items",
-        "_lilypond_language_token",
-        "_lilypond_version_token",
-        "_tag",
-        "_use_relative_includes",
-    )
-
-    ### INITIALIZER ###
-
-    def __init__(
-        self,
-        items=None,
-        *,
-        comments=None,
-        date_time_token=None,
-        default_paper_size=None,
-        global_staff_size=None,
-        includes=None,
-        lilypond_language_token=None,
-        lilypond_version_token=None,
-        tag: _tag.Tag = None,
-        use_relative_includes=None,
-    ) -> None:
-        comments = comments or ()
-        comments = tuple(comments)
-        self._comments = comments
-        self._date_time_token = None
-        if bool(date_time_token):
-            self._date_time_token = DateTimeToken()
-        self._default_paper_size = default_paper_size
-        self._global_staff_size = global_staff_size
-        includes = list(includes or [])
-        self._includes = includes
-        self._items = list(items or [])
-        self._lilypond_language_token = None
-        if lilypond_language_token is not False:
-            language = LilyPondLanguageToken()
-            self._lilypond_language_token = language
-        self._lilypond_version_token = None
-        if lilypond_version_token is not False:
-            version = LilyPondVersionToken()
-            self._lilypond_version_token = version
-        if tag is not None:
-            assert isinstance(tag, _tag.Tag), repr(tag)
-        self._tag = tag
-        self._use_relative_includes = use_relative_includes
-
-    ### SPECIAL METHODS ###
+    items: list = dataclasses.field(default_factory=list)
+    lilypond_language_token: typing.Union[bool, str] = True
+    lilypond_version_token: typing.Union[bool, str] = True
+    tag: typing.Optional[_tag.Tag] = None  # TODO: externalize
 
     def __contains__(self, argument) -> bool:
         """
@@ -1120,13 +230,10 @@ class LilyPondFile:
 
         ..  container:: example
 
-            >>> staff = abjad.Staff("c'4 d' e' f'")
+            >>> staff = abjad.Staff("c'4 d' e' f'", name="Staff")
             >>> lilypond_file = abjad.LilyPondFile([staff])
 
-            >>> staff in lilypond_file
-            True
-
-            >>> abjad.Staff in lilypond_file
+            >>> "Staff" in lilypond_file
             True
 
             >>> "Allegro" in lilypond_file
@@ -1162,7 +269,7 @@ class LilyPondFile:
             ...     name="Staff",
             ... )
             >>> score = abjad.Score([staff], name="Score")
-            >>> block = abjad.Block(name="score")
+            >>> block = abjad.Block("score")
             >>> block.items.append(score)
             >>> lilypond_file = abjad.LilyPondFile([block])
             >>> abjad.show(score) # doctest: +SKIP
@@ -1195,18 +302,12 @@ class LilyPondFile:
                 >>
 
             >>> lilypond_file["score"]
-            <Block(name='score')>
+            Block(name='score', items=[<Score-"Score"<<1>>>])
 
             >>> lilypond_file["Score"]
             <Score-"Score"<<1>>>
 
-            >>> lilypond_file[abjad.Score]
-            <Score-"Score"<<1>>>
-
             >>> lilypond_file["Staff"]
-            <Staff-"Staff"<<2>>>
-
-            >>> lilypond_file[abjad.Staff]
             <Staff-"Staff"<<2>>>
 
             >>> lilypond_file["Voice_1"]
@@ -1214,9 +315,6 @@ class LilyPondFile:
 
             >>> lilypond_file["Voice_2"]
             Voice("c'4 d'4 e'4 f'4", name='Voice_2')
-
-            >>> lilypond_file[abjad.Voice]
-            Voice("c''4 b'4 a'4 g'4", name='Voice_1')
 
         ..  container:: example
 
@@ -1267,13 +365,7 @@ class LilyPondFile:
             >>> lilypond_file["Score"]
             <Score-"Score"<<1>>>
 
-            >>> lilypond_file[abjad.Score]
-            <Score-"Score"<<1>>>
-
             >>> lilypond_file["Staff"]
-            <Staff-"Staff"<<2>>>
-
-            >>> lilypond_file[abjad.Staff]
             <Staff-"Staff"<<2>>>
 
             >>> lilypond_file["Voice_1"]
@@ -1281,9 +373,6 @@ class LilyPondFile:
 
             >>> lilypond_file["Voice_2"]
             Voice("c'4 d'4 e'4 f'4", name='Voice_2')
-
-            >>> lilypond_file[abjad.Voice]
-            Voice("c''4 b'4 a'4 g'4", name='Voice_1')
 
         ..  container:: example
 
@@ -1298,7 +387,7 @@ class LilyPondFile:
             ...     [include_container, staff],
             ...     simultaneous=True,
             ... )
-            >>> block = abjad.Block(name="score")
+            >>> block = abjad.Block("score")
             >>> block.items.append(container)
             >>> lilypond_file = abjad.LilyPondFile(
             ...     items=[block],
@@ -1307,7 +396,6 @@ class LilyPondFile:
             ... )
             >>> string = abjad.lilypond(lilypond_file)
             >>> print(string)
-            <BLANKLINE>
             \score
             {
                 <<
@@ -1324,194 +412,85 @@ class LilyPondFile:
                 >>
             }
 
-            >>> lilypond_file[abjad.Staff]
-            Staff("c'4 d'4 e'4 f'4", name='Staff')
-
             >>> lilypond_file['Staff']
             Staff("c'4 d'4 e'4 f'4", name='Staff')
 
-        Returns item.
+        ..  container:: example
 
-        Raises key error when ``argument`` identifies no item in LilyPond file.
+            Finds blocks by name:
+
+            >>> blocks = [abjad.Block("header"), abjad.Block("score")]
+            >>> lilypond_file = abjad.LilyPondFile(items=blocks)
+            >>> lilypond_file["score"]
+            Block(name='score', items=[])
+
+            >>> score = abjad.Score([abjad.Staff("c'4 d' e' f'")], name="Score")
+            >>> lilypond_file["score"].items.append(score)
+            >>> string = abjad.lilypond(lilypond_file)
+            >>> print(string)
+            \version "..."
+            \language "english"
+            \header {}
+            \score
+            {
+                \context Score = "Score"
+                <<
+                    \new Staff
+                    {
+                        c'4
+                        d'4
+                        e'4
+                        f'4
+                    }
+                >>
+            }
+
+        Returns block or component.
         """
-        if not isinstance(argument, str):
-            if inspect.isclass(argument):
-                assert issubclass(argument, _score.Component), repr(argument)
-            else:
-                assert isinstance(argument, _score.Component), repr(argument)
+        assert isinstance(argument, str), repr(argument)
         for item in self.items:
-            if isinstance(item, _score.Component):
-                for context in iterate_.components(item, _score.Context):
-                    if context.name == argument:
-                        return context
-                    if context is argument:
-                        return context
-                    if inspect.isclass(argument) and isinstance(context, argument):
-                        return context
-        score = None
-        if self.score_block and self.score_block.items:
-            items = self.score_block.items
-            for container in iterate_.components(items, _score.Container):
-                if isinstance(container, _score.Context):
-                    score = container
-                    break
-        if isinstance(argument, str):
-            for item in self.items:
-                if getattr(item, "name", None) == argument:
-                    return item
-            if score is not None:
-                if score.name == argument:
-                    return score
-                context = score[argument]
-                return context
-            raise KeyError(f"can not find item with name {argument!r}.")
-        elif isinstance(argument, _score.Component):
-            for item in self.items:
-                if item is argument:
-                    return item
-            if score is not None:
-                if score is argument:
-                    return score
-                prototype = _score.Context
-                for context in iterate_.components(score, prototype):
-                    if context is argument:
-                        return context
-            raise KeyError(f"can not find {argument}.")
-        elif inspect.isclass(argument) and issubclass(argument, _score.Component):
-            for item in self.items:
-                if isinstance(item, argument):
-                    return item
-            if score is not None:
-                if isinstance(score, argument):
-                    return score
-                prototype = _score.Context
-                for context in iterate_.components(score, prototype):
-                    if isinstance(context, argument):
-                        return context
-            raise KeyError(f"can not find item of class {argument}.")
-        else:
-            raise TypeError(argument)
-
-    def __illustrate__(self) -> "LilyPondFile":
-        """
-        Illustrates LilyPond file.
-
-        Returns LilyPond file unchanged.
-        """
-        return self
-
-    def __repr__(self) -> str:
-        """
-        Gets interpreter representation of LilyPond file.
-        """
-        return _format.get_repr(self)
-
-    ### PRIVATE METHODS ###
+            if getattr(item, "name", None) == argument:
+                return item
+            elif hasattr(item, "items"):
+                for item_ in item.items:
+                    if getattr(item_, "name", None) == argument:
+                        return item_
+                    if isinstance(item_, _score.Component):
+                        for component in iterate_.components(item_):
+                            if getattr(component, "name", None) == argument:
+                                return component
+            elif isinstance(item, _score.Component):
+                for component in iterate_.components(item):
+                    if getattr(component, "name", None) == argument:
+                        return component
+        raise KeyError(f"no block or component with name {argument!r}.")
 
     def _get_format_pieces(self, tag=None):
         result = []
-        if self.date_time_token is not None:
-            string = f"% {self.date_time_token}"
-            result.append(string)
-        result.extend(self._get_formatted_comments())
-        includes = []
-        if self.lilypond_version_token is not None:
-            string = f"{self.lilypond_version_token._get_lilypond_format()}"
-            includes.append(string)
-        if self.lilypond_language_token is not None:
-            string = f"{self.lilypond_language_token._get_lilypond_format()}"
-            includes.append(string)
+        strings = []
+        if self.lilypond_version_token is True:
+            string = configuration.get_lilypond_version_string()
+            string = rf'\version "{string}"'
+            strings.append(string)
+        elif isinstance(self.lilypond_version_token, str):
+            strings.append(self.lilypond_version_token)
+        if self.lilypond_language_token is True:
+            string = r'\language "english"'
+            strings.append(string)
         tag = _tag.Tag("abjad.LilyPondFile._get_format_pieces()")
-        includes = _tag.double_tag(includes, self.get_tag(tag))
-        includes = "\n".join(includes)
-        if includes:
-            result.append(includes)
-        postincludes = []
-        if self.use_relative_includes:
-            string = "#(ly:set-option 'relative-includes #t)"
-            postincludes.append(string)
-        postincludes.extend(self._get_formatted_includes())
-        postincludes.extend(self._get_formatted_scheme_settings())
-        result.extend(postincludes)
-        strings = self._get_formatted_blocks()
-        if strings:
-            result.append("")
-        result.extend(strings)
-        return result
-
-    ### PRIVATE METHODS ###
-
-    def _get_format_specification(self):
-        return _format.FormatSpecification()
-
-    def _get_formatted_blocks(self):
-        result = []
-        tag = _tag.Tag("abjad.LilyPondFile._get_formatted_blocks()")
         tag = self.get_tag(tag)
+        strings = _tag.double_tag(strings, tag)
+        result.extend(strings)
         for item in self.items:
-            if "_get_lilypond_format" in dir(item) and not isinstance(item, str):
+            if "_get_lilypond_format" in dir(item):
                 try:
                     string = item._get_lilypond_format(tag=tag)
                 except TypeError:
                     string = item._get_lilypond_format()
-                if string:
-                    result.append(string)
+                assert isinstance(string, str), repr(string)
+                result.append(string)
             else:
                 result.append(str(item))
-        return result
-
-    def _get_formatted_comments(self):
-        result = []
-        for comment in self.comments:
-            if "_get_lilypond_format" in dir(comment) and not isinstance(comment, str):
-                lilypond_format = comment._get_lilypond_format()
-                if lilypond_format:
-                    string = f"% {comment}"
-                    result.append(string)
-            else:
-                string = f"% {comment!s}"
-                result.append(string)
-        if result:
-            result = ["\n".join(result)]
-        return result
-
-    def _get_formatted_includes(self):
-        result = []
-        tag = _tag.Tag("abjad.LilyPondFile._get_formatted_includes()")
-        tag = self.get_tag(tag)
-        for include in self.includes:
-            if isinstance(include, str):
-                string = rf'\include "{include}"'
-                result.append(string)
-            elif isinstance(include, pathlib.Path):
-                string = rf'\include "{include!s}"'
-                result.append(string)
-            elif isinstance(include, _overrides.LilyPondLiteral):
-                string = str(include.argument)
-                result.append(string)
-            else:
-                result.append(include._get_lilypond_format())
-        if result:
-            result = _tag.double_tag(result, tag)
-            result = ["\n".join(result)]
-        return result
-
-    def _get_formatted_scheme_settings(self):
-        result = []
-        tag = _tag.Tag("abjad.LilyPondFile._get_formatted_scheme_settings()")
-        tag = self.get_tag(tag)
-        default_paper_size = self.default_paper_size
-        if default_paper_size is not None:
-            dimension, orientation = default_paper_size
-            string = f'#(set-default-paper-size "{dimension}" \'{orientation})'
-            result.append(string)
-        global_staff_size = self.global_staff_size
-        if global_staff_size is not None:
-            string = f"#(set-global-staff-size {global_staff_size})"
-            result.append(string)
-        if result:
-            result = _tag.double_tag(result, tag)
-            result = ["\n".join(result)]
         return result
 
     def _get_lilypond_format(self):
@@ -1525,249 +504,10 @@ class LilyPondFile:
                 lines.append(line)
         return "\n".join(lines)
 
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def comments(self) -> typing.List[LilyPondComment]:
-        """
-        Gets comments of Lilypond file.
-
-        ..  container:: example
-
-            >>> lilypond_file = abjad.LilyPondFile()
-            >>> lilypond_file.comments
-            []
-
-        """
-        return list(self._comments)
-
-    @property
-    def date_time_token(self) -> typing.Optional[DateTimeToken]:
-        """
-        Gets date-time token.
-
-        ..  container:: example
-
-            >>> lilypond_file = abjad.LilyPondFile(date_time_token=True)
-            >>> lilypond_file.date_time_token
-            DateTimeToken()
-
-        """
-        return self._date_time_token
-
-    @property
-    def default_paper_size(self):
-        """
-        Gets default paper size of LilyPond file.
-
-        ..  container:: example
-
-            >>> lilypond_file = abjad.LilyPondFile()
-            >>> lilypond_file.default_paper_size is None
-            True
-
-        Returns pair or none.
-        """
-        return self._default_paper_size
-
-    @property
-    def global_staff_size(self) -> typing.Union[int, float]:
-        """
-        Gets global staff size of LilyPond file.
-
-        ..  container:: example
-
-            >>> lilypond_file = abjad.LilyPondFile()
-            >>> lilypond_file.global_staff_size is None
-            True
-
-        """
-        return self._global_staff_size
-
-    @property
-    def header_block(self) -> typing.Optional[Block]:
-        """
-        Gets header block.
-
-        ..  container:: example
-
-            >>> block = abjad.Block(name="header")
-            >>> lilypond_file = abjad.LilyPondFile([block])
-            >>> lilypond_file.header_block
-            <Block(name='header')>
-
-        """
-        for item in self.items:
-            if isinstance(item, Block):
-                if item.name == "header":
-                    return item
-        return None
-
-    @property
-    def includes(self) -> typing.List[str]:
-        """
-        Gets includes of LilyPond file.
-
-        ..  container:: example
-
-            >>> lilypond_file = abjad.LilyPondFile()
-            >>> lilypond_file.includes
-            []
-
-        """
-        return self._includes
-
-    @property
-    def items(self) -> typing.List:
-        r"""
-        Gets items in LilyPond file.
-
-        ..  container:: example
-
-            >>> lilypond_file = abjad.LilyPondFile()
-            >>> lilypond_file.items
-            []
-
-        ..  container:: example
-
-            Accepts strings:
-
-            >>> staff = abjad.Staff("c'4 d' e' f'")
-            >>> score_block = abjad.Block(name="score")
-            >>> score_block.items.append(staff)
-            >>> lilypond_file = abjad.LilyPondFile(
-            ...     lilypond_language_token=False,
-            ...     lilypond_version_token=False,
-            ... )
-            >>> string = r"\customCommand"
-            >>> lilypond_file.items.append(string)
-            >>> lilypond_file.items.append(score_block)
-
-            >>> string = abjad.lilypond(lilypond_file)
-            >>> print(string)
-            <BLANKLINE>
-            \customCommand
-            \score
-            {
-                \new Staff
-                {
-                    c'4
-                    d'4
-                    e'4
-                    f'4
-                }
-            }
-
-        """
-        return self._items
-
-    @property
-    def layout_block(self) -> typing.Optional[Block]:
-        """
-        Gets layout block.
-
-        ..  container:: example
-
-            >>> block = abjad.Block(name="layout")
-            >>> lilypond_file = abjad.LilyPondFile([block])
-            >>> lilypond_file.layout_block
-            <Block(name='layout')>
-
-        """
-        for item in self.items:
-            if isinstance(item, Block):
-                if item.name == "layout":
-                    return item
-        return None
-
-    @property
-    def lilypond_language_token(self) -> typing.Optional[LilyPondLanguageToken]:
-        """
-        Gets LilyPond language token.
-
-        ..  container:: example
-
-            >>> lilypond_file = abjad.LilyPondFile()
-            >>> lilypond_file.lilypond_language_token
-            LilyPondLanguageToken()
-
-        """
-        return self._lilypond_language_token
-
-    @property
-    def lilypond_version_token(self) -> typing.Optional[LilyPondVersionToken]:
-        """
-        Gets LilyPond version token.
-
-        ..  container:: example
-
-            >>> lilypond_file = abjad.LilyPondFile()
-            >>> lilypond_file.lilypond_version_token # doctest: +SKIP
-            LilyPondVersionToken('2.19.35')
-
-        """
-        return self._lilypond_version_token
-
-    @property
-    def paper_block(self) -> typing.Optional[Block]:
-        """
-        Gets paper block.
-
-        ..  container:: example
-
-            Gets paper block:
-
-            >>> block = abjad.Block(name="paper")
-            >>> lilypond_file = abjad.LilyPondFile([block])
-            >>> lilypond_file.paper_block
-            <Block(name='paper')>
-
-        """
-        for item in self.items:
-            if isinstance(item, Block):
-                if item.name == "paper":
-                    return item
-        return None
-
-    @property
-    def score_block(self) -> typing.Optional[Block]:
-        """
-        Gets score block.
-
-        ..  container:: example
-
-            >>> block = abjad.Block(name="score")
-            >>> lilypond_file = abjad.LilyPondFile([block])
-            >>> lilypond_file.score_block
-            <Block(name='score')>
-
-        """
-        for item in self.items:
-            if isinstance(item, Block):
-                if item.name == "score":
-                    return item
-        return None
-
-    @property
-    def use_relative_includes(self) -> typing.Optional[bool]:
-        """
-        Is true when LilyPond file should use relative includes.
-
-        ..  container:: example
-
-            >>> lilypond_file = abjad.LilyPondFile()
-            >>> lilypond_file.use_relative_includes is None
-            True
-
-        """
-        return self._use_relative_includes
-
-    ### PUBLIC METHODS ###
-
     def get_tag(self, site=None):
         """
         Gets tag.
         """
-        tag = _tag.Tag(self._tag)
+        tag = _tag.Tag(self.tag)
         tag = tag.append(site)
         return tag

--- a/abjad/lilypondformat.py
+++ b/abjad/lilypondformat.py
@@ -1,5 +1,6 @@
 from . import bundle as _bundle
 from . import enums as _enums
+from . import format as _format
 from . import new as _new
 from . import overrides as _overrides
 from . import tag as _tag
@@ -211,9 +212,9 @@ def _report_leaf_format_contributions(leaf):
     packet = leaf._format_opening_slot(bundle)
     report += leaf._process_contribution_packet(packet)
     report += 'slot "contents slot":\n'
-    report += _bundle.LilyPondFormatBundle.indent + "leaf body:\n"
+    report += _format.INDENT + "leaf body:\n"
     string = leaf._format_contents_slot(bundle)[0][1][0]
-    report += (2 * _bundle.LilyPondFormatBundle.indent) + string + "\n"
+    report += (2 * _format.INDENT) + string + "\n"
     report += 'slot "closing":\n'
     packet = leaf._format_closing_slot(bundle)
     report += leaf._process_contribution_packet(packet)
@@ -257,7 +258,7 @@ def left_shift_tags(text, realign=None) -> str:
         string_ = string[4:]
         tag_start = string_.find("%!")
         string_ = list(string_)
-        string_[tag_start:tag_start] = _bundle.LilyPondFormatBundle.indent
+        string_[tag_start:tag_start] = _format.INDENT
         string_ = "".join(string_)
         strings_.append(string_)
     text = "\n".join(strings_)

--- a/abjad/meter.py
+++ b/abjad/meter.py
@@ -2526,262 +2526,260 @@ class MeterList(TypedList):
                 ]
             )
 
-        >>> abjad.show(meters, scale=0.5) # doctest: +SKIP
+        >>> lilypond_file = abjad.meter.illustrate_meter_list(meters, scale=0.5)
+        >>> abjad.show(lilypond_file) # doctest: +SKIP
 
     """
 
-    ### CLASS VARIABLES ###
-
     __slots__ = ()
-
-    ### SPECIAL METHODS ###
-
-    def __illustrate__(self, denominator=16, range_=None, scale=None) -> LilyPondFile:
-        r"""
-        Illustrates meters.
-
-        ..  container:: example
-
-            >>> meters = abjad.MeterList([(3, 4), (5, 16), (7, 8)])
-            >>> abjad.show(meters, scale=0.5) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> lilypond_file = meters.__illustrate__()
-                >>> markup = lilypond_file.items[0]
-                >>> string = abjad.lilypond(markup)
-                >>> print(string)
-                \markup
-                \column
-                {
-                \combine
-                \combine
-                \translate #'(1.0 . 1)
-                \sans \fontsize #-3 \center-align \fraction 3 4
-                \translate #'(49.38709677419355 . 1)
-                \sans \fontsize #-3 \center-align \fraction 5 16
-                \translate #'(69.54838709677419 . 1)
-                \sans \fontsize #-3 \center-align \fraction 7 8
-                \combine
-                \postscript
-                #"
-                0.2 setlinewidth
-                1 0.5 moveto
-                49.38709677419355 0.5 lineto
-                stroke
-                1 1.25 moveto
-                1 -0.25 lineto
-                stroke
-                49.38709677419355 1.25 moveto
-                49.38709677419355 -0.25 lineto
-                stroke
-                49.38709677419355 0.5 moveto
-                69.54838709677419 0.5 lineto
-                stroke
-                49.38709677419355 1.25 moveto
-                49.38709677419355 -0.25 lineto
-                stroke
-                69.54838709677419 1.25 moveto
-                69.54838709677419 -0.25 lineto
-                stroke
-                69.54838709677419 0.5 moveto
-                126 0.5 lineto
-                stroke
-                69.54838709677419 1.25 moveto
-                69.54838709677419 -0.25 lineto
-                stroke
-                126 1.25 moveto
-                126 -0.25 lineto
-                stroke
-                "
-                \postscript
-                #"
-                1 -2 moveto
-                0 -6.153846153846154 rlineto
-                stroke
-                5.032258064516129 -2 moveto
-                0 -1.5384615384615385 rlineto
-                stroke
-                9.064516129032258 -2 moveto
-                0 -3.076923076923077 rlineto
-                stroke
-                13.096774193548388 -2 moveto
-                0 -1.5384615384615385 rlineto
-                stroke
-                17.129032258064516 -2 moveto
-                0 -4.615384615384616 rlineto
-                stroke
-                21.161290322580644 -2 moveto
-                0 -1.5384615384615385 rlineto
-                stroke
-                25.193548387096776 -2 moveto
-                0 -3.076923076923077 rlineto
-                stroke
-                29.225806451612904 -2 moveto
-                0 -1.5384615384615385 rlineto
-                stroke
-                33.25806451612903 -2 moveto
-                0 -4.615384615384616 rlineto
-                stroke
-                37.29032258064516 -2 moveto
-                0 -1.5384615384615385 rlineto
-                stroke
-                41.32258064516129 -2 moveto
-                0 -3.076923076923077 rlineto
-                stroke
-                45.354838709677416 -2 moveto
-                0 -1.5384615384615385 rlineto
-                stroke
-                49.38709677419355 -2 moveto
-                0 -6.153846153846154 rlineto
-                stroke
-                49.38709677419355 -2 moveto
-                0 -10.909090909090908 rlineto
-                stroke
-                53.41935483870968 -2 moveto
-                0 -3.6363636363636367 rlineto
-                stroke
-                57.45161290322581 -2 moveto
-                0 -3.6363636363636367 rlineto
-                stroke
-                61.483870967741936 -2 moveto
-                0 -7.272727272727273 rlineto
-                stroke
-                65.51612903225806 -2 moveto
-                0 -3.6363636363636367 rlineto
-                stroke
-                69.54838709677419 -2 moveto
-                0 -10.909090909090908 rlineto
-                stroke
-                69.54838709677419 -2 moveto
-                0 -5.517241379310345 rlineto
-                stroke
-                73.58064516129032 -2 moveto
-                0 -1.3793103448275863 rlineto
-                stroke
-                77.61290322580645 -2 moveto
-                0 -2.7586206896551726 rlineto
-                stroke
-                81.64516129032258 -2 moveto
-                0 -1.3793103448275863 rlineto
-                stroke
-                85.6774193548387 -2 moveto
-                0 -2.7586206896551726 rlineto
-                stroke
-                89.70967741935483 -2 moveto
-                0 -1.3793103448275863 rlineto
-                stroke
-                93.74193548387096 -2 moveto
-                0 -4.137931034482759 rlineto
-                stroke
-                97.7741935483871 -2 moveto
-                0 -1.3793103448275863 rlineto
-                stroke
-                101.80645161290323 -2 moveto
-                0 -2.7586206896551726 rlineto
-                stroke
-                105.83870967741936 -2 moveto
-                0 -1.3793103448275863 rlineto
-                stroke
-                109.87096774193549 -2 moveto
-                0 -4.137931034482759 rlineto
-                stroke
-                113.90322580645162 -2 moveto
-                0 -1.3793103448275863 rlineto
-                stroke
-                117.93548387096774 -2 moveto
-                0 -2.7586206896551726 rlineto
-                stroke
-                121.96774193548387 -2 moveto
-                0 -1.3793103448275863 rlineto
-                stroke
-                126 -2 moveto
-                0 -5.517241379310345 rlineto
-                stroke
-                "
-                }
-
-        Returns LilyPond file.
-        """
-        durations = [_.duration for _ in self]
-        total_duration = sum(durations)
-        offsets = math.cumulative_sums(durations, start=0)
-        timespans = TimespanList()
-        for one, two in Sequence(offsets).nwise():
-            timespan = Timespan(start_offset=one, stop_offset=two)
-            timespans.append(timespan)
-        if range_ is not None:
-            minimum, maximum = range_
-        else:
-            minimum, maximum = 0, total_duration
-        minimum = float(Offset(minimum))
-        maximum = float(Offset(maximum))
-        if scale is None:
-            scale = 1.0
-        assert 0 < scale
-        postscript_scale = 125.0 / (maximum - minimum)
-        postscript_scale *= float(scale)
-        postscript_x_offset = (minimum * postscript_scale) - 1
-        timespan_markup = _timespan._make_timespan_list_markup(
-            timespans,
-            postscript_x_offset,
-            postscript_scale,
-            draw_offsets=False,
-        )
-        postscript_strings = []
-        rational_x_offset = Offset(0)
-        for meter in self:
-            kernel_denominator = denominator or meter.denominator
-            kernel = MetricAccentKernel.from_meter(meter, kernel_denominator)
-            for offset, weight in sorted(kernel.kernel.items()):
-                weight = float(weight) * -40
-                ps_x_offset = float(rational_x_offset + offset)
-                ps_x_offset *= postscript_scale
-                ps_x_offset += 1
-                postscript_strings.append(f"{markups._fpa(ps_x_offset)} -2 moveto")
-                postscript_strings.append(f"0 {markups._fpa(weight)} rlineto")
-                postscript_strings.append("stroke")
-            rational_x_offset += meter.duration
-        fraction_pairs = []
-        for meter, offset in zip(self, offsets):
-            numerator, denominator = meter.numerator, meter.denominator
-            x_translation = float(offset) * postscript_scale
-            x_translation -= postscript_x_offset
-            top_string = rf"\translate #'({x_translation} . 1)"
-            bottom_string = r"\sans \fontsize #-3 \center-align"
-            bottom_string = bottom_string + rf" \fraction {numerator} {denominator}"
-            pair = (top_string, bottom_string)
-            fraction_pairs.append(pair)
-        fraction_strings = []
-        fraction_strings.append(fraction_pairs[0][0])
-        fraction_strings.append(fraction_pairs[0][1])
-        for pair in fraction_pairs[1:]:
-            fraction_strings.insert(0, r"\combine")
-            fraction_strings.append(pair[0])
-            fraction_strings.append(pair[1])
-        strings = []
-        strings.append(r"\markup")
-        strings.append(r"\column")
-        strings.append("{")
-        strings.extend(fraction_strings)
-        strings.append(r"\combine")
-        strings.append(str(timespan_markup))
-        strings.append(r"\postscript")
-        strings.append('#"')
-        strings.extend(postscript_strings)
-        strings.append('"')
-        strings.append("}")
-        string = "\n".join(strings)
-        markup = markups.Markup(string)
-        lilypond_file = LilyPondFile()
-        markup = new(markup, direction=None)
-        lilypond_file.items.append(markup)
-        return lilypond_file
-
-    ### PRIVATE METHODS ###
 
     def _coerce_item(self, item):
         return Meter(item)
+
+
+def illustrate_meter_list(
+    meter_list, denominator=16, range_=None, scale=None
+) -> LilyPondFile:
+    r"""
+    Illustrates meters.
+
+    ..  container:: example
+
+        >>> meters = abjad.MeterList([(3, 4), (5, 16), (7, 8)])
+        >>> lilypond_file = abjad.meter.illustrate_meter_list(meters, scale=0.5)
+        >>> abjad.show(lilypond_file) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> lilypond_file = abjad.meter.illustrate_meter_list(meters)
+            >>> markup = lilypond_file.items[0]
+            >>> string = abjad.lilypond(markup)
+            >>> print(string)
+            \markup
+            \column
+            {
+            \combine
+            \combine
+            \translate #'(1.0 . 1)
+            \sans \fontsize #-3 \center-align \fraction 3 4
+            \translate #'(49.38709677419355 . 1)
+            \sans \fontsize #-3 \center-align \fraction 5 16
+            \translate #'(69.54838709677419 . 1)
+            \sans \fontsize #-3 \center-align \fraction 7 8
+            \combine
+            \postscript
+            #"
+            0.2 setlinewidth
+            1 0.5 moveto
+            49.38709677419355 0.5 lineto
+            stroke
+            1 1.25 moveto
+            1 -0.25 lineto
+            stroke
+            49.38709677419355 1.25 moveto
+            49.38709677419355 -0.25 lineto
+            stroke
+            49.38709677419355 0.5 moveto
+            69.54838709677419 0.5 lineto
+            stroke
+            49.38709677419355 1.25 moveto
+            49.38709677419355 -0.25 lineto
+            stroke
+            69.54838709677419 1.25 moveto
+            69.54838709677419 -0.25 lineto
+            stroke
+            69.54838709677419 0.5 moveto
+            126 0.5 lineto
+            stroke
+            69.54838709677419 1.25 moveto
+            69.54838709677419 -0.25 lineto
+            stroke
+            126 1.25 moveto
+            126 -0.25 lineto
+            stroke
+            "
+            \postscript
+            #"
+            1 -2 moveto
+            0 -6.153846153846154 rlineto
+            stroke
+            5.032258064516129 -2 moveto
+            0 -1.5384615384615385 rlineto
+            stroke
+            9.064516129032258 -2 moveto
+            0 -3.076923076923077 rlineto
+            stroke
+            13.096774193548388 -2 moveto
+            0 -1.5384615384615385 rlineto
+            stroke
+            17.129032258064516 -2 moveto
+            0 -4.615384615384616 rlineto
+            stroke
+            21.161290322580644 -2 moveto
+            0 -1.5384615384615385 rlineto
+            stroke
+            25.193548387096776 -2 moveto
+            0 -3.076923076923077 rlineto
+            stroke
+            29.225806451612904 -2 moveto
+            0 -1.5384615384615385 rlineto
+            stroke
+            33.25806451612903 -2 moveto
+            0 -4.615384615384616 rlineto
+            stroke
+            37.29032258064516 -2 moveto
+            0 -1.5384615384615385 rlineto
+            stroke
+            41.32258064516129 -2 moveto
+            0 -3.076923076923077 rlineto
+            stroke
+            45.354838709677416 -2 moveto
+            0 -1.5384615384615385 rlineto
+            stroke
+            49.38709677419355 -2 moveto
+            0 -6.153846153846154 rlineto
+            stroke
+            49.38709677419355 -2 moveto
+            0 -10.909090909090908 rlineto
+            stroke
+            53.41935483870968 -2 moveto
+            0 -3.6363636363636367 rlineto
+            stroke
+            57.45161290322581 -2 moveto
+            0 -3.6363636363636367 rlineto
+            stroke
+            61.483870967741936 -2 moveto
+            0 -7.272727272727273 rlineto
+            stroke
+            65.51612903225806 -2 moveto
+            0 -3.6363636363636367 rlineto
+            stroke
+            69.54838709677419 -2 moveto
+            0 -10.909090909090908 rlineto
+            stroke
+            69.54838709677419 -2 moveto
+            0 -5.517241379310345 rlineto
+            stroke
+            73.58064516129032 -2 moveto
+            0 -1.3793103448275863 rlineto
+            stroke
+            77.61290322580645 -2 moveto
+            0 -2.7586206896551726 rlineto
+            stroke
+            81.64516129032258 -2 moveto
+            0 -1.3793103448275863 rlineto
+            stroke
+            85.6774193548387 -2 moveto
+            0 -2.7586206896551726 rlineto
+            stroke
+            89.70967741935483 -2 moveto
+            0 -1.3793103448275863 rlineto
+            stroke
+            93.74193548387096 -2 moveto
+            0 -4.137931034482759 rlineto
+            stroke
+            97.7741935483871 -2 moveto
+            0 -1.3793103448275863 rlineto
+            stroke
+            101.80645161290323 -2 moveto
+            0 -2.7586206896551726 rlineto
+            stroke
+            105.83870967741936 -2 moveto
+            0 -1.3793103448275863 rlineto
+            stroke
+            109.87096774193549 -2 moveto
+            0 -4.137931034482759 rlineto
+            stroke
+            113.90322580645162 -2 moveto
+            0 -1.3793103448275863 rlineto
+            stroke
+            117.93548387096774 -2 moveto
+            0 -2.7586206896551726 rlineto
+            stroke
+            121.96774193548387 -2 moveto
+            0 -1.3793103448275863 rlineto
+            stroke
+            126 -2 moveto
+            0 -5.517241379310345 rlineto
+            stroke
+            "
+            }
+
+    """
+    durations = [_.duration for _ in meter_list]
+    total_duration = sum(durations)
+    offsets = math.cumulative_sums(durations, start=0)
+    timespans = TimespanList()
+    for one, two in Sequence(offsets).nwise():
+        timespan = Timespan(start_offset=one, stop_offset=two)
+        timespans.append(timespan)
+    if range_ is not None:
+        minimum, maximum = range_
+    else:
+        minimum, maximum = 0, total_duration
+    minimum = float(Offset(minimum))
+    maximum = float(Offset(maximum))
+    if scale is None:
+        scale = 1.0
+    assert 0 < scale
+    postscript_scale = 125.0 / (maximum - minimum)
+    postscript_scale *= float(scale)
+    postscript_x_offset = (minimum * postscript_scale) - 1
+    timespan_markup = _timespan._make_timespan_list_markup(
+        timespans,
+        postscript_x_offset,
+        postscript_scale,
+        draw_offsets=False,
+    )
+    postscript_strings = []
+    rational_x_offset = Offset(0)
+    for meter in meter_list:
+        kernel_denominator = denominator or meter.denominator
+        kernel = MetricAccentKernel.from_meter(meter, kernel_denominator)
+        for offset, weight in sorted(kernel.kernel.items()):
+            weight = float(weight) * -40
+            ps_x_offset = float(rational_x_offset + offset)
+            ps_x_offset *= postscript_scale
+            ps_x_offset += 1
+            postscript_strings.append(f"{markups._fpa(ps_x_offset)} -2 moveto")
+            postscript_strings.append(f"0 {markups._fpa(weight)} rlineto")
+            postscript_strings.append("stroke")
+        rational_x_offset += meter.duration
+    fraction_pairs = []
+    for meter, offset in zip(meter_list, offsets):
+        numerator, denominator = meter.numerator, meter.denominator
+        x_translation = float(offset) * postscript_scale
+        x_translation -= postscript_x_offset
+        top_string = rf"\translate #'({x_translation} . 1)"
+        bottom_string = r"\sans \fontsize #-3 \center-align"
+        bottom_string = bottom_string + rf" \fraction {numerator} {denominator}"
+        pair = (top_string, bottom_string)
+        fraction_pairs.append(pair)
+    fraction_strings = []
+    fraction_strings.append(fraction_pairs[0][0])
+    fraction_strings.append(fraction_pairs[0][1])
+    for pair in fraction_pairs[1:]:
+        fraction_strings.insert(0, r"\combine")
+        fraction_strings.append(pair[0])
+        fraction_strings.append(pair[1])
+    strings = []
+    strings.append(r"\markup")
+    strings.append(r"\column")
+    strings.append("{")
+    strings.extend(fraction_strings)
+    strings.append(r"\combine")
+    strings.append(str(timespan_markup))
+    strings.append(r"\postscript")
+    strings.append('#"')
+    strings.extend(postscript_strings)
+    strings.append('"')
+    strings.append("}")
+    string = "\n".join(strings)
+    markup = markups.Markup(string)
+    lilypond_file = LilyPondFile()
+    markup = new(markup, direction=None)
+    lilypond_file.items.append(markup)
+    return lilypond_file
 
 
 class MetricAccentKernel:

--- a/abjad/metricmodulation.py
+++ b/abjad/metricmodulation.py
@@ -25,7 +25,7 @@ class MetricModulation:
         ...     )
 
         >>> lilypond_file = abjad.LilyPondFile(
-        ...     [metric_modulation], includes=["abjad.ily"],
+        ...     [r'\include "abjad.ily"', metric_modulation]
         ... )
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -45,7 +45,7 @@ class MetricModulation:
         ...     )
 
         >>> lilypond_file = abjad.LilyPondFile(
-        ...     [metric_modulation], includes=["abjad.ily"],
+        ...     [r'\include "abjad.ily"', metric_modulation]
         ... )
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -61,7 +61,7 @@ class MetricModulation:
         ...     )
 
         >>> lilypond_file = abjad.LilyPondFile(
-        ...     [metric_modulation], includes=["abjad.ily"],
+        ...     [r'\include "abjad.ily"', metric_modulation]
         ... )
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -81,7 +81,7 @@ class MetricModulation:
         ...     )
 
         >>> lilypond_file = abjad.LilyPondFile(
-        ...     [metric_modulation], includes=["abjad.ily"],
+        ...     [r'\include "abjad.ily"', metric_modulation]
         ... )
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -103,7 +103,7 @@ class MetricModulation:
         ...     )
 
         >>> lilypond_file = abjad.LilyPondFile(
-        ...     [metric_modulation], includes=["abjad.ily"],
+        ...     [r'\include "abjad.ily"', metric_modulation]
         ... )
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -201,7 +201,7 @@ class MetricModulation:
         ...     )
 
         >>> lilypond_file = abjad.LilyPondFile(
-        ...     [metric_modulation], includes=["abjad.ily"],
+        ...     [r'\include "abjad.ily"', metric_modulation]
         ... )
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -306,9 +306,7 @@ class MetricModulation:
         >>> abjad.attach(metric_modulation, staff[3])
         >>> abjad.override(staff).TextScript.staff_padding = 2.5
 
-        >>> lilypond_file = abjad.LilyPondFile(
-        ...     [score], includes=["abjad.ily"],
-        ... )
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', score])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -716,9 +714,7 @@ class MetricModulation:
             >>> abjad.attach(metric_modulation, staff[3])
             >>> abjad.override(staff).TextScript.staff_padding = 2.5
 
-            >>> lilypond_file = abjad.LilyPondFile(
-            ...     [score], includes=["abjad.ily"],
-            ... )
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', score])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::

--- a/abjad/overrides.py
+++ b/abjad/overrides.py
@@ -1451,7 +1451,7 @@ class SettingInterface(Interface):
             result = rf"{string!s} = {value_parts[0]!s}"
             pieces = [result]
             for part in value_parts[1:]:
-                pieces.append(LilyPondFormatBundle.indent + part)
+                pieces.append(_format.INDENT + part)
             string = "\n".join(pieces)
             strings.append(string)
         return strings

--- a/abjad/parentage.py
+++ b/abjad/parentage.py
@@ -134,7 +134,7 @@ class Parentage(collections.abc.Sequence):
             >>> container = abjad.AfterGraceContainer("fs'16")
             >>> abjad.attach(container, music_voice[3])
             >>> staff = abjad.Staff([music_voice])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -229,7 +229,7 @@ class Parentage(collections.abc.Sequence):
             >>> container = abjad.AfterGraceContainer("fs'16")
             >>> abjad.attach(container, music_voice[3])
             >>> staff = abjad.Staff([music_voice])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -389,7 +389,7 @@ class Parentage(collections.abc.Sequence):
             >>> container = abjad.AfterGraceContainer("fs'16")
             >>> abjad.attach(container, music_voice[3])
             >>> staff = abjad.Staff([music_voice])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -484,7 +484,7 @@ class Parentage(collections.abc.Sequence):
             >>> container = abjad.AfterGraceContainer("fs'16")
             >>> abjad.attach(container, music_voice[3])
             >>> staff = abjad.Staff([music_voice])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -583,7 +583,7 @@ class Parentage(collections.abc.Sequence):
             >>> container = abjad.AfterGraceContainer("fs'16")
             >>> abjad.attach(container, music_voice[1][2])
             >>> staff = abjad.Staff([music_voice])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -685,7 +685,7 @@ class Parentage(collections.abc.Sequence):
             >>> container = abjad.AfterGraceContainer("fs'16")
             >>> abjad.attach(container, music_voice[3])
             >>> staff = abjad.Staff([music_voice])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -902,7 +902,7 @@ class Parentage(collections.abc.Sequence):
             >>> container = abjad.AfterGraceContainer("fs'16")
             >>> abjad.attach(container, music_voice[3])
             >>> staff = abjad.Staff([music_voice])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1159,7 +1159,7 @@ class Parentage(collections.abc.Sequence):
             >>> container = abjad.AfterGraceContainer("fs'16")
             >>> abjad.attach(container, music_voice[3])
             >>> staff = abjad.Staff([music_voice])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1475,7 +1475,7 @@ class Parentage(collections.abc.Sequence):
             >>> container = abjad.AfterGraceContainer("fs'16")
             >>> abjad.attach(container, music_voice[3])
             >>> staff = abjad.Staff([music_voice])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::

--- a/abjad/parsers/parser.py
+++ b/abjad/parsers/parser.py
@@ -16,7 +16,6 @@ from ply.yacc import (  # type: ignore
     format_stack_entry,
 )
 
-from .. import bundle as _bundle
 from .. import exceptions
 from .. import format as _format
 from .. import fsv as _fsv
@@ -185,7 +184,7 @@ class MarkupCommand:
                         result.append(f"#{formatted}")
             return [f"{indent}{item}" for item in result]
 
-        indent = _bundle.LilyPondFormatBundle.indent
+        indent = _format.INDENT
         parts = [rf"\{self.name}"]
         parts.extend(recurse(self.arguments))
         return parts

--- a/abjad/persist.py
+++ b/abjad/persist.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 
 from . import io
+from . import lilypondfile as _lilypondfile
 from .contextmanagers import Timer
 from .illustrators import illustrate
 
@@ -21,10 +22,10 @@ def as_ly(
 
     Returns output path and elapsed formatting time when LilyPond output is written.
     """
-    if illustrate_function is not None:
+    if isinstance(argument, _lilypondfile.LilyPondFile):
+        lilypond_file = argument
+    elif illustrate_function is not None:
         lilypond_file = illustrate_function(**keywords)
-    elif hasattr(argument, "__illustrate__"):
-        lilypond_file = argument.__illustrate__(**keywords)
     else:
         lilypond_file = illustrate(argument, **keywords)
     assert ly_file_path is not None, repr(ly_file_path)
@@ -49,11 +50,11 @@ def as_midi(argument, midi_file_path, *, remove_ly=False, **keywords):
     Returns 4-tuple of output MIDI path, Abjad formatting time, LilyPond rendering time
     and success boolean.
     """
-    if hasattr(argument, "score_block"):
+    if isinstance(argument, _lilypondfile.LilyPondFile) and "score" in argument:
         lilypond_file = argument
     else:
         lilypond_file = illustrate(argument, **keywords)
-    assert hasattr(lilypond_file, "score_block")
+    assert "score" in lilypond_file, repr(lilypond_file)
     assert midi_file_path is not None, repr(midi_file_path)
     midi_file_path = os.path.expanduser(midi_file_path)
     midi_file_path = pathlib.Path(midi_file_path)

--- a/abjad/selection.py
+++ b/abjad/selection.py
@@ -1312,7 +1312,7 @@ class Selection(collections.abc.Sequence):
             Note("g'8")
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1371,7 +1371,7 @@ class Selection(collections.abc.Sequence):
             Note("f'8")
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1432,7 +1432,7 @@ class Selection(collections.abc.Sequence):
             Note("f'8")
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1489,7 +1489,7 @@ class Selection(collections.abc.Sequence):
             Note("gf'16")
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1549,7 +1549,7 @@ class Selection(collections.abc.Sequence):
             Note("f'8")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1596,7 +1596,7 @@ class Selection(collections.abc.Sequence):
             LogicalTie([Note("f'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1643,7 +1643,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("f'8")])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1701,7 +1701,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("d'8"), Note("e'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1756,7 +1756,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("d'8"), Note("e'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1797,7 +1797,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("d'8"), Note("e'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1846,7 +1846,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("f'8"), Note("g'8"), Note("a'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1889,7 +1889,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("d'8"), Note("e'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1940,7 +1940,7 @@ class Selection(collections.abc.Sequence):
             Chord("<c' e' g'>4")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -1986,7 +1986,7 @@ class Selection(collections.abc.Sequence):
             Chord("<c' e' g'>4")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2031,7 +2031,7 @@ class Selection(collections.abc.Sequence):
             LogicalTie([Chord("<c' e' g'>8"), Chord("<c' e' g'>4")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2082,7 +2082,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("d'8"), Note("e'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2123,7 +2123,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("d'8"), Note("e'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2366,7 +2366,7 @@ class Selection(collections.abc.Sequence):
             Rest('r8')
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2413,7 +2413,7 @@ class Selection(collections.abc.Sequence):
             LogicalTie([Note("e'8"), Note("e'8"), Note("e'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2460,7 +2460,7 @@ class Selection(collections.abc.Sequence):
             Selection(items=())
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2519,7 +2519,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("c'8"), Note("c'16"), Note("c'16"), Note("c'16"), Note("c'16"), Note("d'8"), Note("d'16"), Note("d'16"), Note("d'16"), Note("d'16")])
 
             >>> abjad.label.by_selector(result, lone=True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2583,7 +2583,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("c'8"), Note("c'16"), Note("c'16"), Note("c'16"), Note("c'16"), Note("d'8"), Note("d'16"), Note("d'16"), Note("d'16"), Note("d'16")])
 
             >>> abjad.label.by_selector(result, lone=True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2659,7 +2659,7 @@ class Selection(collections.abc.Sequence):
             Selection([Chord("<c' e' g'>8"), Chord("<c' e' g'>4")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2715,7 +2715,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("f'16"), Note("f'16"), Note("f'16"), Note("f'16")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2766,7 +2766,7 @@ class Selection(collections.abc.Sequence):
             Note("g'8")
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2814,7 +2814,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("d'16"), Note("d'16")])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2876,7 +2876,7 @@ class Selection(collections.abc.Sequence):
             Selection([LogicalTie([Note("d'16")]), LogicalTie([Note("d'16")])])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -2962,7 +2962,7 @@ class Selection(collections.abc.Sequence):
             Selection([LogicalTie([Note("f'16")])])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3030,7 +3030,7 @@ class Selection(collections.abc.Sequence):
             Selection([LogicalTie([Note("f'16")])])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3103,7 +3103,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("c''8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3158,7 +3158,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("g'8"), Note("a'8"), Note("b'8"), Note("c''8")])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3213,7 +3213,7 @@ class Selection(collections.abc.Sequence):
             Note("c''8")
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3265,7 +3265,7 @@ class Selection(collections.abc.Sequence):
             Note("c''8")
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3314,7 +3314,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("g'4"), Note("a'4"), Note("b'4"), Note("c''4")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3365,7 +3365,7 @@ class Selection(collections.abc.Sequence):
             Selection([LogicalTie([Note("f'8")]), LogicalTie([Note("g'8"), Note("g'8")])])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3460,7 +3460,7 @@ class Selection(collections.abc.Sequence):
             Selection([LogicalTie([Note("f'16"), Note("f'16")]), LogicalTie([Note("f'16")])])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3655,7 +3655,7 @@ class Selection(collections.abc.Sequence):
             Rest('r8')
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3718,7 +3718,7 @@ class Selection(collections.abc.Sequence):
             Note("d'8")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3782,7 +3782,7 @@ class Selection(collections.abc.Sequence):
 
             >>> abjad.ottava(result)
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3850,7 +3850,7 @@ class Selection(collections.abc.Sequence):
 
             >>> abjad.ottava(result)
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3918,7 +3918,7 @@ class Selection(collections.abc.Sequence):
             Note("c'8")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -3982,7 +3982,7 @@ class Selection(collections.abc.Sequence):
             Rest('r8')
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4040,7 +4040,7 @@ class Selection(collections.abc.Sequence):
             Note("d'8")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4098,7 +4098,7 @@ class Selection(collections.abc.Sequence):
             Note("c'8")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4158,7 +4158,7 @@ class Selection(collections.abc.Sequence):
             Note("c'8")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4216,7 +4216,7 @@ class Selection(collections.abc.Sequence):
             Chord("<c' d'>8")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4277,7 +4277,7 @@ class Selection(collections.abc.Sequence):
             Note("e'8")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4341,7 +4341,7 @@ class Selection(collections.abc.Sequence):
             Note("f'8")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4398,7 +4398,7 @@ class Selection(collections.abc.Sequence):
             Note("f'8")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4451,7 +4451,7 @@ class Selection(collections.abc.Sequence):
             Note("gf'16")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4558,7 +4558,7 @@ class Selection(collections.abc.Sequence):
             LogicalTie([Rest('r8')])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4610,7 +4610,7 @@ class Selection(collections.abc.Sequence):
             LogicalTie([Note("f'8"), Note("f'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4660,7 +4660,7 @@ class Selection(collections.abc.Sequence):
             LogicalTie([Note("f'8"), Note("f'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4712,7 +4712,7 @@ class Selection(collections.abc.Sequence):
             Selection([LogicalTie([Note("c''8")]), LogicalTie([Note("d''8")])])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4782,7 +4782,7 @@ class Selection(collections.abc.Sequence):
             Selection([LogicalTie([Note("c''8")]), LogicalTie([Note("d''8")])])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4853,7 +4853,7 @@ class Selection(collections.abc.Sequence):
             LogicalTie([Note("f'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4910,7 +4910,7 @@ class Selection(collections.abc.Sequence):
             LogicalTie([Note("f'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -4964,7 +4964,7 @@ class Selection(collections.abc.Sequence):
             LogicalTie([Note("gf'16")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5015,7 +5015,7 @@ class Selection(collections.abc.Sequence):
             LogicalTie([Rest('r8')])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5066,7 +5066,7 @@ class Selection(collections.abc.Sequence):
             LogicalTie([Note("d'8"), Note("d'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5129,7 +5129,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("f'8"), Note("g'8"), Note("a'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5380,7 +5380,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("c'8"), Rest('r8'), Note("d'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5425,7 +5425,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("e'8"), Rest('r8'), Note("f'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5474,7 +5474,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("g'8"), Note("a'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5526,7 +5526,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("e'8"), Rest('r8'), Note("f'8"), Note("g'8"), Note("a'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5581,7 +5581,7 @@ class Selection(collections.abc.Sequence):
             Selection([Rest('r8'), Note("c''8")])
 
             >>> abjad.label.by_selector(result, colors=["#red", "#blue", "#cyan"])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5639,7 +5639,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("f'8"), Note("g'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5692,7 +5692,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("c''8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5742,7 +5742,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("e'8"), Rest('r8'), Note("f'8"), Note("g'8"), Note("a'8"), Note("b'8"), Rest('r8'), Note("c''8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5843,7 +5843,7 @@ class Selection(collections.abc.Sequence):
             ...     abjad.attach(time_signature, container[0])
             ...
             >>> abjad.setting(staff).autoBeaming = False
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             >>> result = abjad.select(staff).leaves().partition_by_durations(
@@ -5861,7 +5861,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("b'8"), Note("c''8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -5934,7 +5934,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("c'8"), Note("d'8"), Note("e'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6007,7 +6007,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("b'8"), Note("c''8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6087,7 +6087,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("b'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6160,7 +6160,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("c'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6231,7 +6231,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("f'8"), Note("g'8"), Note("a'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6309,7 +6309,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("b'8"), Note("c''8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6387,7 +6387,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("c'8"), Note("d'8"), Note("e'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6466,7 +6466,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("b'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6543,7 +6543,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("c'8")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6688,7 +6688,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("f'8"), Note("g'8"), Note("a'8"), Rest('r8')])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -6742,7 +6742,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("g'8"), Note("a'8"), Rest('r8')])
 
             >>> abjad.label.by_selector(result, colors=["#red", "#blue", "#cyan"])
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -7185,7 +7185,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("f'8"), Note("fs'16")])
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -7286,7 +7286,7 @@ class Selection(collections.abc.Sequence):
             Rest('r8')
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -7449,7 +7449,7 @@ class Selection(collections.abc.Sequence):
             Tuplet('3:2', "c'4 d'4 e'4")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -7502,7 +7502,7 @@ class Selection(collections.abc.Sequence):
             Tuplet('3:2', "c'4 d'4 e'4")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -7554,7 +7554,7 @@ class Selection(collections.abc.Sequence):
             Tuplet('3:2', "c'4 d'4 e'4")
 
             >>> abjad.label.by_selector(result)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -7634,7 +7634,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("f'8"), Note("g'8"), Note("a'8")])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -7683,7 +7683,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("f'8")])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -7742,7 +7742,7 @@ class Selection(collections.abc.Sequence):
 
             >>> abjad.label.by_selector(result, True)
             >>> abjad.override(staff).SustainPedalLineSpanner.staff_padding = 6
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -7816,7 +7816,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("fs'16")])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -7914,7 +7914,7 @@ class Selection(collections.abc.Sequence):
             Selection([Rest('r8'), Note("f'8"), Note("g'8"), Note("a'8")])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -7963,7 +7963,7 @@ class Selection(collections.abc.Sequence):
             Selection([Rest('r8'), Note("f'8")])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::
@@ -8025,7 +8025,7 @@ class Selection(collections.abc.Sequence):
             Selection([Note("f'4"), Note("fs'16")])
 
             >>> abjad.label.by_selector(result, True)
-            >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
 
             ..  docs::

--- a/abjad/spanners.py
+++ b/abjad/spanners.py
@@ -1240,7 +1240,7 @@ def glissando(
         ...     abjad.override(note).NoteHead.transparent = True
         ...     abjad.override(note).NoteHead.X_extent = "#'(0 . 0)"
         ...
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -1280,7 +1280,7 @@ def glissando(
         ...     abjad.override(note).NoteHead.transparent = True
         ...     abjad.override(note).NoteHead.X_extent = "#'(0 . 0)"
         ...
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -1321,7 +1321,7 @@ def glissando(
         ...     abjad.override(note).NoteHead.transparent = True
         ...     abjad.override(note).NoteHead.X_extent = "#'(0 . 0)"
         ...
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -1959,7 +1959,7 @@ def text_spanner(
         ... )
         >>> abjad.text_spanner(staff[:], start_text_span=start_text_span)
         >>> abjad.override(staff[0]).TextSpanner.staff_padding = 4
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -1997,7 +1997,7 @@ def text_spanner(
         ... )
         >>> abjad.text_spanner(staff[-3:], start_text_span=start_text_span)
         >>> abjad.override(staff).TextSpanner.staff_padding = 4
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
@@ -2038,7 +2038,7 @@ def text_spanner(
         ... )
         >>> abjad.text_spanner(staff[-3:], start_text_span=start_text_span)
         >>> abjad.override(staff).TextSpanner.staff_padding = 4
-        >>> lilypond_file = abjad.LilyPondFile([staff], includes=["abjad.ily"])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::

--- a/abjad/timespan.py
+++ b/abjad/timespan.py
@@ -218,7 +218,7 @@ class Timespan:
 
     __documentation_section__ = "Timespans"
 
-    __slots__ = ("_start_offset", "_stop_offset")
+    __slots__ = ("_annotation", "_start_offset", "_stop_offset")
 
     ### INITIALIZER ###
 
@@ -226,6 +226,7 @@ class Timespan:
         self,
         start_offset=None,
         stop_offset=None,
+        annotation=None,
     ) -> None:
         if isinstance(start_offset, type(self)):
             raise Exception("can not initialize from timespan.")
@@ -240,6 +241,7 @@ class Timespan:
         assert start_offset <= stop_offset, repr((start_offset, stop_offset))
         self._start_offset = start_offset
         self._stop_offset = stop_offset
+        self._annotation = annotation
 
     ### SPECIAL METHODS ###
 
@@ -965,6 +967,50 @@ class Timespan:
         return Offset(offset)
 
     ### PUBLIC PROPERTIES ###
+
+    @property
+    def annotation(self) -> object:
+        """
+        Gets and sets annotated timespan annotation.
+
+        ..  container:: example
+
+            Gets annotation:
+
+            >>> annotated_timespan = abjad.Timespan(
+            ...     annotation=["a", "b", "c", "foo"],
+            ...     start_offset=(1, 4),
+            ...     stop_offset=(7, 8),
+            ... )
+            >>> annotated_timespan.annotation
+            ['a', 'b', 'c', 'foo']
+
+        ..  container:: example
+
+            Annotated timespans maintain their annotations duration mutation:
+
+            >>> left, right = annotated_timespan.split_at_offset((1, 2))
+            >>> left.annotation.append("foo")
+            >>> string = abjad.storage(right)
+            >>> print(string)
+            abjad.Timespan(
+                start_offset=abjad.Offset((1, 2)),
+                stop_offset=abjad.Offset((7, 8)),
+                annotation=['a', 'b', 'c', 'foo', 'foo'],
+                )
+
+        ..  container:: example
+
+            Sets annotation:
+
+            >>> annotated_timespan.annotation = "baz"
+
+        """
+        return self._annotation
+
+    @annotation.setter
+    def annotation(self, argument):
+        self._annotation = argument
 
     @property
     def axis(self) -> Offset:
@@ -2341,91 +2387,6 @@ class Timespan:
         )
 
 
-class AnnotatedTimespan(Timespan):
-    """
-    Annotated timespan.
-
-    ..  container:: example
-
-        >>> annotated_timespan = abjad.AnnotatedTimespan(
-        ...     annotation=['a', 'b', 'c'],
-        ...     start_offset=(1, 4),
-        ...     stop_offset=(7, 8),
-        ... )
-        >>> string = abjad.storage(annotated_timespan)
-        >>> print(string)
-        abjad.AnnotatedTimespan(
-            start_offset=abjad.Offset((1, 4)),
-            stop_offset=abjad.Offset((7, 8)),
-            annotation=['a', 'b', 'c'],
-            )
-
-    Annotated timespans maintain their annotations duration mutation:
-
-    ..  container:: example
-
-        >>> left, right = annotated_timespan.split_at_offset((1, 2))
-        >>> left.annotation.append('foo')
-        >>> string = abjad.storage(right)
-        >>> print(string)
-        abjad.AnnotatedTimespan(
-            start_offset=abjad.Offset((1, 2)),
-            stop_offset=abjad.Offset((7, 8)),
-            annotation=['a', 'b', 'c', 'foo'],
-            )
-
-    """
-
-    ### CLASS VARIABLES ###
-
-    __documentation_section__ = "Timespans"
-
-    __slots__ = ("_annotation",)
-
-    ### INITIALIZER ###
-
-    def __init__(
-        self,
-        start_offset=None,
-        stop_offset=None,
-        annotation=None,
-    ) -> None:
-        Timespan.__init__(self, start_offset=start_offset, stop_offset=stop_offset)
-        self._annotation = annotation
-
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def annotation(self) -> object:
-        """
-        Gets and sets annotated timespan annotation.
-
-        ..  container:: example
-
-            Gets annotation:
-
-            >>> annotated_timespan = abjad.AnnotatedTimespan(
-            ...     annotation=['a', 'b', 'c', 'foo'],
-            ...     start_offset=(1, 4),
-            ...     stop_offset=(7, 8),
-            ... )
-            >>> annotated_timespan.annotation
-            ['a', 'b', 'c', 'foo']
-
-        ..  container:: example
-
-            Sets annotation:
-
-            >>> annotated_timespan.annotation = 'baz'
-
-        """
-        return self._annotation
-
-    @annotation.setter
-    def annotation(self, argument):
-        self._annotation = argument
-
-
 class TimespanList(TypedList):
     """
     Timespan list.
@@ -2726,9 +2687,9 @@ class TimespanList(TypedList):
             timespan sorting:
 
             >>> timespans = abjad.TimespanList([
-            ...     abjad.AnnotatedTimespan(0, (1, 4), annotation="voice 1"),
-            ...     abjad.AnnotatedTimespan(0, (1, 4), annotation="voice 2"),
-            ...     abjad.AnnotatedTimespan(0, (1, 4), annotation="voice 10"),
+            ...     abjad.Timespan(0, (1, 4), annotation="voice 1"),
+            ...     abjad.Timespan(0, (1, 4), annotation="voice 2"),
+            ...     abjad.Timespan(0, (1, 4), annotation="voice 10"),
             ... ])
 
             >>> def to_digit(string):

--- a/docs/source/_pending/row-derivation-by-trichord.rst
+++ b/docs/source/_pending/row-derivation-by-trichord.rst
@@ -26,7 +26,8 @@ First we define functions to illustrate the examples that follow:
     ...     abjad.override(treble_staff).TimeSignature.stencil = False
     ...     string = "#(ly:make-moment 1 25)"
     ...     abjad.setting(treble_staff).proportionalNotationDuration = string
-    ...     lilypond_file = abjad.LilyPondFile([treble_staff], global_staff_size=16)
+    ...     string = "#(set-global-staff-size 16)"
+    ...     lilypond_file = abjad.LilyPondFile([string, treble_staff])
     ...     return lilypond_file
 
 ----

--- a/docs/source/_pending/scale-derivation-by-sieve.rst
+++ b/docs/source/_pending/scale-derivation-by-sieve.rst
@@ -29,12 +29,12 @@ First we define a function to illustrate the examples that follow:
     ...     abjad.setting(score).proportionalNotationDuration = "#(ly:make-moment 1 25)"
     ...     lilypond_file = abjad.LilyPondFile(
     ...         items=[
+    ...             "#(set-global-staff-size 16)",
     ...             score,
-    ...             abjad.Block(name="layout"),
+    ...             abjad.Block("layout"),
     ...         ],
-    ...         global_staff_size=16,
     ...     )
-    ...     lilypond_file.layout_block.indent = "#0"
+    ...     lilypond_file["layout"].items.append("indent = #0")
     ...     return lilypond_file
 
 ----

--- a/docs/source/_pending/superimposition-of-partials.rst
+++ b/docs/source/_pending/superimposition-of-partials.rst
@@ -65,7 +65,8 @@ First we define functions to illustrate the examples that follow:
     ...     abjad.override(score).Stem.stencil = False
     ...     abjad.override(score).TimeSignature.stencil = False
     ...     abjad.setting(score).proportionalNotationDuration = "#(ly:make-moment 1 25)"
-    ...     lilypond_file = abjad.LilyPondFile([score], global_staff_size=16)
+    ...     string = "#(set-global-staff-size 16)"
+    ...     lilypond_file = abjad.LilyPondFile([string, score])
     ...     return lilypond_file
 
 ----

--- a/docs/source/_pending/tone-clock-tesselation.rst
+++ b/docs/source/_pending/tone-clock-tesselation.rst
@@ -24,7 +24,8 @@ Tone-clock tesselation in Jenny McLeod's `Tone Clock Piece I`.
     ...     abjad.override(score).BarNumber.stencil = False
     ...     abjad.override(score).SpanBar.stencil = False
     ...     abjad.setting(score).proportionalNotationDuration = "#(ly:make-moment 1 5)"
-    ...     lilypond_file = abjad.LilyPondFile([score], global_staff_size=16)
+    ...     string = "#(set-global-staff-size 16)"
+    ...     lilypond_file = abjad.LilyPondFile([string, score])
     ...     return lilypond_file
     ...
 

--- a/docs/source/_pending/trichord-definition-by-ratio.rst
+++ b/docs/source/_pending/trichord-definition-by-ratio.rst
@@ -132,12 +132,14 @@ Define helper functions:
     ...     abjad.override(score).SpacingSpanner.strict_note_spacing = True
     ...     abjad.override(score).TimeSignature.stencil = False
     ...     abjad.setting(score).proportionalNotationDuration = "#(ly:make-moment 1 5)"
-    ...     items= [score, abjad.Block(name="layout"), abjad.Block(name="paper")]
-    ...     lilypond_file = abjad.LilyPondFile(items, global_staff_size=16)
-    ...     lilypond_file.layout_block.indent = "#0"
+    ...     items = [score, abjad.Block(name="layout"), abjad.Block(name="paper")]
+    ...     string = "#(set-global-staff-size 16)"
+    ...     items.insert(0, string)
+    ...     lilypond_file = abjad.LilyPondFile(items)
+    ...     lilypond_file["layout"].items.append("indent = #0")
     ...     space = "system-system-spacing = #'((basic-distance . 13)"
     ...     space += " (minimum-distance . 13) (padding . 4))"
-    ...     lilypond_file.paper_block.items.append(space)
+    ...     lilypond_file["paper"].items.append(space)
     ...     return lilypond_file
     ...
 

--- a/tests/test_ext_sphinx.py
+++ b/tests/test_ext_sphinx.py
@@ -19,38 +19,38 @@ def test_ext_sphinx_01(app, status, warning, rm_dirs):
     assert not warning.getvalue().strip()
     images_path = pathlib.Path(app.outdir) / "_images"
     assert sorted(path.name for path in images_path.iterdir()) == [
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-1.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-2.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-3.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-4.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78.cropped.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78.ly",
-        "lilypond-d85b6f545cbf75344c7cf33a35063b0623b3ff7a217081827f76bc22aad946d6.cropped.svg",
-        "lilypond-d85b6f545cbf75344c7cf33a35063b0623b3ff7a217081827f76bc22aad946d6.ly",
-        "lilypond-d85b6f545cbf75344c7cf33a35063b0623b3ff7a217081827f76bc22aad946d6.svg",
+        "lilypond-2065254c213caa1da7f276b113c411fe735780505cfebb626eb6af1832248d37.cropped.svg",
+        "lilypond-2065254c213caa1da7f276b113c411fe735780505cfebb626eb6af1832248d37.ly",
+        "lilypond-2065254c213caa1da7f276b113c411fe735780505cfebb626eb6af1832248d37.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-1.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-2.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-3.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-4.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef.cropped.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef.ly",
     ]
 
     index_path = pathlib.Path(app.srcdir) / "_build" / "html" / "index.html"
     index_source = index_path.read_text()
     assert re.findall(r"lilypond-\w{64}(?:-\d+|.cropped)?\.svg", index_source) == [
-        "lilypond-d85b6f545cbf75344c7cf33a35063b0623b3ff7a217081827f76bc22aad946d6.cropped.svg",
-        "lilypond-d85b6f545cbf75344c7cf33a35063b0623b3ff7a217081827f76bc22aad946d6.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78.cropped.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-1.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-2.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-3.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-4.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-2.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-3.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-1.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-1.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-1.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-2.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-2.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-3.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-3.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-4.svg",
-        "lilypond-d5d910c50c8632716c4e835cf0ee997ba8165d433302f5c8c9ebbea663443e78-4.svg",
+        "lilypond-2065254c213caa1da7f276b113c411fe735780505cfebb626eb6af1832248d37.cropped.svg",
+        "lilypond-2065254c213caa1da7f276b113c411fe735780505cfebb626eb6af1832248d37.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef.cropped.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-1.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-2.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-3.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-4.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-2.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-3.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-1.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-1.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-1.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-2.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-2.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-3.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-3.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-4.svg",
+        "lilypond-2e1d3707c4c266f8abec146c8af80dd191b7ab568a99eb82417c2bed8a8872ef-4.svg",
     ]
 
 
@@ -71,7 +71,6 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
 
            \version "2.19.83"
            \language "english"
-
            \score
            {
                \new Staff
@@ -89,7 +88,6 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
 
            \version "2.19.83"
            \language "english"
-
            \score
            {
                \new Staff
@@ -112,7 +110,6 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
 
            \version "2.19.83"
            \language "english"
-
            \score
            {
                \new Staff
@@ -135,7 +132,6 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
 
            \version "2.19.83"
            \language "english"
-
            \score
            {
                \new Staff
@@ -157,7 +153,6 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
 
            \version "2.19.83"
            \language "english"
-
            \score
            {
                \new Staff
@@ -179,7 +174,6 @@ def test_ext_sphinx_02(app, status, warning, rm_dirs):
 
            \version "2.19.83"
            \language "english"
-
            \score
            {
                \new Staff


### PR DESCRIPTION
Closes #1293.
    
    CHANGED: removed abjad.ContextBlock; use abjad.Block instead:

        >>> string = r"""\Staff
        ...     \name FluteStaff
        ...     \type Engraver_group
        ...     \alias Staff
        ...     \remove Forbid_line_break_engraver
        ...     \consists Horizontal_bracket_engraver
        ...     \accepts FluteUpperVoice
        ...     \accepts FluteLowerVoice
        ...     \override Beam.positions = #'(-4 . -4)
        ...     \override Stem.stem-end-position = -6
        ...     autoBeaming = ##f
        ...     tupletFullLength = ##t
        ...     \accidentalStyle dodecaphonic"""
        >>> block = abjad.Block(name="context")
        >>> block.items.append(string)

        >>> string = abjad.lilypond(block)
        >>> print(string)
        \context
        {
            \Staff
            \name FluteStaff
            \type Engraver_group
            \alias Staff
            \remove Forbid_line_break_engraver
            \consists Horizontal_bracket_engraver
            \accepts FluteUpperVoice
            \accepts FluteLowerVoice
            \override Beam.positions = #'(-4 . -4)
            \override Stem.stem-end-position = -6
            autoBeaming = ##f
            tupletFullLength = ##t
            \accidentalStyle dodecaphonic
        }

    Removed abjad.Block.__setattr__();
    use abjad.Block.items instead

    REMOVED:

        * abjad.DateTimeToken
        * abjad.LilyPondDimension
        * abjad.LilyPondLanguageToken
        * abjad.LilyPondVersionToken
        * abjad.PackageGitCommitToken
        * abjad.LilyPondFile.comments
        * abjad.LilyPondFile.includes
        * abjad.LilyPondFile.use_relative_includes
        * Removed courtesy blank lines from abjad.LilyPondFile output

    REMOVED abjad.LilyPondFile.default_paper_size, global_staff_size.

        OLD:

            * abjad.LilyPondFile.default_paper_size = ("a4", "letter")
            * abjad.LilyPondFile.global_staff_size = 16

        NEW:

            preamble = r"""
                #(set-default-paper-size "a4" 'letter)
                #(set-global-staff-size 16)"""

            * abjad.LilyPondFile(items=[preamble, ...])

    REMOVED three abjad.LilyPondFile properties:

        OLD:

            * abjad.LilyPondFile.header_block
            * abjad.LilyPondFile.layout_block
            * abjad.LilyPondFile.paper_block

        NEW:

            * abjad.LilyPondFile["header"]
            * abjad.LilyPondFile["layout"]
            * abjad.LilyPondFile["paper"]

    Limited LilyPondFile.__getitem__() to strings.

        OLD:

            * lilypond_file["My_Staff"]
            * lilypond_file[abjad.Staff]

        NEW:

            * lilypond_file["My_Staff"]

Removed `abjad.MeterList.__illustrate__()`;
Use `abjad.meter.illustrate_meter_list()` instead.

Removed Abjad Sphinx extension stylesheet, no-stylesheet options;
Add includes as strings to abjad.LilyPondFile objects instead.

Collapsed abjad.AnnotatedTimespan into abjad.Timespan. Closes #1136.

    OLD: abjad.AnntotedTimespan(start, stop, annotation="foo")
    NEW: abjad.Timespan(start, stop, annotation="foo")