### PR TITLE
Removed most definitions of __str__().

### DIFF
--- a/abjad/bind.py
+++ b/abjad/bind.py
@@ -20,7 +20,7 @@ class Wrapper:
         >>> articulation = abjad.Articulation("accent")
         >>> abjad.attach(articulation, component, direction=abjad.UP)
         >>> abjad.get.wrapper(component)
-        Wrapper(annotation=None, context=None, deactivate=False, direction=<Vertical.UP: 1>, indicator=Articulation(name='accent', tweaks=None), synthetic_offset=None, tag=Tag())
+        Wrapper(annotation=None, context=None, deactivate=False, direction=<Vertical.UP: 1>, indicator=Articulation(name='accent', tweaks=None), synthetic_offset=None, tag=Tag(''))
 
     ..  container:: example
 
@@ -95,7 +95,7 @@ class Wrapper:
         direction: _enums.Vertical = None,
         indicator: typing.Any = None,
         synthetic_offset: int = None,
-        tag: str | _tag.Tag | None = None,
+        tag: _tag.Tag = _tag.Tag(),
     ) -> None:
         assert not isinstance(indicator, type(self)), repr(indicator)
         if annotation is not None:
@@ -119,8 +119,8 @@ class Wrapper:
         self._synthetic_offset = synthetic_offset
         if tag is not None:
             assert isinstance(tag, str | _tag.Tag)
-        tag = _tag.Tag(tag)
-        self._tag: _tag.Tag = tag
+        assert isinstance(tag, _tag.Tag), repr(tag)
+        self._tag = tag
         if component is not None:
             self._bind_component(
                 component, check_duplicate_indicator=check_duplicate_indicator
@@ -632,10 +632,9 @@ class Wrapper:
 
     @tag.setter
     def tag(self, argument):
-        if not isinstance(argument, str | _tag.Tag):
-            raise Exception(f"string or tag: {argument!r}.")
-        tag = _tag.Tag(argument)
-        self._tag = tag
+        if not isinstance(argument, _tag.Tag):
+            raise Exception(f"must be tag: {argument!r}.")
+        self._tag = argument
 
 
 def annotate(component, annotation, indicator) -> None:
@@ -888,7 +887,7 @@ def attach(  # noqa: 302
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> abjad.attach(abjad.Clef('alto'), staff[0], wrapper=True)
-        Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+        Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
 
     Otherwise returns none.
     """
@@ -963,6 +962,9 @@ def attach(  # noqa: 302
 
     if hasattr(attachable, "context"):
         context = context or attachable.context
+
+    if tag is None:
+        tag = _tag.Tag()
 
     wrapper_ = Wrapper(
         annotation=annotation,
@@ -1184,7 +1186,7 @@ def detach(argument, target=None, by_id=False):
 
         >>> wrapper = abjad.get.wrappers(staff[0])[0]
         >>> abjad.detach(wrapper, wrapper.component)
-        (Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag()),)
+        (Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag('')),)
 
         >>> abjad.show(staff) # doctest: +SKIP
 

--- a/abjad/cyclictuple.py
+++ b/abjad/cyclictuple.py
@@ -109,32 +109,6 @@ class CyclicTuple:
         assert isinstance(self.items, tuple | CyclicTuple), repr(self.items)
         return self.items.__len__()
 
-    def __str__(self) -> str:
-        """
-        Gets string representation of cyclic tuple.
-
-        ..  container:: example
-
-            Gets string:
-
-            >>> str(abjad.CyclicTuple('abcd'))
-            '(a, b, c, d)'
-
-        ..  container:: example
-
-            Gets string:
-
-            >>> str(abjad.CyclicTuple([1, 2, 3, 4]))
-            '(1, 2, 3, 4)'
-
-        """
-        if self:
-            contents = [str(item) for item in self.items]
-            string = ", ".join(contents)
-            string = f"({string})"
-            return string
-        return "()"
-
     def _get_slice(self, start_index, stop_index):
         if stop_index is not None and 1000000 < stop_index:
             stop_index = len(self)

--- a/abjad/get.py
+++ b/abjad/get.py
@@ -203,8 +203,8 @@ def annotation_wrappers(argument):
             }
 
         >>> for wrapper in abjad.get.annotation_wrappers(staff[0]): wrapper
-        Wrapper(annotation='default_instrument', context=None, deactivate=False, direction=None, indicator=Cello(), synthetic_offset=None, tag=Tag())
-        Wrapper(annotation='default_clef', context=None, deactivate=False, direction=None, indicator=Clef(name='tenor', hide=False), synthetic_offset=None, tag=Tag())
+        Wrapper(annotation='default_instrument', context=None, deactivate=False, direction=None, indicator=Cello(), synthetic_offset=None, tag=Tag(''))
+        Wrapper(annotation='default_clef', context=None, deactivate=False, direction=None, indicator=Clef(name='tenor', hide=False), synthetic_offset=None, tag=Tag(''))
 
     """
     return _inspect._get_annotation_wrappers(argument)
@@ -237,9 +237,9 @@ def bar_line_crossing(argument) -> bool:
         ...     result = abjad.get.bar_line_crossing(note)
         ...     print(note, result)
         ...
-        c'4 False
-        d'4 True
-        e'4 False
+        Note("c'4") False
+        Note("d'4") True
+        Note("e'4") False
 
     """
     if not isinstance(argument, _score.Component):
@@ -1086,10 +1086,10 @@ def effective(
         ...     print(component, repr(string))
         ...
         Staff("c'8 d'8 e'8 f'8") None
-        c'8 None
-        d'8 'color'
-        e'8 'color'
-        f'8 'color'
+        Note("c'8") None
+        Note("d'8") 'color'
+        Note("e'8") 'color'
+        Note("f'8") 'color'
 
     ..  container:: example
 
@@ -1276,11 +1276,11 @@ def effective(
         ...     time_signature = abjad.get.effective(component, prototype)
         ...     print(component, time_signature)
         ...
-        Staff("c'4 d'4 e'4 f'4") 3/8
-        c'4 3/8
-        d'4 3/8
-        e'4 3/8
-        f'4 3/8
+        Staff("c'4 d'4 e'4 f'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
+        Note("c'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
+        Note("d'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
+        Note("e'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
+        Note("f'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
 
     ..  container:: example
 
@@ -1649,27 +1649,27 @@ def effective_wrapper(
         Note("d'4")
             None
         Container("{ <e' g'>16 gs'16 a'16 as'16 } { e'4 }")
-            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
         OnBeatGraceContainer("<e' g'>16 gs'16 a'16 as'16")
-            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
         Chord("<e' g'>16")
-            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
         Note("gs'16")
-            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
         Note("a'16")
-            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
         Note("as'16")
-            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
         Voice("e'4", name='Music_Voice')
-            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
         Note("e'4")
-            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
         Note("f'4")
-            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
         AfterGraceContainer("fs'16")
-            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
         Note("fs'16")
-            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(''))
 
     """
     if attributes is not None:
@@ -4137,35 +4137,35 @@ def wrapper(
         Voice("c'4 d'4 { { <e' g'>16 gs'16 a'16 as'16 } { e'4 } } f'4", name='Music_Voice'):
             None
         Note("c'4"):
-            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))
         BeforeGraceContainer("cs'16"):
             None
         Note("cs'16"):
-            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))
         Note("d'4"):
