### PR TITLE
Removed six package dependency.

### DIFF
--- a/abjad/configuration.py
+++ b/abjad/configuration.py
@@ -1,4 +1,5 @@
 import collections
+import configparser
 import importlib
 import os
 import pathlib
@@ -9,7 +10,6 @@ import traceback
 import types
 import typing
 
-import six
 import uqbar.apis
 
 
@@ -118,16 +118,11 @@ class Configuration:
     def _configuration_from_string(self, string):
         if "[main]" not in string:
             string = "[main]\n" + string
-        config_parser = six.moves.configparser.ConfigParser()
+        config_parser = configparser.ConfigParser()
         try:
-            if six.PY3:
-                config_parser.read_string(string)
-                configuration = dict(config_parser["main"].items())
-            else:
-                string_io = six.moves.StringIO(string)
-                config_parser.readfp(string_io)
-                configuration = dict(config_parser.items("main"))
-        except six.moves.configparser.ParsingError:
+            config_parser.read_string(string)
+            configuration = dict(config_parser["main"].items())
+        except configparser.ParsingError:
             configuration = {}
         return configuration
 

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,8 @@ classifiers = [
 ]
 
 extras_require = {
-    "nauert": ["abjad-ext-nauert==3.6"],
-    "rmakers": ["abjad-ext-rmakers==3.6"],
+    "nauert": ["abjad-ext-nauert>=3.6"],
+    "rmakers": ["abjad-ext-rmakers>=3.6"],
 }
 
 keywords = [
@@ -75,15 +75,13 @@ install_requires = [
     "flake8>=4.0.1",
     "isort>=5.10.1",
     "mypy>=0.931",
-    "ply",
+    "ply>=3.11",
     "pytest>=6.2.5",
-    "pytest-cov",
-    "pytest-helpers-namespace",
-    "quicktions",
-    "roman",
-    "six",
-    "sphinx-autodoc-typehints",
-    "types-six",
+    "pytest-cov>=3.0.0",
+    "pytest-helpers-namespace>=2021.12.29",
+    "quicktions>=1.13",
+    "roman>=1.4",
+    "sphinx-autodoc-typehints>=1.16.0",
     "uqbar>=0.5.9",
 ]
 


### PR DESCRIPTION
The `six` module smoothed over differences between Python 2 and Python 3.

No longer necessary because Abjad requires Python 3.

Closes #1425.