### PR TITLE
Cleaned up abjad.on_beat_grace_container().

### DIFF
--- a/abjad/_getlib.py
+++ b/abjad/_getlib.py
@@ -234,7 +234,7 @@ def _get_leaf_from_leaf(leaf, n):
         if (
             isinstance(sibling, _score.Container)
             and len(sibling) == 2
-            and any(hasattr(_, "_leaf_duration") for _ in sibling)
+            and any(hasattr(_, "_grace_leaf_duration") for _ in sibling)
         ):
             if sibling[0].__class__.__name__ == "OnBeatGraceContainer":
                 main_voice = sibling[1]
@@ -326,7 +326,7 @@ def _get_sibling_with_graces(component, n):
         and component is component._parent[-1]
         and component._parent.__class__.__name__ == "OnBeatGraceContainer"
     ):
-        return component._parent._get_on_beat_anchor_leaf()
+        return component._parent.get_anchor_leaf()
     if (
         n == 1
         and getattr(component._parent, "_main_leaf", None)

--- a/abjad/_updatelib.py
+++ b/abjad/_updatelib.py
@@ -108,7 +108,7 @@ def _get_measure_start_offsets(component):
 
 def _get_on_beat_grace_leaf_offsets(leaf):
     container = leaf._parent
-    anchor_leaf = container._get_on_beat_anchor_leaf()
+    anchor_leaf = container.get_anchor_leaf()
     anchor_leaf_start_offset = anchor_leaf._start_offset
     assert anchor_leaf_start_offset is not None
     anchor_leaf_start_offset = _duration.Offset(anchor_leaf_start_offset.pair)

--- a/abjad/bind.py
+++ b/abjad/bind.py
@@ -348,9 +348,9 @@ class Wrapper:
         return self
 
     def _find_correct_effective_context(self):
-        abjad = importlib.import_module("abjad")
         if self.context is None:
             return None
+        abjad = importlib.import_module("abjad")
         context = getattr(abjad, self.context, self.context)
         candidate = None
         parentage = self.component._get_parentage()
@@ -401,6 +401,9 @@ class Wrapper:
         correct_effective_context = self._find_correct_effective_context()
         if self._effective_context is not correct_effective_context:
             self._bind_effective_context(correct_effective_context)
+        if correct_effective_context is not None:
+            if self not in correct_effective_context._dependent_wrappers:
+                correct_effective_context._dependent_wrappers.append(self)
 
     def _warn_duplicate_indicator(self, component):
         if self.deactivate is True:

--- a/abjad/grace_corner_cases.py
+++ b/abjad/grace_corner_cases.py
@@ -10,7 +10,7 @@ r"""
     >>> container = abjad.BeforeGraceContainer("gs'16")
     >>> abjad.attach(container, music_voice[1])
     >>> container = abjad.on_beat_grace_container(
-    ...     "a'8 b' c'' b'", music_voice[1:3], leaf_duration=(1, 24)
+    ...     "a'8 b' c'' b'", music_voice[1:3], grace_leaf_duration=(1, 24)
     ... )
     >>> abjad.attach(abjad.Articulation(">"), container[0])
     >>> staff = abjad.Staff([music_voice])
@@ -67,7 +67,7 @@ r"""
 
     >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
     >>> container = abjad.on_beat_grace_container(
-    ...     "a'8 b' c'' b'", music_voice[1:3], leaf_duration=(1, 24)
+    ...     "a'8 b' c'' b'", music_voice[1:3], grace_leaf_duration=(1, 24)
     ... )
     >>> abjad.attach(abjad.Articulation(">"), container[0])
     >>> container = abjad.BeforeGraceContainer("gs'16")
@@ -129,7 +129,7 @@ r"""
     >>> container = abjad.AfterGraceContainer("cs'16")
     >>> abjad.attach(container, music_voice[1])
     >>> container = abjad.on_beat_grace_container(
-    ...     "a'8 b' c'' b'", music_voice[1:3], leaf_duration=(1, 24)
+    ...     "a'8 b' c'' b'", music_voice[1:3], grace_leaf_duration=(1, 24)
     ... )
     >>> abjad.attach(abjad.Articulation(">"), container[0])
     >>> staff = abjad.Staff([music_voice])
@@ -238,7 +238,7 @@ r"""
     >>> container = abjad.AfterGraceContainer("c'16")
     >>> abjad.attach(container, music_voice[0])
     >>> container = abjad.on_beat_grace_container(
-    ...     "a'8 b' c'' b'", music_voice[1:3], leaf_duration=(1, 24)
+    ...     "a'8 b' c'' b'", music_voice[1:3], grace_leaf_duration=(1, 24)
     ... )
     >>> abjad.attach(abjad.Articulation(">"), container[0])
     >>> staff = abjad.Staff([music_voice])

--- a/abjad/illustrators.py
+++ b/abjad/illustrators.py
@@ -244,6 +244,8 @@ def components(
 ):
     """
     Wraps ``components`` in LilyPond file for doc examples.
+
+    Sets LilyPond ``proportionalSpacingDuration`` to 1/24.
     """
     time_signatures = time_signatures or []
     assert all(isinstance(_, _indicators.TimeSignature) for _ in time_signatures), repr(

--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -2369,6 +2369,22 @@ def swap(argument, container):
                 }
             }
 
