### PR TITLE
Bumped LilyPond to 2.23.6.

### DIFF
--- a/abjad/_stylesheets/abjad-coloring.ily
+++ b/abjad/_stylesheets/abjad-coloring.ily
@@ -3,16 +3,16 @@
 abjad-color-music = #(
     define-music-function (parser location color music) (symbol? ly:music?)
     #{
-    \once \override Accidental.color = #(x11-color #'color)
-    \once \override Beam.color = #(x11-color #'color)
-    \once \override Dots.color = #(x11-color #'color)
-    \once \override Flag.color = #(x11-color #'color)
-    \once \override MultiMeasureRest.color = #(x11-color #'color)
-    \once \override NoteHead.color = #(x11-color #'color)
-    \once \override RepeatTie.color = #(x11-color #'color)
-    \once \override Rest.color = #(x11-color #'color)
-    \once \override Stem.color = #(x11-color #'color)
-    \once \override StemTremolo.color = #(x11-color #'color)
+    \once \override Accidental.color = #(x11-color color)
+    \once \override Beam.color = #(x11-color color)
+    \once \override Dots.color = #(x11-color color)
+    \once \override Flag.color = #(x11-color color)
+    \once \override MultiMeasureRest.color = #(x11-color color)
+    \once \override NoteHead.color = #(x11-color color)
+    \once \override RepeatTie.color = #(x11-color color)
+    \once \override Rest.color = #(x11-color color)
+    \once \override Stem.color = #(x11-color color)
+    \once \override StemTremolo.color = #(x11-color color)
     $music
     #}
     )

--- a/abjad/_stylesheets/nalesnik-text-spanner-id.ily
+++ b/abjad/_stylesheets/nalesnik-text-spanner-id.ily
@@ -14,7 +14,7 @@
 %    \stopTextSpanTwo
 %    \stopTextSpanThre
 
-\version "2.19"
+\version "2.23.6"
 
 %% Incorporating some code from the rewrite in scheme of
 %% Text_spanner_engraver in input/regression/scheme-text-spanner.ly

--- a/abjad/_stylesheets/solomon-flared-hairpin.ily
+++ b/abjad/_stylesheets/solomon-flared-hairpin.ily
@@ -1,6 +1,6 @@
 % AUTHOR: MIKE SOLOMON
 
-\version "2.19"
+\version "2.23.6"
 
 %{
   'height of any piece of a broken hairpin is always the same.  It


### PR DESCRIPTION
LilyPond 2.23 introduces a few breaking changes.

One shows up in stylesheets:
```
OLD: \on-the-fly #print-page-number-check-first
NEW: \if \should-print-page-number
```
Another shows up in coloring quoting:
```
OLD:

    abjad-color-music = #(
        define-music-function (parser location color music) (symbol? ly:music?)
        #{
        \once \override Accidental.color = #(x11-color #'color)
        ...
        $music #})

NEW:

    abjad-color-music = #(
        define-music-function (parser location color music) (symbol? ly:music?)
        #{
        \once \override Accidental.color = #(x11-color color)
        ...
        $music #})
```
These differences change no functionality in Abjad. But we will use these differences to motivate the release of Abjad 3.8.

Abjad 3.8 will work with LilyPond 2.23 but function the same as Abjad 3.7.

Closes #1444.