### PR TITLE
Taught abjad.MetronomeMark to handle textual_indication literally.

### DIFF
--- a/abjad/indicators.py
+++ b/abjad/indicators.py
@@ -2644,22 +2644,17 @@ class MetronomeMark:
         return string
 
     def _get_lilypond_format(self):
-        text, equation = None, None
-        if self.textual_indication is not None:
-            text = self.textual_indication
-            assert isinstance(text, str)
-            if " " in text:
-                text = f'"{text}"'
+        equation = None
         if self.reference_duration is not None and self.units_per_minute is not None:
             equation = self._equation
         if self.custom_markup is not None:
             return rf"\tempo {self.custom_markup.string}"
-        elif text and equation:
-            return rf"\tempo {text} {equation}"
+        elif self.textual_indication and equation:
+            return rf"\tempo {self.textual_indication} {equation}"
         elif equation:
             return rf"\tempo {equation}"
-        elif text:
-            return rf"\tempo {text}"
+        elif self.textual_indication:
+            return rf"\tempo {self.textual_indication}"
         else:
             return r"\tempo \default"
 

--- a/abjad/parsers/parser.py
+++ b/abjad/parsers/parser.py
@@ -6524,16 +6524,24 @@ class LilyPondSyntacticalDefinition:
 
     def p_tempo_event__TEMPO__scalar(self, p):
         "tempo_event : TEMPO scalar"
-        p[0] = _indicators.MetronomeMark(textual_indication=str(p[2]))
+        if " " in p[2]:
+            string = f'"{p[2]}"'
+        else:
+            string = p[2]
+        p[0] = _indicators.MetronomeMark(textual_indication=string)
 
     def p_tempo_event__TEMPO__scalar_closed__steno_duration__Chr61__tempo_range(
         self, p
     ):
         "tempo_event : TEMPO scalar_closed steno_duration '=' tempo_range"
+        if " " in p[2]:
+            string = f'"{p[2]}"'
+        else:
+            string = p[2]
         p[0] = _indicators.MetronomeMark(
             reference_duration=p[3].duration,
             units_per_minute=p[5],
-            textual_indication=str(p[2]),
+            textual_indication=string,
         )
 
     def p_tempo_event__TEMPO__steno_duration__Chr61__tempo_range(self, p):

--- a/tests/test_LilyPondParser__indicators__MetronomeMark.py
+++ b/tests/test_LilyPondParser__indicators__MetronomeMark.py
@@ -4,7 +4,7 @@ import abjad
 def test_LilyPondParser__indicators__MetronomeMark_01():
 
     target = abjad.Score([abjad.Staff([abjad.Note(0, 1)])])
-    mark = abjad.MetronomeMark(textual_indication="As fast as possible")
+    mark = abjad.MetronomeMark(textual_indication='"As fast as possible"')
     abjad.attach(mark, target[0][0], context="Staff")
 
     assert abjad.lilypond(target) == abjad.string.normalize(
@@ -93,7 +93,7 @@ def test_LilyPondParser__indicators__MetronomeMark_04():
     mark = abjad.MetronomeMark(
         reference_duration=(1, 4),
         units_per_minute=60,
-        textual_indication="Like a majestic swan, alive with youth and vigour!",
+        textual_indication='"Like a majestic swan, alive with youth and vigour!"',
     )
     leaves = abjad.select.leaves(target)
     abjad.attach(mark, leaves[0], context="Staff")
@@ -126,7 +126,7 @@ def test_LilyPondParser__indicators__MetronomeMark_05():
     mark = abjad.MetronomeMark(
         reference_duration=(1, 16),
         units_per_minute=(34, 55),
-        textual_indication="Faster than a thousand suns",
+        textual_indication='"Brighter than a thousand suns"',
     )
     leaves = abjad.select.leaves(target)
     abjad.attach(mark, leaves[0], context="Staff")
@@ -137,7 +137,7 @@ def test_LilyPondParser__indicators__MetronomeMark_05():
         <<
             \new Staff
             {
-                \tempo "Faster than a thousand suns" 16=34-55
+                \tempo "Brighter than a thousand suns" 16=34-55
                 c'1
             }
         >>


### PR DESCRIPTION
Closes #1498.

Abjad 3.13 wraps `abjad.MetronomeMark.textual_indication` with an extra pair of double quotes when `textual_indication` contains whitespace:
```
>>> mark = abjad.MetronomeMark(textual_indication="Allegro")
>>> string = abjad.lilypond(mark)
>>> print(string)
\tempo Allegro

>>> mark = abjad.MetronomeMark(textual_indication="Allegro ma")
>>> string = abjad.lilypond(mark)
>>> print(string)
\tempo "Allegro ma"
```
The behavior was designed to be helpful (the second example above does make good LilyPond input), but is at odds with the literal (WYSIWYG) way of working with `abjad.Markup`, and almost all other objects in Abjad.

The right way to produce `\tempo "Allegro ma"` should be with `text_indication='"Allegro ma"'`, but this results in a redundant pair of double quotes in Abjad 3.13:
```
>>> mark = abjad.MetronomeMark(textual_indication='"Allegro ma"')
>>> string = abjad.lilypond(mark)
>>> print(string)
\tempo ""Allegro ma""
```
Abjad 3.14 removes this behavior and outputs the contents of `textual_indication` exactly as entered by the user:
```
>>> mark = abjad.MetronomeMark(textual_indication="Allegro")                                  
>>> string = abjad.lilypond(mark)                                                             
>>> print(string)
\tempo Allegro
                                                                             
>>> mark = abjad.MetronomeMark(textual_indication="Allegro ma")                               
>>> string = abjad.lilypond(mark)                                                             
>>> print(string)
\tempo Allegro ma
                                                                             
>>> mark = abjad.MetronomeMark(textual_indication='"Allegro ma"')                             
>>> string = abjad.lilypond(mark)                                                             
>>> print(string)      
\tempo "Allegro ma"                  
```                                                     