### PR TITLE
CHANGED. Froze abjad.MetronomeMark, abjad.TimeSignature.

### DIFF
--- a/abjad/label.py
+++ b/abjad/label.py
@@ -1779,7 +1779,7 @@ def with_start_offsets(
 
         >>> staff = abjad.Staff(r"c'2 d' e' f'")
         >>> score = abjad.Score([staff])
-        >>> mark = abjad.MetronomeMark((1, 4), 60)
+        >>> mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         >>> abjad.attach(mark, staff[0])
         >>> abjad.label.with_start_offsets(staff, clock_time=True)
         Duration(8, 1)
@@ -1820,7 +1820,7 @@ def with_start_offsets(
 
         >>> staff = abjad.Staff(r"c'2 d' e' f'")
         >>> score = abjad.Score([staff])
-        >>> mark = abjad.MetronomeMark((1, 4), 60)
+        >>> mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         >>> abjad.attach(mark, staff[0])
         >>> abjad.label.with_start_offsets(
         ...     staff,

--- a/abjad/meter.py
+++ b/abjad/meter.py
@@ -724,7 +724,12 @@ class Meter:
 
         Returns time signature.
         """
-        return _indicators.TimeSignature(self.root_node.preprolated_duration)
+        duration = self.root_node.preprolated_duration
+        if hasattr(duration, "pair"):
+            pair = duration.pair
+        else:
+            pair = duration
+        return _indicators.TimeSignature(pair)
 
     @property
     def increase_monotonic(self) -> bool | None:

--- a/abjad/select.py
+++ b/abjad/select.py
@@ -2164,7 +2164,7 @@ def group_by_measure(argument) -> list[list]:
 
         >>> staff = abjad.Staff(r"c'4 | d'4 e'4 f'4 | g'4 a'4 b'4")
         >>> score = abjad.Score([staff], name="Score")
-        >>> time_signature = abjad.TimeSignature((3, 4), partial=(1, 4))
+        >>> time_signature = abjad.TimeSignature((3, 4), partial=abjad.Duration(1, 4))
         >>> abjad.attach(time_signature, staff[0])
 
         >>> leaves = abjad.select.leaves(staff)
@@ -4981,7 +4981,7 @@ def partition_by_durations(
         ...     abjad.attach(time_signature, container[0])
         ...
         >>> abjad.setting(staff).autoBeaming = False
-        >>> mark = abjad.MetronomeMark((1, 4), 60)
+        >>> mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         >>> leaf = abjad.get.leaf(staff, 0)
         >>> abjad.attach(mark, leaf, context='Staff')
 
@@ -5060,7 +5060,7 @@ def partition_by_durations(
         ...     abjad.attach(time_signature, container[0])
         ...
         >>> abjad.setting(staff).autoBeaming = False
-        >>> mark = abjad.MetronomeMark((1, 4), 60)
+        >>> mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         >>> leaf = abjad.get.leaf(staff, 0)
         >>> abjad.attach(mark, leaf, context='Staff')
 
@@ -5142,7 +5142,7 @@ def partition_by_durations(
         ...     abjad.attach(time_signature, container[0])
         ...
         >>> abjad.setting(staff).autoBeaming = False
-        >>> mark = abjad.MetronomeMark((1, 4), 60)
+        >>> mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         >>> leaf = abjad.get.leaf(staff, 0)
         >>> abjad.attach(mark, leaf, context='Staff')
 
@@ -5217,7 +5217,7 @@ def partition_by_durations(
         ...     abjad.attach(time_signature, container[0])
         ...
         >>> abjad.setting(staff).autoBeaming = False
-        >>> mark = abjad.MetronomeMark((1, 4), 60)
+        >>> mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         >>> leaf = abjad.get.leaf(staff, 0)
         >>> abjad.attach(mark, leaf, context='Staff')
 
@@ -5302,7 +5302,7 @@ def partition_by_durations(
         ...     abjad.attach(time_signature, container[0])
         ...
         >>> abjad.setting(staff).autoBeaming = False
-        >>> mark = abjad.MetronomeMark((1, 4), 60)
+        >>> mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
         >>> leaf = abjad.get.leaf(staff, 0)
         >>> abjad.attach(mark, leaf, context='Staff')
 

--- a/tests/test_LilyPondParser__indicators__MetronomeMark.py
+++ b/tests/test_LilyPondParser__indicators__MetronomeMark.py
@@ -31,7 +31,7 @@ def test_LilyPondParser__indicators__MetronomeMark_01():
 def test_LilyPondParser__indicators__MetronomeMark_02():
     target = abjad.Score([abjad.Staff([abjad.Note(0, 1)])])
     leaves = abjad.select.leaves(target)
-    mark = abjad.MetronomeMark((1, 4), 60)
+    mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
     abjad.attach(mark, leaves[0], context="Staff")
 
     assert abjad.lilypond(target) == abjad.string.normalize(
@@ -59,7 +59,7 @@ def test_LilyPondParser__indicators__MetronomeMark_02():
 def test_LilyPondParser__indicators__MetronomeMark_03():
     target = abjad.Score([abjad.Staff([abjad.Note(0, 1)])])
     leaves = abjad.select.leaves(target)
-    mark = abjad.MetronomeMark((1, 4), (59, 63))
+    mark = abjad.MetronomeMark(abjad.Duration(1, 4), (59, 63))
     abjad.attach(mark, leaves[0], context="Staff")
 
     assert abjad.lilypond(target) == abjad.string.normalize(
@@ -87,7 +87,7 @@ def test_LilyPondParser__indicators__MetronomeMark_03():
 def test_LilyPondParser__indicators__MetronomeMark_04():
     target = abjad.Score([abjad.Staff([abjad.Note(0, 1)])])
     mark = abjad.MetronomeMark(
-        reference_duration=(1, 4),
+        reference_duration=abjad.Duration(1, 4),
         units_per_minute=60,
         textual_indication='"Like a majestic swan, alive with youth and vigour!"',
     )
@@ -119,7 +119,7 @@ def test_LilyPondParser__indicators__MetronomeMark_04():
 def test_LilyPondParser__indicators__MetronomeMark_05():
     target = abjad.Score([abjad.Staff([abjad.Note(0, 1)])])
     mark = abjad.MetronomeMark(
-        reference_duration=(1, 16),
+        reference_duration=abjad.Duration(1, 16),
         units_per_minute=(34, 55),
         textual_indication='"Brighter than a thousand suns"',
     )

--- a/tests/test_LilyPondParser__spanners__Hairpin.py
+++ b/tests/test_LilyPondParser__spanners__Hairpin.py
@@ -141,8 +141,8 @@ def test_LilyPondParser__spanners__Hairpin_07():
             d'4
             e'4
             f'4
-            \!
             )
+            \!
         }
         """
     )

--- a/tests/test_MetronomeMark_attach.py
+++ b/tests/test_MetronomeMark_attach.py
@@ -5,8 +5,8 @@ import abjad
 
 def test_MetronomeMark_attach_01():
     score = abjad.Score(r"\new Staff { c'' d'' e'' f'' } \new Staff { c' d' e' f' }")
-    mark_1 = abjad.MetronomeMark((1, 8), 52)
-    mark_2 = abjad.MetronomeMark((1, 8), 73)
+    mark_1 = abjad.MetronomeMark(abjad.Duration(1, 8), 52)
+    mark_2 = abjad.MetronomeMark(abjad.Duration(1, 8), 73)
     abjad.attach(mark_1, score[0][0])
 
     with pytest.raises(Exception):

--- a/tests/test_Tuplet_get_timespan.py
+++ b/tests/test_Tuplet_get_timespan.py
@@ -5,7 +5,7 @@ def test_Tuplet_get_timespan_01():
     staff = abjad.Staff(r"c'4 d'4 \times 2/3 { e'4 f'4 g'4 }")
     leaves = abjad.select.leaves(staff)
     score = abjad.Score([staff])
-    mark = abjad.MetronomeMark((1, 4), 60)
+    mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
     abjad.attach(mark, leaves[0])
 
     assert abjad.lilypond(score) == abjad.string.normalize(

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -14,7 +14,7 @@ def test_bind_01():
     staff = abjad.Staff([voice])
     score = abjad.Score([staff])
     leaf = abjad.select.leaf(staff, 0)
-    mark = abjad.MetronomeMark((1, 4), 72)
+    mark = abjad.MetronomeMark(abjad.Duration(1, 4), 72)
     abjad.attach(mark, leaf)
     score[:] = []
     string = abjad.lilypond(staff)

--- a/tests/test_class_design.py
+++ b/tests/test_class_design.py
@@ -21,7 +21,7 @@ class_to_default_values = {
     abjad.LilyPondLiteral: ("", "before"),
     abjad.Markup: (r"\markup Allegro",),
     abjad.MetricModulation: (abjad.Note("c'4"), abjad.Note("c'4.")),
-    abjad.MetronomeMark: ((1, 4), 90),
+    abjad.MetronomeMark: (abjad.Duration(1, 4), 90),
     abjad.TimeSignature: ((4, 4),),
     abjad.Tweak: (r"\tweak color #red",),
 }

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -28,30 +28,30 @@ def test_indicators_01():
     assert abjad.Dynamic("p", hide=True) != abjad.Dynamic("f", hide=False)
     assert abjad.Dynamic("p", hide=True) != abjad.Dynamic("f", hide=True)
 
-    assert abjad.MetronomeMark((1, 4), 60, hide=False) == abjad.MetronomeMark(
-        (1, 4), 60, hide=False
-    )
-    assert abjad.MetronomeMark((1, 4), 60, hide=False) == abjad.MetronomeMark(
-        (1, 4), 60, hide=True
-    )
-    assert abjad.MetronomeMark((1, 4), 60, hide=True) == abjad.MetronomeMark(
-        (1, 4), 60, hide=False
-    )
-    assert abjad.MetronomeMark((1, 4), 60, hide=True) == abjad.MetronomeMark(
-        (1, 4), 60, hide=True
-    )
-    assert abjad.MetronomeMark((1, 4), 60, hide=False) != abjad.MetronomeMark(
-        (1, 4), 72, hide=False
-    )
-    assert abjad.MetronomeMark((1, 4), 60, hide=False) != abjad.MetronomeMark(
-        (1, 4), 72, hide=True
-    )
-    assert abjad.MetronomeMark((1, 4), 60, hide=True) != abjad.MetronomeMark(
-        (1, 4), 72, hide=False
-    )
-    assert abjad.MetronomeMark((1, 4), 60, hide=True) != abjad.MetronomeMark(
-        (1, 4), 72, hide=True
-    )
+    assert abjad.MetronomeMark(
+        abjad.Duration(1, 4), 60, hide=False
+    ) == abjad.MetronomeMark(abjad.Duration(1, 4), 60, hide=False)
+    assert abjad.MetronomeMark(
+        abjad.Duration(1, 4), 60, hide=False
+    ) == abjad.MetronomeMark(abjad.Duration(1, 4), 60, hide=True)
+    assert abjad.MetronomeMark(
+        abjad.Duration(1, 4), 60, hide=True
+    ) == abjad.MetronomeMark(abjad.Duration(1, 4), 60, hide=False)
+    assert abjad.MetronomeMark(
+        abjad.Duration(1, 4), 60, hide=True
+    ) == abjad.MetronomeMark(abjad.Duration(1, 4), 60, hide=True)
+    assert abjad.MetronomeMark(
+        abjad.Duration(1, 4), 60, hide=False
+    ) != abjad.MetronomeMark(abjad.Duration(1, 4), 72, hide=False)
+    assert abjad.MetronomeMark(
+        abjad.Duration(1, 4), 60, hide=False
+    ) != abjad.MetronomeMark(abjad.Duration(1, 4), 72, hide=True)
+    assert abjad.MetronomeMark(
+        abjad.Duration(1, 4), 60, hide=True
+    ) != abjad.MetronomeMark(abjad.Duration(1, 4), 72, hide=False)
+    assert abjad.MetronomeMark(
+        abjad.Duration(1, 4), 60, hide=True
+    ) != abjad.MetronomeMark(abjad.Duration(1, 4), 72, hide=True)
 
     assert abjad.TimeSignature(((3, 4)), hide=False) == abjad.TimeSignature(
         ((3, 4)), hide=False

--- a/tests/test_mutate__fuse_leaves_by_immediate_parent.py
+++ b/tests/test_mutate__fuse_leaves_by_immediate_parent.py
@@ -151,7 +151,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_06():
     """
 
     voice = abjad.Voice(r"c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
-    abjad.attach(abjad.MetronomeMark((1, 4), 120), voice[0])
+    abjad.attach(abjad.MetronomeMark(abjad.Duration(1, 4), 120), voice[0])
     logical_tie = abjad.get.logical_tie(voice[0])
     result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
 


### PR DESCRIPTION
The initializers are now strict. That is, initializers no longer coerce input.

Intialize metronome marks like this:

    OLD:

        * abjad.MetronomeMark(abjad.Duration(1, 4), 72)
        * abjad.MetronomeMark((1, 4), 72)

    NEW:

        * abjad.MetronomeMark(abjad.Duration(1, 4), 72)

Initialize time signatures like this:

    OLD:

        * abjad.TimeSignature(pair)
        * abjad.TimeSignature(duration)
        * abjad.TimeSignature(time_signature)

    NEW:

        * abjad.TimeSignature(pair)

Also, moved LilyPond stop-hairpin \! from articulations to spanner-stops site.