### PR TITLE
Replaced quicktions with built-in fractions.

### DIFF
--- a/abjad/__init__.py
+++ b/abjad/__init__.py
@@ -1,4 +1,4 @@
-from quicktions import Fraction
+from fractions import Fraction
 
 from . import (
     _updatelib,

--- a/abjad/bind.py
+++ b/abjad/bind.py
@@ -112,9 +112,11 @@ class Wrapper:
         self._direction = direction
         self._effective_context = None
         self._indicator = indicator
+        self._synthetic_offset: _duration.Offset | None
         if synthetic_offset is not None:
-            synthetic_offset = _duration.Offset(synthetic_offset)
-        self._synthetic_offset = synthetic_offset
+            self._synthetic_offset = _duration.Offset(synthetic_offset)
+        else:
+            self._synthetic_offset = synthetic_offset
         if tag is not None:
             assert isinstance(tag, str | _tag.Tag)
         assert isinstance(tag, _tag.Tag), repr(tag)

--- a/abjad/duration.py
+++ b/abjad/duration.py
@@ -1,13 +1,13 @@
+import fractions
 import math
 import re
-
-import quicktions
+import typing
 
 from . import exceptions as _exceptions
 from . import math as _math
 
 
-class Duration(quicktions.Fraction):
+class Duration(fractions.Fraction):
     """
     Duration.
 
@@ -64,8 +64,8 @@ class Duration(quicktions.Fraction):
 
         Intializes from fraction:
 
-        >>> import quicktions
-        >>> abjad.Duration(quicktions.Fraction(3, 16))
+        >>> import fractions
+        >>> abjad.Duration(fractions.Fraction(3, 16))
         Duration(3, 16)
 
     ..  container:: example
@@ -86,7 +86,7 @@ class Duration(quicktions.Fraction):
 
         Durations inherit from built-in fraction:
 
-        >>> isinstance(abjad.Duration(3, 16), quicktions.Fraction)
+        >>> isinstance(abjad.Duration(3, 16), fractions.Fraction)
         True
 
     ..  container:: example
@@ -104,6 +104,14 @@ class Duration(quicktions.Fraction):
 
     __slots__ = ()
 
+    ### DUMMY INITIALIZER ###
+
+    # dummy initializer so that mypy knows about _denominator, _numerator
+    def __init__(self, *arguments):
+        self._denominator = self._denominator
+        self._numerator = self._numerator
+        return None
+
     ### CONSTRUCTOR ###
 
     def __new__(class_, *arguments):
@@ -115,13 +123,13 @@ class Duration(quicktions.Fraction):
             if type(argument) is class_:
                 return argument
             if isinstance(argument, NonreducedFraction):
-                return quicktions.Fraction.__new__(class_, *argument.pair)
+                return fractions.Fraction.__new__(class_, *argument.pair)
             try:
-                return quicktions.Fraction.__new__(class_, *argument)
+                return fractions.Fraction.__new__(class_, *argument)
             except (AttributeError, TypeError):
                 pass
             try:
-                return quicktions.Fraction.__new__(class_, argument)
+                return fractions.Fraction.__new__(class_, argument)
             except (AttributeError, TypeError):
                 pass
             if (
@@ -131,29 +139,29 @@ class Duration(quicktions.Fraction):
                 and _math.is_integer_equivalent(argument[1])
                 and not argument[1] == 0
             ):
-                return quicktions.Fraction.__new__(
+                return fractions.Fraction.__new__(
                     class_, int(argument[0]), int(argument[1])
                 )
             try:
-                return quicktions.Fraction.__new__(class_, argument.duration)
+                return fractions.Fraction.__new__(class_, argument.duration)
             except AttributeError:
                 pass
             if isinstance(argument, str) and "/" not in argument:
                 result = Duration._initialize_from_lilypond_duration_string(argument)
-                return quicktions.Fraction.__new__(class_, result)
+                return fractions.Fraction.__new__(class_, result)
             if (
                 isinstance(argument, tuple)
                 and len(argument) == 1
                 and _math.is_integer_equivalent(argument[0])
             ):
-                return quicktions.Fraction.__new__(class_, int(argument[0]))
+                return fractions.Fraction.__new__(class_, int(argument[0]))
         else:
             try:
-                return quicktions.Fraction.__new__(class_, *arguments)
+                return fractions.Fraction.__new__(class_, *arguments)
             except TypeError:
                 pass
             if _math.all_are_integer_equivalent_numbers(arguments):
-                return quicktions.Fraction.__new__(class_, *[int(x) for x in arguments])
+                return fractions.Fraction.__new__(class_, *[int(x) for x in arguments])
         raise ValueError(f"can not construct duration: {arguments!r}.")
 
     ### SPECIAL METHODS ###
@@ -164,7 +172,7 @@ class Duration(quicktions.Fraction):
 
         Returns nonnegative duration.
         """
-        return type(self)(quicktions.Fraction.__abs__(self, *arguments))
+        return type(self)(fractions.Fraction.__abs__(self, *arguments))
 
     def __add__(self, *arguments):
         """
@@ -194,7 +202,7 @@ class Duration(quicktions.Fraction):
         if len(arguments) == 1 and isinstance(arguments[0], NonreducedFraction):
             result = arguments[0].__radd__(self)
         else:
-            result = type(self)(quicktions.Fraction.__add__(self, *arguments))
+            result = type(self)(fractions.Fraction.__add__(self, *arguments))
         return result
 
     def __div__(self, *arguments):
@@ -213,12 +221,12 @@ class Duration(quicktions.Fraction):
         Returns multiplier.
         """
         if len(arguments) == 1 and isinstance(arguments[0], type(self)):
-            fraction = quicktions.Fraction.__truediv__(self, *arguments)
+            fraction = fractions.Fraction.__truediv__(self, *arguments)
             result = Multiplier(fraction)
         elif len(arguments) == 1 and isinstance(arguments[0], NonreducedFraction):
             result = arguments[0].__rdiv__(self)
         else:
-            result = type(self)(quicktions.Fraction.__truediv__(self, *arguments))
+            result = type(self)(fractions.Fraction.__truediv__(self, *arguments))
         return result
 
     def __divmod__(self, *arguments):
@@ -227,7 +235,7 @@ class Duration(quicktions.Fraction):
 
         Returns pair.
         """
-        truncated, residue = quicktions.Fraction.__divmod__(self, *arguments)
+        truncated, residue = fractions.Fraction.__divmod__(self, *arguments)
         truncated = type(self)(truncated)
         residue = type(self)(residue)
         return truncated, residue
@@ -236,19 +244,19 @@ class Duration(quicktions.Fraction):
         """
         Is true when duration equals ``argument``.
         """
-        return quicktions.Fraction.__eq__(self, argument)
+        return fractions.Fraction.__eq__(self, argument)
 
     def __ge__(self, argument) -> bool:
         """
         Is true when duration is greater than or equal to ``argument``.
         """
-        return quicktions.Fraction.__ge__(self, argument)
+        return fractions.Fraction.__ge__(self, argument)
 
     def __gt__(self, argument) -> bool:
         """
         Is true when duration is greater than ``argument``.
         """
-        return quicktions.Fraction.__gt__(self, argument)
+        return fractions.Fraction.__gt__(self, argument)
 
     def __hash__(self) -> int:
         """
@@ -260,13 +268,13 @@ class Duration(quicktions.Fraction):
         """
         Is true when duration is less than or equal to ``argument``.
         """
-        return quicktions.Fraction.__le__(self, argument)
+        return fractions.Fraction.__le__(self, argument)
 
     def __lt__(self, argument) -> bool:
         """
         Is true when duration is less than ``argument``.
         """
-        return quicktions.Fraction.__lt__(self, argument)
+        return fractions.Fraction.__lt__(self, argument)
 
     def __mod__(self, *arguments):
         """
@@ -274,15 +282,15 @@ class Duration(quicktions.Fraction):
 
         Returns duration.
         """
-        return type(self)(quicktions.Fraction.__mod__(self, *arguments))
+        return type(self)(fractions.Fraction.__mod__(self, *arguments))
 
-    def __mul__(self, *arguments):
+    def __mul__(self, argument):
         """
-        Duration multiplied by ``arguments``.
+        Duration multiplied by ``argument``.
 
         ..  container:: example
 
-            Returns a new duration when ``arguments`` is a duration:
+            Returns a new duration when ``argument`` is a duration:
 
             >>> duration_1 = abjad.Duration(1, 2)
             >>> duration_2 = abjad.Duration(3, 2)
@@ -291,8 +299,7 @@ class Duration(quicktions.Fraction):
 
         ..  container:: example
 
-            Returns nonreduced fraction when ``arguments`` is a nonreduced
-            fraction:
+            Returns nonreduced fraction when ``argument`` is a nonreduced fraction:
 
             >>> duration = abjad.Duration(1, 2)
             >>> nonreduced_fraction = abjad.NonreducedFraction(3, 6)
@@ -301,16 +308,16 @@ class Duration(quicktions.Fraction):
 
         Returns duration or nonreduced fraction.
         """
-        if len(arguments) == 1 and isinstance(arguments[0], NonreducedFraction):
-            result = arguments[0].__rmul__(self)
+        if isinstance(argument, NonreducedFraction):
+            result = argument.__rmul__(self)
         else:
-            result = type(self)(quicktions.Fraction.__mul__(self, *arguments))
+            result = type(self)(fractions.Fraction.__mul__(self, argument))
         return result
 
     def __ne__(self, argument) -> bool:
         """
         Redefined explicitly because ``abjad.Duration`` inherits from built-in
-        ``quicktions.Fraction``:
+        ``fractions.Fraction``:
 
         "The __ne__ method follows automatically from __eq__ only if __ne__
         isn't already defined in a superclass.  So, if you're inheriting from a
@@ -340,7 +347,7 @@ class Duration(quicktions.Fraction):
 
         Returns new duration.
         """
-        return type(self)(quicktions.Fraction.__neg__(self, *arguments))
+        return type(self)(fractions.Fraction.__neg__(self, *arguments))
 
     def __pos__(self, *arguments):
         """
@@ -348,7 +355,7 @@ class Duration(quicktions.Fraction):
 
         Returns new duration.
         """
-        return type(self)(quicktions.Fraction.__pos__(self, *arguments))
+        return type(self)(fractions.Fraction.__pos__(self, *arguments))
 
     def __pow__(self, *arguments):
         """
@@ -356,7 +363,7 @@ class Duration(quicktions.Fraction):
 
         Returns new duration.
         """
-        return type(self)(quicktions.Fraction.__pow__(self, *arguments))
+        return type(self)(fractions.Fraction.__pow__(self, *arguments))
 
     def __radd__(self, *arguments):
         """
@@ -364,7 +371,7 @@ class Duration(quicktions.Fraction):
 
         Returns new duration.
         """
-        return type(self)(quicktions.Fraction.__radd__(self, *arguments))
+        return type(self)(fractions.Fraction.__radd__(self, *arguments))
 
     def __rdiv__(self, *arguments):
         """
@@ -372,13 +379,13 @@ class Duration(quicktions.Fraction):
 
         Returns new duration.
         """
-        return type(self)(quicktions.Fraction.__rdiv__(self, *arguments))
+        return type(self)(fractions.Fraction.__rdiv__(self, *arguments))
 
     def __rdivmod__(self, *arguments):
         """
         Documentation required.
         """
-        return type(self)(quicktions.Fraction.__rdivmod__(self, *arguments))
+        return type(self)(fractions.Fraction.__rdivmod__(self, *arguments))
 
     def __reduce__(self):
         """
@@ -402,7 +409,7 @@ class Duration(quicktions.Fraction):
         """
         Documentation required.
         """
-        return type(self)(quicktions.Fraction.__rmod__(self, *arguments))
+        return type(self)(fractions.Fraction.__rmod__(self, *arguments))
 
     def __rmul__(self, *arguments):
         """
@@ -410,7 +417,7 @@ class Duration(quicktions.Fraction):
 
         Returns new duration.
         """
-        return type(self)(quicktions.Fraction.__rmul__(self, *arguments))
+        return type(self)(fractions.Fraction.__rmul__(self, *arguments))
 
     def __rpow__(self, *arguments):
         """
@@ -418,7 +425,7 @@ class Duration(quicktions.Fraction):
 
         Returns new duration.
         """
-        return type(self)(quicktions.Fraction.__rpow__(self, *arguments))
+        return type(self)(fractions.Fraction.__rpow__(self, *arguments))
 
     def __rsub__(self, *arguments):
         """
@@ -426,7 +433,7 @@ class Duration(quicktions.Fraction):
 
         Returns new duration.
         """
-        return type(self)(quicktions.Fraction.__rsub__(self, *arguments))
+        return type(self)(fractions.Fraction.__rsub__(self, *arguments))
 
     def __rtruediv__(self, *arguments):
         """
@@ -434,7 +441,7 @@ class Duration(quicktions.Fraction):
 
         Returns new duration.
         """
-        return type(self)(quicktions.Fraction.__rtruediv__(self, *arguments))
+        return type(self)(fractions.Fraction.__rtruediv__(self, *arguments))
 
     def __sub__(self, *arguments):
         """
@@ -453,7 +460,7 @@ class Duration(quicktions.Fraction):
         if len(arguments) == 1 and isinstance(arguments[0], NonreducedFraction):
             return arguments[0].__rsub__(self)
         else:
-            return type(self)(quicktions.Fraction.__sub__(self, *arguments))
+            return type(self)(fractions.Fraction.__sub__(self, *arguments))
 
     def __truediv__(self, *arguments):
         """
@@ -494,21 +501,21 @@ class Duration(quicktions.Fraction):
         body_string, dots_string = match.groups()
         try:
             body_denominator = int(body_string)
-            body_duration = quicktions.Fraction(1, body_denominator)
+            body_duration = fractions.Fraction(1, body_denominator)
         except ValueError:
             if body_string == r"\breve":
-                body_duration = quicktions.Fraction(2)
+                body_duration = fractions.Fraction(2)
             elif body_string == r"\longa":
-                body_duration = quicktions.Fraction(4)
+                body_duration = fractions.Fraction(4)
             elif body_string == r"\maxima":
-                body_duration = quicktions.Fraction(8)
+                body_duration = fractions.Fraction(8)
             else:
                 raise ValueError(f"unknown body string: {body_string!r}.")
         rational = body_duration
         for n in range(len(dots_string)):
             exponent = n + 1
             denominator = 2**exponent
-            multiplier = quicktions.Fraction(1, denominator)
+            multiplier = fractions.Fraction(1, denominator)
             addend = multiplier * body_duration
             rational += addend
         return rational
@@ -521,7 +528,7 @@ class Duration(quicktions.Fraction):
         general, return the ``i`` th integer power of 2 greater than the least
         integer power of 2 greater than or equal to ``n``.
         """
-        assert isinstance(n, int | float | quicktions.Fraction), repr(n)
+        assert isinstance(n, int | float | fractions.Fraction), repr(n)
         assert 0 <= n, repr(n)
         result = 2 ** (int(math.ceil(math.log(n, 2))) + i)
         return result
@@ -1204,8 +1211,8 @@ class Multiplier(Duration):
 
         Intializes from fraction:
 
-        >>> import quicktions
-        >>> abjad.Multiplier(quicktions.Fraction(3, 16))
+        >>> import fractions
+        >>> abjad.Multiplier(fractions.Fraction(3, 16))
         Multiplier(3, 16)
 
     ..  container:: example
@@ -1226,7 +1233,7 @@ class Multiplier(Duration):
 
         Multipliers inherit from built-in fraction:
 
-        >>> isinstance(abjad.Multiplier(3, 16), quicktions.Fraction)
+        >>> isinstance(abjad.Multiplier(3, 16), fractions.Fraction)
         True
 
     ..  container:: example
@@ -1244,9 +1251,17 @@ class Multiplier(Duration):
 
     __slots__ = ()
 
+    ### DUMMY INITIALIZER ###
+
+    # dummy initializer so that mypy knows about _denominator, _numerator
+    def __init__(self, *arguments):
+        self._denominator = self._denominator
+        self._numerator = self._numerator
+        return None
+
     ### SPECIAL METHODS ###
 
-    def __mul__(self, *arguments) -> "Duration":
+    def __mul__(self, *arguments):
         """
         Multiplier times duration gives duration.
         """
@@ -1372,8 +1387,8 @@ class Offset(Duration):
 
         Intializes from fraction:
 
-        >>> import quicktions
-        >>> abjad.Offset(quicktions.Fraction(3, 16))
+        >>> import fractions
+        >>> abjad.Offset(fractions.Fraction(3, 16))
         Offset((3, 16))
 
     ..  container:: example
@@ -1394,7 +1409,7 @@ class Offset(Duration):
 
         Offsets inherit from built-in fraction:
 
-        >>> isinstance(abjad.Offset(3, 16), quicktions.Fraction)
+        >>> isinstance(abjad.Offset(3, 16), fractions.Fraction)
         True
 
     ..  container:: example
@@ -1411,6 +1426,15 @@ class Offset(Duration):
     ### CLASS VARIABLES ###
 
     __slots__ = ("_displacement",)
+
+    ### DUMMY INITIALIZER ###
+
+    # dummy initializer so that mypy knows about _denominator, _displacement, _numerator
+    def __init__(self, *arguments, **keywords):
+        self._denominator = self._denominator
+        self._displacement = self._displacement
+        self._numerator = self._numerator
+        return None
 
     ### CONSTRUCTOR ###
 
@@ -1848,8 +1872,8 @@ class Offset(Duration):
             Coerces ``argument`` to offset when ``argument`` is neither offset nor
             duration:
 
-            >>> import quicktions
-            >>> abjad.Offset(2) - quicktions.Fraction(1, 2)
+            >>> import fractions
+            >>> abjad.Offset(2) - fractions.Fraction(1, 2)
             Duration(3, 2)
 
         """
@@ -1871,7 +1895,7 @@ class Offset(Duration):
     ### PUBLIC PROPERTIES ###
 
     @property
-    def displacement(self) -> "Duration":
+    def displacement(self):
         """
         Gets displacement.
 
@@ -1906,7 +1930,7 @@ class Offset(Duration):
         return self._displacement
 
 
-class NonreducedFraction(quicktions.Fraction):
+class NonreducedFraction(fractions.Fraction):
     """
     Nonreduced fraction.
 
@@ -1942,8 +1966,8 @@ class NonreducedFraction(quicktions.Fraction):
 
         Nonreduced fractions inherit from built-in fraction:
 
-        >>> import quicktions
-        >>> isinstance(abjad.NonreducedFraction(3, 6), quicktions.Fraction)
+        >>> import fractions
+        >>> isinstance(abjad.NonreducedFraction(3, 6), fractions.Fraction)
         True
 
     ..  container:: example
@@ -1959,7 +1983,15 @@ class NonreducedFraction(quicktions.Fraction):
 
     ### CLASS VARIABLES ###
 
-    __slots__ = ("_numerator", "_denominator")
+    __slots__ = ()
+
+    ### DUMMY INITIALIZER ###
+
+    # dummy initializer so that mypy knows about _denominator, _numerator
+    def __init__(self, *arguments):
+        self._denominator = self._denominator
+        self._numerator = self._numerator
+        return None
 
     ### CONSTRUCTOR ###
 
@@ -2012,7 +2044,7 @@ class NonreducedFraction(quicktions.Fraction):
             raise ValueError(f"can not initialize {class_.__name__}: {arguments!r}.")
         numerator *= _math.sign(denominator)
         denominator = abs(denominator)
-        self = quicktions.Fraction.__new__(class_, numerator, denominator)
+        self = fractions.Fraction.__new__(class_, numerator, denominator)
         self._numerator = numerator
         self._denominator = denominator
         return self
@@ -2032,7 +2064,7 @@ class NonreducedFraction(quicktions.Fraction):
         pair = (abs(self.numerator), self.denominator)
         return type(self)(pair)
 
-    def __add__(self, argument) -> "NonreducedFraction":
+    def __add__(self, argument):
         """
         Adds ``argument`` to nonreduced fraction.
 
@@ -2202,7 +2234,7 @@ class NonreducedFraction(quicktions.Fraction):
         """
         return self.reduce() < argument
 
-    def __mul__(self, argument) -> "NonreducedFraction":
+    def __mul__(self, argument):
         """
         Multiplies nonreduced fraction by ``argument``.
 
@@ -2232,7 +2264,7 @@ class NonreducedFraction(quicktions.Fraction):
         pair = (-self.numerator, self.denominator)
         return type(self)(pair)
 
-    def __pow__(self, argument) -> "NonreducedFraction":
+    def __pow__(self, argument):
         """
         Raises nonreduced fraction to ``argument``.
 
@@ -2247,7 +2279,7 @@ class NonreducedFraction(quicktions.Fraction):
             return type(self)(pair)
         return super().__pow__(argument)
 
-    def __radd__(self, argument) -> "NonreducedFraction":
+    def __radd__(self, argument):
         """
         Adds nonreduced fraction to ``argument``.
 
@@ -2276,7 +2308,12 @@ class NonreducedFraction(quicktions.Fraction):
         fraction = argument / self.reduce()
         return self._fraction_with_denominator(fraction, max(denominators))
 
-    __rtruediv__ = __rdiv__
+    def __rtruediv__(self, argument):
+        """
+        Aliases __rdiv__
+        """
+        result = self.__rdiv__(argument)
+        return result
 
     def __repr__(self) -> str:
         """
@@ -2290,7 +2327,7 @@ class NonreducedFraction(quicktions.Fraction):
         """
         return f"{type(self).__name__}({self.numerator}, {self.denominator})"
 
-    def __rmul__(self, argument) -> "NonreducedFraction":
+    def __rmul__(self, argument):
         """
         Multiplies ``argument`` by nonreduced fraction.
 
@@ -2302,7 +2339,7 @@ class NonreducedFraction(quicktions.Fraction):
         """
         return self * argument
 
-    def __rsub__(self, argument) -> "NonreducedFraction":
+    def __rsub__(self, argument):
         """
         Subtracts nonreduced fraction from ``argument``.
 
@@ -2328,7 +2365,7 @@ class NonreducedFraction(quicktions.Fraction):
         """
         return f"{self.numerator}/{self.denominator}"
 
-    def __sub__(self, argument) -> "NonreducedFraction":
+    def __sub__(self, argument):
         """
         Subtracts ``argument`` from nonreduced fraction.
 
@@ -2351,7 +2388,7 @@ class NonreducedFraction(quicktions.Fraction):
         fraction = self.reduce() - argument
         return self._fraction_with_denominator(fraction, max(denominators))
 
-    def __truediv__(self, argument) -> "NonreducedFraction":
+    def __truediv__(self, argument):
         """
         Divides nonreduced fraction in Python 3.
         """
@@ -2435,7 +2472,7 @@ class NonreducedFraction(quicktions.Fraction):
 
         """
         if preserve_numerator:
-            multiplier = quicktions.Fraction(*multiplier)
+            multiplier = fractions.Fraction(*multiplier)
             self_denominator = self.denominator
             candidate_result_denominator = self_denominator / multiplier
             if candidate_result_denominator.denominator == 1:
@@ -2475,7 +2512,7 @@ class NonreducedFraction(quicktions.Fraction):
             NonreducedFraction(1, 1)
 
         """
-        multiplier = quicktions.Fraction(*multiplier)
+        multiplier = fractions.Fraction(*multiplier)
         self_numerator_factors = _math.factors(self.numerator)
         multiplier_denominator_factors = _math.factors(multiplier.denominator)
         for factor in multiplier_denominator_factors[:]:
@@ -2527,7 +2564,7 @@ class NonreducedFraction(quicktions.Fraction):
         pair = (numerator, denominator)
         return type(self)(pair)
 
-    def reduce(self) -> quicktions.Fraction:
+    def reduce(self) -> fractions.Fraction:
         """
         Reduces nonreduced fraction.
 
@@ -2539,7 +2576,7 @@ class NonreducedFraction(quicktions.Fraction):
             Fraction(-2, 1)
 
         """
-        return quicktions.Fraction(self.numerator, self.denominator)
+        return fractions.Fraction(self.numerator, self.denominator)
 
     def with_denominator(self, denominator) -> "NonreducedFraction":
         """
@@ -2605,7 +2642,7 @@ class NonreducedFraction(quicktions.Fraction):
 
         """
         current_numerator, current_denominator = self.pair
-        multiplier = quicktions.Fraction(denominator, current_denominator)
+        multiplier = fractions.Fraction(denominator, current_denominator)
         new_numerator = multiplier * current_numerator
         new_denominator = multiplier * current_denominator
         if new_numerator.denominator == 1 and new_denominator.denominator == 1:
@@ -2650,7 +2687,7 @@ class NonreducedFraction(quicktions.Fraction):
     ### PUBLIC PROPERTIES ###
 
     @property
-    def denominator(self) -> int:
+    def denominator(self):
         """
         Gets denominator of nonreduced fraction.
 
@@ -2663,7 +2700,7 @@ class NonreducedFraction(quicktions.Fraction):
         return self._denominator
 
     @property
-    def imag(self) -> int:
+    def imag(self) -> typing.Literal[0]:
         """
         Gets zero because nonreduced fractions have no imaginary part.
 

--- a/abjad/get.py
+++ b/abjad/get.py
@@ -1,4 +1,5 @@
 import collections
+import enum
 import typing
 
 from . import _getlib, _iterlib, _updatelib
@@ -1924,7 +1925,7 @@ def has_effective_indicator(
 
 def has_indicator(
     argument,
-    prototype: str | _typings.Prototype | None = None,
+    prototype: str | _typings.Prototype | enum.Enum | None = None,
     *,
     attributes: dict = None,
 ) -> bool:

--- a/abjad/indicators.py
+++ b/abjad/indicators.py
@@ -3,11 +3,10 @@ Indicators
 """
 import collections
 import dataclasses
+import fractions
 import functools
 import math
 import typing
-
-import quicktions
 
 from . import contributions as _contributions
 from . import duration as _duration
@@ -2304,11 +2303,11 @@ class MetronomeMark:
 
         Initializes rational-valued metronome mark:
 
-        >>> import quicktions
+        >>> import fractions
         >>> score = abjad.Score()
         >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
         >>> score.append(staff)
-        >>> mark = abjad.MetronomeMark((1, 4), quicktions.Fraction(272, 3))
+        >>> mark = abjad.MetronomeMark((1, 4), fractions.Fraction(272, 3))
         >>> abjad.attach(mark, staff[0])
         >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', score])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -2336,7 +2335,7 @@ class MetronomeMark:
         >>> score.append(staff)
         >>> mark = abjad.MetronomeMark(
         ...     (1, 4),
-        ...     quicktions.Fraction(272, 3),
+        ...     fractions.Fraction(272, 3),
         ...     decimal="90.66",
         ... )
         >>> abjad.attach(mark, staff[0])
@@ -2366,7 +2365,7 @@ class MetronomeMark:
         >>> score.append(staff)
         >>> mark = abjad.MetronomeMark(
         ...     (1, 4),
-        ...     quicktions.Fraction(901, 10),
+        ...     fractions.Fraction(901, 10),
         ...     decimal=True,
         ... )
         >>> abjad.attach(mark, staff[0])
@@ -2420,14 +2419,14 @@ class MetronomeMark:
 
         Custom markup:
 
-        >>> import quicktions
+        >>> import fractions
         >>> markup = abjad.MetronomeMark.make_tempo_equation_markup(
         ...     abjad.Duration(1, 4),
         ...     67.5,
         ...  )
         >>> mark = abjad.MetronomeMark(
         ...     reference_duration=(1, 4),
-        ...     units_per_minute=quicktions.Fraction(135, 2),
+        ...     units_per_minute=fractions.Fraction(135, 2),
         ...     custom_markup=markup,
         ...  )
         >>> staff = abjad.Staff("c'4 d'4 e'4 f'4")
@@ -2456,17 +2455,17 @@ class MetronomeMark:
 
         Decimal overrides:
 
-        >>> import quicktions
+        >>> import fractions
         >>> mark = abjad.MetronomeMark(
         ...     (1, 4),
-        ...     quicktions.Fraction(272, 3),
+        ...     fractions.Fraction(272, 3),
         ... )
         >>> mark.decimal
         False
 
         >>> mark = abjad.MetronomeMark(
         ...     (1, 4),
-        ...     quicktions.Fraction(272, 3),
+        ...     fractions.Fraction(272, 3),
         ...     decimal="90.66",
         ... )
         >>> mark.decimal
@@ -2474,7 +2473,7 @@ class MetronomeMark:
 
         >>> mark = abjad.MetronomeMark(
         ...     (1, 4),
-        ...     quicktions.Fraction(901, 10),
+        ...     fractions.Fraction(901, 10),
         ...     decimal=True,
         ... )
         >>> mark.decimal
@@ -2522,7 +2521,7 @@ class MetronomeMark:
     """
 
     reference_duration: _typings.Duration | None = None
-    units_per_minute: int | quicktions.Fraction = None
+    units_per_minute: int | fractions.Fraction | None = None
     textual_indication: str | None = None
     custom_markup: Markup | None = None
     decimal: bool | str = False
@@ -2543,7 +2542,7 @@ class MetronomeMark:
                 f"do not set units-per-minute to float ({self.units_per_minute});"
                 " use fraction with decimal override instead."
             )
-        prototype = (int, quicktions.Fraction, collections.abc.Sequence, type(None))
+        prototype = (int, fractions.Fraction, collections.abc.Sequence, type(None))
         assert isinstance(self.units_per_minute, prototype)
         if isinstance(self.units_per_minute, collections.abc.Sequence):
             assert len(self.units_per_minute) == 2
@@ -2615,9 +2614,9 @@ class MetronomeMark:
         assert isinstance(argument, type(self)), repr(argument)
         self_quarters_per_minute = self.quarters_per_minute or 0
         argument_quarters_per_minute = argument.quarters_per_minute or 0
-        assert isinstance(self_quarters_per_minute, int | float | quicktions.Fraction)
+        assert isinstance(self_quarters_per_minute, int | float | fractions.Fraction)
         assert isinstance(
-            argument_quarters_per_minute, (int, float, quicktions.Fraction)
+            argument_quarters_per_minute, (int, float, fractions.Fraction)
         )
         return self_quarters_per_minute < argument_quarters_per_minute
 
@@ -2633,7 +2632,7 @@ class MetronomeMark:
             first, second = self.units_per_minute
             string = f"{self._dotted}={first}-{second}"
             return string
-        elif isinstance(self.units_per_minute, quicktions.Fraction):
+        elif isinstance(self.units_per_minute, fractions.Fraction):
             markup = MetronomeMark.make_tempo_equation_markup(
                 self.reference_duration,
                 self.units_per_minute,
@@ -2740,7 +2739,7 @@ class MetronomeMark:
         return True
 
     @property
-    def quarters_per_minute(self) -> tuple | None | quicktions.Fraction:
+    def quarters_per_minute(self) -> tuple | None | fractions.Fraction:
         """
         Gets metronome mark quarters per minute.
 
@@ -2773,7 +2772,7 @@ class MetronomeMark:
         result = (
             _duration.Duration(1, 4) / self.reference_duration * self.units_per_minute
         )
-        return quicktions.Fraction(result)
+        return fractions.Fraction(result)
 
     def duration_to_milliseconds(self, duration) -> _duration.Duration:
         """
@@ -2836,10 +2835,10 @@ class MetronomeMark:
 
             Rational-valued metronome mark:
 
-            >>> import quicktions
+            >>> import fractions
             >>> markup = abjad.MetronomeMark.make_tempo_equation_markup(
             ...     abjad.Duration(1, 4),
-            ...     quicktions.Fraction(272, 3),
+            ...     fractions.Fraction(272, 3),
             ... )
             >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', markup])
             >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -2856,7 +2855,7 @@ class MetronomeMark:
         dots = reference_duration_.dot_count
         stem = 1
         if isinstance(
-            units_per_minute, quicktions.Fraction
+            units_per_minute, fractions.Fraction
         ) and not _math.is_integer_equivalent_number(units_per_minute):
             if decimal:
                 decimal_: float | str

--- a/abjad/math.py
+++ b/abjad/math.py
@@ -2,12 +2,11 @@
 Abjad's math library.
 """
 import collections
+import fractions
 import itertools
 import math
 import numbers
 import typing
-
-import quicktions
 
 
 def all_are_equal(argument) -> bool:
@@ -50,8 +49,8 @@ def all_are_integer_equivalent(argument) -> bool:
 
     ..  container:: example
 
-        >>> import quicktions
-        >>> items = [1, '2', 3.0, quicktions.Fraction(4, 1)]
+        >>> import fractions
+        >>> items = [1, '2', 3.0, fractions.Fraction(4, 1)]
         >>> abjad.math.all_are_integer_equivalent(items)
         True
 
@@ -72,8 +71,8 @@ def all_are_integer_equivalent_numbers(argument) -> bool:
 
     ..  container:: example
 
-        >>> import quicktions
-        >>> items = [1, 2, 3.0, quicktions.Fraction(4, 1)]
+        >>> import fractions
+        >>> items = [1, 2, 3.0, fractions.Fraction(4, 1)]
         >>> abjad.math.all_are_integer_equivalent_numbers(items)
         True
 
@@ -94,12 +93,12 @@ def all_are_nonnegative_integer_equivalent_numbers(argument) -> bool:
 
     ..  container:: example
 
-        >>> import quicktions
-        >>> items = [0, 0.0, quicktions.Fraction(0), 2, 2.0, quicktions.Fraction(2)]
+        >>> import fractions
+        >>> items = [0, 0.0, fractions.Fraction(0), 2, 2.0, fractions.Fraction(2)]
         >>> abjad.math.all_are_nonnegative_integer_equivalent_numbers(items)
         True
 
-        >>> items = [0, 0.0, quicktions.Fraction(0), -2, 2.0, quicktions.Fraction(2)]
+        >>> items = [0, 0.0, fractions.Fraction(0), -2, 2.0, fractions.Fraction(2)]
         >>> abjad.math.all_are_nonnegative_integer_equivalent_numbers(items)
         False
 
@@ -274,7 +273,7 @@ def arithmetic_mean(argument) -> int | float:
     length = len(argument)
     if isinstance(total, float):
         return total / length
-    result = quicktions.Fraction(sum(argument), len(argument))
+    result = fractions.Fraction(sum(argument), len(argument))
     int_result = int(result)
     if int_result == result:
         return int_result
@@ -470,18 +469,18 @@ def factors(n) -> list[int]:
 
 def fraction_to_proper_fraction(
     rational,
-) -> tuple[int, quicktions.Fraction]:
+) -> tuple[int, fractions.Fraction]:
     """
     Changes ``rational`` to proper fraction.
 
     ..  container:: example
 
-        >>> import quicktions
-        >>> abjad.math.fraction_to_proper_fraction(quicktions.Fraction(116, 8))
+        >>> import fractions
+        >>> abjad.math.fraction_to_proper_fraction(fractions.Fraction(116, 8))
         (14, Fraction(1, 2))
 
     """