-            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))
         Container("{ <e' g'>16 gs'16 a'16 as'16 } { e'4 }"):
             None
         OnBeatGraceContainer("<e' g'>16 gs'16 a'16 as'16"):
             None
         Chord("<e' g'>16"):
-            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='>', tweaks=None), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='>', tweaks=None), synthetic_offset=None, tag=Tag(''))
         Note("gs'16"):
-            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))
         Note("a'16"):
-            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))
         Note("as'16"):
-            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))
         Voice("e'4", name='Music_Voice'):
             None
         Note("e'4"):
-            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))
         Note("f'4"):
-            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))
         AfterGraceContainer("fs'16"):
             None
         Note("fs'16"):
-            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())
+            Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))
 
     Raises exception when more than one indicator of ``prototype`` attach to
     ``argument``.
@@ -4273,35 +4273,35 @@ def wrappers(
         Voice("c'4 d'4 { { <e' g'>16 gs'16 a'16 as'16 } { e'4 } } f'4", name='Music_Voice'):
             []
         Note("c'4"):
-            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())]
+            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))]
         BeforeGraceContainer("cs'16"):
             []
         Note("cs'16"):
-            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())]
+            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))]
         Note("d'4"):
-            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())]
+            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))]
         Container("{ <e' g'>16 gs'16 a'16 as'16 } { e'4 }"):
             []
         OnBeatGraceContainer("<e' g'>16 gs'16 a'16 as'16"):
             []
         Chord("<e' g'>16"):
-            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='>', tweaks=None), synthetic_offset=None, tag=Tag())]
+            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='>', tweaks=None), synthetic_offset=None, tag=Tag(''))]
         Note("gs'16"):
-            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())]
+            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))]
         Note("a'16"):
-            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())]
+            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))]
         Note("as'16"):
-            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())]
+            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))]
         Voice("e'4", name='Music_Voice'):
             []
         Note("e'4"):
-            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())]
+            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))]
         Note("f'4"):
-            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())]
+            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))]
         AfterGraceContainer("fs'16"):
             []
         Note("fs'16"):
-            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag())]
+            [Wrapper(annotation=None, context=None, deactivate=False, direction=None, indicator=Articulation(name='.', tweaks=None), synthetic_offset=None, tag=Tag(''))]
 
     """
     if attributes is not None:

--- a/abjad/instruments.py
+++ b/abjad/instruments.py
@@ -451,7 +451,9 @@ class Tuning:
         """
         result = []
         for pitch in self.pitches or []:
-            pitch_range = _pcollections.PitchRange(f"[{pitch}, {pitch + 24}]")
+            pitch_range = _pcollections.PitchRange(
+                f"[{pitch.name}, {(pitch + 24).name}]"
+            )
             result.append(pitch_range)
         return result
 

--- a/abjad/label.py
+++ b/abjad/label.py
@@ -1253,7 +1253,14 @@ def with_intervals(argument, direction=_enums.UP, prototype=None) -> None:
         if isinstance(next_leaf, _score.Note):
             interval = _pitch.NamedInterval.from_pitch_carriers(note, next_leaf)
             interval = prototype(interval)
-            label = _markups.Markup(rf"\markup {interval}")
+            if hasattr(interval, "name"):
+                label = _markups.Markup(rf"\markup {interval.name}")
+            elif isinstance(interval, _pitch.NumberedInversionEquivalentIntervalClass):
+                label = _markups.Markup(rf"\markup {interval.number}")
+            elif isinstance(
+                interval, _pitch.NumberedIntervalClass | _pitch.NumberedInterval
+            ):
+                label = _markups.Markup(rf"\markup {interval.signed_string}")
             if label is not None:
                 _attach(label, note, direction=direction)
 

