### PR TITLE
Move development-only dependencies in setup.py from `install_requires` to `extras_require[dev]`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         echo $PATH
     - name: Install Abjad
       run: |
-        pip install -e .
+        pip install -e .[dev]
         # echo the configuration file path to debug read-only-filesystem handling
         python -c "import abjad; print(abjad.Configuration().configuration_file_path)"
         scr/prime-parser-tables

--- a/docs/source/appendices/developer-installation.rst
+++ b/docs/source/appendices/developer-installation.rst
@@ -25,7 +25,7 @@ install the clone in "editable" mode:
 
     ~$ git clone https://github.com/Abjad/abjad.git
     ~$ cd abjad
-    abjad$ python -m pip install --editable .
+    abjad$ python -m pip install --editable .[dev]
 
 "Cloned" installation of Abjad is necessary for users who want to develop Abjad. Cloned
 installation is also required for users who want to build Abjad's docs locally.

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,17 @@ classifiers = [
 extras_require = {
     "nauert": ["abjad-ext-nauert>=3.13"],
     "rmakers": ["abjad-ext-rmakers>=3.13"],
+    "dev": [
+        "black>=22.8.0",
+        "flake8>=5.0.4",
+        "isort>=5.10.1",
+        "mypy>=0.971",
+        "pytest>=7.1.3",
+        "pytest-cov>=3.0.0",
+        "pytest-helpers-namespace>=2021.12.29",
+        "sphinx-autodoc-typehints>=1.19.2",
+        "sphinx-rtd-theme>=1.0.0",
+    ],
 }
 
 keywords = [
@@ -71,18 +82,9 @@ keywords = [
 ]
 
 install_requires = [
-    "black>=22.8.0",
-    "flake8>=5.0.4",
-    "isort>=5.10.1",
-    "mypy>=0.971",
     "ply>=3.11",
-    "pytest>=7.1.3",
-    "pytest-cov>=3.0.0",
-    "pytest-helpers-namespace>=2021.12.29",
     "quicktions>=1.13",
     "roman>=1.4",
-    "sphinx-autodoc-typehints>=1.19.2",
-    "sphinx-rtd-theme>=1.0.0",
     "uqbar>=0.6.3",
 ]
 


### PR DESCRIPTION
Closes #1483.

I've installed abjad in a fresh, empty venv, and importing works. Then manually installing `pytest` makes all tests run. So I assume I have split up the dependencies correctly.

I've also looked for `install -e` and `--editable`, so I hope I have found all the places in the documentation that need to have `[dev]` added, but please do double check, as I do not know the library well.