### PR TITLE
Alphabetized all format contributions (by format site).

### DIFF
--- a/abjad/bind.py
+++ b/abjad/bind.py
@@ -810,11 +810,11 @@ def attach(  # noqa: 302
             >>> print(string)
             \new Staff
             {
-                \clef "treble"
                 %! +PARTS
                 %@% \clef "alto"
                 %! +PARTS
                 %@% \clef "tenor"
+                \clef "treble"
                 c'4
                 d'4
                 e'4

--- a/abjad/contributions.py
+++ b/abjad/contributions.py
@@ -1,6 +1,45 @@
 import dataclasses
+import enum
 
 from . import tag as _tag
+
+
+class Sites(enum.Enum):
+    """
+    Contribution sites.
+    """
+
+    ABSOLUTE_BEFORE = enum.auto()
+    BEFORE = enum.auto()
+    OPEN_BRACKETS = enum.auto()
+    OPENING = enum.auto()
+    CONTENTS = enum.auto()
+    CLOSING = enum.auto()
+    CLOSE_BRACKETS = enum.auto()
+    AFTER = enum.auto()
+    ABSOLUTE_AFTER = enum.auto()
+
+
+class Types(enum.Enum):
+    """
+    Contribution types.
+    """
+
+    ARTICULATIONS = enum.auto()
+    COMMANDS = enum.auto()
+    CONTEXT_SETTINGS = enum.auto()
+    GROB_OVERRIDES = enum.auto()
+    GROB_REVERTS = enum.auto()
+    LEAK = enum.auto()
+    LEAKS = enum.auto()
+    MARKUP = enum.auto()
+    PITCHED_TRILL = enum.auto()
+    SPANNER_STARTS = enum.auto()
+    SPANNER_STOPS = enum.auto()
+    START_BEAM = enum.auto()
+    STEM_TREMOLOS = enum.auto()
+    STOP_BEAM = enum.auto()
+    TRILL_SPANNER_STARTS = enum.auto()
 
 
 @dataclasses.dataclass(slots=True)
@@ -57,21 +96,33 @@ class _ContributionsByType:
 
     def update(self, contributions):
         """
-        Updates contributions.
+        Updates contributions with ``contributions``.
         """
         assert isinstance(contributions, type(self))
-        self.articulations.extend(contributions.articulations)
-        self.commands.extend(contributions.commands)
-        self.leak.extend(contributions.leak)
-        self.leaks.extend(contributions.leaks)
-        self.markup.extend(contributions.markup)
-        self.pitched_trill.extend(contributions.pitched_trill)
-        self.spanner_starts.extend(contributions.spanner_starts)
-        self.spanner_stops.extend(contributions.spanner_stops)
-        self.start_beam.extend(contributions.start_beam)
-        self.stem_tremolos.extend(contributions.stem_tremolos)
-        self.stop_beam.extend(contributions.stop_beam)
-        self.trill_spanner_starts.extend(contributions.trill_spanner_starts)
+        if contributions.articulations:
+            self.articulations.append(contributions.articulations)
+        if contributions.commands:
+            self.commands.append(contributions.commands)
+        if contributions.leak:
+            self.leak.append(contributions.leak)
+        if contributions.leaks:
+            self.leaks.append(contributions.leaks)
+        if contributions.markup:
+            self.markup.append(contributions.markup)
+        if contributions.pitched_trill:
+            self.pitched_trill.append(contributions.pitched_trill)
+        if contributions.spanner_starts:
+            self.spanner_starts.append(contributions.spanner_starts)
+        if contributions.spanner_stops:
+            self.spanner_stops.append(contributions.spanner_stops)
+        if contributions.start_beam:
+            self.start_beam.append(contributions.start_beam)
+        if contributions.stem_tremolos:
+            self.stem_tremolos.append(contributions.stem_tremolos)
+        if contributions.stop_beam:
+            self.stop_beam.append(contributions.stop_beam)
+        if contributions.trill_spanner_starts:
+            self.trill_spanner_starts.append(contributions.trill_spanner_starts)
 
 
 @dataclasses.dataclass(slots=True)
@@ -116,6 +167,24 @@ class ContributionsBySite:
         ):
             yield site
 
+    @staticmethod
+    def alphabetize(lists):
+        assert isinstance(lists, list)
+        for item in lists:
+            assert isinstance(item, list), repr(item)
+
+        def key(list_):
+            list_ = [_ for _ in list_ if not _.lstrip().startswith("%! ")]
+            list_ = [_.removeprefix("%@% ") for _ in list_]
+            return list_
+
+        lists_ = lists[:]
+        lists_.sort(key=key)
+        strings = []
+        for list_ in lists_:
+            strings.extend(list_)
+        return strings
+
     # TODO: rename or remove?
     def freeze_overrides(self):
         """
@@ -149,7 +218,7 @@ class ContributionsBySite:
 
     def update(self, contributions):
         """
-        Updates format contributions with contributions in ``contributions``.
+        Updates contributions with ``contributions``.
         """
         assert isinstance(contributions, type(self)), repr(contributions)
         self.absolute_before.update(contributions.absolute_before)

--- a/abjad/ext/sphinx.py
+++ b/abjad/ext/sphinx.py
@@ -23,6 +23,7 @@ from sphinx.util.osutil import copyfile, ensuredir
 from uqbar.book.extensions import Extension
 from uqbar.strings import normalize
 
+from .. import format as _format
 from .. import lilypondfile as _lilypondfile
 from .. import tag as _tag
 from ..configuration import Configuration
@@ -264,6 +265,7 @@ class LilyPondExtension(Extension):
             illustration["score"].items.append(block)
         illustration.lilypond_version_token = r'\version "2.19.83"'
         code = illustration._get_lilypond_format()
+        code = _format.remove_site_comments(code)
         code = _tag.remove_tags(code)
         node = self.lilypond_block(code, code)
         node["kind"] = self.kind.name.lower()

--- a/abjad/illustrators.py
+++ b/abjad/illustrators.py
@@ -4,6 +4,7 @@ import dataclasses
 from . import bind as _bind
 from . import duration as _duration
 from . import enums as _enums
+from . import format as _format
 from . import get as _get
 from . import indicators as _indicators
 from . import iterate as _iterate
@@ -249,16 +250,17 @@ def illustrate(item, **keywords):
     return method(item, **keywords)
 
 
-def lilypond(argument, tags=False):
+def lilypond(argument, *, site_comments=False, tags=False):
     """
     Gets LilyPond format of ``argument``.
     """
     if not hasattr(argument, "_get_lilypond_format"):
         raise Exception(f"no LilyPond format defined for {argument!r}.")
     string = argument._get_lilypond_format()
-    if tags:
-        return string
-    string = _tag.remove_tags(string)
+    if site_comments is False:
+        string = _format.remove_site_comments(string)
+    if tags is False:
+        string = _tag.remove_tags(string)
     return string
 
 

--- a/abjad/indicators.py
+++ b/abjad/indicators.py
@@ -2216,8 +2216,8 @@ class Markup:
             \new Staff
             {
                 c'4
-                ^ \markup \italic Allegro
                 ^ \markup \italic "non troppo"
+                ^ \markup \italic Allegro
                 d'4
                 e'4
                 f'4

--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -1394,8 +1394,8 @@ def replace(argument, recipients, wrappers=False):
                 {
                     c'4
                     \p
-                    \<
                     (
+                    \<
                     d'4
                     e'4
                 }
@@ -2331,8 +2331,8 @@ def swap(argument, container):
                     \time 3/4
                     c'4
                     \p
-                    \<
                     (
+                    \<
                     d'4
                     e'4
                 }
@@ -2362,8 +2362,8 @@ def swap(argument, container):
                     \time 3/4
                     c'4
                     \p
-                    \<
                     (
+                    \<
                     d'4
                     e'4
                     d'4

--- a/abjad/parsers/parser.py
+++ b/abjad/parsers/parser.py
@@ -2447,8 +2447,8 @@ class LilyPondParser(Parser):
             {
                 c'8
                 \f
-                \>
                 (
+                \>
                 d'8
                 - \portato
                 [
@@ -2466,8 +2466,8 @@ class LilyPondParser(Parser):
                 \stopTrillSpan
                 ]
                 c''8
-                \sfz
                 - \accent
+                \sfz
                 )
             }
 

--- a/abjad/select.py
+++ b/abjad/select.py
@@ -933,8 +933,8 @@ def flatten(argument, depth: int = 1) -> list:
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 10/9
                     {
-                        \time 7/4
                         \abjad-color-music #'red
+                        \time 7/4
                         r16
                         \abjad-color-music #'red
                         bf'16
@@ -1023,8 +1023,8 @@ def flatten(argument, depth: int = 1) -> list:
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 10/9
                     {
-                        \time 7/4
                         \abjad-color-music #'red
+                        \time 7/4
                         r16
                         \abjad-color-music #'blue
                         bf'16
@@ -1863,8 +1863,8 @@ def group_by_measure(argument) -> list[list]:
                 autoBeaming = ##f
             }
             {
-                \time 2/8
                 \abjad-color-music #'red
+                \time 2/8
                 c'8
                 \abjad-color-music #'red
                 d'8
@@ -1872,15 +1872,15 @@ def group_by_measure(argument) -> list[list]:
                 e'8
                 \abjad-color-music #'blue
                 f'8
-                \time 3/8
                 \abjad-color-music #'red
+                \time 3/8
                 g'8
                 \abjad-color-music #'red
                 a'8
                 \abjad-color-music #'red
                 b'8
-                \time 1/8
                 \abjad-color-music #'blue
+                \time 1/8
                 c''8
             }
 
@@ -1918,8 +1918,8 @@ def group_by_measure(argument) -> list[list]:
                 autoBeaming = ##f
             }
             {
-                \time 2/8
                 \abjad-color-music #'red
+                \time 2/8
                 c'8
                 \abjad-color-music #'red
                 d'8
@@ -1927,15 +1927,15 @@ def group_by_measure(argument) -> list[list]:
                 e'8
                 \abjad-color-music #'red
                 f'8
-                \time 3/8
                 \abjad-color-music #'blue
+                \time 3/8
                 g'8
                 \abjad-color-music #'blue
                 a'8
                 \abjad-color-music #'blue
                 b'8
-                \time 1/8
                 \abjad-color-music #'blue
+                \time 1/8
                 c''8
             }
 
@@ -1973,20 +1973,20 @@ def group_by_measure(argument) -> list[list]:
                 autoBeaming = ##f
             }
             {
-                \time 2/8
                 \abjad-color-music #'red
+                \time 2/8
                 c'8
                 d'8
                 \abjad-color-music #'blue
                 e'8
                 f'8
-                \time 3/8
                 \abjad-color-music #'red
+                \time 3/8
                 g'8
                 a'8
                 b'8
-                \time 1/8
                 \abjad-color-music #'blue
+                \time 1/8
                 c''8
             }
 
@@ -2037,8 +2037,8 @@ def group_by_measure(argument) -> list[list]:
                 a'8
                 \abjad-color-music #'red
                 b'8
-                \time 1/8
                 \abjad-color-music #'blue
+                \time 1/8
                 c''8
             }
 
@@ -2125,8 +2125,8 @@ def group_by_measure(argument) -> list[list]:
                 autoBeaming = ##f
             }
             {
-                \time 2/8
                 \abjad-color-music #'red
+                \time 2/8
                 c'8
                 \abjad-color-music #'red
                 d'8
@@ -2136,16 +2136,16 @@ def group_by_measure(argument) -> list[list]:
                 \abjad-color-music #'blue
                 e'8
                 ~
-                \time 3/8
                 \abjad-color-music #'blue
+                \time 3/8
                 e'8
                 \abjad-color-music #'red
                 f'8
                 \abjad-color-music #'red
                 g'8
                 ~
-                \time 1/8
                 \abjad-color-music #'red
+                \time 1/8
                 g'8
             }
 
@@ -4620,29 +4620,29 @@ def partition_by_durations(
             }
             {
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     c'8
                     \abjad-color-music #'red
                     d'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     e'8
                     \abjad-color-music #'blue
                     f'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'blue
+                    \time 2/8
                     g'8
                     \abjad-color-music #'blue
                     a'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     b'8
                     \abjad-color-music #'red
                     c''8
@@ -4694,15 +4694,15 @@ def partition_by_durations(
             }
             {
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     c'8
                     \abjad-color-music #'red
                     d'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     e'8
                     f'8
                 }
@@ -4768,29 +4768,29 @@ def partition_by_durations(
             }
             {
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     c'8
                     \abjad-color-music #'red
                     d'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'blue
+                    \time 2/8
                     e'8
                     \abjad-color-music #'red
                     f'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     g'8
                     \abjad-color-music #'blue
                     a'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     b'8
                     \abjad-color-music #'red
                     c''8
@@ -4849,29 +4849,29 @@ def partition_by_durations(
             }
             {
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     c'8
                     \abjad-color-music #'blue
                     d'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     e'8
                     \abjad-color-music #'blue
                     f'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     g'8
                     \abjad-color-music #'blue
                     a'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     b'8
                     c''8
                 }
@@ -4923,8 +4923,8 @@ def partition_by_durations(
             }
             {
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     c'8
                     d'8
                 }
@@ -4996,22 +4996,22 @@ def partition_by_durations(
             {
                 {
                     \tempo 4=60
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     c'8
                     \abjad-color-music #'red
                     d'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     e'8
                     \abjad-color-music #'blue
                     f'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'blue
+                    \time 2/8
                     g'8
                     \abjad-color-music #'blue
                     a'8
@@ -5075,29 +5075,29 @@ def partition_by_durations(
             {
                 {
                     \tempo 4=60
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     c'8
                     \abjad-color-music #'red
                     d'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     e'8
                     \abjad-color-music #'blue
                     f'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'blue
+                    \time 2/8
                     g'8
                     \abjad-color-music #'blue
                     a'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     b'8
                     \abjad-color-music #'red
                     c''8
@@ -5154,15 +5154,15 @@ def partition_by_durations(
             {
                 {
                     \tempo 4=60
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     c'8
                     \abjad-color-music #'red
                     d'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     e'8
                     f'8
                 }
@@ -5234,29 +5234,29 @@ def partition_by_durations(
             {
                 {
                     \tempo 4=60
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     c'8
                     \abjad-color-music #'blue
                     d'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     e'8
                     \abjad-color-music #'blue
                     f'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     g'8
                     \abjad-color-music #'blue
                     a'8
                 }
                 {
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     b'8
                     c''8
                 }
@@ -5312,8 +5312,8 @@ def partition_by_durations(
             {
                 {
                     \tempo 4=60
-                    \time 2/8
                     \abjad-color-music #'red
+                    \time 2/8
                     c'8
                     d'8
                 }
@@ -5682,8 +5682,8 @@ def rests(
                     \tweak text #tuplet-number::calc-fraction-text
                     \times 10/9
                     {
-                        \time 7/4
                         \abjad-color-music #'red
+                        \time 7/4
                         r16
                         bf'16
                         <a'' b''>16
@@ -5971,9 +5971,9 @@ def runs(
                         \context Voice = "On_Beat_Grace_Container"
                         {
                             \set fontSize = #-3
+                            \abjad-color-music #'blue
                             \slash
                             \voiceOne
-                            \abjad-color-music #'blue
                             <
                                 \tweak font-size 0
                                 \tweak transparent ##t
@@ -5994,8 +5994,8 @@ def runs(
                         }
                         \context Voice = "Music_Voice"
                         {
-                            \voiceTwo
                             \abjad-color-music #'blue
+                            \voiceTwo
                             e'4
                             r8
                         }
@@ -6221,14 +6221,14 @@ def tuplets(
                     c'2
                     \times 2/3
                     {
-                        \abjad-color-music #'red
                         \abjad-color-music #'blue
+                        \abjad-color-music #'red
                         d'8
-                        \abjad-color-music #'red
                         \abjad-color-music #'blue
+                        \abjad-color-music #'red
                         e'8
-                        \abjad-color-music #'red
                         \abjad-color-music #'blue
+                        \abjad-color-music #'red
                         f'8
                     }
                 }
@@ -6600,9 +6600,9 @@ def with_next_leaf(argument, *, grace: bool = None) -> list[_score.Leaf]:
                         \context Voice = "On_Beat_Grace_Container"
                         {
                             \set fontSize = #-3
+                            \abjad-color-music #'blue
                             \slash
                             \voiceOne
-                            \abjad-color-music #'blue
                             <
                                 \tweak font-size 0
                                 \tweak transparent ##t
@@ -6623,8 +6623,8 @@ def with_next_leaf(argument, *, grace: bool = None) -> list[_score.Leaf]:
                         }
                         \context Voice = "Music_Voice"
                         {
-                            \voiceTwo
                             \abjad-color-music #'blue
+                            \voiceTwo
                             e'4
                         }
                     >>
@@ -6812,9 +6812,9 @@ def with_previous_leaf(argument) -> list[_score.Leaf]:
                         \context Voice = "On_Beat_Grace_Container"
                         {
                             \set fontSize = #-3
+                            \abjad-color-music #'blue
                             \slash
                             \voiceOne
-                            \abjad-color-music #'blue
                             <
                                 \tweak font-size 0
                                 \tweak transparent ##t

--- a/tests/test_LilyPondParser__spanners__Hairpin.py
+++ b/tests/test_LilyPondParser__spanners__Hairpin.py
@@ -141,8 +141,8 @@ def test_LilyPondParser__spanners__Hairpin_07():
         {
             c'4
             \p
-            \<
             (
+            \<
             d'4
             e'4
             f'4

--- a/tests/test_mutate__fuse_leaves_by_immediate_parent.py
+++ b/tests/test_mutate__fuse_leaves_by_immediate_parent.py
@@ -239,8 +239,8 @@ def test_mutate__fuse_leaves_by_immediate_parent_08():
             \clef "alto"
             \time 3/4
             c'4
-            - \staccato
             - \accent
+            - \staccato
             ~
             c'16
             r16
@@ -291,8 +291,8 @@ def test_mutate__fuse_leaves_by_immediate_parent_09():
                 b'16
             }
             c'8
-            - \staccato
             - \accent
+            - \staccato
             ~
             c'32
             ]
@@ -339,8 +339,8 @@ def test_mutate__fuse_leaves_by_immediate_parent_10():
             \time 3/4
             c'4
             :16
-            - \staccato
             - \accent
+            - \staccato
             ~
             c'16
             :16


### PR DESCRIPTION
The lexical order of commands in LilyPond output no longer depends on
the (dynamic) order in which indicators are attached to leaves.

Alphabetized tags, and offset tags two spaces to the right in LilyPond
output.

Added abjad.lilypond(..., site_comments=False) keyword. Set to true to
debug the names and contents of every format site.

Closes #1450.