### PR TITLE
Alphabetized tags in LilyPond output.

### DIFF
--- a/abjad/bind.py
+++ b/abjad/bind.py
@@ -172,8 +172,8 @@ class Wrapper:
             >>> print(string)
             \new Staff
             {
-                %! RED
                 %! M1
+                %! RED
                 \clef "alto"
                 c'4
                 d'4
@@ -190,8 +190,8 @@ class Wrapper:
             >>> print(string)
             \new Staff
             {
-                %! RED
                 %! M1
+                %! RED
                 \clef "alto"
                 c'4
                 d'4
@@ -218,8 +218,8 @@ class Wrapper:
             >>> print(string)
             \new Staff
             {
-                %! RED
                 %! M1
+                %! RED
                 %@% \clef "alto"
                 c'4
                 d'4
@@ -236,8 +236,8 @@ class Wrapper:
             >>> print(string)
             \new Staff
             {
-                %! RED
                 %! M1
+                %! RED
                 %@% \clef "alto"
                 c'4
                 d'4

--- a/abjad/indicators.py
+++ b/abjad/indicators.py
@@ -2164,8 +2164,8 @@ class Markup:
         \new Staff
         {
             c'4
-            %! RED
             %! M1
+            %! RED
             ^ \markup \italic Allegro
             d'4
             e'4
@@ -2190,8 +2190,8 @@ class Markup:
         \new Staff
         {
             c'4
-            %! RED
             %! M1
+            %! RED
             %@% ^ \markup \italic Allegro
             d'4
             e'4

--- a/abjad/spanners.py
+++ b/abjad/spanners.py
@@ -599,8 +599,8 @@ def glissando(
             %! abjad.glissando(7)
             \glissando
             f'8
-            %! abjad.glissando(7)
             %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(7)
             %@% \glissando
         }
 
@@ -625,39 +625,39 @@ def glissando(
             c'8
             %! abjad.glissando(7)
             \glissando
-            %! abjad.glissando(0)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(0)
             \hide NoteHead
-            %! abjad.glissando(0)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(0)
             \override Accidental.stencil = ##f
-            %! abjad.glissando(0)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(0)
             \override NoteColumn.glissando-skip = ##t
-            %! abjad.glissando(0)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(0)
             \override NoteHead.no-ledgers = ##t
             d'8
             e'8
-            %! abjad.glissando(4)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! abjad.glissando(4)
             \revert Accidental.stencil
-            %! abjad.glissando(4)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! abjad.glissando(4)
             \revert NoteColumn.glissando-skip
-            %! abjad.glissando(4)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! abjad.glissando(4)
             \revert NoteHead.no-ledgers
-            %! abjad.glissando(4)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! abjad.glissando(4)
             \undo \hide NoteHead
             f'8
         }
@@ -685,56 +685,56 @@ def glissando(
             c'8
             %! abjad.glissando(7)
             \glissando
-            %! abjad.glissando(0)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(0)
             \hide NoteHead
-            %! abjad.glissando(0)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(0)
             \override Accidental.stencil = ##f
-            %! abjad.glissando(0)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(0)
             \override NoteColumn.glissando-skip = ##t
-            %! abjad.glissando(0)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(0)
             \override NoteHead.no-ledgers = ##t
             d'8
             e'8
-            %! abjad.glissando(4)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! abjad.glissando(4)
             \revert Accidental.stencil
-            %! abjad.glissando(4)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! abjad.glissando(4)
             \revert NoteColumn.glissando-skip
-            %! abjad.glissando(4)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! abjad.glissando(4)
             \revert NoteHead.no-ledgers
-            %! abjad.glissando(4)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN
+            %! abjad.glissando(4)
             \undo \hide NoteHead
             f'8
-            %! abjad.glissando(5)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN_SHOW_NEXT
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(5)
             %@% \revert Accidental.stencil
-            %! abjad.glissando(5)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN_SHOW_NEXT
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(5)
             %@% \revert NoteColumn.glissando-skip
-            %! abjad.glissando(5)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN_SHOW_NEXT
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(5)
             %@% \revert NoteHead.no-ledgers
-            %! abjad.glissando(5)
-            %! SHOW_TO_JOIN_BROKEN_SPANNERS
             %! RIGHT_BROKEN_SHOW_NEXT
+            %! SHOW_TO_JOIN_BROKEN_SPANNERS
+            %! abjad.glissando(5)
             %@% \undo \hide NoteHead
         }
 
@@ -756,24 +756,24 @@ def glissando(
         >>> print(string)
         \new Staff
         {
-            %! abjad.glissando(2)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! LEFT_BROKEN
+            %! abjad.glissando(2)
             \hide NoteHead
-            %! abjad.glissando(2)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! LEFT_BROKEN
+            %! abjad.glissando(2)
             \override Accidental.stencil = ##f
-            %! abjad.glissando(2)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! LEFT_BROKEN
+            %! abjad.glissando(2)
             \override NoteHead.no-ledgers = ##t
             c'8
             %! abjad.glissando(7)
             \glissando
-            %! abjad.glissando(3)
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! LEFT_BROKEN
+            %! abjad.glissando(3)
             \override NoteColumn.glissando-skip = ##t
             d'8
             e'8

--- a/abjad/tag.py
+++ b/abjad/tag.py
@@ -722,22 +722,21 @@ def double_tag(strings: list[str], tag_: Tag, deactivate: bool = False) -> list[
     """
     assert all(isinstance(_, str) for _ in strings), repr(strings)
     assert isinstance(tag_, Tag), repr(tag_)
-    before_tags = []
+    tag_lines = []
     if tag_.string:
-        line = tag_.string
-        lines = line.split(":")
-        lines = ["%! " + _ for _ in lines]
-        before_tags.extend(lines)
-    right_tagged_lines = strings
+        tag_lines_ = tag_.string.split(":")
+        tag_lines_ = ["%! " + _ for _ in tag_lines_]
+        tag_lines.extend(tag_lines_)
+        tag_lines.sort()
     if deactivate is True:
-        right_tagged_lines = ["%@% " + _ for _ in right_tagged_lines]
+        strings = ["%@% " + _ for _ in strings]
     result = []
-    for right_tagged_line in right_tagged_lines:
-        if right_tagged_line.strip().startswith("%!"):
-            result.append(right_tagged_line)
+    for string in strings:
+        if string.strip().startswith("%!"):
+            result.append(string)
             continue
-        result.extend(before_tags)
-        result.append(right_tagged_line)
+        result.extend(tag_lines)
+        result.append(string)
     return result
 
 


### PR DESCRIPTION
Test input:
```
staff = abjad.Staff("c'4 d' e' f'")
markup = abjad.Markup(r"\markup Allegro")
tag = abjad.Tag("RED:BLUE:GREEN")
abjad.attach(markup, staff[0], tag=tag)
string = abjad.lilypond(staff, tags=True)
```

OLD. Tags preserve order of contents:
```
>>> print(string)
\new Staff
{
    c'4
    %! RED
    %! GREEN
    %! BLUE
    - \markup Allegro
    d'4
    e'4
    f'4
}
```

NEW. Tags alphabetize order of contents:
```
>>> print(string)
\new Staff
{
    c'4
    %! BLUE
    %! GREEN
    %! RED
    - \markup Allegro
    d'4
    e'4
    f'4
}
```
Alphabetized output helps standardize LilyPond output and make it possible to check LilyPond output visually.