+        REGRESSION: context indicators survive swap:
+
+        >>> prototype = abjad.TimeSignature
+        >>> for component in abjad.iterate.components(staff):
+        ...     time_signature = abjad.get.effective(component, prototype)
+        ...     print(component, time_signature)
+        ...
+        Staff("{ 2/3 c'4 d'4 e'4 d'4 e'4 f'4 }") TimeSignature(pair=(3, 4), hide=False, partial=None)
+        Tuplet('3:2', "c'4 d'4 e'4 d'4 e'4 f'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
+        Note("c'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
+        Note("d'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
+        Note("e'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
+        Note("d'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
+        Note("e'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
+        Note("f'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
+
     Returns none.
     """
     if isinstance(argument, list):
@@ -2676,7 +2692,3 @@ def wrap(argument, container):
     if parent is not None:
         parent._components.insert(start, container)
         container._set_parent(parent)
-    for component in selection:
-        for wrapper in component._wrappers:
-            wrapper._effective_context = None
-            wrapper._update_effective_context()

--- a/abjad/obgc.py
+++ b/abjad/obgc.py
@@ -1,6 +1,9 @@
+import typing
+
 from . import _indentlib, _iterlib
 from . import bind as _bind
 from . import duration as _duration
+from . import get as _get
 from . import indicators as _indicators
 from . import iterate as _iterate
 from . import mutate as _mutate
@@ -21,13 +24,12 @@ class OnBeatGraceContainer(_score.Container):
 
     ..  container:: example
 
-        On-beat grace containers implement custom formatting not available in
-        LilyPond:
+        On-beat grace containers implement custom formatting not available in LilyPond:
 
         >>> music_voice = abjad.Voice("c'4 d'4 e'4 f'4", name="MusicVoice")
         >>> string = "<d' g'>8 a' b' c'' d'' c'' b' a' b' c'' d''"
         >>> container = abjad.on_beat_grace_container(
-        ...     string, music_voice[1:3], leaf_duration=(1, 24)
+        ...     string, music_voice[1:3], grace_leaf_duration=(1, 24)
         ... )
         >>> abjad.attach(abjad.Articulation(">"), container[0])
         >>> staff = abjad.Staff([music_voice])
@@ -87,22 +89,23 @@ class OnBeatGraceContainer(_score.Container):
 
     ### CLASS VARIABLES ###
 
-    __slots__ = ("_leaf_duration",)
+    __slots__ = ("_grace_leaf_duration",)
 
     ### INITIALIZER ###
 
     def __init__(
         self,
-        components=None,
+        components: str | typing.Sequence[_score.Leaf] = (),
+        *,
+        grace_leaf_duration: _typings.Duration | None = None,
         identifier: str | None = None,
-        leaf_duration: _typings.Duration | None = None,
         name: str | None = None,
         tag: _tag.Tag | None = None,
     ) -> None:
         super().__init__(components, identifier=identifier, name=name, tag=tag)
-        if leaf_duration is not None:
-            leaf_duration = _duration.Duration(leaf_duration)
-        self._leaf_duration = leaf_duration
+        if grace_leaf_duration is not None:
+            grace_leaf_duration = _duration.Duration(grace_leaf_duration)
+        self._grace_leaf_duration = grace_leaf_duration
 
     ### SPECIAL METHODS ###
 
@@ -131,19 +134,24 @@ class OnBeatGraceContainer(_score.Container):
     # This is hackish, and some sort of longer term solution should
     # happen later.
     def _attach_lilypond_one_voice(self):
-        anchor_leaf = self._get_on_beat_anchor_leaf()
+        anchor_leaf = self.get_anchor_leaf()
         anchor_voice = _parentage.Parentage(anchor_leaf).get(_score.Voice)
         final_anchor_leaf = _iterlib._get_leaf(anchor_voice, -1)
         next_leaf = _iterlib._get_leaf(final_anchor_leaf, 1)
+        if next_leaf is None:
+            return
         literal = _indicators.LilyPondLiteral(r"\oneVoice", site="absolute_before")
-        if next_leaf._has_indicator(literal):
+        if _get.has_indicator(next_leaf, literal):
             return
-        if isinstance(next_leaf._parent, OnBeatGraceContainer):
+        next_leaf_parent = _get.parentage(next_leaf).parent
+        if isinstance(next_leaf_parent, OnBeatGraceContainer):
             return
-        if self._is_on_beat_anchor_voice(next_leaf._parent):
+        if self._is_on_beat_anchor_voice(next_leaf_parent):
             return
-        site = "abjad.OnBeatGraceContainer._attach_lilypond_one_voice()"
-        tag = _tag.Tag(site)
+        tag = self.tag
+        tag = tag.append(
+            _tag.Tag("abjad.OnBeatGraceContainer._attach_lilypond_one_voice()")
+        )
         tag = tag.append(_tag.Tag("ONE_VOICE_COMMAND"))
         _bind.attach(literal, next_leaf, tag=tag)
 
@@ -182,8 +190,82 @@ class OnBeatGraceContainer(_score.Container):
             result.extend(contributions)
         return result
 
-    def _get_on_beat_anchor_leaf(self):
-        container = self._parent
+    @staticmethod
+    def _is_on_beat_anchor_voice(container):
+        wrapper = _get.parentage(container).parent
+        if wrapper is None:
+            return False
+        if not isinstance(container, _score.Voice):
+            return False
+        return OnBeatGraceContainer._is_on_beat_wrapper(wrapper)
+
+    @staticmethod
+    def _is_on_beat_wrapper(container):
+        if not container.simultaneous:
+            return False
+        if len(container) != 2:
+            return False
+        if isinstance(container[0], OnBeatGraceContainer) and isinstance(
+            container[1], _score.Voice
+        ):
+            return True
+        if isinstance(container[0], _score.Voice) and isinstance(
+            container[1], OnBeatGraceContainer
+        ):
+            return True
+        return False
+
+    def _match_anchor_leaf(self):
+        string = "abjad.OnBeatGraceContainer._match_anchor_leaf()"
+        tag = self.tag.append(_tag.Tag(string))
+        first_grace = _iterlib._get_leaf(self, 0)
+        if not isinstance(first_grace, _score.Note | _score.Chord):
+            message = "must start with note or chord:\n"
+            message += f"    {repr(self)}"
+            raise Exception(message)
+        anchor_leaf = self.get_anchor_leaf()
+        if not isinstance(anchor_leaf, _score.Note | _score.Chord):
+            return
+        if not isinstance(first_grace, _score.Note | _score.Chord):
+            return
+        if isinstance(first_grace, _score.Note):
+            chord = _score.Chord(first_grace, tag=tag)
+            _mutate.replace(first_grace, chord)
+            first_grace = chord
+        generator = _iterate.pitches(anchor_leaf)
+        anchor_pitches = list(generator)
+        highest_pitch = list(sorted(anchor_pitches))[-1]
+        if highest_pitch not in first_grace.note_heads:
+            first_grace.note_heads.append(highest_pitch)
+        grace_mate_head = first_grace.note_heads.get(highest_pitch)
+        _tweaks.tweak(grace_mate_head, r"\tweak font-size 0", tag=tag)
+        _tweaks.tweak(grace_mate_head, r"\tweak transparent ##t", tag=tag)
+
+    def _set_leaf_durations(self):
+        if self.grace_leaf_duration is None:
+            return
+        for leaf in _select.leaves(self):
+            duration = _get.duration(leaf)
+            if duration != self.grace_leaf_duration:
+                multiplier = self.grace_leaf_duration / duration
+                leaf.multiplier = _duration.pair(multiplier)
+
+    ### PUBLIC PROPERTIES ###
+
+    @property
+    def grace_leaf_duration(self) -> _duration.Duration | None:
+        """
+        Gets grace leaf duration.
+        """
+        return self._grace_leaf_duration
+
+    ### PUBLIC METHODS ###
+
+    def get_anchor_leaf(self):
+        """
+        Gets anchor leaf.
+        """
+        container = _get.parentage(self).parent
         if container is None:
             return None
         if len(container) != 2:
@@ -196,88 +278,45 @@ class OnBeatGraceContainer(_score.Container):
         anchor_leaf = _select.leaf(anchor_voice, 0, grace=False)
         return anchor_leaf
 
-    @staticmethod
-    def _is_on_beat_anchor_voice(CONTAINER):
-        wrapper = CONTAINER._parent
-        if wrapper is None:
-            return False
-        if not isinstance(CONTAINER, _score.Voice):
-            return False
-        return OnBeatGraceContainer._is_on_beat_wrapper(wrapper)
-
-    @staticmethod
-    def _is_on_beat_wrapper(CONTAINER):
-        if not CONTAINER.simultaneous:
-            return False
-        if len(CONTAINER) != 2:
-            return False
-        if isinstance(CONTAINER[0], OnBeatGraceContainer) and isinstance(
-            CONTAINER[1], _score.Voice
-        ):
-            return True
-        if isinstance(CONTAINER[0], _score.Voice) and isinstance(
-            CONTAINER[1], OnBeatGraceContainer
-        ):
-            return True
-        return False
-
-    def _match_anchor_leaf(self):
-        first_grace = _iterlib._get_leaf(self, 0)
-        if not isinstance(first_grace, _score.Note | _score.Chord):
-            message = "must start with note or chord:\n"
-            message += f"    {repr(self)}"
-            raise Exception(message)
-        anchor_leaf = self._get_on_beat_anchor_leaf()
-        if isinstance(anchor_leaf, _score.Note | _score.Chord) and isinstance(
-            first_grace, (_score.Note, _score.Chord)
-        ):
-            if isinstance(first_grace, _score.Note):
-                chord = _score.Chord(first_grace)
-                _mutate.replace(first_grace, chord)
-                first_grace = chord
-            generator = _iterate.pitches(anchor_leaf)
-            anchor_pitches = list(generator)
-            highest_pitch = list(sorted(anchor_pitches))[-1]
-            if highest_pitch not in first_grace.note_heads:
-                first_grace.note_heads.append(highest_pitch)
-            grace_mate_head = first_grace.note_heads.get(highest_pitch)
-            _tweaks.tweak(grace_mate_head, r"\tweak font-size 0")
-            _tweaks.tweak(grace_mate_head, r"\tweak transparent ##t")
-
-    def _set_leaf_durations(self):
-        if self.leaf_duration is None:
-            return
-        for leaf in _select.leaves(self):
-            duration = leaf._get_duration()
-            if duration != self.leaf_duration:
-                multiplier = self.leaf_duration / duration
-                leaf.multiplier = _duration.pair(multiplier)
-
-    ### PUBLIC PROPERTIES ###
-
-    @property
-    def leaf_duration(self) -> _duration.Duration | None:
-        """
-        Gets leaf duration.
-        """
-        return self._leaf_duration
-
 
 def on_beat_grace_container(
-    contents,
-    anchor_voice_selection,
+    grace_leaves: str | typing.Sequence[_score.Leaf],
+    nongrace_leaves: typing.Sequence[_score.Leaf],
     *,
-    anchor_voice_number=2,
-    do_not_beam=None,
-    do_not_slash=None,
-    do_not_slur=None,
-    do_not_stop_polyphony=None,
-    font_size=-3,
-    grace_voice_number=1,
-    leaf_duration=None,
-):
+    do_not_beam: bool = False,
+    do_not_slash: bool = False,
+    do_not_slur: bool = False,
+    do_not_stop_polyphony: bool = False,
+    grace_font_size: int = -3,
+    grace_leaf_duration: _typings.Duration | None = None,
+    grace_polyphony_command: str = r"\voiceOne",
+    nongrace_polyphony_command: str = r"\voiceTwo",
+    tag: _tag.Tag = _tag.Tag(),
+) -> "OnBeatGraceContainer":
     r"""
-    Makes on-beat grace container and wraps around ``selection``.
+    Makes on-beat grace container (with ``grace_leaves``) and attaches to
+    ``nongrace_leaves``.
+
+    ..  container:: example
+
+        >>> def make_lilypond_file(anchor_voice_string, obgc_string, *, below=False):
+        ...     music_voice = abjad.Voice(anchor_voice_string, name="MusicVoice")
+        ...     if below is False:
+        ...         nongrace_polyphony_command = r"\voiceTwo"
+        ...         grace_polyphony_command = r"\voiceOne"
+        ...     else:
+        ...         nongrace_polyphony_command = r"\voiceOne"
+        ...         grace_polyphony_command = r"\voiceTwo"
+        ...     result = abjad.on_beat_grace_container(
+        ...         obgc_string,
+        ...         music_voice[1:3],
+        ...         grace_leaf_duration=abjad.Duration(1, 30),
+        ...         grace_polyphony_command=grace_polyphony_command,
+        ...         nongrace_polyphony_command=nongrace_polyphony_command,
+        ...     )
+        ...     staff = abjad.Staff([music_voice])
+        ...     lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        ...     return lilypond_file
 
     ..  container:: example
 
@@ -285,17 +324,15 @@ def on_beat_grace_container(
 
         Note-to-note anchor:
 
-        >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
-        >>> string = "g'8 a' b' c'' d'' c'' b' a' b' c'' d''"
-        >>> result = abjad.on_beat_grace_container(
-        ...     string, music_voice[1:3], leaf_duration=(1, 30)
+        >>> lilypond_file = make_lilypond_file(
+        ...     "c'4 d' e' f'",
+        ...     "g'8 a' b' c'' d'' c'' b' a' b' c'' d''",
         ... )
-        >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
+            >>> staff = lilypond_file.items[-1]
             >>> string = abjad.lilypond(staff)
             >>> print(string)
             \new Staff
@@ -344,19 +381,15 @@ def on_beat_grace_container(
 
         Note-to-chord anchor:
 
-        >>> music_voice = abjad.Voice(
-        ...     "<a c'>4 <b d'> <c' e'> <d' f'>", name="MusicVoice"
+        >>> lilypond_file = make_lilypond_file(
+        ...     "<a c'>4 <b d'> <c' e'> <d' f'>",
+        ...     "g'8 a' b' c'' d'' c'' b' a' b' c'' d''",
         ... )
-        >>> string = "g'8 a' b' c'' d'' c'' b' a' b' c'' d''"
-        >>> result = abjad.on_beat_grace_container(
-        ...     string, music_voice[1:3], leaf_duration=(1, 30)
-        ... )
-        >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
+            >>> staff = lilypond_file.items[-1]
             >>> string = abjad.lilypond(staff)
             >>> print(string)
             \new Staff
@@ -405,17 +438,15 @@ def on_beat_grace_container(
 
         Chord-to-note anchor:
 
-        >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
-        >>> string = "<g' b'>8 a' b' c'' d'' c'' b' a' b' c'' d''"
-        >>> result = abjad.on_beat_grace_container(
-        ...     string, music_voice[1:3], leaf_duration=(1, 30)
+        >>> lilypond_file = make_lilypond_file(
+        ...     "c'4 d' e' f'",
+        ...     "<g' b'>8 a' b' c'' d'' c'' b' a' b' c'' d''",
         ... )
-        >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
+            >>> staff = lilypond_file.items[-1]
             >>> string = abjad.lilypond(staff)
             >>> print(string)
             \new Staff
@@ -465,19 +496,15 @@ def on_beat_grace_container(
 
         Chord-to-chord anchor:
 
-        >>> music_voice = abjad.Voice(
-        ...     "<a c'>4 <b d'> <c' e'> <d' f'>", name="MusicVoice"
+        >>> lilypond_file = make_lilypond_file(
+        ...     "<a c'>4 <b d'> <c' e'> <d' f'>",
+        ...     "<g' b'>8 a' b' c'' d'' c'' b' a' b' c'' d''",
         ... )
-        >>> string = "<g' b'>8 a' b' c'' d'' c'' b' a' b' c'' d''"
-        >>> result = abjad.on_beat_grace_container(
-        ...     string, music_voice[1:3], leaf_duration=(1, 30)
-        ... )
-        >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
+            >>> staff = lilypond_file.items[-1]
             >>> string = abjad.lilypond(staff)
             >>> print(string)
             \new Staff
@@ -531,21 +558,16 @@ def on_beat_grace_container(
 
         Note-to-note anchor:
 
-        >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
-        >>> string = "g8 a b c' d' c' b a b c' d'"
-        >>> result = abjad.on_beat_grace_container(
-        ...     string,
-        ...     music_voice[1:3],
-        ...     anchor_voice_number=1,
-        ...     grace_voice_number=2,
-        ...     leaf_duration=(1, 30),
+        >>> lilypond_file = make_lilypond_file(
+        ...     "c'4 d' e' f'",
+        ...     "g8 a b c' d' c' b a b c' d'",
+        ...     below=True,
         ... )
-        >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
+            >>> staff = lilypond_file.items[-1]
             >>> string = abjad.lilypond(staff)
             >>> print(string)
             \new Staff
@@ -594,23 +616,16 @@ def on_beat_grace_container(
 
         Note-to-chord anchor:
 
-        >>> music_voice = abjad.Voice(
-        ...     "<c' e'>4 <d' f'> <e' g'> <f' a'>", name="MusicVoice"
+        >>> lilypond_file = make_lilypond_file(
+        ...     "<c' e'>4 <d' f'> <e' g'> <f' a'>",
+        ...     "g8 a b c' d' c' b a b c' d'",
+        ...     below=True,
         ... )
-        >>> string = "g8 a b c' d' c' b a b c' d'"
-        >>> result = abjad.on_beat_grace_container(
-        ...     string,
-        ...     music_voice[1:3],
-        ...     anchor_voice_number=1,
-        ...     grace_voice_number=2,
-        ...     leaf_duration=(1, 30),
-        ... )
-        >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
+            >>> staff = lilypond_file.items[-1]
             >>> string = abjad.lilypond(staff)
             >>> print(string)
             \new Staff
@@ -659,21 +674,16 @@ def on_beat_grace_container(
 
         Chord-to-note anchor:
 
-        >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
-        >>> string = "<e g>8 a b c' d' c' b a b c' d'"
-        >>> result = abjad.on_beat_grace_container(
-        ...     string,
-        ...     music_voice[1:3],
-        ...     anchor_voice_number=1,
-        ...     grace_voice_number=2,
-        ...     leaf_duration=(1, 30),
+        >>> lilypond_file = make_lilypond_file(
+        ...     "c'4 d' e' f'",
+        ...     "<e g>8 a b c' d' c' b a b c' d'",
+        ...     below=True,
         ... )
-        >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
+            >>> staff = lilypond_file.items[-1]
             >>> string = abjad.lilypond(staff)
             >>> print(string)
             \new Staff
@@ -723,23 +733,16 @@ def on_beat_grace_container(
 
         Chord-to-chord anchor:
 
-        >>> music_voice = abjad.Voice(
-        ...     "<c' e'>4 <d' f'> <e' g'> <f' a'>", name="MusicVoice"
+        >>> lilypond_file = make_lilypond_file(
+        ...     "<c' e'>4 <d' f'> <e' g'> <f' a'>",
+        ...     "<e g>8 a b c' d' c' b a b c' d'",
+        ...     below=True,
         ... )
-        >>> string = "<e g>8 a b c' d' c' b a b c' d'"
-        >>> result = abjad.on_beat_grace_container(
-        ...     string,
-        ...     music_voice[1:3],
-        ...     anchor_voice_number=1,
-        ...     grace_voice_number=2,
-        ...     leaf_duration=(1, 30),
-        ... )
-        >>> staff = abjad.Staff([music_voice])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
+            >>> staff = lilypond_file.items[-1]
             >>> string = abjad.lilypond(staff)
             >>> print(string)
             \new Staff
@@ -787,85 +790,79 @@ def on_beat_grace_container(
                 }
             }
 
-    ..  container:: example
-
-        Raises exception when duration of on-beat grace container exceeds
-        duration of anchor container:
-
-        >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
-        >>> string = "g'8 a' b' c'' d'' c'' b' a' b' c'' d''"
-        >>> result = abjad.on_beat_grace_container(
-        ...     string, music_voice[1:2], leaf_duration=(1, 8)
-        ... )
-        Traceback (most recent call last):
-            ...
-        Exception: grace Duration(11, 8) exceeds anchor Duration(1, 4).
+        ..  TODO:: Fix stem-alignment in final example.
 
     """
-
-    def _site(n):
-        return _tag.Tag(f"abjad.on_beat_grace_container({n})")
-
+    if not isinstance(grace_leaves, str):
+        assert all(isinstance(_, _score.Leaf) for _ in grace_leaves), repr(grace_leaves)
+    assert all(isinstance(_, _score.Leaf) for _ in nongrace_leaves), repr(
+        nongrace_leaves
+    )
+    assert isinstance(grace_font_size, int), repr(grace_font_size)
+    polyphony_commands = (r"\voiceOne", r"\voiceTwo", r"\voiceThree", r"\voiceFour")
+    assert grace_polyphony_command in polyphony_commands, repr(grace_polyphony_command)
+    assert nongrace_polyphony_command in polyphony_commands, repr(
+        nongrace_polyphony_command
+    )
+    assert isinstance(tag, _tag.Tag), repr(tag)
+    tag = tag.append(_tag.Tag("abjad.on_beat_grace_container()"))
     if not _mutate._are_contiguous_same_parent(
-        anchor_voice_selection, ignore_before_after_grace=True
+        nongrace_leaves, ignore_before_after_grace=True
     ):
-        message = "selection must be contiguous in same parent:\n"
-        message += f"   {repr(anchor_voice_selection)}"
+        message = "nongrace leaves must be contiguous in same parent:\n"
+        message += f"   {repr(nongrace_leaves)}"
         raise Exception(message)
     on_beat_grace_container = OnBeatGraceContainer(
-        contents, leaf_duration=leaf_duration
+        grace_leaves, grace_leaf_duration=grace_leaf_duration, tag=tag
     )
-    anchor_leaf = _iterlib._get_leaf(anchor_voice_selection, 0)
+    anchor_leaf = _iterlib._get_leaf(nongrace_leaves, 0)
     anchor_voice = _parentage.Parentage(anchor_leaf).get(_score.Voice)
+    assert isinstance(anchor_voice, _score.Voice), repr(anchor_voice)
     if anchor_voice.name is None:
         raise Exception(f"anchor voice must be named:\n   {repr(anchor_voice)}")
-    anchor_voice_insert = _score.Voice(name=anchor_voice.name)
-    _mutate.wrap(anchor_voice_selection, anchor_voice_insert)
-    container = _score.Container(simultaneous=True)
+    anchor_voice_insert = _score.Voice(name=anchor_voice.name, tag=tag)
+    _mutate.wrap(nongrace_leaves, anchor_voice_insert)
+    container = _score.Container(simultaneous=True, tag=tag)
     _mutate.wrap(anchor_voice_insert, container)
     container.insert(0, on_beat_grace_container)
     on_beat_grace_container._match_anchor_leaf()
     on_beat_grace_container._set_leaf_durations()
-    insert_duration = anchor_voice_insert._get_duration()
-    grace_container_duration = on_beat_grace_container._get_duration()
+    insert_duration = _get.duration(anchor_voice_insert)
+    grace_container_duration = _get.duration(on_beat_grace_container)
     if insert_duration < grace_container_duration:
         message = f"grace {repr(grace_container_duration)}"
         message += f" exceeds anchor {repr(insert_duration)}."
         raise Exception(message)
-    if font_size is not None:
-        string = rf"\set fontSize = #{font_size}"
-        literal = _indicators.LilyPondLiteral(string)
-        _bind.attach(literal, on_beat_grace_container, tag=_site(1))
+    string = rf"\set fontSize = #{grace_font_size}"
+    literal = _indicators.LilyPondLiteral(string)
+    _bind.attach(literal, on_beat_grace_container, tag=tag)
     if not do_not_beam:
-        _spanners.beam(on_beat_grace_container[:])
+        _spanners.beam(on_beat_grace_container[:], tag=tag)
     if not do_not_slash:
         literal = _indicators.LilyPondLiteral(r"\slash")
-        _bind.attach(literal, on_beat_grace_container[0], tag=_site(2))
+        _bind.attach(literal, on_beat_grace_container[0], tag=tag)
     if not do_not_slur:
-        _spanners.slur(on_beat_grace_container[:])
-    voice_number_to_string = {
-        1: r"\voiceOne",
-        2: r"\voiceTwo",
-        3: r"\voiceThree",
-        4: r"\voiceFour",
-    }
+        _spanners.slur(on_beat_grace_container[:], tag=tag)
     first_grace = _iterlib._get_leaf(on_beat_grace_container, 0)
     one_voice_literal = _indicators.LilyPondLiteral(
         r"\oneVoice", site="absolute_before"
     )
-    string = voice_number_to_string.get(grace_voice_number, None)
-    if string is not None:
-        literal
-        _bind.detach(one_voice_literal, anchor_leaf)
-        _bind.attach(_indicators.LilyPondLiteral(string), first_grace, tag=_site(3))
-    string = voice_number_to_string.get(anchor_voice_number, None)
-    if string is not None:
-        _bind.detach(one_voice_literal, anchor_leaf)
-        _bind.attach(_indicators.LilyPondLiteral(string), anchor_leaf, tag=_site(4))
+    _bind.detach(one_voice_literal, anchor_leaf)
+    _bind.attach(
+        _indicators.LilyPondLiteral(grace_polyphony_command),
+        first_grace,
+        tag=tag,
+    )
+    _bind.detach(one_voice_literal, anchor_leaf)
+    _bind.attach(
+        _indicators.LilyPondLiteral(nongrace_polyphony_command),
+        anchor_leaf,
+        tag=tag,
+    )
     if not do_not_stop_polyphony:
-        last_anchor_leaf = _iterlib._get_leaf(anchor_voice_selection, -1)
+        last_anchor_leaf = _iterlib._get_leaf(nongrace_leaves, -1)
         next_leaf = _iterlib._get_leaf(last_anchor_leaf, 1)
         if next_leaf is not None:
             literal = _indicators.LilyPondLiteral(r"\oneVoice", site="absolute_before")
-            _bind.attach(literal, next_leaf, tag=_site(5))
+            _bind.attach(literal, next_leaf, tag=tag)
     return on_beat_grace_container

--- a/abjad/parsers/parse.py
+++ b/abjad/parsers/parse.py
@@ -4,7 +4,7 @@ from .reduced import parse_reduced_ly_syntax
 _lilypond_parsers_by_language: dict = {}
 
 
-def parse(string, language="english"):
+def parse(string: str, language: str = "english", *, tag=None):
     r"""
     Parses LilyPond ``string``.
 
@@ -15,15 +15,28 @@ def parse(string, language="english"):
         >>> container = abjad.parse("{c'4 d'4 e'4 f'4}")
         >>> abjad.show(container) # doctest: +SKIP
 
-    ..  container:: example
-
         Parses LilyPond string with Dutch note names:
 
-        >>> container = abjad.parse(
-        ...     "{c'8 des' e' fis'}",
-        ...     language='nederlands',
-        ...     )
+        >>> container = abjad.parse("{c'8 des' e' fis'}", language='nederlands')
         >>> abjad.show(container) # doctest: +SKIP
+
+        Tags output:
+
+        >>> container = abjad.parse("{c'4 d'4 e'4 f'4}", tag=abjad.Tag("FOO"))
+        >>> string = abjad.lilypond(container, tags=True)
+        >>> print(string)
+          %! FOO
+        {
+              %! FOO
+            c'4
+              %! FOO
+            d'4
+              %! FOO
+            e'4
+              %! FOO
+            f'4
+          %! FOO
+        }
 
     Returns Abjad component.
     """
@@ -32,4 +45,13 @@ def parse(string, language="english"):
     if language not in _lilypond_parsers_by_language:
         parser = LilyPondParser(default_language=language)
         _lilypond_parsers_by_language[language] = parser
-    return _lilypond_parsers_by_language[language](string)
+    parser = _lilypond_parsers_by_language[language]
+    parser.tag = tag
+    if hasattr(parser, "_guile"):
+        parser._guile.tag = tag
+    if hasattr(parser, "_lexdef"):
+        parser._lexdef.tag = tag
+    if hasattr(parser, "_syndef"):
+        parser._syndef.tag = tag
+    result = parser(string)
+    return result

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -4128,7 +4128,7 @@ class Note(Leaf):
             written_pitch = _pitch.NamedPitch("C4")
             written_duration = _duration.Duration(1, 4)
         else:
-            raise ValueError("can not initialize note from {arguments!r}.")
+            raise ValueError(f"can not initialize note from {arguments!r}.")
         Leaf.__init__(self, written_duration, multiplier=multiplier, tag=tag)
         if written_pitch is not None:
             if written_pitch not in _lyconst.drums:

--- a/abjad/tag.py
+++ b/abjad/tag.py
@@ -221,9 +221,7 @@ def _match_line(line, tag, current_tags):
     return False
 
 
-def activate(
-    text: str, tag: Tag | typing.Callable, skipped: bool = False
-) -> tuple[str, int] | tuple[str, int, int]:
+def activate(text: str, tag: Tag | typing.Callable) -> tuple[str, int, int]:
     r"""
     Activates ``tag`` in ``text``.
 
@@ -257,7 +255,7 @@ def activate(
 
         Activates tag:
 
-        >>> text, count = abjad.activate(text, abjad.Tag("RED_MARKUP"))
+        >>> text, count, skipped = abjad.activate(text, abjad.Tag("RED_MARKUP"))
         >>> print(text)
         \new Staff
         {
@@ -276,7 +274,7 @@ def activate(
 
         Deactivates tag again:
 
-        >>> text, count = abjad.deactivate(text, abjad.Tag("RED_MARKUP"))
+        >>> text, count, skipped = abjad.deactivate(text, abjad.Tag("RED_MARKUP"))
         >>> print(text)
         \new Staff
         {
@@ -295,7 +293,7 @@ def activate(
 
         Activates tag again:
 
-        >>> text, count = abjad.activate(text, abjad.Tag("RED_MARKUP"))
+        >>> text, count, skipped = abjad.activate(text, abjad.Tag("RED_MARKUP"))
         >>> print(text)
         \new Staff
         {
@@ -314,9 +312,11 @@ def activate(
 
     Tags can toggle indefinitely.
 
-    Returns text, count pair.
+    Returns (text, count, skipped) triple.
 
     Count gives number of activated tags.
+
+    Skipped gives number of skipped tags.
     """
     assert isinstance(text, str), repr(text)
     assert isinstance(tag, Tag) or callable(tag), repr(tag)
@@ -365,18 +365,14 @@ def activate(
         lines.append(line)
         current_tags = []
     text = "".join(lines)
-    if skipped is True:
-        return text, count, skipped_count
-    else:
-        return text, count
+    return text, count, skipped_count
 
 
 def deactivate(
     text: str,
     tag: Tag | typing.Callable,
     prepend_empty_chord: bool = False,
-    skipped: bool = False,
-) -> tuple[str, int] | tuple[str, int, int]:
+) -> tuple[str, int, int]:
     r"""
     Deactivates ``tag`` in ``text``.
 
@@ -411,7 +407,7 @@ def deactivate(
         Deactivates tag:
 
         >>> text = abjad.lilypond(staff, tags=True)
-        >>> text, count = abjad.deactivate(text, abjad.Tag("RED_MARKUP"))
+        >>> text, count, skipped = abjad.deactivate(text, abjad.Tag("RED_MARKUP"))
         >>> print(text)
         \new Staff
         {
@@ -430,7 +426,7 @@ def deactivate(
 
         Activates tag again:
 
-        >>> text, count = abjad.activate(text, abjad.Tag("RED_MARKUP"))
+        >>> text, count, skipped = abjad.activate(text, abjad.Tag("RED_MARKUP"))
         >>> print(text)
         \new Staff
         {
@@ -449,7 +445,7 @@ def deactivate(
 
         Deactivates tag again:
 
-        >>> text, count = abjad.deactivate(text, abjad.Tag("RED_MARKUP"))
+        >>> text, count, skipped = abjad.deactivate(text, abjad.Tag("RED_MARKUP"))
         >>> print(text)
         \new Staff
         {
@@ -492,7 +488,7 @@ def deactivate(
         start_column = len(line) - len(line.lstrip())
         if line[start_column] != "%":
             if " %@%" in line:
-                prefix = "%@% "
+                prefix = "    " + "%@% "
                 line = line.replace(" %@%", "")
             else:
                 prefix = "%%% "
@@ -516,10 +512,7 @@ def deactivate(
         previous_line_was_tweak = "tweak" in line
         current_tags = []
     text = "".join(lines)
-    if skipped is True:
-        return text, count, skipped_count
-    else:
-        return text, count
+    return text, count, skipped_count
 
 
 def double_tag(strings: list[str], tag_: Tag, deactivate: bool = False) -> list[str]:

--- a/abjad/wf.py
+++ b/abjad/wf.py
@@ -1,8 +1,8 @@
 import enum
 import typing
 
-from . import _getlib
 from . import duration as _duration
+from . import get as _get
 from . import indicators as _indicators
 from . import instruments as _instruments
 from . import iterate as _iterate
@@ -19,13 +19,55 @@ def _aggregate_context_wrappers(argument):
     This currently happens with OnBeatGraceContainer.
     This method aggregates all Special_Voice wrappers for checks.
     """
-    name_to_wrappers = {}
+    context_name_to_wrappers = {}
     for context in _iterate.components(argument, _score.Context):
-        if context.name not in name_to_wrappers:
-            name_to_wrappers[context.name] = []
+        if context.name not in context_name_to_wrappers:
+            context_name_to_wrappers[context.name] = []
         wrappers = context._dependent_wrappers[:]
-        name_to_wrappers[context.name].extend(wrappers)
-    return name_to_wrappers
+        context_name_to_wrappers[context.name].extend(wrappers)
+    return context_name_to_wrappers
+
+
+def check_beamed_lone_notes(argument) -> tuple[list, int]:
+    r"""
+    Checks beamed lone notes.
+
+    Beamed single notes are not wellformed:
+
+    ..  container:: example
+
+        >>> voice = abjad.Voice("c'8 d' e' f'")
+        >>> abjad.attach(abjad.StartBeam(), voice[0])
+        >>> abjad.attach(abjad.StopBeam(), voice[0])
+        >>> abjad.show(voice) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> string = abjad.lilypond(voice)
+            >>> print(string)
+            \new Voice
+            {
+                c'8
+                [
+                ]
+                d'8
+                e'8
+                f'8
+            }
+
+        >>> abjad.wf.check_beamed_lone_notes(voice)
+        ([Note("c'8")], 4)
+
+    The examples above feature Abjad voice containers because beams are
+    voice-persistent.
+    """
+    violators, total = [], 0
+    for leaf in _iterate.leaves(argument):
+        total += 1
+        if _get.has_indicator(leaf, _indicators.StartBeam):
+            if _get.has_indicator(leaf, _indicators.StopBeam):
+                violators.append(leaf)
+    return violators, total
 
 
 def check_beamed_long_notes(argument) -> tuple[list, int]:
@@ -55,18 +97,8 @@ def check_beamed_long_notes(argument) -> tuple[list, int]:
                 f'4
             }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(voice)
-        >>> print(string)
-        2 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    0 overlapping text spanners
-        0 /    0 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        0 /    0 unterminated text spanners
+        >>> abjad.wf.check_beamed_long_notes(voice)
+        ([Note("c'4"), Note("d'4")], 4)
 
         Beamed eighth notes are wellformed:
 
@@ -89,55 +121,8 @@ def check_beamed_long_notes(argument) -> tuple[list, int]:
                 f'8
             }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(voice)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    0 overlapping text spanners
-        0 /    0 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        0 /    0 unterminated text spanners
-
-    ..  container:: example
-
-        REGRESSION. Matching start- and stop-beam indicators work
-        correctly:
-
-        >>> voice = abjad.Voice("c'8 d'8 e'4 f'2")
-        >>> abjad.attach(abjad.StartBeam(), voice[0])
-        >>> abjad.attach(abjad.StopBeam(), voice[1])
-        >>> abjad.show(voice) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(voice)
-            >>> print(string)
-            \new Voice
-            {
-                c'8
-                [
-                d'8
-                ]
-                e'4
-                f'2
-            }
-
-        >>> count, string = abjad.wf.tabulate_wellformedness(voice)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    0 overlapping text spanners
-        0 /    0 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        0 /    0 unterminated text spanners
+        >>> abjad.wf.check_beamed_long_notes(voice)
+        ([], 4)
 
     The examples above feature Abjad voice containers because beams are
     voice-persistent.
@@ -147,12 +132,10 @@ def check_beamed_long_notes(argument) -> tuple[list, int]:
         total += 1
         if leaf.written_duration < _duration.Duration((1, 4)):
             continue
-        start_wrapper = _getlib._get_effective(
-            leaf, _indicators.StartBeam, unwrap=False
-        )
+        start_wrapper = _get.effective(leaf, _indicators.StartBeam, unwrap=False)
         if start_wrapper is None:
             continue
-        stop_wrapper = _getlib._get_effective(leaf, _indicators.StopBeam, unwrap=False)
+        stop_wrapper = _get.effective(leaf, _indicators.StopBeam, unwrap=False)
         if stop_wrapper is None:
             violators.append(leaf)
             continue
@@ -255,22 +238,12 @@ def check_notes_on_wrong_clef(argument) -> tuple[list, int]:
                 f'8
             }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(staff)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        4 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    0 overlapping text spanners
-        0 /    0 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        0 /    0 unterminated text spanners
+        >>> abjad.wf.check_notes_on_wrong_clef(staff)
+        ([Note("c'8"), Note("d'8"), Note("e'8"), Note("f'8")], 4)
 
     ..  container:: example
 
-        Always allows percussion clef:
+        All instruments allow percussion clef:
 
         >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
         >>> clef = abjad.Clef('percussion')
@@ -292,27 +265,17 @@ def check_notes_on_wrong_clef(argument) -> tuple[list, int]:
                 f'8
             }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(staff)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    0 overlapping text spanners
-        0 /    0 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        0 /    0 unterminated text spanners
+        >>> abjad.wf.check_notes_on_wrong_clef(staff)
+        ([], 4)
 
     """
     violators, total = [], set()
     for leaf in _iterate.leaves(argument):
         total.add(leaf)
-        instrument = _getlib._get_effective(leaf, _instruments.Instrument)
+        instrument = _get.effective(leaf, _instruments.Instrument)
         if instrument is None:
             continue
-        effective_clef = _getlib._get_effective(leaf, _indicators.Clef)
+        effective_clef = _get.effective(leaf, _indicators.Clef)
         if effective_clef is None:
             continue
         clefs = []
@@ -354,18 +317,8 @@ def check_out_of_range_pitches(
                 r8
             }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(staff)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        1 /    2 out of range pitches
-        0 /    0 overlapping text spanners
-        0 /    0 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        0 /    0 unterminated text spanners
+        >>> abjad.wf.check_out_of_range_pitches(staff)
+        ([Chord('<d fs>8')], 2)
 
     ..  container:: example
 
@@ -415,12 +368,88 @@ def check_out_of_range_pitches(
             continue
         if "unpitched" in argument._get_indicators(str):
             continue
-        instrument = _getlib._get_effective(leaf, _instruments.Instrument)
+        instrument = _get.effective(leaf, _instruments.Instrument)
         if instrument is None:
             continue
         if not _iterpitches.sounding_pitches_are_in_range(leaf, instrument.pitch_range):
             violators.append(leaf)
     return violators, len(total)
+
+
+def check_overlapping_beams(argument) -> tuple[list, int]:
+    r"""
+    Checks overlapping beams.
+
+    ..  container:: example
+
+        >>> voice = abjad.Voice("c'8 [ d' [ e' f' ]")
+        >>> string = abjad.lilypond(voice)
+        >>> print(string)
+        \new Voice
+        {
+            c'8
+            [
+            d'8
+            [
+            e'8
+            f'8
+            ]
+        }
+
+        >>> abjad.wf.check_overlapping_beams(voice)
+        ([Note("d'8")], 3)
+
+        >>> voice = abjad.Voice("c'8 [ d' [ e' ] f' ]")
+        >>> string = abjad.lilypond(voice)
+        >>> print(string)
+        \new Voice
+        {
+            c'8
+            [
+            d'8
+            [
+            e'8
+            ]
+            f'8
+            ]
+        }
+
+        >>> abjad.wf.check_overlapping_beams(voice)
+        ([Note("d'8")], 4)
+
+        >>> voice = abjad.Voice("c'8 [ d' e' f' ]")
+        >>> string = abjad.lilypond(voice)
+        >>> print(string)
+        \new Voice
+        {
+            c'8
+            [
+            d'8
+            e'8
+            f'8
+            ]
+        }
+
+        >>> abjad.wf.check_overlapping_beams(voice)
+        ([], 2)
+
+    """
+    violators, total = [], 0
+    context_name_to_wrappers = _aggregate_context_wrappers(argument)
+    for _, wrappers in context_name_to_wrappers.items():
+        wrappers.sort(key=lambda _: _get.timespan(_.component).start_offset)
+        open_beam_count = 0
+        for wrapper in wrappers:
+            if _get.grace(wrapper.component) is True:
+                continue
+            total += 1
+            if isinstance(wrapper.unbundle_indicator(), _indicators.StartBeam):
+                open_beam_count += 1
+            elif isinstance(wrapper.unbundle_indicator(), _indicators.StopBeam):
+                open_beam_count -= 1
+            if open_beam_count < 0 or 1 < open_beam_count:
+                violators.append(wrapper.component)
+    return violators, total
 
 
 def check_overlapping_text_spanners(argument) -> tuple[list, int]:
@@ -431,7 +460,7 @@ def check_overlapping_text_spanners(argument) -> tuple[list, int]:
 
     ..  container:: example
 
-        >>> voice = abjad.Voice("c'4 c'4 c'4 c'4")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> abjad.text_spanner(voice)
         >>> abjad.text_spanner(voice[1:3])
         >>> string = abjad.lilypond(voice)
@@ -440,32 +469,22 @@ def check_overlapping_text_spanners(argument) -> tuple[list, int]:
         {
             c'4
             \startTextSpan
-            c'4
+            d'4
             \startTextSpan
-            c'4
+            e'4
             \stopTextSpan
-            c'4
+            f'4
             \stopTextSpan
         }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(voice)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        1 /    2 overlapping text spanners
-        0 /    2 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        0 /    2 unterminated text spanners
+        >>> abjad.wf.check_overlapping_text_spanners(voice)
+        ([Note("d'4")], 2)
 
     ..  container:: example
 
         Overlapping text spanners with different IDs are wellformed:
 
-        >>> voice = abjad.Voice("c'4 c'4 c'4 c'4")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> abjad.text_spanner(voice)
         >>> command = r'\startTextSpanOne'
         >>> start_text_span = abjad.StartTextSpan(command=command)
@@ -479,32 +498,22 @@ def check_overlapping_text_spanners(argument) -> tuple[list, int]:
         {
             c'4
             \startTextSpan
-            c'4
+            d'4
             \startTextSpanOne
-            c'4
+            e'4
             \stopTextSpanOne
-            c'4
+            f'4
             \stopTextSpan
         }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(voice)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    2 overlapping text spanners
-        0 /    2 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        0 /    2 unterminated text spanners
+        >>> abjad.wf.check_overlapping_text_spanners(voice)
+        ([], 2)
 
     ..  container:: example
 
         Enchained text spanners do not overlap (and are wellformed):
 
-        >>> voice = abjad.Voice("c'4 c'4 c'4 c'4")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> abjad.text_spanner(voice[:3])
         >>> abjad.text_spanner(voice[-2:])
         >>> string = abjad.lilypond(voice)
@@ -513,26 +522,16 @@ def check_overlapping_text_spanners(argument) -> tuple[list, int]:
         {
             c'4
             \startTextSpan
-            c'4
-            c'4
+            d'4
+            e'4
             \stopTextSpan
             \startTextSpan
-            c'4
+            f'4
             \stopTextSpan
         }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(voice)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    2 overlapping text spanners
-        0 /    2 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        0 /    2 unterminated text spanners
+        >>> abjad.wf.check_overlapping_text_spanners(voice)
+        ([], 2)
 
     ..  container:: example
 
@@ -563,18 +562,8 @@ def check_overlapping_text_spanners(argument) -> tuple[list, int]:
             \stopTextSpan
         }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(voice)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    2 overlapping text spanners
-        0 /    2 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        0 /    2 unterminated text spanners
+        >>> abjad.wf.check_overlapping_text_spanners(voice)
+        ([], 2)
 
     """
     violators, total = [], 0
@@ -586,8 +575,8 @@ def check_overlapping_text_spanners(argument) -> tuple[list, int]:
             priority = 0
         return (wrapper.leaked_start_offset, priority)
 
-    name_to_wrappers = _aggregate_context_wrappers(argument)
-    for name, wrappers in name_to_wrappers.items():
+    context_name_to_wrappers = _aggregate_context_wrappers(argument)
+    for _, wrappers in context_name_to_wrappers.items():
         wrappers.sort(key=key)
         open_spanners: dict = {}
         for wrapper in wrappers:
@@ -632,18 +621,8 @@ def check_unmatched_stop_text_spans(argument) -> tuple[list, int]:
             \stopTextSpan
         }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(voice)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    0 overlapping text spanners
-        1 /    0 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        0 /    0 unterminated text spanners
+        >>> abjad.wf.check_unmatched_stop_text_spans(voice)
+        ([Note("c'4")], 0)
 
         Matched stop text span is wellformed:
 
@@ -673,8 +652,8 @@ def check_unmatched_stop_text_spans(argument) -> tuple[list, int]:
 
     """
     violators, total = [], 0
-    name_to_wrappers = _aggregate_context_wrappers(argument)
-    for name, wrappers in name_to_wrappers.items():
+    context_name_to_wrappers = _aggregate_context_wrappers(argument)
+    for _, wrappers in context_name_to_wrappers.items():
         wrappers.sort(key=lambda _: _.leaked_start_offset)
         open_spanners: dict = {}
         for wrapper in wrappers:
@@ -719,18 +698,8 @@ def check_unterminated_hairpins(argument) -> tuple[list, int]:
             c'4
         }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(voice)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    0 overlapping text spanners
-        0 /    0 unmatched stop text spans
-        1 /    1 unterminated hairpins
-        0 /    0 unterminated text spanners
+        >>> abjad.wf.check_unterminated_hairpins(voice)
+        ([Note("c'4")], 1)
 
         Even with start dynamic:
 
@@ -751,18 +720,8 @@ def check_unterminated_hairpins(argument) -> tuple[list, int]:
             c'4
         }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(voice)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    0 overlapping text spanners
-        0 /    0 unmatched stop text spans
-        1 /    1 unterminated hairpins
-        0 /    0 unterminated text spanners
+        >>> abjad.wf.check_unterminated_hairpins(voice)
+        ([Note("c'4")], 1)
 
         Terminated crescendo is wellformed:
 
@@ -820,8 +779,8 @@ def check_unterminated_hairpins(argument) -> tuple[list, int]:
 
     """
     violators, total = [], 0
-    name_to_wrappers = _aggregate_context_wrappers(argument)
-    for name, wrappers in name_to_wrappers.items():
+    context_name_to_wrappers = _aggregate_context_wrappers(argument)
+    for _, wrappers in context_name_to_wrappers.items():
         last_dynamic = None
         last_tag = _tag.Tag()
         wrappers.sort(key=lambda _: _.leaked_start_offset)
@@ -864,18 +823,8 @@ def check_unterminated_text_spanners(argument) -> tuple[list, int]:
             c'4
         }
 
-        >>> count, string = abjad.wf.tabulate_wellformedness(voice)
-        >>> print(string)
-        0 /    4 beamed long notes
-        0 /    5 duplicate ids
-        0 /    1 empty containers
-        0 /    5 missing parents
-        0 /    4 notes on wrong clef
-        0 /    4 out of range pitches
-        0 /    1 overlapping text spanners
-        0 /    1 unmatched stop text spans
-        0 /    0 unterminated hairpins
-        1 /    1 unterminated text spanners
+        >>> abjad.wf.check_unterminated_text_spanners(voice)
+        ([Note("c'4")], 1)
 
         Terminated text span is wellformed:
 
@@ -905,8 +854,8 @@ def check_unterminated_text_spanners(argument) -> tuple[list, int]:
 
     """
     violators, total = [], 0
-    name_to_wrappers = _aggregate_context_wrappers(argument)
-    for name, wrappers in name_to_wrappers.items():
+    context_name_to_wrappers = _aggregate_context_wrappers(argument)
+    for _, wrappers in context_name_to_wrappers.items():
         wrappers.sort(key=lambda _: _.leaked_start_offset)
         open_spanners: dict = {}
         for wrapper in wrappers:
@@ -938,18 +887,24 @@ _globals = globals()
 
 def _call_functions(
     component,
+    check_beamed_lone_notes: bool = True,
     check_beamed_long_notes: bool = True,
     check_duplicate_ids: bool = True,
     check_empty_containers: bool = True,
     check_missing_parents: bool = True,
     check_notes_on_wrong_clef: bool = True,
     check_out_of_range_pitches: bool = True,
+    check_overlapping_beams: bool = True,
     check_overlapping_text_spanners: bool = True,
     check_unmatched_stop_text_spans: bool = True,
     check_unterminated_hairpins: bool = True,
     check_unterminated_text_spanners: bool = True,
 ):
     triples = []
+    if check_beamed_lone_notes:
+        name = "check_beamed_lone_notes"
+        violators, count = _globals[name](component)
+        triples.append((violators, count, name))
     if check_beamed_long_notes:
         name = "check_beamed_long_notes"
         violators, count = _globals[name](component)
@@ -974,6 +929,10 @@ def _call_functions(
         name = "check_out_of_range_pitches"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
+    if check_overlapping_beams:
+        name = "check_overlapping_beams"
+        violators, count = _globals[name](component)
+        triples.append((violators, count, name))
     if check_overlapping_text_spanners:
         name = "check_overlapping_text_spanners"
         violators, count = _globals[name](component)
@@ -995,12 +954,14 @@ def _call_functions(
 
 def tabulate_wellformedness(
     component,
+    check_beamed_lone_notes: bool = True,
     check_beamed_long_notes: bool = True,
     check_duplicate_ids: bool = True,
     check_empty_containers: bool = True,
     check_missing_parents: bool = True,
     check_notes_on_wrong_clef: bool = True,
     check_out_of_range_pitches: bool = True,
+    check_overlapping_beams: bool = True,
     check_overlapping_text_spanners: bool = True,
     check_unmatched_stop_text_spans: bool = True,
     check_unterminated_hairpins: bool = True,
@@ -1011,12 +972,14 @@ def tabulate_wellformedness(
     """
     triples = _call_functions(
         component,
+        check_beamed_lone_notes=check_beamed_lone_notes,
         check_beamed_long_notes=check_beamed_long_notes,
         check_duplicate_ids=check_duplicate_ids,
         check_empty_containers=check_empty_containers,
         check_missing_parents=check_missing_parents,
         check_notes_on_wrong_clef=check_notes_on_wrong_clef,
         check_out_of_range_pitches=check_out_of_range_pitches,
+        check_overlapping_beams=check_overlapping_beams,
         check_overlapping_text_spanners=check_overlapping_text_spanners,
         check_unmatched_stop_text_spans=check_unmatched_stop_text_spans,
         check_unterminated_hairpins=check_unterminated_hairpins,
@@ -1036,12 +999,14 @@ def tabulate_wellformedness(
 
 def wellformed(
     component,
+    check_beamed_lone_notes: bool = True,
     check_beamed_long_notes: bool = True,
     check_duplicate_ids: bool = True,
     check_empty_containers: bool = True,
     check_missing_parents: bool = True,
     check_notes_on_wrong_clef: bool = True,
     check_out_of_range_pitches: bool = True,
+    check_overlapping_beams: bool = True,
     check_overlapping_text_spanners: bool = True,
     check_unmatched_stop_text_spans: bool = True,
     check_unterminated_hairpins: bool = True,
@@ -1052,12 +1017,14 @@ def wellformed(
     """
     triples = _call_functions(
         component,
+        check_beamed_lone_notes=check_beamed_lone_notes,
         check_beamed_long_notes=check_beamed_long_notes,
         check_duplicate_ids=check_duplicate_ids,
         check_empty_containers=check_empty_containers,
         check_missing_parents=check_missing_parents,
         check_notes_on_wrong_clef=check_notes_on_wrong_clef,
         check_out_of_range_pitches=check_out_of_range_pitches,
+        check_overlapping_beams=check_overlapping_beams,
         check_overlapping_text_spanners=check_overlapping_text_spanners,
         check_unmatched_stop_text_spans=check_unmatched_stop_text_spans,
         check_unterminated_hairpins=check_unterminated_hairpins,

--- a/tests/test_Container___delitem__.py
+++ b/tests/test_Container___delitem__.py
@@ -135,7 +135,7 @@ def test_Container___delitem___04():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.wellformed(voice, check_overlapping_beams=False)
 
 
 def test_Container___delitem___05():

--- a/tests/test_Container_append.py
+++ b/tests/test_Container_append.py
@@ -130,8 +130,6 @@ def test_Container_append_04():
         """
     ), print(abjad.lilypond(voice_1))
 
-    assert abjad.wf.wellformed(voice_1)
-
     assert abjad.lilypond(voice_2) == abjad.string.normalize(
         r"""
         \new Voice
@@ -143,8 +141,6 @@ def test_Container_append_04():
         }
         """
     ), print(abjad.lilypond(voice_2))
-
-    assert abjad.wf.wellformed(voice_2)
 
 
 def test_Container_append_05():

--- a/tests/test_Container_extend.py
+++ b/tests/test_Container_extend.py
@@ -166,8 +166,6 @@ def test_Container_extend_07():
         """
     ), print(abjad.lilypond(voice_1))
 
-    assert abjad.wf.wellformed(voice_1)
-
     assert abjad.lilypond(voice_2) == abjad.string.normalize(
         r"""
         \new Voice
@@ -178,8 +176,6 @@ def test_Container_extend_07():
         }
         """
     ), print(abjad.lilypond(voice_2))
-
-    assert abjad.wf.wellformed(voice_2)
 
 
 def test_Container_extend_08():
@@ -230,8 +226,6 @@ def test_Container_extend_08():
         """
     ), print(abjad.lilypond(voice_1))
 
-    assert abjad.wf.wellformed(voice_1)
-
     assert abjad.lilypond(voice_2) == abjad.string.normalize(
         r"""
         \new Voice
@@ -242,8 +236,6 @@ def test_Container_extend_08():
         }
         """
     ), print(abjad.lilypond(voice_2))
-
-    assert abjad.wf.wellformed(voice_2)
 
 
 def test_Container_extend_09():

--- a/tests/test_Container_pop.py
+++ b/tests/test_Container_pop.py
@@ -46,8 +46,8 @@ def test_Container_pop_01():
 
     "Result is now d'8 [ ]"
 
-    assert abjad.wf.wellformed(result)
     assert abjad.lilypond(result) == "d'8\n[\n]"
+    assert abjad.wf.wellformed(result, check_beamed_lone_notes=False)
 
 
 def test_Container_pop_02():

--- a/tests/test_Container_remove.py
+++ b/tests/test_Container_remove.py
@@ -51,7 +51,7 @@ def test_Container_remove_01():
     assert abjad.lilypond(note) == "d'8\n[\n]"
 
     assert abjad.wf.wellformed(voice)
-    assert abjad.wf.wellformed(note)
+    assert abjad.wf.wellformed(note, check_beamed_lone_notes=False)
 
 
 def test_Container_remove_02():

--- a/tests/test_Staff___getitem__.py
+++ b/tests/test_Staff___getitem__.py
@@ -39,8 +39,8 @@ def test_Staff___getitem___02():
 
     assert len(staff) == 5
     assert abjad.wf.wellformed(staff)
-    selection = staff[0:0]
-    assert len(selection) == 0
+    components = staff[0:0]
+    assert len(components) == 0
     assert abjad.wf.wellformed(staff)
 
 
@@ -57,9 +57,9 @@ def test_Staff___getitem___03():
 
     assert len(staff) == 5
     assert abjad.wf.wellformed(staff)
-    selection = staff[0:1]
-    assert len(selection) == 1
-    assert isinstance(selection[0], abjad.Note)
+    components = staff[0:1]
+    assert len(components) == 1
+    assert isinstance(components[0], abjad.Note)
     for x in staff:
         assert x._parent == staff
     assert abjad.wf.wellformed(staff)
@@ -78,10 +78,10 @@ def test_Staff___getitem___04():
 
     assert len(staff) == 5
     assert abjad.wf.wellformed(staff)
-    selection = staff[-1:]
-    assert len(selection) == 1
-    assert isinstance(selection[0], abjad.Tuplet)
-    for x in selection:
+    components = staff[-1:]
+    assert len(components) == 1
+    assert isinstance(components[0], abjad.Tuplet)
+    for x in components:
         assert x._parent == staff
     assert abjad.wf.wellformed(staff)
 
@@ -99,12 +99,12 @@ def test_Staff___getitem___05():
 
     assert len(staff) == 5
     assert abjad.wf.wellformed(staff)
-    selection = staff[1:-1]
-    assert len(selection) == 3
-    assert isinstance(selection[0], abjad.Rest)
-    assert isinstance(selection[1], abjad.Chord)
-    assert isinstance(selection[2], abjad.Skip)
-    for x in selection:
+    components = staff[1:-1]
+    assert len(components) == 3
+    assert isinstance(components[0], abjad.Rest)
+    assert isinstance(components[1], abjad.Chord)
+    assert isinstance(components[2], abjad.Skip)
+    for x in components:
         assert x._parent == staff
     assert abjad.wf.wellformed(staff)
 
@@ -122,12 +122,12 @@ def test_Staff___getitem___06():
 
     assert len(staff) == 5
     assert abjad.wf.wellformed(staff)
-    selection = staff[2:]
-    assert len(selection) == 3
-    assert isinstance(selection[0], abjad.Chord)
-    assert isinstance(selection[1], abjad.Skip)
-    assert isinstance(selection[2], abjad.Tuplet)
-    for x in selection:
+    components = staff[2:]
+    assert len(components) == 3
+    assert isinstance(components[0], abjad.Chord)
+    assert isinstance(components[1], abjad.Skip)
+    assert isinstance(components[2], abjad.Tuplet)
+    for x in components:
         assert x._parent == staff
     assert abjad.wf.wellformed(staff)
 
@@ -145,12 +145,12 @@ def test_Staff___getitem___07():
 
     assert len(staff) == 5
     assert abjad.wf.wellformed(staff)
-    selection = staff[:-2]
-    assert len(selection) == 3
-    assert isinstance(selection[0], abjad.Note)
-    assert isinstance(selection[1], abjad.Rest)
-    assert isinstance(selection[2], abjad.Chord)
-    for x in selection:
+    components = staff[:-2]
+    assert len(components) == 3
+    assert isinstance(components[0], abjad.Note)
+    assert isinstance(components[1], abjad.Rest)
+    assert isinstance(components[2], abjad.Chord)
+    for x in components:
         assert x._parent == staff
     assert abjad.wf.wellformed(staff)
 

--- a/tests/test_mutate_extract.py
+++ b/tests/test_mutate_extract.py
@@ -94,7 +94,7 @@ def test_mutate_extract_02():
     for note in notes:
         assert abjad.wf.wellformed(note)
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.wellformed(voice, check_overlapping_beams=False)
 
 
 def test_mutate_extract_03():

--- a/tests/test_mutate_swap.py
+++ b/tests/test_mutate_swap.py
@@ -59,7 +59,7 @@ def test_Mutation_swap_01():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.wellformed(voice, check_overlapping_beams=False)
 
 
 def test_Mutation_swap_02():

--- a/tests/test_obgc.py
+++ b/tests/test_obgc.py
@@ -1,0 +1,19 @@
+import pytest
+
+import abjad
+
+
+def test_obgc_01():
+    """
+    Raises exception when duration of on-beat grace container exceeds duration
+    of anchor container.
+    """
+
+    music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
+    string = "g'8 a' b' c'' d'' c'' b' a' b' c'' d''"
+    with pytest.raises(Exception):
+        abjad.on_beat_grace_container(
+            string,
+            music_voice[1:2],
+            grace_leaf_duration=(1, 8),
+        )


### PR DESCRIPTION
CHANGED. Changed abjad.on_beat_grace_container() parameter names:

    OLD: abjad.on_beat_grace_container(..., anchor_voice_number=2)
    NEW: abjad.on_beat_grace_container(..., nongrace_polyphony_command=r"\voiceTwo")

    OLD: abjad.on_beat_grace_container(..., grace_voice_number=1)
    NEW: abjad.on_beat_grace_container(..., grace_polyphony_command=r"\voiceOne")

    OLD: abjad.on_beat_grace_container(..., font_size=-3)
    NEW: abjad.on_beat_grace_container(..., grace_font_size=-3)

    OLD: abjad.on_beat_grace_container(..., leaf_duration=None)
    NEW: abjad.on_beat_grace_container(..., grace_leaf_duration=None)

CHANGED. Changed abjad.activate(), abjad.deactivate() return types:

    OLD:
        * both functions returned (text, count) pair when skipped=False
        * both functions returned (text, count, skipped) triple when skipped=True

    NEW:
        * both functions return (text, count, skipped) triple

NEW. Added abjad.parse(..., tag=None) keyword.

NEW. Added abjad.wf.check_overlapping_beams().

NEW. Added abjad.wf.check_beamed_lone_notes().

BUGFIX. Taught abjad.ForbidUpdate to update indicators on entrance.

    REGRESSION. Indicators need to be updated after swap; context
    manager updates indicators before forbidding further updates:

    >>> staff = abjad.Staff(r"\times 1/1 { c'4 d' }")
    >>> abjad.attach(abjad.Clef("alto"), staff[0][0])
    >>> container = abjad.Container()
    >>> abjad.mutate.swap(staff[0], container)
    >>> with abjad.ForbidUpdate(staff):
    ...     for note in staff[0]:
    ...         print(note)
    ...         print(abjad.get.effective(note, abjad.Clef))
    ...
    Note("c'4")
    Clef(name='alto', hide=False)
    Note("d'4")
    Clef(name='alto', hide=False)

    Users encountered this bug (up to Abjad 3.16) only if using abjad.ForbidContext
    immediately after some type of score mutatation, like in the example
    above.