### PR TITLE
Add doctest example for CyclicTyple contains magic method.

### DIFF
--- a/abjad/cyclictuple.py
+++ b/abjad/cyclictuple.py
@@ -44,6 +44,13 @@ class CyclicTuple:
     def __contains__(self, item) -> bool:
         """
         Is true when cyclic tuple contains ``item``.
+
+        ..  container:: example
+
+            >>> tuple_ = abjad.CyclicTuple('abcd')
+            >>> 'a' in tuple_
+            True
+
         """
         return self.items.__contains__(item)
 


### PR DESCRIPTION
@trevorbaca this closes #1468 