-    assert isinstance(rational, quicktions.Fraction), repr(rational)
+    assert isinstance(rational, fractions.Fraction), repr(rational)
     quotient = int(rational)
     residue = rational - quotient
     return quotient, residue
@@ -726,12 +725,12 @@ def is_integer_equivalent_n_tuple(argument, n) -> bool:
 
     ..  container:: example
 
-        >>> import quicktions
-        >>> tuple_ = (2.0, '3', quicktions.Fraction(4, 1))
+        >>> import fractions
+        >>> tuple_ = (2.0, '3', fractions.Fraction(4, 1))
         >>> abjad.math.is_integer_equivalent_n_tuple(tuple_, 3)
         True
 
-        >>> tuple_ = (2.5, '3', quicktions.Fraction(4, 1))
+        >>> tuple_ = (2.5, '3', fractions.Fraction(4, 1))
         >>> abjad.math.is_integer_equivalent_n_tuple(tuple_, 3)
         False
 
@@ -821,7 +820,7 @@ def is_nonnegative_integer_power_of_two(argument) -> bool:
     """
     if isinstance(argument, int):
         return not bool(argument & (argument - 1))
-    elif isinstance(argument, quicktions.Fraction):
+    elif isinstance(argument, fractions.Fraction):
         return is_nonnegative_integer_power_of_two(
             argument.numerator * argument.denominator
         )

--- a/abjad/parsers/parser.py
+++ b/abjad/parsers/parser.py
@@ -1,11 +1,11 @@
 import collections
 import copy
+import fractions
 import itertools
 import sys
 import typing
 
 import ply
-import quicktions
 from ply import lex
 from ply.yacc import (  # type: ignore
     YaccProduction,
@@ -4758,7 +4758,7 @@ class LilyPondSyntacticalDefinition:
 
     def p_fraction__UNSIGNED__Chr47__UNSIGNED(self, p):
         "fraction : UNSIGNED '/' UNSIGNED"
-        p[0] = quicktions.Fraction(p[1], p[3])
+        p[0] = fractions.Fraction(p[1], p[3])
 
     ### full_markup ###
 
@@ -5644,7 +5644,7 @@ class LilyPondSyntacticalDefinition:
             p[0] = LilyPondDuration(p[1].duration, p[1].multiplier * p[3])
         else:
             p[0] = LilyPondDuration(
-                p[1].duration, quicktions.Fraction(p[3].numerator, p[3].denominator)
+                p[1].duration, fractions.Fraction(p[3].numerator, p[3].denominator)
             )
 
     def p_multiplied_duration__multiplied_duration__Chr42__bare_unsigned(self, p):

--- a/abjad/pitch.py
+++ b/abjad/pitch.py
@@ -1,12 +1,11 @@
 import copy
 import dataclasses
+import fractions
 import functools
 import math
 import numbers
 import re
 import typing
-
-import quicktions
 
 from . import enums as _enums
 from . import math as _math
@@ -5652,9 +5651,9 @@ class NumberedPitch(Pitch):
 
         """
         try:
-            fraction = quicktions.Fraction(*fraction)
+            fraction = fractions.Fraction(*fraction)
         except TypeError:
-            fraction = quicktions.Fraction(fraction)
+            fraction = fractions.Fraction(fraction)
         assert 0 <= fraction <= 1, repr(fraction)
         stop_pitch = type(self)(stop_pitch)
         distance = stop_pitch - self

--- a/abjad/ratio.py
+++ b/abjad/ratio.py
@@ -1,8 +1,7 @@
 import collections
 import dataclasses
+import fractions
 import typing
-
-import quicktions
 
 from . import duration as _duration
 from . import math as _math
@@ -119,7 +118,7 @@ class NonreducedRatio(collections.abc.Sequence):
         Returns list of fractions or list of floats.
         """
         denominator = sum(self.numbers)
-        factors = [quicktions.Fraction(_, denominator) for _ in self.numbers]
+        factors = [fractions.Fraction(_, denominator) for _ in self.numbers]
         result = [_ * number for _ in factors]
         return result
 

--- a/abjad/rhythmtrees.py
+++ b/abjad/rhythmtrees.py
@@ -1,7 +1,8 @@
 """
 Tools for modeling IRCAM-style rhythm trees.
 """
-import quicktions
+import fractions
+
 import uqbar.containers
 import uqbar.graphs
 
@@ -182,7 +183,7 @@ class RhythmTreeMixin:
 
     @preprolated_duration.setter
     def preprolated_duration(self, argument):
-        if not isinstance(argument, quicktions.Fraction):
+        if not isinstance(argument, fractions.Fraction):
             argument = _duration.Duration(argument)
         assert 0 < argument
         self._duration = argument

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -1,10 +1,9 @@
 import collections
 import copy
+import fractions
 import functools
 import math
 import typing
-
-import quicktions
 
 from . import _indentlib, _updatelib
 from . import contributions as _contributions
@@ -634,6 +633,7 @@ class Leaf(Component):
 
     ### PUBLIC PROPERTIES ###
 
+    # TODO: restrict to NonreducedFraction | None
     @property
     def multiplier(
         self,
@@ -2559,7 +2559,7 @@ class Chord(Leaf):
         self,
         *arguments,
         language: str = "english",
-        multiplier: _typings.Duration = None,
+        multiplier: _duration.Multiplier | _duration.NonreducedFraction | None = None,
         tag: _tag.Tag = None,
     ) -> None:
         assert len(arguments) in (0, 1, 2)
@@ -3285,7 +3285,7 @@ class MultimeasureRest(Leaf):
         self,
         *arguments,
         language: str = "english",
-        multiplier: _typings.Duration = None,
+        multiplier: _duration.Multiplier | _duration.NonreducedFraction | None = None,
         tag: _tag.Tag = None,
     ) -> None:
         if len(arguments) == 0:
@@ -4114,7 +4114,7 @@ class Note(Leaf):
         self,
         *arguments,
         language: str = "english",
-        multiplier: _typings.Duration = None,
+        multiplier: _duration.Multiplier | _duration.NonreducedFraction | None = None,
         tag: _tag.Tag = None,
     ) -> None:
         assert len(arguments) in (0, 1, 2)
@@ -4395,7 +4395,7 @@ class Rest(Leaf):
         written_duration=None,
         *,
         language: str = "english",
-        multiplier: _typings.Duration = None,
+        multiplier: _duration.Multiplier | _duration.NonreducedFraction | None = None,
         tag: _tag.Tag = None,
     ) -> None:
         original_input = written_duration
@@ -4589,7 +4589,7 @@ class Skip(Leaf):
         self,
         *arguments,
         language: str = "english",
-        multiplier: _typings.Duration = None,
+        multiplier: _duration.Multiplier | _duration.NonreducedFraction | None = None,
         tag: _tag.Tag = None,
     ) -> None:
         input_leaf = None
@@ -5730,7 +5730,7 @@ class Tuplet(Container):
 
     @multiplier.setter
     def multiplier(self, argument):
-        if isinstance(argument, int | quicktions.Fraction):
+        if isinstance(argument, int | fractions.Fraction):
             multiplier = _duration.NonreducedFraction(argument)
         elif isinstance(argument, tuple):
             multiplier = _duration.NonreducedFraction(argument)
@@ -6790,7 +6790,7 @@ class Tuplet(Container):
                 component.written_duration *= self.multiplier
             else:
                 raise TypeError(component)
-        self.multiplier = _duration.Multiplier(1)
+        self.multiplier = _duration.NonreducedFraction(1)
 
 
 class Voice(Context):

--- a/abjad/sequence.py
+++ b/abjad/sequence.py
@@ -1,12 +1,11 @@
 import builtins
 import collections
 import copy
+import fractions
 import itertools
 import math
 import sys
 import typing
-
-import quicktions
 
 from . import cyclictuple as _cyclictuple
 from . import enums as _enums
@@ -814,7 +813,7 @@ def partition_by_ratio_of_weights(sequence, weights) -> list:
     items.append(sublist)
     current_cumulative_weight = cumulative_weights.pop(0)
     for item in sequence:
-        if not isinstance(item, int | float | quicktions.Fraction):
+        if not isinstance(item, int | float | fractions.Fraction):
             raise TypeError(f"must be number: {item!r}.")
         sublist.append(item)
         while current_cumulative_weight <= _math.weight(flatten(items, depth=-1)):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ uqbar_api_member_documenter_classes = [
     "uqbar.apis.SummarizingClassDocumenter",
 ]
 
-uqbar_book_console_setup = ["import abjad", "from quicktions import Fraction"]
+uqbar_book_console_setup = ["import abjad", "from fractions import Fraction"]
 uqbar_book_console_teardown = []
 uqbar_book_extensions = [
     "uqbar.book.extensions.GraphExtension",

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,13 +6,13 @@ ignore_missing_imports = True
 [mypy-docutils.*]
 ignore_missing_imports = True
 
+[mypy-fractions]
+ignore_missing_imports = True
+
 [mypy-ply]
 ignore_missing_imports = True
 
 [mypy-pytest]
-ignore_missing_imports = True
-
-[mypy-quicktions]
 ignore_missing_imports = True
 
 [mypy-roman]

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,11 @@ addopts =
 doctest_optionflags =
     ELLIPSIS
     NORMALIZE_WHITESPACE
+filterwarnings =
+    # the babel (cgi) and sphinx (imghdr) developers have to fix these;
+    # remove these ignore-filters are babel and sphinx update themselves:
+    ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning
+    ignore:'imghdr' is deprecated and slated for removal in Python 3.13:DeprecationWarning
 markers =
     sphinx
 norecursedirs =
@@ -11,4 +16,3 @@ norecursedirs =
 testpaths =
     tests
     abjad
-

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ install_requires = [
     "pytest>=7.1.3",
     "pytest-cov>=3.0.0",
     "pytest-helpers-namespace>=2021.12.29",
-    "quicktions>=1.13",
     "roman>=1.4",
     "sphinx-autodoc-typehints>=1.19.2",
     "sphinx-rtd-theme>=1.0.0",


### PR DESCRIPTION
Third-party quicktions raises an import error under Python 3.11. The replacement is the fractions module in Python's standard library.

Background. Years ago, the decision was made to replace built-in fractions with third-party quicktions. The near 10x speed increase provided by quicktions seemed important, especially at the time of Josiah's implementation of Abjad's timespan collection logic for Josiah's dissertation. Two things make quicktions no longer necessary. First, over successive releases of Python 3.x, built-in fractions has become increasingly performant: the quicktions pypi page indicates that quicktions may only be 2x faster than built-in fractions under Python 3.10. Second, the significant performance enhancements I added to Abjad in 2022 probably render the original problem moot: I think the original problem wasn't the performance of rational construction but rather calls to Python's (costly) inspect module for object comparison. Those calls to inspect are now all removed from 2022-era versions of Abjad.

Closes #1489.