### PR TITLE
Cleaned up abjad.Octave initializer.

### DIFF
--- a/abjad/string.py
+++ b/abjad/string.py
@@ -151,69 +151,92 @@ def is_lilypond_identifier(string: str) -> bool:
 
     ..  container:: example
 
-        >>> abjad.string.is_lilypond_identifier('ViolinOne')
+        >>> abjad.string.is_lilypond_identifier("ViolinOne")
         True
 
-        >>> abjad.string.is_lilypond_identifier('Violin_One')
+        >>> abjad.string.is_lilypond_identifier("Violin_One")
         True
 
-        >>> abjad.string.is_lilypond_identifier('Violin One')
+        >>> abjad.string.is_lilypond_identifier("Violin One")
         False
 
     ..  container:: example
 
-        >>> abjad.string.is_lilypond_identifier('ViolinI')
+        >>> abjad.string.is_lilypond_identifier("ViolinI")
         True
 
-        >>> abjad.string.is_lilypond_identifier('Violin_I')
+        >>> abjad.string.is_lilypond_identifier("Violin_I")
         True
 
-        >>> abjad.string.is_lilypond_identifier('Violin I')
+        >>> abjad.string.is_lilypond_identifier("Violin I")
         False
 
     ..  container:: example
 
-        >>> abjad.string.is_lilypond_identifier('Violin1')
+        >>> abjad.string.is_lilypond_identifier("Violin1")
         False
 
-        >>> abjad.string.is_lilypond_identifier('Violin_1')
+        >>> abjad.string.is_lilypond_identifier("Violin_1")
         False
 
-        >>> abjad.string.is_lilypond_identifier('Violin 1')
+        >>> abjad.string.is_lilypond_identifier("Violin 1")
         False
 
     ..  container:: example
 
-        >>> abjad.string.is_lilypond_identifier('Violin.1')
+        >>> abjad.string.is_lilypond_identifier("Violin.1")
         True
 
-        >>> abjad.string.is_lilypond_identifier('Violin.1.1')
-        True
-
-        >>> abjad.string.is_lilypond_identifier('Violin.1_1')
+        >>> abjad.string.is_lilypond_identifier("Violin.1.1")
         False
 
-        >>> abjad.string.is_lilypond_identifier('Violin_1.1')
+        >>> abjad.string.is_lilypond_identifier("Violin.1_1")
+        False
+
+        >>> abjad.string.is_lilypond_identifier("Violin_1.1")
+        False
+
+    ..  container:: example
+
+        >>> abjad.string.is_lilypond_identifier("Violin.1.Music_Voice.1")
+        True
+
+        >>> abjad.string.is_lilypond_identifier("Violin.1.1.Music_Voice")
+        False
+
+        >>> abjad.string.is_lilypond_identifier("Violin.1_Music_Voice")
+        False
+
+        >>> abjad.string.is_lilypond_identifier("Violin.Music_Voice_1")
+        False
+
+        >>> abjad.string.is_lilypond_identifier("Violin.1_Music_Voice")
         False
 
     """
-    if string and string[0] == "_":
+    if not string:
         return False
-    if string and string[0] == ".":
+    if string[0] in "_.":
         return False
-    if "_" in string:
-        for character in string:
-            if not (character.isalpha() or character == "_"):
-                return False
-        return True
-    if "." in string:
-        for character in string:
-            if not (character.isalnum() or character == "."):
-                return False
-        return True
+    if string[0].isdigit():
+        return False
     for character in string:
-        if not character.isalpha():
+        if not (character.isalnum() or character == "_" or character == "."):
             return False
+    words = string.split(".")
+    if words[0].isdigit():
+        return False
+    previous_word_ends_in_digit = False
+    for word in words:
+        if previous_word_ends_in_digit and word[0].isdigit():
+            return False
+        if any(_.isdigit() for _ in word):
+            if any(not _.isdigit() for _ in word):
+                return False
+        if word[-1].isdigit():
+            previous_word_ends_in_digit = True
+        else:
+            previous_word_ends_in_digit = False
     return True
 
 

--- a/tests/test_Octave.py
+++ b/tests/test_Octave.py
@@ -3,24 +3,6 @@ import pytest
 import abjad
 
 values = [
-    ("'", 4),
-    ("''", 5),
-    ("'''", 6),
-    ("''''", 7),
-    ("", 3),
-    (",", 2),
-    (",,", 1),
-    (",,,", 0),
-    ("-0", 0),
-    ("-1", -1),
-    ("-2", -2),
-    ("-3", -3),
-    ("-4", -4),
-    ("0", 0),
-    ("1", 1),
-    ("2", 2),
-    ("3", 3),
-    ("4", 4),
     (-1, -1),
     (-2, -2),
     (-3, -3),
@@ -43,6 +25,28 @@ def test_init(input_, expected_number):
             abjad.Octave(input_)
         return
     octave = abjad.Octave(input_)
+    assert octave.number == expected_number
+
+
+values = [
+    ("'", 4),
+    ("''", 5),
+    ("'''", 6),
+    ("''''", 7),
+    ("", 3),
+    (",", 2),
+    (",,", 1),
+    (",,,", 0),
+]
+
+
+@pytest.mark.parametrize("input_, expected_number", values)
+def test_from_ticks(input_, expected_number):
+    if isinstance(expected_number, type) and issubclass(expected_number, Exception):
+        with pytest.raises(expected_number):
+            abjad.Octave.from_ticks(input_)
+        return
+    octave = abjad.Octave.from_ticks(input_)
     assert octave.number == expected_number
 
 


### PR DESCRIPTION
OLD. Octave objects are usually initialized by octave number. But the
abjad.Octave initialzer allowed for undocumented initialization by tick
string:

    >>> abjad.Octave("'")
    Octave(number=4)

NEW. Use the new abjad.Octave.from_ticks() constructor instead:

    abjad.Octave.from_ticks("'")
    Octave(number=4)

Also Cleaned up abjad.string.is_lilypond_identifier(). Taught
abjad.string.is_lilypond_identifier() to return true on strings (like
"Violin.1.Music_Voice.1") that contain mixed periods and underscores.