### PR TITLE
WIP: C flat does not work properly in relative mode

### DIFF
--- a/abjad/parsers/parser.py
+++ b/abjad/parsers/parser.py
@@ -533,7 +533,10 @@ class GuileProxy:
             _bind.attach(annotation, music)
 
     def _to_relative_octave(self, pitch, reference):
-        if pitch.pitch_class.number > reference.pitch_class.number:
+        if (
+            pitch.pitch_class.number > reference.pitch_class.number
+            and reference.pitch_class.number not in [9]
+        ):
             pair = (pitch.pitch_class.name, reference.octave.number)
             up_pitch = _pitch.NamedPitch(pair)
             pair = (pitch.pitch_class.name, reference.octave.number - 1)


### PR DESCRIPTION
Closes #1471 

This is my hacky attempt for now to get that particular input to do the right thing but I haven't tested against all possible inputs to see if I've introduced a bug now somewhere else.

My thinking at the moment is to not go into the first `if` branch when `pitch.pitch_class.number > reference.pitch_class.number` **and** the `reference.pitch_class.number` is in the following list `[9]`. I realize this might only fix one edge case and introduce others...

@trevorbaca 

Were you thinking of a different conceptual logic to fix this?

Feel free to work on this if you'd like to fix the bug sooner as I might not be able to try again until next weekend.