--- a/abjad/lilypondfile.py
+++ b/abjad/lilypondfile.py
@@ -507,6 +507,9 @@ class LilyPondFile:
         """
         Gets tag.
         """
-        tag = _tag.Tag(self.tag)
+        if self.tag:
+            tag = _tag.Tag(self.tag.string)
+        else:
+            tag = _tag.Tag()
         tag = tag.append(site)
         return tag

--- a/abjad/markups.py
+++ b/abjad/markups.py
@@ -273,16 +273,6 @@ class Markup:
         >>> markup_1 is markup_2
         False
 
-    ..  container:: example
-
-        String:
-
-        >>> markup = abjad.Markup(rf'\markup \italic "Allegro assai"')
-        >>> print(str(markup))
-        \markup \italic "Allegro assai"
-
-        >>> abjad.show(markup) # doctest: +SKIP
-
     """
 
     string: str
@@ -292,13 +282,6 @@ class Markup:
 
     def __post_init__(self):
         self.tweaks = _overrides.TweakInterface.set_dataclass_tweaks(self, self.tweaks)
-
-    # TODO: remove eventually
-    def __str__(self) -> str:
-        """
-        Gets string representation of markup.
-        """
-        return self._get_lilypond_format()
 
     def _get_format_pieces(self, *, wrapper=None):
         tweaks = []

--- a/abjad/meter.py
+++ b/abjad/meter.py
@@ -651,29 +651,6 @@ class Meter:
         """
         return f"{type(self).__name__}({self.rtm_format!r})"
 
-    def __str__(self) -> str:
-        """
-        Gets string representation of meter.
-
-        ..  container:: example
-
-            Gets string representation of meters over ``8``:
-
-            >>> for numerator in range(1, 9):
-            ...     meter = abjad.Meter((numerator, 8))
-            ...     print(str(meter))
-            1/8
-            2/8
-            3/8
-            4/8
-            5/8
-            6/8
-            7/8
-            8/8
-
-        """
-        return f"{self.numerator}/{self.denominator}"
-
     ### PUBLIC PROPERTIES ###
 
     @property
@@ -731,6 +708,13 @@ class Meter:
         Returns duration.
         """
         return _duration.Duration(self.numerator, self.denominator)
+
+    @property
+    def fraction(self):
+        """
+        Gets nonreduced fraction.
+        """
+        return _duration.NonreducedFraction(self.pair)
 
     @property
     def implied_time_signature(self):
@@ -820,7 +804,7 @@ class Meter:
             >>> for numerator in range(1, 13):
             ...     meter = abjad.Meter((numerator, 4))
             ...     string = True if meter.is_compound else ''
-            ...     print(str(meter), string)
+            ...     print(str(meter.fraction), string)
             ...
             1/4
             2/4
@@ -842,7 +826,7 @@ class Meter:
             >>> for numerator in range(1, 13):
             ...     meter = abjad.Meter((numerator, 8))
             ...     string = True if meter.is_compound else ''
-            ...     print(str(meter), string)
+            ...     print(str(meter.fraction), string)
             ...
             1/8
             2/8
@@ -879,7 +863,7 @@ class Meter:
             >>> for numerator in range(1, 13):
             ...     meter = abjad.Meter((numerator, 4))
             ...     string = True if meter.is_simple else ''
-            ...     print(str(meter), string)
+            ...     print(str(meter.fraction), string)
             ...
             1/4     True
             2/4     True
@@ -901,7 +885,7 @@ class Meter:
             >>> for numerator in range(1, 13):
             ...     meter = abjad.Meter((numerator, 8))
             ...     string = True if meter.is_simple else ''
-            ...     print(str(meter), string)
+            ...     print(str(meter.fraction), string)
             ...
             1/8     True
             2/8     True
@@ -1073,10 +1057,10 @@ class Meter:
             >>> for meter in abjad.Meter.fit_meters(argument, meters):
             ...     print(meter.implied_time_signature)
             ...
-            4/4
-            4/4
-            4/4
-            4/4
+            TimeSignature(pair=(4, 4), hide=False, partial=None)
+            TimeSignature(pair=(4, 4), hide=False, partial=None)
+            TimeSignature(pair=(4, 4), hide=False, partial=None)
+            TimeSignature(pair=(4, 4), hide=False, partial=None)
 
         ..  container:: example
 
@@ -1086,11 +1070,11 @@ class Meter:
             >>> for meter in abjad.Meter.fit_meters(argument, meters):
             ...     print(meter.implied_time_signature)
             ...
-            3/4
-            4/4
-            3/4
-            5/4
-            5/4
+            TimeSignature(pair=(3, 4), hide=False, partial=None)
+            TimeSignature(pair=(4, 4), hide=False, partial=None)
+            TimeSignature(pair=(3, 4), hide=False, partial=None)
+            TimeSignature(pair=(5, 4), hide=False, partial=None)
+            TimeSignature(pair=(5, 4), hide=False, partial=None)
 
         Coerces offsets from ``argument`` via ``MetricAccentKernel.count_offsets()``.
 
@@ -2681,7 +2665,7 @@ def illustrate_meter_list(
     strings.append("{")
     strings.extend(fraction_strings)
     strings.append(r"\combine")
-    strings.append(str(timespan_markup))
+    strings.append(timespan_markup.string)
     strings.append(r"\postscript")
     strings.append('#"')
     strings.extend(postscript_strings)

--- a/abjad/metricmodulation.py
+++ b/abjad/metricmodulation.py
@@ -437,23 +437,6 @@ class MetricModulation:
         """
         return f"{type(self).__name__}(left_rhythm={self.left_rhythm!r}, right_rhythm={self.right_rhythm!r})"
 
