### PR TITLE
Cleaned up instrument classes.

### DIFF
--- a/abjad/get.py
+++ b/abjad/get.py
@@ -138,7 +138,7 @@ def annotation(
 
         >>> string = 'default_instrument'
         >>> abjad.get.annotation(staff[0], string)
-        Cello()
+        Cello(clefs=('bass', 'tenor', 'treble'), context='Staff', middle_c_sounding_pitch=NamedPitch("c'"), pitch_range=PitchRange(range_string='[C2, G5]'), tuning=Tuning(pitches=(NamedPitch('c,'), NamedPitch('g,'), NamedPitch('d'), NamedPitch('a'))))
 
         >>> abjad.get.annotation(staff[1], string) is None
         True
@@ -152,7 +152,7 @@ def annotation(
         Returns default when no annotation is found:
 
         >>> abjad.get.annotation(staff[3], string, abjad.Violin())
-        Violin()
+        Violin(clefs=('treble',), context='Staff', middle_c_sounding_pitch=NamedPitch("c'"), pitch_range=PitchRange(range_string='[G3, G7]'), tuning=Tuning(pitches=(NamedPitch('g'), NamedPitch("d'"), NamedPitch("a'"), NamedPitch("e''"))))
 
     ..  container:: example
 
@@ -199,7 +199,7 @@ def annotation_wrappers(argument):
             }
 
         >>> for wrapper in abjad.get.annotation_wrappers(staff[0]): wrapper
-        Wrapper(annotation='default_instrument', context=None, deactivate=False, direction=None, indicator=Cello(), synthetic_offset=None, tag=Tag(string=''))
+        Wrapper(annotation='default_instrument', context=None, deactivate=False, direction=None, indicator=Cello(clefs=('bass', 'tenor', 'treble'), context='Staff', middle_c_sounding_pitch=NamedPitch("c'"), pitch_range=PitchRange(range_string='[C2, G5]'), tuning=Tuning(pitches=(NamedPitch('c,'), NamedPitch('g,'), NamedPitch('d'), NamedPitch('a')))), synthetic_offset=None, tag=Tag(string=''))
         Wrapper(annotation='default_clef', context=None, deactivate=False, direction=None, indicator=Clef(name='tenor', hide=False), synthetic_offset=None, tag=Tag(string=''))
 
     """

--- a/abjad/wf.py
+++ b/abjad/wf.py
@@ -315,14 +315,14 @@ def check_notes_on_wrong_clef(argument) -> tuple[list, int]:
         effective_clef = _getlib._get_effective(leaf, _indicators.Clef)
         if effective_clef is None:
             continue
-        allowable_clefs = []
-        for clef in instrument.allowable_clefs:
+        clefs = []
+        for clef in instrument.clefs:
             if isinstance(clef, str):
                 clef = _indicators.Clef(clef)
             assert isinstance(clef, _indicators.Clef), repr(clef)
-            allowable_clefs.append(clef)
-        allowable_clefs.append(_indicators.Clef("percussion"))
-        if effective_clef not in allowable_clefs:
+            clefs.append(clef)
+        clefs.append(_indicators.Clef("percussion"))
+        if effective_clef not in clefs:
             violators.append(leaf)
     return violators, len(total)
 

--- a/docs/source/_mothballed/instruments.rst
+++ b/docs/source/_mothballed/instruments.rst
@@ -62,36 +62,6 @@ Use ``abjad.detach()`` to detach an instrument from a component:
     >>> abjad.detach(violin, staff[0])
     >>> abjad.show(staff)
 
-Getting the name of an instrument
----------------------------------
-
-Use ``name`` to get the name of any instrument:
-
-::
-
-    >>> violin.name
-
-Use ``markup`` to get the instrument name markup of any instrument:
-
-::
-
-    >>> violin.markup
-
-Getting the short name of an instrument
----------------------------------------
-
-Use ``short_name`` to get the short name of any instrument:
-
-::
-
-    >>> violin.short_name
-
-Use ``short_markup`` to get the short instrument name markup of any instrument:
-
-::
-
-    >>> violin.short_markup
-
 Getting an instrument's range
 -----------------------------
 
@@ -137,16 +107,14 @@ You can change the properties of any instrument at initialization:
 ::
 
     >>> viola = abjad.Viola(
-    ...     name='Bratsche',
-    ...     short_name='Br.',
-    ...     allowable_clefs=['alto', 'treble'],
-    ...     pitch_range='[C3, C6]',
+    ...     allowable_clefs=("alto", "treble"),
+    ...     pitch_range=abjad.PitchRange("[C3, C6]"),
     ... )
 
 ::
 
     >>> staff = abjad.Staff("c'4 d'4 e'4 fs'4")
     >>> abjad.attach(viola, staff[0])
-    >>> clef = abjad.Clef('alto')
+    >>> clef = abjad.Clef("alto")
     >>> abjad.attach(clef, staff[0])
     >>> abjad.show(staff)

--- a/tests/test_class_design.py
+++ b/tests/test_class_design.py
@@ -22,7 +22,6 @@ class_to_default_values = {
     abjad.Markup: (r"\markup Allegro",),
     abjad.MetricModulation: (abjad.Note("c'4"), abjad.Note("c'4.")),
     abjad.MetronomeMark: ((1, 4), 90),
-    abjad.StringNumber: ([1],),
     abjad.TimeSignature: ((4, 4),),
     abjad.Tweak: (r"\tweak color #red",),
 }


### PR DESCRIPTION
Reimplemented instruments as frozen data classes.

REMOVED:

    * abjad.Instrument.markup
    * abjad.Instrument.name
    * abjad.Instrument.short_markup
    * abjad.Instrument.short_name

CHANGED:

    OLD: abjad.Instrument.allowable_clefs=("treble", "bass")
    NEW: abjad.Instrument.clefs==("treble", "bass")

Closes #1460 