### PR TITLE
Moved abjad.illustrators.selection() to abjad.illustrators.components().

### DIFF
--- a/abjad/metricmodulation.py
+++ b/abjad/metricmodulation.py
@@ -482,11 +482,11 @@ class MetricModulation:
             markup = _indicators.Markup(rf"\markup {string}")
             return markup
         strings = []
-        string = _illustrators.selection_to_score_markup_string(self.left_rhythm)
+        string = _illustrators.components_to_score_markup_string(self.left_rhythm)
         strings.extend(string.split("\n"))
         strings.append("=")
         strings.append(r"\hspace #-0.5")
-        string = _illustrators.selection_to_score_markup_string(self.right_rhythm)
+        string = _illustrators.components_to_score_markup_string(self.right_rhythm)
         strings.extend(string.split("\n"))
         string = "\n".join(strings)
         string = rf"\markup {{ {string} }}"

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -5478,7 +5478,7 @@ class Tuplet(Container):
             >>> tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
             >>> duration = abjad.get.duration(tuplet)
             >>> note = abjad.Note.from_pitch_and_duration(0, duration)
-            >>> string = abjad.illustrators.selection_to_score_markup_string([note])
+            >>> string = abjad.illustrators.components_to_score_markup_string([note])
             >>> string = rf"\markup {{ {string} }}"
             >>> abjad.override(tuplet).TupletNumber.text = string
             >>> staff = abjad.Staff([tuplet])

--- a/abjad/select.py
+++ b/abjad/select.py
@@ -264,7 +264,7 @@ def chord(
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP
@@ -351,7 +351,7 @@ def chords(
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP
@@ -901,7 +901,7 @@ def flatten(argument, depth: int = 1) -> list:
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP
@@ -987,7 +987,7 @@ def flatten(argument, depth: int = 1) -> list:
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP
@@ -2288,7 +2288,7 @@ def leaf(
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP
@@ -3911,7 +3911,7 @@ def note(
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP
@@ -3998,7 +3998,7 @@ def notes(
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP
@@ -5570,7 +5570,7 @@ def rest(
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP
@@ -5657,7 +5657,7 @@ def rests(
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP
@@ -5755,7 +5755,7 @@ def run(
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP
@@ -5846,7 +5846,7 @@ def runs(
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP
@@ -6125,7 +6125,7 @@ def tuplet(
         ... ]
         >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
-        >>> lilypond_file = abjad.illustrators.selection(tuplets)
+        >>> lilypond_file = abjad.illustrators.components(tuplets)
         >>> staff = lilypond_file["Staff"]
         >>> abjad.setting(staff).autoBeaming = False
         >>> abjad.override(staff).TupletBracket.direction = abjad.UP


### PR DESCRIPTION
    OLD: abjad.illustrators.selection()
    NEW: abjad.illustrators.components()

    OLD: abjad.illustrators.selection_to_score_markup_string()
    NEW: abjad.illustrators.components_to_score_markup_string()

Closes #1525.