-    def __str__(self) -> str:
-        r"""
-        Gets string representation of metric modulation.
-
-        ..  container:: example
-
-            >>> metric_modulation = abjad.MetricModulation(
-            ...     left_rhythm=abjad.Tuplet((2, 3), [abjad.Note("c'4")]),
-            ...     right_rhythm=abjad.Note("c'4"),
-            ... )
-
-            >>> print(str(metric_modulation))
-            \markup \abjad-metric-modulation-tuplet-lhs #2 #0 #2 #3 #2 #0 #'(1 . 1)
-
-        """
-        return str(self._get_markup())
-
     ### PRIVATE METHODS ###
 
     def _get_lilypond_command_string(self):
@@ -485,7 +468,8 @@ class MetricModulation:
         return string
 
     def _get_lilypond_format(self):
-        return str(self)
+        markup = self._get_markup()
+        return markup.string
 
     def _get_lilypond_format_bundle(self, *, component=None, wrapper=None):
         bundle = _bundle.LilyPondFormatBundle()

--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -2655,12 +2655,12 @@ def wrap(argument, container):
         ...     time_signature = abjad.get.effective(component, prototype)
         ...     print(component, time_signature)
         ...
-        Staff("{ c'4 d'4 e'4 f'4 }") 3/8
-        Container("c'4 d'4 e'4 f'4") 3/8
-        c'4 3/8
-        d'4 3/8
-        e'4 3/8
-        f'4 3/8
+        Staff("{ c'4 d'4 e'4 f'4 }") TimeSignature(pair=(3, 8), hide=False, partial=None)
+        Container("c'4 d'4 e'4 f'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
+        Note("c'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
+        Note("d'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
+        Note("e'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
+        Note("f'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
 
     Returns none.
     """

--- a/abjad/overrides.py
+++ b/abjad/overrides.py
@@ -93,6 +93,8 @@ def format_scheme_value(
         return f"({string})"
     elif value is None:
         return "#f"
+    elif hasattr(value, "string"):
+        return value.string
     return str(value)
 
 

--- a/abjad/parentage.py
+++ b/abjad/parentage.py
@@ -874,15 +874,15 @@ class Parentage(collections.abc.Sequence):
             ...     depth = abjad.get.parentage(leaf).count(abjad.Voice)
             ...     print(leaf, depth)
             ...
-            e''8 1
-            d''8 1
-            c''4 2
-            b'4 2
-            c''8 2
-            e'4 2
-            f'4 2
-            e'8 2
-            d''8 1
+            Note("e''8") 1
+            Note("d''8") 1
+            Note("c''4") 2
+            Note("b'4") 2
+            Note("c''8") 2
+            Note("e'4") 2
+            Note("f'4") 2
+            Note("e'8") 2
+            Note("d''8") 1
 
         ..  container:: example
 

--- a/abjad/parsers/reduced.py
+++ b/abjad/parsers/reduced.py
@@ -455,19 +455,19 @@ class ReducedLyParser(Parser):
         """
         pitch : PITCHNAME
         """
-        p[0] = _pitch.NamedPitch(str(p[1]))
+        p[0] = _pitch.NamedPitch(p[1].name)
 
     def p_pitch__PITCHNAME__apostrophes(self, p):
         """
         pitch : PITCHNAME apostrophes
         """
-        p[0] = _pitch.NamedPitch(str(p[1]) + "'" * p[2])
+        p[0] = _pitch.NamedPitch(p[1].name + "'" * p[2])
 
     def p_pitch__PITCHNAME__commas(self, p):
         """
         pitch : PITCHNAME commas
         """
-        p[0] = _pitch.NamedPitch(str(p[1]) + "," * p[2])
+        p[0] = _pitch.NamedPitch(p[1].name + "," * p[2])
 
     def p_pitches__pitch(self, p):
         """

--- a/abjad/pcollections.py
+++ b/abjad/pcollections.py
@@ -1228,7 +1228,7 @@ class PitchSegment:
             '<-2, -1.5, 6, 7, -1.5, 7>'
 
         """
-        string = ", ".join([str(_) for _ in self])
+        string = ", ".join([str(_.number) for _ in self])
         return f"<{string}>"
 
     def invert(self, axis=None) -> "PitchSegment":
@@ -1849,11 +1849,11 @@ class PitchSet(frozenset):
             string = f"{type(self).__name__}()"
         return string
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Gets string.
         """
-        string = ", ".join([str(_) for _ in sorted(self)])
+        string = ", ".join([str(_.number) for _ in sorted(self)])
         return f"{{{string}}}"
 
 

--- a/abjad/pitch.py
+++ b/abjad/pitch.py
@@ -822,7 +822,8 @@ class Accidental:
         """
         raise NotImplementedError
 
-    def __str__(self):
+    # TODO: remove?
+    def __str__(self) -> str:
         """
         Gets string representation of accidental.
 
@@ -852,15 +853,13 @@ class Accidental:
             >>> str(abjad.Accidental("ss"))
             'ss'
 
-        Returns string.
         """
         if self.semitones in _accidental_semitones_to_abbreviation:
             return _accidental_semitones_to_abbreviation[self.semitones]
         character = "s"
         if self.semitones < 0:
             character = "f"
-        semitones = abs(self.semitones)
-        semitones, remainder = divmod(semitones, 1.0)
+        semitones, remainder = divmod(abs(self.semitones), 1.0)
         abbreviation = character * int(semitones)
         if remainder:
             abbreviation += f"q{character}"
@@ -1056,28 +1055,6 @@ class Octave:
         """
         return int(self.number)
 
-    # TODO: remove
-    def __str__(self):
-        """
-        Gets string representation of octave.
-
-        Defined equal to LilyPond octave / tick representation of octave.
-
-        ..  container:: example
-
-            >>> str(abjad.Octave(4))
-            "'"
-
-            >>> str(abjad.Octave(1))
-            ',,'
-
-            >>> str(abjad.Octave(3))
-            ''
-
-        Returns string.
-        """
-        return self.ticks
-
     def _is_tick_string(argument):
         if not isinstance(argument, str):
             return False
@@ -1240,7 +1217,7 @@ class IntervalClass:
         """
         Hashes interval-class.
         """
-        return hash(self.__class__.__name__ + str(self))
+        return hash(self.__class__.__name__ + repr(self))
 
     def __lt__(self, argument) -> bool:
         """
@@ -1248,15 +1225,6 @@ class IntervalClass:
         """
         assert isinstance(argument, type(self))
         return self.number < argument.number
-
-    # TODO: remove
-    def __str__(self):
-        """
-        Gets string representation of interval-class.
-
-        Returns string.
-        """
-        return str(self.number)
 
     @staticmethod
     def _named_to_numbered(direction, quality, diatonic_number):
@@ -1540,20 +1508,6 @@ class NamedIntervalClass(IntervalClass):
         Gets repr.
         """
         return f"{type(self).__name__}({self.name!r})"
-
-    # TODO: remove
-    def __str__(self):
-        """
-        Gets string representation of named interval-class.
-
-        ..  container:: example
-
-            >>> str(abjad.NamedIntervalClass("-M9"))
-            '-M2'
-
-        Returns string.
-        """
-        return self.name
 
     def __sub__(self, argument):
         """
@@ -1851,7 +1805,7 @@ class NamedInversionEquivalentIntervalClass(NamedIntervalClass):
         named_interval = NamedInterval.from_pitch_carriers(
             pitch_carrier_1, pitch_carrier_2
         )
-        string = str(named_interval)
+        string = named_interval.name
         return class_(string)
 
 
@@ -2021,28 +1975,6 @@ class NumberedIntervalClass(IntervalClass):
         """
         return f"{type(self).__name__}({self.number!r})"
 
-    # TODO: remove
-    def __str__(self):
-        """
-        Gets string representation of numbered interval-class.
-
-        ..  container:: example
-
-            >>> str(abjad.NumberedIntervalClass(-13))
-            '-1'
-
-            >>> str(abjad.NumberedIntervalClass(0))
-            '0'
-
-            >>> str(abjad.NumberedIntervalClass(13))
-            '+1'
-
-        """
-        string = super().__str__()
-        if 0 < self.number:
-            string = "+" + string
-        return string
-
     def __sub__(self, argument):
         """
         Subtracts ``argument`` from numbered interval-class.
@@ -2082,6 +2014,16 @@ class NumberedIntervalClass(IntervalClass):
             return 0
         else:
             return 1
+
+    @property
+    def signed_string(self):
+        """
+        Gets signed string.
+        """
+        direction_symbol = _direction_number_to_direction_symbol[
+            _math.sign(self.number)
+        ]
+        return f"{direction_symbol}{abs(self.number)}"
 
     @classmethod
     def from_pitch_carriers(
@@ -2227,24 +2169,6 @@ class NumberedInversionEquivalentIntervalClass(NumberedIntervalClass):
         """
         return f"{type(self).__name__}({self.number!r})"
 
-    # TODO: remove
-    def __str__(self):
-        """
-        Gets string representation of numbered inversion-equivalent
-        interval-class.
-
-        ..  container:: example
-
-            >>> str(abjad.NumberedInversionEquivalentIntervalClass(0))
-            '0'
-
-            >>> str(abjad.NumberedInversionEquivalentIntervalClass(1.5))
-            '1.5'
-
-        Returns string.
-        """
-        return str(self.number)
-
 
 @functools.total_ordering
 class Interval:
@@ -2300,17 +2224,17 @@ class Interval:
 
     def __eq__(self, argument) -> bool:
         """
-        Compares string formats.
+        Compares repr formats.
         """
         if isinstance(argument, type(self)):
-            return str(self) == str(argument)
+            return repr(self) == repr(argument)
         return False
 
     def __hash__(self) -> int:
         """
         Hashes interval.
         """
-        return hash(self.__class__.__name__ + str(self))
+        return hash(self.__class__.__name__ + repr(self))
 
     def __lt__(self, argument):
         """
@@ -2319,15 +2243,6 @@ class Interval:
         Returns true or false.
         """
         raise NotImplementedError
-
-    # TODO: remove
-    def __str__(self):
-        """
-        Gets string representation of interval.
-
-        Returns string.
-        """
-        return str(self.number)
 
     def _from_interval_or_interval_class(self, argument):
         raise NotImplementedError
@@ -2731,19 +2646,6 @@ class NamedInterval(Interval):
 
         """
         return self * argument
-
-    # TODO: remove
-    def __str__(self) -> str:
-        """
-        Gets string representation of named interval.
-
-        ..  container:: example
-
-            >>> str(abjad.NamedInterval("+M9"))
-            '+M9'
-
-        """
-        return self.name
 
     def __sub__(self, argument) -> "NamedInterval":
         """
@@ -3241,11 +3143,6 @@ class NumberedInterval(Interval):
 
         Returns true or false.
         """
-        #        if not isinstance(argument, type(self)):
-        #            raise TypeError(f"must be numbered interval: {argument!r}.")
-        #        if not self.direction_number == argument.direction_number:
-        #            raise ValueError("can only compare intervals of same direction.")
-        #        return abs(self.number) < abs(argument.number)
         if isinstance(argument, type(self)):
             return self.number < argument.number
         return False
@@ -3288,16 +3185,6 @@ class NumberedInterval(Interval):
         Gets repr.
         """
         return f"{type(self).__name__}({self.number!r})"
-
-    # TODO: remove
-    def __str__(self):
-        """
-        Gets string.
-        """
-        direction_symbol = _direction_number_to_direction_symbol[
-            _math.sign(self.number)
-        ]
-        return f"{direction_symbol}{abs(self.number)}"
 
     def __sub__(self, argument) -> "NumberedInterval":
         """
@@ -3393,6 +3280,16 @@ class NumberedInterval(Interval):
 
         """
         return self.number
+
+    @property
+    def signed_string(self):
+        """
+        Gets signed string.
+        """
+        direction_symbol = _direction_number_to_direction_symbol[
+            _math.sign(self.number)
+        ]
+        return f"{direction_symbol}{abs(self.number)}"
 
     @classmethod
     def from_pitch_carriers(
@@ -3498,10 +3395,10 @@ class PitchClass:
 
     def __eq__(self, argument) -> bool:
         """
-        Compares string formats.
+        Compares reprs.
         """
         if isinstance(argument, type(self)):
-            return str(self) == str(argument)
+            return repr(self) == repr(argument)
         return False
 
     # TODO: remove
@@ -3517,7 +3414,7 @@ class PitchClass:
         """
         Hashes pitch-class.
         """
-        return hash(self.__class__.__name__ + str(self))
+        return hash(self.__class__.__name__ + repr(self))
 
     def __lt__(self, argument):
         """
@@ -3791,20 +3688,6 @@ class NamedPitchClass(PitchClass):
         Gets repr.
         """
         return f"{type(self).__name__}({self.name!r})"
-
-    # TODO: remove
-    def __str__(self):
-        """
-        Gets string representation of named pitch-class.
-
-        ..  container:: example
-
-            >>> str(abjad.NamedPitchClass("cs"))
-            'cs'
-
-        Returns string.
-        """
-        return self.name
 
     def __sub__(self, argument) -> "NamedInversionEquivalentIntervalClass":
         """
@@ -4176,13 +4059,6 @@ class NumberedPitchClass(PitchClass):
         """
         return f"{type(self).__name__}({self.number!r})"
 
-    # TODO: remove
-    def __str__(self) -> str:
-        """
-        Gets string.
-        """
-        return str(self.number)
-
     def __sub__(
         self, argument
     ) -> typing.Union["NumberedPitchClass", "NumberedInversionEquivalentIntervalClass"]:
@@ -4472,7 +4348,7 @@ class Pitch:
         """
         Hashes pitch.
         """
-        return hash(self.__class__.__name__ + str(self))
+        return hash(self.__class__.__name__ + repr(self))
 
     def __lt__(self, argument):
         """
@@ -4904,25 +4780,6 @@ class NamedPitch(Pitch):
         else:
             return f"{type(self).__name__}({self.name!r})"
 
-    # TODO: remove
-    def __str__(self):
-        """
-        Gets string representation of named pitch.
-
-        ..  container:: example
-
-            >>> str(abjad.NamedPitch("c''"))
-            "c''"
-
-            >>> str(abjad.NamedPitch("cs''"))
-            "cs''"
-
-            >>> str(abjad.NamedPitch("df''"))
-            "df''"
-
-        """
-        return self.name
-
     def __sub__(self, argument) -> "NamedInterval":
         """
         Subtracts ``argument`` from named pitch.
@@ -4995,7 +4852,7 @@ class NamedPitch(Pitch):
         return diatonic_pitch_number
 
     def _get_lilypond_format(self):
-        return str(self)
+        return self.name
 
     def _list_format_contributions(self):
         contributions = []
@@ -5091,7 +4948,7 @@ class NamedPitch(Pitch):
             "df''"
 
         """
-        return f"{self.pitch_class!s}{self.octave!s}"
+        return f"{self.pitch_class.name}{self.octave.ticks}"
 
     @property
     def number(self) -> int | float:
@@ -5544,13 +5401,6 @@ class NumberedPitch(Pitch):
         Gets repr.
         """
         return f"{type(self).__name__}({self.number!r})"
-
-    # TODO: remove
-    def __str__(self):
-        """
-        Gets string.
-        """
-        return str(self.number)
 
     def __sub__(self, argument) -> "NumberedInterval":
         """

--- a/abjad/ratio.py
+++ b/abjad/ratio.py
@@ -271,28 +271,20 @@ class Ratio(NonreducedRatio):
         """
         return len(self.numbers)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Gets string representation of ratio.
 
         ..  container:: example
 
-            Ratio of two numbers:
-
             >>> str(abjad.Ratio((2, 4)))
             '1:2'
-
-        ..  container:: example
-
-            Ratio of three numbers:
 
             >>> str(abjad.Ratio((2, 4, 2)))
             '1:2:1'
 
-        Returns string.
         """
-        numbers = (str(x) for x in self.numbers)
-        return ":".join(numbers)
+        return ":".join([str(_) for _ in self.numbers])
 
     @property
     def multipliers(self):

--- a/abjad/setclass.py
+++ b/abjad/setclass.py
@@ -1033,7 +1033,7 @@ class SetClass:
         assert isinstance(self.lex_rank, type(None) | bool)
         assert isinstance(self.transposition_only, type(None) | bool)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Gets string representation.
 
@@ -1068,7 +1068,6 @@ class SetClass:
             >>> print(set_class)
             SC(4-29){0, 2, 6, 7}
 
-        Returns string.
         """
         string = f"SC({self.cardinality}-{self.rank}){self.prime_form!s}"
         string = string.replace("PC", "")

--- a/abjad/tag.py
+++ b/abjad/tag.py
@@ -21,13 +21,6 @@ class Tag:
 
     ..  container:: example
 
-        Initializes from other tag:
-
-        >>> abjad.Tag(abjad.Tag("YELLOW"))
-        Tag('YELLOW')
-
-    ..  container:: example
-
         Raises exception on multiple only-edition tags:
 
         >>> abjad.Tag("+SEGMENT:+PARTS")
@@ -48,20 +41,12 @@ class Tag:
 
     """
 
-    ### CLASS VARIABLES ###
-
     __slots__ = ("_string", "_words")
 
-    ### INITIALIZER ###
-
-    def __init__(self, string: typing.Union[str, "Tag"] = None) -> None:
-        if isinstance(string, Tag):
-            string = str(string)
-        if string is not None:
-            assert not string.startswith(":"), repr(string)
-            words = string.split(":")
-        else:
-            words = []
+    def __init__(self, string: str = "") -> None:
+        assert isinstance(string, str), repr(string)
+        assert not string.startswith(":"), repr(string)
+        words = string.split(":")
         assert isinstance(words, list), repr(words)
         words_: list[str] = []
         for word in words:
@@ -84,10 +69,8 @@ class Tag:
             string = ":".join(words_)
             assert not string.startswith(":"), repr(string)
         else:
-            string = None
+            string = ""
         self._string = string
-
-    ### SPECIAL METHODS ###
 
     def __bool__(self):
         """
@@ -102,7 +85,7 @@ class Tag:
             True
 
         """
-        return bool(str(self))
+        return bool(self.string)
 
     def __contains__(self, argument) -> bool:
         """
@@ -123,7 +106,10 @@ class Tag:
             True
 
         """
-        return str(argument) in self.words
+        if isinstance(argument, str):
+            return argument in self.words
+        else:
+            return argument.string in self.words
 
     def __eq__(self, argument):
         """
@@ -158,7 +144,7 @@ class Tag:
 
         """
         if isinstance(argument, Tag):
-            return str(self) == str(argument)
+            return self.string == argument.string
         return False
 
     def __hash__(self):
@@ -175,7 +161,7 @@ class Tag:
             True
 
         """
-        return hash(self.__class__.__name__ + str(self))
+        return hash(self.__class__.__name__ + self.string)
 
     def __iter__(self):
         """
@@ -203,32 +189,15 @@ class Tag:
         else:
             return f"{type(self).__name__}({self.string!r})"
 
-    def __str__(self):
-        """
-        Changes tag to string.
-
-        ..  container:: example
-
-            >>> str(abjad.Tag())
-            ''
-
-            >>> str(abjad.Tag("-PARTS:-SCORE:DEFAULT_CLEF"))
-            '-PARTS:-SCORE:DEFAULT_CLEF'
-
-        """
-        return self.string or ""
-
-    ### PUBLIC PROPERTIES ###
-
     @property
-    def string(self) -> str | None:
+    def string(self) -> str:
         """
         Gets string.
 
         ..  container:: example
 
-            >>> abjad.Tag().string is None
-            True
+            >>> abjad.Tag().string
+            ''
 
             >>> abjad.Tag("-PARTS:DEFAULT_CLEF").string
             '-PARTS:DEFAULT_CLEF'
@@ -249,8 +218,6 @@ class Tag:
         """
         return list(self._words)
 
-    ### PUBLIC METHODS ###
-
     def append(self, word: typing.Optional["Tag"]) -> "Tag":
         """
         Appends ``word`` to tag.
@@ -262,12 +229,12 @@ class Tag:
 
         """
         if not bool(word):
-            return Tag(self)
+            return Tag(self.string)
         assert isinstance(word, Tag), repr(word)
         words = []
-        if str(self) != "":
-            words.append(str(self))
-        words.append(str(word))
+        if self.string:
+            words.append(self.string)
+        words.append(word.string)
         string = ":".join(words)
         return Tag(string)
 
@@ -505,13 +472,13 @@ class Line:
 
             Lambdas:
 
-            >>> line.match(lambda x: any(_ for _ in x if str(_).startswith("M")))
+            >>> line.match(lambda x: any(_ for _ in x if _.string.startswith("M")))
             True
 
-            >>> line.match(lambda x: any(_ for _ in x if str(_).startswith("S")))
+            >>> line.match(lambda x: any(_ for _ in x if _.string.startswith("S")))
             True
 
-            >>> line.match(lambda x: any(_ for _ in x if str(_)[0] in "SM"))
+            >>> line.match(lambda x: any(_ for _ in x if _.string[0] in "SM"))
             True
 
         ..  container:: example
@@ -875,9 +842,10 @@ def double_tag(strings, tag_, deactivate=None):
     """
     Double tags ``strings``.
     """
+    assert isinstance(tag_, Tag), repr(tag_)
     before_tags = []
     if tag_:
-        line = str(tag_)
+        line = tag_.string
         lines = line.split(":")
         lines = ["%! " + _ for _ in lines]
         before_tags.extend(lines)

--- a/abjad/wf.py
+++ b/abjad/wf.py
@@ -816,7 +816,7 @@ def check_unterminated_hairpins(argument) -> tuple[list, int]:
     name_to_wrappers = _aggregate_context_wrappers(argument)
     for name, wrappers in name_to_wrappers.items():
         last_dynamic = None
-        last_tag = None
+        last_tag = _tag.Tag()
         wrappers.sort(key=lambda _: _.leaked_start_offset)
         for wrapper in wrappers:
             parameter = getattr(wrapper.indicator, "parameter", None)
@@ -827,9 +827,10 @@ def check_unterminated_hairpins(argument) -> tuple[list, int]:
                 last_tag = wrapper.tag
                 if isinstance(wrapper.indicator, _indicators.StartHairpin):
                     total += 1
-        if isinstance(last_dynamic, _indicators.StartHairpin) and str(
-            _tag.Tag("RIGHT_BROKEN")
-        ) not in str(last_tag):
+        if (
+            isinstance(last_dynamic, _indicators.StartHairpin)
+            and _tag.Tag("RIGHT_BROKEN").string not in last_tag.string
+        ):
             violators.append(wrapper.component)
     return violators, total
 

--- a/tests/test_Chord___str__.py
+++ b/tests/test_Chord___str__.py
@@ -1,8 +1,0 @@
-import abjad
-
-
-def test_Chord___str___01():
-
-    chord = abjad.Chord("<ef' cs'' f''>4")
-
-    assert str(chord) == "<ef' cs'' f''>4"

--- a/tests/test_NamedInterval.py
+++ b/tests/test_NamedInterval.py
@@ -1567,6 +1567,6 @@ def test_NamedInterval_01(pitch_a, pitch_b, name):
     pitch_a = abjad.NamedPitch(pitch_a)
     pitch_b = abjad.NamedPitch(pitch_b)
     interval = abjad.NamedInterval.from_pitch_carriers(pitch_a, pitch_b)
-    assert str(interval) == name
+    assert interval.name == name
     assert pitch_a.transpose(interval) == pitch_b
     assert pitch_b.transpose(-interval) == pitch_a

--- a/tests/test_Note___str__.py
+++ b/tests/test_Note___str__.py
@@ -1,8 +1,0 @@
-import abjad
-
-
-def test_Note___str___01():
-
-    note = abjad.Note("c'4")
-
-    assert str(note) == "c'4"

--- a/tests/test_Rest___str__.py
+++ b/tests/test_Rest___str__.py
@@ -1,8 +1,0 @@
-import abjad
-
-
-def test_Rest___str___01():
-
-    rest = abjad.Rest((1, 4))
-
-    assert str(rest) == "r4"

--- a/tests/test_Skip__str__.py
+++ b/tests/test_Skip__str__.py
@@ -1,8 +1,0 @@
-import abjad
-
-
-def test_Skip__str___01():
-
-    skip = abjad.Skip((1, 4))
-
-    assert str(skip) == "s4"


### PR DESCRIPTION
BREAKING CHANGE.

REMOVED:

    abjad.NamedInterval.__str__()
    abjad.NamedIntervalClass.__str__()
    abjad.NamedPitch.__str__()
    abjad.NamedPitchClass.__str__()
    abjad.NumberedInversionEquivalentIntervalClass.__str__()
    abjad.NumberedInterval.__str__()
    abjad.NumberedIntervalClass.__str__()
    abjad.NumberedPitch.__str__()
    abjad.NumberedPitchClass.__str__()
    abjad.Octave.__str__()

    abjad.Articulation.__str__()
    abjad.BendAfter.__str__()
    abjad.Fermata.__str__()
    abjad.LaissezVibrer.__str__()
    abjad.Markup.__str__()
    abjad.Meter.__str__()
    abjad.MetricModulation.__str__()
    abjad.MetronomeMark.__str__()
    abjad.Tag.__str__()
    abjad.TimeSignature.__str__()

    abjad.CyclicTuple.__str__()

    abjad.Chord.__str__()
    abjad.MultimeasureRest.__str__()
    abjad.Note.__str__()
    abjad.NoteHead.__str__()
    abjad.Rest.__str__()

The elevation of one attribute to the status of `__str__()` was always
arbitrary in Abjad. Note, too, that Python's `dataclass` decorator
equips classes with a `__repr__()` but not a `__str__()`.

Use a specific attribute on each object instead of `str()`. Or use `repr()`.

Closes #1434.