### PR TITLE
FIXED. abjad.beam(..., stemlet_length=0.75) formats \revert correctly.

### DIFF
--- a/abjad/bind.py
+++ b/abjad/bind.py
@@ -31,7 +31,8 @@ def _before_attach(indicator, deactivate, component):
                 component, indicator.context
             )
             if context is None:
-                message = f"can not find {indicator.context} context"
+                message = f"\n    {indicator} requires {indicator.context} context;"
+                message += f"\n    can not find {indicator.context}"
                 message += f" in parentage of {component!r}."
                 raise _exceptions.MissingContextError(message)
     if getattr(indicator, "nestable_spanner", False) is True:

--- a/abjad/get.py
+++ b/abjad/get.py
@@ -931,6 +931,7 @@ def effective(
     ..  container:: example
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
+        >>> staff = abjad.Staff([music_voice])
         >>> container = abjad.BeforeGraceContainer("cs'16")
         >>> abjad.attach(container, music_voice[1])
         >>> container = abjad.on_beat_grace_container(
@@ -940,7 +941,6 @@ def effective(
         >>> abjad.attach(abjad.Articulation(">"), container[0])
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
-        >>> staff = abjad.Staff([music_voice])
         >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -1566,6 +1566,7 @@ def effective_wrapper(
         REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
+        >>> staff = abjad.Staff([music_voice])
         >>> container = abjad.BeforeGraceContainer("cs'16")
         >>> abjad.attach(container, music_voice[1])
         >>> container = abjad.on_beat_grace_container(
@@ -1575,7 +1576,6 @@ def effective_wrapper(
         >>> abjad.attach(abjad.Articulation(">"), container[0])
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
-        >>> staff = abjad.Staff([music_voice])
         >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -1786,6 +1786,7 @@ def has_effective_indicator(
     ..  container:: example
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
+        >>> staff = abjad.Staff([music_voice])
         >>> container = abjad.BeforeGraceContainer("cs'16")
         >>> abjad.attach(container, music_voice[1])
         >>> container = abjad.on_beat_grace_container(
@@ -1795,7 +1796,6 @@ def has_effective_indicator(
         >>> abjad.attach(abjad.Articulation(">"), container[0])
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
-        >>> staff = abjad.Staff([music_voice])
         >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -1939,6 +1939,7 @@ def has_indicator(
     ..  container:: example
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
+        >>> staff = abjad.Staff([music_voice])
         >>> container = abjad.BeforeGraceContainer("cs'16")
         >>> abjad.attach(container, music_voice[1])
         >>> container = abjad.on_beat_grace_container(
@@ -1948,7 +1949,6 @@ def has_indicator(
         >>> abjad.attach(abjad.Articulation(">"), container[0])
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
-        >>> staff = abjad.Staff([music_voice])
         >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -2072,6 +2072,7 @@ def has_indicator(
         Set ``attributes`` dictionary to test indicator attributes:
 
         >>> voice = abjad.Voice("c'4 c'4 c'4 c'4")
+        >>> staff = abjad.Staff([voice], name="Staff")
         >>> abjad.attach(abjad.Clef('treble'), voice[0])
         >>> abjad.attach(abjad.Clef('alto'), voice[2])
         >>> abjad.show(voice) # doctest: +SKIP
@@ -2137,6 +2138,7 @@ def indicator(
     ..  container:: example
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
+        >>> staff = abjad.Staff([music_voice])
         >>> container = abjad.BeforeGraceContainer("cs'16")
         >>> abjad.attach(container, music_voice[1])
         >>> container = abjad.on_beat_grace_container(
@@ -2146,7 +2148,6 @@ def indicator(
         >>> abjad.attach(abjad.Articulation(">"), container[0])
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
-        >>> staff = abjad.Staff([music_voice])
         >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -2288,6 +2289,7 @@ def indicators(
     ..  container:: example
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
+        >>> staff = abjad.Staff([music_voice])
         >>> container = abjad.BeforeGraceContainer("cs'16")
         >>> abjad.attach(container, music_voice[1])
         >>> container = abjad.on_beat_grace_container(
@@ -2297,7 +2299,6 @@ def indicators(
         >>> abjad.attach(abjad.Articulation(">"), container[0])
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
-        >>> staff = abjad.Staff([music_voice])
         >>> for note in abjad.select.notes(staff):
         ...     abjad.attach(abjad.Articulation("."), note)
 
@@ -2538,6 +2539,7 @@ def leaf(argument, n: int = 0) -> typing.Optional["_score.Leaf"]:
         REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
+        >>> staff = abjad.Staff([music_voice])
         >>> container = abjad.BeforeGraceContainer("cs'16")
         >>> abjad.attach(container, music_voice[1])
         >>> container = abjad.on_beat_grace_container(
@@ -2547,7 +2549,6 @@ def leaf(argument, n: int = 0) -> typing.Optional["_score.Leaf"]:
         >>> abjad.attach(abjad.Articulation(">"), container[0])
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
-        >>> staff = abjad.Staff([music_voice])
         >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
@@ -3949,6 +3950,7 @@ def wrapper(
     ..  container:: example
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
+        >>> staff = abjad.Staff([music_voice])
         >>> container = abjad.BeforeGraceContainer("cs'16")
         >>> abjad.attach(container, music_voice[1])
         >>> container = abjad.on_beat_grace_container(
@@ -3958,7 +3960,6 @@ def wrapper(
         >>> abjad.attach(abjad.Articulation(">"), container[0])
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
-        >>> staff = abjad.Staff([music_voice])
         >>> for note in abjad.select.notes(staff):
         ...     abjad.attach(abjad.Articulation("."), note)
 
@@ -4087,6 +4088,7 @@ def wrappers(
         REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
+        >>> staff = abjad.Staff([music_voice])
         >>> container = abjad.BeforeGraceContainer("cs'16")
         >>> abjad.attach(container, music_voice[1])
         >>> container = abjad.on_beat_grace_container(
@@ -4096,7 +4098,6 @@ def wrappers(
         >>> abjad.attach(abjad.Articulation(">"), container[0])
         >>> container = abjad.AfterGraceContainer("fs'16")
         >>> abjad.attach(container, music_voice[3])
-        >>> staff = abjad.Staff([music_voice])
         >>> for note in abjad.select.notes(staff):
         ...     abjad.attach(abjad.Articulation("."), note)
 

--- a/abjad/illustrators.py
+++ b/abjad/illustrators.py
@@ -66,29 +66,31 @@ def _illustrate_pitch_range(range_):
     stop_note = _score.Note(range_.stop_pitch, 1)
     if start_pitch_clef == stop_pitch_clef:
         if start_pitch_clef == _indicators.Clef("bass"):
-            bass_staff = _score.Staff(name="Bass_Staff")
-            _bind.attach(_indicators.Clef("bass"), bass_staff)
-            bass_staff.extend([start_note, stop_note])
-            bass_leaves = _select.leaves(bass_staff)
+            bass_voice = _score.Voice(name="Bass_Voice")
+            bass_staff = _score.Staff([bass_voice], name="Bass_Staff")
+            bass_voice.extend([start_note, stop_note])
+            _bind.attach(_indicators.Clef("bass"), start_note)
+            bass_leaves = _select.leaves(bass_voice)
             _spanners.glissando(bass_leaves)
             score = _score.Score([bass_staff], name="Score")
         else:
-            treble_staff = _score.Staff(name="Treble_Staff")
-            _bind.attach(_indicators.Clef("treble"), treble_staff)
-            treble_staff.extend([start_note, stop_note])
-            treble_leaves = _select.leaves(treble_staff)
+            treble_voice = _score.Voice(name="Treble_Voice")
+            treble_staff = _score.Staff([treble_voice], name="Treble_Staff")
+            treble_voice.extend([start_note, stop_note])
+            _bind.attach(_indicators.Clef("treble"), start_note)
+            treble_leaves = _select.leaves(treble_voice)
             _spanners.glissando(treble_leaves)
             score = _score.Score([treble_staff], name="Score")
     else:
         score = make_piano_score()
-        treble_staff, bass_staff = score["Treble_Staff"], score["Bass_Staff"]
-        bass_staff.extend([start_note, stop_note])
-        treble_staff.extend("s1 s1")
-        bass_leaves = _select.leaves(bass_staff)
+        treble_voice, bass_voice = score["Treble_Voice"], score["Bass_Voice"]
+        bass_voice.extend([start_note, stop_note])
+        treble_voice.extend("s1 s1")
+        bass_leaves = _select.leaves(bass_voice)
         _spanners.glissando(bass_leaves)
-        _bind.attach(_indicators.StaffChange("Treble_Staff"), bass_staff[1])
-        _bind.attach(_indicators.Clef("treble"), treble_staff[0])
-        _bind.attach(_indicators.Clef("bass"), bass_staff[0])
+        _bind.attach(_indicators.StaffChange("Treble_Staff"), bass_voice[1])
+        _bind.attach(_indicators.Clef("treble"), treble_voice[0])
+        _bind.attach(_indicators.Clef("bass"), bass_voice[0])
     for leaf in _iterate.leaves(score):
         leaf.multiplier = (1, 4)
     _overrides.override(score).BarLine.stencil = False
@@ -373,14 +375,20 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        \tweak color #red
-                        c'4
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            \tweak color #red
+                            c'4
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        r4
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            r4
+                        }
                     }
                 >>
             >>
@@ -403,23 +411,29 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        <
-                            \tweak color #blue
-                            a'
-                            \tweak color #blue
-                            bf'
-                        >4
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            <
+                                \tweak color #blue
+                                a'
+                                \tweak color #blue
+                                bf'
+                            >4
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        <
-                            \tweak color #red
-                            c
-                            \tweak color #red
-                            d
-                        >4
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            <
+                                \tweak color #red
+                                c
+                                \tweak color #red
+                                d
+                            >4
+                        }
                     }
                 >>
             >>
@@ -446,25 +460,31 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        <
-                            \tweak color #blue
-                            a'
-                            \tweak color #blue
-                            bf'
-                        >4
-                        ^ \markup loco
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            <
+                                \tweak color #blue
+                                a'
+                                \tweak color #blue
+                                bf'
+                            >4
+                            ^ \markup loco
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        <
-                            \tweak color #red
-                            c
-                            \tweak color #red
-                            d
-                        >4
-                        _ \markup ped.
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            <
+                                \tweak color #red
+                                c
+                                \tweak color #red
+                                d
+                            >4
+                            _ \markup ped.
+                        }
                     }
                 >>
             >>
@@ -472,15 +492,16 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
     """
     leaves = leaves or []
     lowest_treble_pitch = _pitch.NamedPitch(lowest_treble_pitch)
-    treble_staff = _score.Staff(name="Treble_Staff")
-    bass_staff = _score.Staff(name="Bass_Staff")
+    treble_voice = _score.Voice(name="Treble_Voice")
+    treble_staff = _score.Staff([treble_voice], name="Treble_Staff")
+    bass_voice = _score.Voice(name="Bass_Voice")
+    bass_staff = _score.Staff([bass_voice], name="Bass_Staff")
     staff_group = _score.StaffGroup(
         [treble_staff, bass_staff],
         lilypond_type="PianoStaff",
         name="Piano_Staff",
     )
-    score = _score.Score(name="Score")
-    score.append(staff_group)
+    score = _score.Score([staff_group], name="Score")
     for leaf in leaves:
         markup_wrappers = _get.indicators(leaf, _indicators.Markup, unwrap=False)
         written_duration = leaf.written_duration
@@ -521,12 +542,12 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
                 _bind.attach(markup_copy, treble_leaf, direction=wrapper.direction)
             else:
                 _bind.attach(markup_copy, bass_leaf, direction=wrapper.direction)
-        treble_staff.append(treble_leaf)
-        bass_staff.append(bass_leaf)
-    if 0 < len(treble_staff):
+        treble_voice.append(treble_leaf)
+        bass_voice.append(bass_leaf)
+    if 0 < len(treble_voice):
         clef = _indicators.Clef("treble")
-        _bind.attach(clef, treble_staff[0])
-    if 0 < len(bass_staff):
+        _bind.attach(clef, treble_voice[0])
+    if 0 < len(bass_voice):
         clef = _indicators.Clef("bass")
-        _bind.attach(clef, bass_staff[0])
+        _bind.attach(clef, bass_voice[0])
     return score

--- a/abjad/indicators.py
+++ b/abjad/indicators.py
@@ -272,7 +272,7 @@ class BarLine:
     site: str = "after"
 
     context: typing.ClassVar[str] = "Score"
-    find_context_on_attach: typing.ClassVar[bool] = True
+    # find_context_on_attach: typing.ClassVar[bool] = True
     known_abbreviations: typing.ClassVar[tuple[str, ...]] = (
         "",
         "|",
@@ -600,17 +600,17 @@ class Clef:
         LilyPond can not handle simultaneous clefs:
 
         >>> voice_1 = abjad.Voice("e'8 g' f' a' g' b'")
+        >>> voice_2 = abjad.Voice("c'4. c,8 b,, a,,")
+        >>> staff = abjad.Staff([voice_1, voice_2], simultaneous=True)
         >>> abjad.attach(abjad.Clef("treble"), voice_1[0], context="Voice")
         >>> command = abjad.VoiceNumber(1)
         >>> abjad.attach(command, voice_1[0])
         >>> voice_1.consists_commands.append("Clef_engraver")
-        >>> voice_2 = abjad.Voice("c'4. c,8 b,, a,,")
         >>> abjad.attach(abjad.Clef("treble"), voice_2[0], context="Voice")
         >>> abjad.attach(abjad.Clef("bass"), voice_2[1], context="Voice")
         >>> command = abjad.VoiceNumber(2)
         >>> abjad.attach(command, voice_2[0])
         >>> voice_2.consists_commands.append("Clef_engraver")
-        >>> staff = abjad.Staff([voice_1, voice_2], simultaneous=True)
         >>> staff.remove_commands.append("Clef_engraver")
         >>> abjad.show(staff) # doctest: +SKIP
 
@@ -722,6 +722,7 @@ class Clef:
     hide: bool = dataclasses.field(compare=False, default=False)
 
     context: typing.ClassVar[str] = "Staff"
+    # find_context_on_attach: typing.ClassVar[bool] = True
     persistent: typing.ClassVar[bool] = True
     redraw: typing.ClassVar[bool] = True
     site: typing.ClassVar[str] = "before"
@@ -1295,10 +1296,12 @@ class Fermata:
         Tweaks:
 
         >>> note = abjad.Note("c'4")
+        >>> staff = abjad.Staff([note], name="Staff")
+        >>> score = abjad.Score([staff], name="Score")
         >>> fermata = abjad.Fermata()
         >>> bundle = abjad.bundle(fermata, r"- \tweak color #blue")
         >>> abjad.attach(bundle, note)
-        >>> abjad.show(note) # doctest: +SKIP
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
@@ -1319,6 +1322,7 @@ class Fermata:
         "verylongfermata",
     )
     context: typing.ClassVar[str] = "Score"
+    find_context_on_attach: typing.ClassVar[bool] = True
     post_event: typing.ClassVar[bool] = True
     site: typing.ClassVar[str] = "after"
 
@@ -1341,17 +1345,17 @@ class Glissando:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'", name="Voice")
         >>> glissando = abjad.Glissando()
         >>> bundle = abjad.bundle(glissando, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(bundle, voice[0])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \context Voice = "Voice"
             {
                 c'4
                 - \tweak color #blue
@@ -1366,6 +1370,7 @@ class Glissando:
     zero_padding: bool = False
 
     context: typing.ClassVar[str] = "Voice"
+    # find_context_on_attach: typing.ClassVar[bool] = True
     persistent: typing.ClassVar[bool] = True
     post_event: typing.ClassVar[bool] = True
 

--- a/abjad/pcollections.py
+++ b/abjad/pcollections.py
@@ -616,17 +616,23 @@ class PitchRange:
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        s1 * 1/4
-                        s1 * 1/4
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            s1 * 1/4
+                            s1 * 1/4
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        c1 * 1/4
-                        \glissando
-                        \change Staff = Treble_Staff
-                        c''''1 * 1/4
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            c1 * 1/4
+                            \glissando
+                            \change Staff = Treble_Staff
+                            c''''1 * 1/4
+                        }
                     }
                 >>
             >>
@@ -1129,23 +1135,29 @@ class PitchSegment:
             <<
                 \context Staff = "Treble_Staff"
                 {
-                    \clef "treble"
-                    r1 * 1/8
-                    r1 * 1/8
-                    fs'1 * 1/8
-                    g'1 * 1/8
-                    r1 * 1/8
-                    g'1 * 1/8
+                    \context Voice = "Treble_Voice"
+                    {
+                        \clef "treble"
+                        r1 * 1/8
+                        r1 * 1/8
+                        fs'1 * 1/8
+                        g'1 * 1/8
+                        r1 * 1/8
+                        g'1 * 1/8
+                    }
                 }
                 \context Staff = "Bass_Staff"
                 {
-                    \clef "bass"
-                    bf1 * 1/8
-                    bqf1 * 1/8
-                    r1 * 1/8
-                    r1 * 1/8
-                    bqf1 * 1/8
-                    r1 * 1/8
+                    \context Voice = "Bass_Voice"
+                    {
+                        \clef "bass"
+                        bf1 * 1/8
+                        bqf1 * 1/8
+                        r1 * 1/8
+                        r1 * 1/8
+                        bqf1 * 1/8
+                        r1 * 1/8
+                    }
                 }
             >>
 
@@ -1251,23 +1263,29 @@ class PitchSegment:
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        r1 * 1/8
-                        r1 * 1/8
-                        fs'1 * 1/8
-                        g'1 * 1/8
-                        r1 * 1/8
-                        g'1 * 1/8
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            r1 * 1/8
+                            r1 * 1/8
+                            fs'1 * 1/8
+                            g'1 * 1/8
+                            r1 * 1/8
+                            g'1 * 1/8
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        bf1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            bf1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                        }
                     }
                 >>
 
@@ -1288,23 +1306,29 @@ class PitchSegment:
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        d'1 * 1/8
-                        dqf'1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        dqf'1 * 1/8
-                        r1 * 1/8
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            d'1 * 1/8
+                            dqf'1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            dqf'1 * 1/8
+                            r1 * 1/8
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        r1 * 1/8
-                        r1 * 1/8
-                        fs1 * 1/8
-                        f1 * 1/8
-                        r1 * 1/8
-                        f1 * 1/8
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            r1 * 1/8
+                            r1 * 1/8
+                            fs1 * 1/8
+                            f1 * 1/8
+                            r1 * 1/8
+                            f1 * 1/8
+                        }
                     }
                 >>
 
@@ -1332,23 +1356,29 @@ class PitchSegment:
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        r1 * 1/8
-                        r1 * 1/8
-                        fs'1 * 1/8
-                        g'1 * 1/8
-                        r1 * 1/8
-                        g'1 * 1/8
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            r1 * 1/8
+                            r1 * 1/8
+                            fs'1 * 1/8
+                            g'1 * 1/8
+                            r1 * 1/8
+                            g'1 * 1/8
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        bf1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            bf1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                        }
                     }
                 >>
 
@@ -1369,23 +1399,29 @@ class PitchSegment:
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        r1 * 1/8
-                        r1 * 1/8
-                        fs''1 * 1/8
-                        a''1 * 1/8
-                        r1 * 1/8
-                        a''1 * 1/8
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            r1 * 1/8
+                            r1 * 1/8
+                            fs''1 * 1/8
+                            a''1 * 1/8
+                            r1 * 1/8
+                            a''1 * 1/8
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        fs1 * 1/8
-                        gqs1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        gqs1 * 1/8
-                        r1 * 1/8
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            fs1 * 1/8
+                            gqs1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            gqs1 * 1/8
+                            r1 * 1/8
+                        }
                     }
                 >>
 
@@ -1413,23 +1449,29 @@ class PitchSegment:
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        r1 * 1/8
-                        r1 * 1/8
-                        fs'1 * 1/8
-                        g'1 * 1/8
-                        r1 * 1/8
-                        g'1 * 1/8
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            r1 * 1/8
+                            r1 * 1/8
+                            fs'1 * 1/8
+                            g'1 * 1/8
+                            r1 * 1/8
+                            g'1 * 1/8
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        bf1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            bf1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                        }
                     }
                 >>
 
@@ -1450,23 +1492,29 @@ class PitchSegment:
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        g'1 * 1/8
-                        r1 * 1/8
-                        g'1 * 1/8
-                        fs'1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            g'1 * 1/8
+                            r1 * 1/8
+                            g'1 * 1/8
+                            fs'1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        r1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        bqf1 * 1/8
-                        bf1 * 1/8
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            r1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            bqf1 * 1/8
+                            bf1 * 1/8
+                        }
                     }
                 >>
 
@@ -1493,23 +1541,29 @@ class PitchSegment:
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        r1 * 1/8
-                        r1 * 1/8
-                        fs'1 * 1/8
-                        g'1 * 1/8
-                        r1 * 1/8
-                        g'1 * 1/8
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            r1 * 1/8
+                            r1 * 1/8
+                            fs'1 * 1/8
+                            g'1 * 1/8
+                            r1 * 1/8
+                            g'1 * 1/8
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        bf1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            bf1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                        }
                     }
                 >>
 
@@ -1530,23 +1584,29 @@ class PitchSegment:
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        g'1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        fs'1 * 1/8
-                        g'1 * 1/8
-                        r1 * 1/8
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            g'1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            fs'1 * 1/8
+                            g'1 * 1/8
+                            r1 * 1/8
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        r1 * 1/8
-                        bf1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        bqf1 * 1/8
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            r1 * 1/8
+                            bf1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            bqf1 * 1/8
+                        }
                     }
                 >>
 
@@ -1575,23 +1635,29 @@ class PitchSegment:
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        r1 * 1/8
-                        r1 * 1/8
-                        fs'1 * 1/8
-                        g'1 * 1/8
-                        r1 * 1/8
-                        g'1 * 1/8
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            r1 * 1/8
+                            r1 * 1/8
+                            fs'1 * 1/8
+                            g'1 * 1/8
+                            r1 * 1/8
+                            g'1 * 1/8
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        bf1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        bqf1 * 1/8
-                        r1 * 1/8
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            bf1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            bqf1 * 1/8
+                            r1 * 1/8
+                        }
                     }
                 >>
 
@@ -1612,23 +1678,29 @@ class PitchSegment:
                 <<
                     \context Staff = "Treble_Staff"
                     {
-                        \clef "treble"
-                        a'1 * 1/8
-                        aqs'1 * 1/8
-                        f''1 * 1/8
-                        fs''1 * 1/8
-                        aqs'1 * 1/8
-                        fs''1 * 1/8
+                        \context Voice = "Treble_Voice"
+                        {
+                            \clef "treble"
+                            a'1 * 1/8
+                            aqs'1 * 1/8
+                            f''1 * 1/8
+                            fs''1 * 1/8
+                            aqs'1 * 1/8
+                            fs''1 * 1/8
+                        }
                     }
                     \context Staff = "Bass_Staff"
                     {
-                        \clef "bass"
-                        r1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
-                        r1 * 1/8
+                        \context Voice = "Bass_Voice"
+                        {
+                            \clef "bass"
+                            r1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                            r1 * 1/8
+                        }
                     }
                 >>
 

--- a/abjad/spanners.py
+++ b/abjad/spanners.py
@@ -124,7 +124,6 @@ def beam(
         _bind.attach(start_beam_, start_leaf, direction=direction, tag=tag)
         _bind.detach(_indicators.StopBeam, stop_leaf)
         _bind.attach(stop_beam_, stop_leaf, tag=tag)
-
         if stemlet_length is None:
             continue
         staff = _parentage.Parentage(start_leaf).get(_score.Staff)
@@ -139,16 +138,14 @@ def beam(
         staff = _parentage.Parentage(stop_leaf).get(_score.Staff)
         lilypond_type = getattr(staff, "lilypond_type", "Staff")
         string = rf"\revert {lilypond_type}.Stem.stemlet-length"
-        literal = _indicators.LilyPondLiteral(string, site="before")
+        literal = _indicators.LilyPondLiteral(string, site="after")
         for indicator in stop_leaf._get_indicators():
             if indicator == literal:
                 break
         else:
             _bind.attach(literal, stop_leaf, tag=tag)
-
     if not durations:
         return
-
     if len(original_leaves) == 1:
         return
 
@@ -224,7 +221,6 @@ def beam(
                     right = min(previous, flag_count)
             beam_count = _indicators.BeamCount(left, right)
             _bind.attach(beam_count, last_leaf, tag=tag)
-
         # TODO: eventually remove middle leaf beam counts?
         for middle_leaf in part[1:-1]:
             if not _is_beamable(middle_leaf, beam_rests=beam_rests):
@@ -275,123 +271,136 @@ def glissando(
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-        >>> abjad.glissando(staff[:])
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8", name="Voice")
+        >>> staff = abjad.Staff([voice], name="Staff")
+        >>> abjad.glissando(voice[:])
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
 
             >>> string = abjad.lilypond(staff)
             >>> print(string)
-            \new Staff
+            \context Staff = "Staff"
             {
-                c'8
-                \glissando
-                d'8
-                \glissando
-                e'8
-                \glissando
-                f'8
+                \context Voice = "Voice"
+                {
+                    c'8
+                    \glissando
+                    d'8
+                    \glissando
+                    e'8
+                    \glissando
+                    f'8
+                }
             }
 
     ..  container:: example
 
         Glissando avoids bend-after indicators:
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8", name="Voice")
+        >>> staff = abjad.Staff([voice], name="Staff")
         >>> bend_after = abjad.BendAfter()
-        >>> abjad.attach(bend_after, staff[1])
-        >>> abjad.glissando(staff[:])
+        >>> abjad.attach(bend_after, voice[1])
+        >>> abjad.glissando(voice[:])
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
 
             >>> string = abjad.lilypond(staff)
             >>> print(string)
-            \new Staff
+            \context Staff = "Staff"
             {
-                c'8
-                \glissando
-                d'8
-                - \bendAfter #'-4
-                e'8
-                \glissando
-                f'8
+                \context Voice = "Voice"
+                {
+                    c'8
+                    \glissando
+                    d'8
+                    - \bendAfter #'-4
+                    e'8
+                    \glissando
+                    f'8
+                }
             }
 
     ..  container:: example
 
         Does not allow repeated pitches:
 
-        >>> staff = abjad.Staff("a8 a8 b8 ~ b8 c'8 c'8 d'8 ~ d'8")
-        >>> abjad.glissando(
-        ...     staff[:],
-        ...     allow_repeats=False,
-        ... )
+        >>> voice = abjad.Voice("a8 a8 b8 ~ b8 c'8 c'8 d'8 ~ d'8", name="Voice")
+        >>> staff = abjad.Staff([voice], name="Staff")
+        >>> abjad.glissando(voice[:], allow_repeats=True)
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
 
             >>> string = abjad.lilypond(staff)
             >>> print(string)
-            \new Staff
+            \context Staff = "Staff"
             {
-                a8
-                a8
-                \glissando
-                b8
-                ~
-                b8
-                \glissando
-                c'8
-                c'8
-                \glissando
-                d'8
-                ~
-                d'8
+                \context Voice = "Voice"
+                {
+                    a8
+                    \glissando
+                    a8
+                    \glissando
+                    b8
+                    ~
+                    b8
+                    \glissando
+                    c'8
+                    \glissando
+                    c'8
+                    \glissando
+                    d'8
+                    ~
+                    d'8
+                }
             }
 
     ..  container:: example
 
         Allows repeated pitches (but not ties):
 
-        >>> staff = abjad.Staff("a8 a8 b8 ~ b8 c'8 c'8 d'8 ~ d'8")
-        >>> abjad.glissando(
-        ...     staff[:],
-        ...     allow_repeats=True,
-        ... )
+        >>> voice = abjad.Voice("a8 a8 b8 ~ b8 c'8 c'8 d'8 ~ d'8", name="Voice")
+        >>> staff = abjad.Staff([voice], name="Staff")
+        >>> abjad.glissando(voice[:], allow_repeats=True)
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
 
             >>> string = abjad.lilypond(staff)
             >>> print(string)
-            \new Staff
+            \context Staff = "Staff"
             {
-                a8
-                \glissando
-                a8
-                \glissando
-                b8
-                ~
-                b8
-                \glissando
-                c'8
-                \glissando
-                c'8
-                \glissando
-                d'8
-                ~
-                d'8
+                \context Voice = "Voice"
+                {
+                    a8
+                    \glissando
+                    a8
+                    \glissando
+                    b8
+                    ~
+                    b8
+                    \glissando
+                    c'8
+                    \glissando
+                    c'8
+                    \glissando
+                    d'8
+                    ~
+                    d'8
+                }
             }
 
     ..  container:: example
 
         Allows both repeated pitches and ties:
 
-        >>> staff = abjad.Staff("a8 a8 b8 ~ b8 c'8 c'8 d'8 ~ d'8")
+        >>> voice = abjad.Voice("a8 a8 b8 ~ b8 c'8 c'8 d'8 ~ d'8", name="Voice")
+        >>> staff = abjad.Staff([voice], name="Staff")
         >>> abjad.glissando(
-        ...     staff[:],
+        ...     voice[:],
         ...     allow_repeats=True,
         ...     allow_ties=True,
         ... )
@@ -401,25 +410,28 @@ def glissando(
 
             >>> string = abjad.lilypond(staff)
             >>> print(string)
-            \new Staff
+            \context Staff = "Staff"
             {
-                a8
-                \glissando
-                a8
-                \glissando
-                b8
-                \glissando
-                ~
-                b8
-                \glissando
-                c'8
-                \glissando
-                c'8
-                \glissando
-                d'8
-                \glissando
-                ~
-                d'8
+                \context Voice = "Voice"
+                {
+                    a8
+                    \glissando
+                    a8
+                    \glissando
+                    b8
+                    \glissando
+                    ~
+                    b8
+                    \glissando
+                    c'8
+                    \glissando
+                    c'8
+                    \glissando
+                    d'8
+                    \glissando
+                    ~
+                    d'8
+                }
             }
 
         Ties are excluded when repeated pitches are not allowed because all ties
@@ -429,9 +441,10 @@ def glissando(
 
         Spans and parenthesizes repeated pitches:
 
-        >>> staff = abjad.Staff("a8 a8 b8 ~ b8 c'8 c'8 d'8 ~ d'8")
+        >>> voice = abjad.Voice("a8 a8 b8 ~ b8 c'8 c'8 d'8 ~ d'8", name="Voice")
+        >>> staff = abjad.Staff([voice], name="Staff")
         >>> abjad.glissando(
-        ...     staff[:],
+        ...     voice[:],
         ...     allow_repeats=True,
         ...     parenthesize_repeats=True,
         ... )
@@ -441,36 +454,40 @@ def glissando(
 
             >>> string = abjad.lilypond(staff)
             >>> print(string)
-            \new Staff
+            \context Staff = "Staff"
             {
-                a8
-                \glissando
-                \parenthesize
-                a8
-                \glissando
-                b8
-                ~
-                \parenthesize
-                b8
-                \glissando
-                c'8
-                \glissando
-                \parenthesize
-                c'8
-                \glissando
-                d'8
-                ~
-                \parenthesize
-                d'8
+                \context Voice = "Voice"
+                {
+                    a8
+                    \glissando
+                    \parenthesize
+                    a8
+                    \glissando
+                    b8
+                    ~
+                    \parenthesize
+                    b8
+                    \glissando
+                    c'8
+                    \glissando
+                    \parenthesize
+                    c'8
+                    \glissando
+                    d'8
+                    ~
+                    \parenthesize
+                    d'8
+                }
             }
 
     ..  container:: example
 
         Parenthesizes (but does not span) repeated pitches:
 
-        >>> staff = abjad.Staff("a8 a8 b8 ~ b8 c'8 c'8 d'8 ~ d'8")
+        >>> voice = abjad.Voice("a8 a8 b8 ~ b8 c'8 c'8 d'8 ~ d'8", name="Voice")
+        >>> staff = abjad.Staff([voice], name="Staff")
         >>> abjad.glissando(
-        ...     staff[:],
+        ...     voice[:],
         ...     parenthesize_repeats=True,
         ... )
         >>> abjad.show(staff) # doctest: +SKIP
@@ -479,76 +496,80 @@ def glissando(
 
             >>> string = abjad.lilypond(staff)
             >>> print(string)
-            \new Staff
+            \context Staff = "Staff"
             {
-                a8
-                \parenthesize
-                a8
-                \glissando
-                b8
-                ~
-                \parenthesize
-                b8
-                \glissando
-                c'8
-                \parenthesize
-                c'8
-                \glissando
-                d'8
-                ~
-                \parenthesize
-                d'8
+                \context Voice = "Voice"
+                {
+                    a8
+                    \parenthesize
+                    a8
+                    \glissando
+                    b8
+                    ~
+                    \parenthesize
+                    b8
+                    \glissando
+                    c'8
+                    \parenthesize
+                    c'8
+                    \glissando
+                    d'8
+                    ~
+                    \parenthesize
+                    d'8
+                }
             }
 
     ..  container:: example
 
         With ``hide_middle_note_heads=True``:
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-        >>> abjad.glissando(
-        ...     staff[:],
-        ...     hide_middle_note_heads=True,
-        ... )
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8", name="Voice")
+        >>> staff = abjad.Staff([voice], name="Staff")
+        >>> abjad.glissando(voice[:], hide_middle_note_heads=True)
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
 
             >>> string = abjad.lilypond(staff)
             >>> print(string)
-            \new Staff
+            \context Staff = "Staff"
             {
-                c'8
-                \glissando
-                \hide NoteHead
-                \override Accidental.stencil = ##f
-                \override NoteColumn.glissando-skip = ##t
-                \override NoteHead.no-ledgers = ##t
-                d'8
-                e'8
-                \revert Accidental.stencil
-                \revert NoteColumn.glissando-skip
-                \revert NoteHead.no-ledgers
-                \undo \hide NoteHead
-                f'8
+                \context Voice = "Voice"
+                {
+                    c'8
+                    \glissando
+                    \hide NoteHead
+                    \override Accidental.stencil = ##f
+                    \override NoteColumn.glissando-skip = ##t
+                    \override NoteHead.no-ledgers = ##t
+                    d'8
+                    e'8
+                    \revert Accidental.stencil
+                    \revert NoteColumn.glissando-skip
+                    \revert NoteHead.no-ledgers
+                    \undo \hide NoteHead
+                    f'8
+                }
             }
 
     ..  container:: example
 
         With ``hide_middle_note_heads=True`` and ``hide_middle_stems=True``:
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8", name="Voice")
         >>> abjad.glissando(
-        ...     staff[:],
+        ...     voice[:],
         ...     hide_middle_note_heads=True,
         ...     hide_middle_stems=True,
         ... )
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \context Voice = "Voice"
             {
                 c'8
                 \glissando
@@ -576,18 +597,15 @@ def glissando(
 
         With ``right_broken=True``:
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-        >>> abjad.glissando(
-        ...     staff[:],
-        ...     right_broken=True,
-        ... )
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8", name="Voice")
+        >>> abjad.glissando(voice[:], right_broken=True)
+        >>> abjad.show(voice) # doctest: +SKIP
 
         LilyPond output looks like this:
 
-        >>> string = abjad.lilypond(staff, tags=True)
+        >>> string = abjad.lilypond(voice, tags=True)
         >>> print(string)
-        \new Staff
+        \context Voice = "Voice"
         {
             c'8
             %! abjad.glissando(7)
@@ -608,19 +626,19 @@ def glissando(
 
         With ``right_broken=True`` and ``hide_middle_note_heads=True``:
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8", name="Voice")
         >>> abjad.glissando(
-        ...     staff[:],
+        ...     voice[:],
         ...     right_broken=True,
         ...     hide_middle_note_heads=True,
         ... )
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.show(voice) # doctest: +SKIP
 
         LilyPond output looks like this:
 
-        >>> string = abjad.lilypond(staff, tags=True)
+        >>> string = abjad.lilypond(voice, tags=True)
         >>> print(string)
-        \new Staff
+        \context Voice = "Voice"
         {
             c'8
             %! abjad.glissando(7)
@@ -667,20 +685,20 @@ def glissando(
         With ``right_broken=True``, ``hide_middle_note_heads=True`` and
         ``right_broken_show_next=True``:
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8", name="Voice")
         >>> abjad.glissando(
-        ...     staff[:],
+        ...     voice[:],
         ...     hide_middle_note_heads=True,
         ...     right_broken=True,
         ...     right_broken_show_next=True,
         ... )
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.show(voice) # doctest: +SKIP
 
         LilyPond output looks like this:
 
-        >>> string = abjad.lilypond(staff, tags=True)
+        >>> string = abjad.lilypond(voice, tags=True)
         >>> print(string)
-        \new Staff
+        \context Voice = "Voice"
         {
             c'8
             %! abjad.glissando(7)
@@ -742,19 +760,19 @@ def glissando(
 
         With ``left_broken=True`` (and ``hide_middle_note_heads=True``):
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8", name="Voice")
         >>> abjad.glissando(
-        ...     staff[:],
+        ...     voice[:],
         ...     left_broken=True,
         ...     hide_middle_note_heads=True,
         ... )
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.show(voice) # doctest: +SKIP
 
         LilyPond output looks like this:
 
-        >>> string = abjad.lilypond(staff, tags=True)
+        >>> string = abjad.lilypond(voice, tags=True)
         >>> print(string)
-        \new Staff
+        \context Voice = "Voice"
         {
             %! HIDE_TO_JOIN_BROKEN_SPANNERS
             %! LEFT_BROKEN
@@ -794,18 +812,18 @@ def glissando(
 
         Tweaks apply to every glissando:
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8", name="Voice")
         >>> abjad.glissando(
-        ...     staff[:],
+        ...     voice[:],
         ...     abjad.Tweak(r"- \tweak style #'trill"),
         ... )
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \context Voice = "Voice"
             {
                 c'8
                 - \tweak style #'trill
@@ -823,25 +841,25 @@ def glissando(
 
         With ``zero_padding=True`` on fixed pitch:
 
-        >>> staff = abjad.Staff("d'8 d'4. d'4. d'8")
+        >>> voice = abjad.Voice("d'8 d'4. d'4. d'8", name="Voice")
 
         >>> abjad.glissando(
-        ...     staff[:],
+        ...     voice[:],
         ...     allow_repeats=True,
         ...     zero_padding=True,
         ... )
-        >>> for note in staff[1:]:
+        >>> for note in voice[1:]:
         ...     abjad.override(note).NoteHead.transparent = True
         ...     abjad.override(note).NoteHead.X_extent = "#'(0 . 0)"
         ...
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \context Voice = "Voice"
             {
                 d'8
                 - \abjad-zero-padding-glissando
@@ -865,23 +883,20 @@ def glissando(
 
         With ``zero_padding=True`` on changing pitches:
 
-        >>> staff = abjad.Staff("c'8. d'8. e'8. f'8.")
-        >>> abjad.glissando(
-        ...     staff[:],
-        ...     zero_padding=True,
-        ... )
-        >>> for note in staff[1:-1]:
+        >>> voice = abjad.Voice("c'8. d'8. e'8. f'8.", name="Voice")
+        >>> abjad.glissando(voice[:], zero_padding=True)
+        >>> for note in voice[1:-1]:
         ...     abjad.override(note).NoteHead.transparent = True
         ...     abjad.override(note).NoteHead.X_extent = "#'(0 . 0)"
         ...
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \context Voice = "Voice"
             {
                 c'8.
                 - \abjad-zero-padding-glissando
@@ -903,26 +918,26 @@ def glissando(
 
         With indexed tweaks:
 
-        >>> staff = abjad.Staff("d'4 d' d' d'")
+        >>> voice = abjad.Voice("d'4 d' d' d'", name="Voice")
         >>> abjad.glissando(
-        ...     staff[:],
+        ...     voice[:],
         ...     (abjad.Tweak(r"- \tweak color #red"), 0),
         ...     (abjad.Tweak(r"- \tweak color #red"), -1),
         ...     allow_repeats=True,
         ...     zero_padding=True,
         ... )
-        >>> for note in staff[1:-1]:
+        >>> for note in voice[1:-1]:
         ...     abjad.override(note).NoteHead.transparent = True
         ...     abjad.override(note).NoteHead.X_extent = "#'(0 . 0)"
         ...
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \context Voice = "Voice"
             {
                 d'4
                 - \tweak color #red

--- a/docs/source/_mothballed/lilypond-literals.rst
+++ b/docs/source/_mothballed/lilypond-literals.rst
@@ -9,11 +9,11 @@ components.
 Creating LilyPond literals
 --------------------------
 
-Use ``LilyPondLiteral`` to create a LilyPond literal:
+Use ``abjad.LilyPondLiteral`` to create a LilyPond literal:
 
 ::
 
-    >>> literal = abjad.LilyPondLiteral(r'\bar "||"', 'after')
+    >>> literal = abjad.LilyPondLiteral(r'\bar "||"', site="after")
 
 Understanding the interpreter representation of LilyPond literals
 -----------------------------------------------------------------
@@ -26,13 +26,13 @@ Understanding the interpreter representation of LilyPond literals
 
 ``r'\bar "||"'`` tells you the LilyPond literal to be formatted.
 
-``'after'`` tells you where the literal will be formatted relative to the leaf to which
+``"after"`` tells you where the literal will be formatted relative to the leaf to which
 it is attached.
 
 Attaching LilyPond literals to Abjad components
 -----------------------------------------------
 
-Use ``attach()`` to attach a LilyPond literal to any Abjad leaf:
+Use ``abjad.attach()`` to attach a LilyPond literal to any Abjad leaf:
 
 ::
 
@@ -102,9 +102,9 @@ compare equal:
 
 ::
 
-    >>> literal_1 = abjad.LilyPondLiteral(r'\bar "||"', 'after')
-    >>> literal_2 = abjad.LilyPondLiteral(r'\bar "||"', 'before')
-    >>> literal_3 = abjad.LilyPondLiteral(r'\slurUp')
+    >>> literal_1 = abjad.LilyPondLiteral(r'\bar "||"', site="after")
+    >>> literal_2 = abjad.LilyPondLiteral(r'\bar "||"', site="before")
+    >>> literal_3 = abjad.LilyPondLiteral(r"\slurUp")
 
 ::
 


### PR DESCRIPTION
    EXAMPLE.

        >>> voice = abjad.Voice("c'8 d' e' f'")
        >>> abjad.beam(voice[:], stemlet_length=0.75)
        >>> string = abjad.lilypond(voice)

    OLD:

        >>> print(string)
        \new Voice
        {
            \override Staff.Stem.stemlet-length = 0.75
            c'8
            [
            d'8
            e'8
            \revert Staff.Stem.stemlet-length
            f'8
            ]
        }

    NEW:

        >>> print(string)
        \new Voice
        {
            \override Staff.Stem.stemlet-length = 0.75
            c'8
            [
            d'8
            e'8
            f'8
            ]
            \revert Staff.Stem.stemlet-length
        }

CHANGED. abjad.illustrators.make_piano_score() includes explicit voices.

    OLD:

        >>> score = abjad.illustrators.make_piano_score()
        >>> string = abjad.lilypond(score)
        >>> print(string)
        \context Score = "Score"
        <<
            \context PianoStaff = "Piano_Staff"
            <<
                \context Staff = "Treble_Staff"
                {
                }
                \context Staff = "Bass_Staff"
                {
                }
            >>
        >>

    NEW:

        >>> score = abjad.illustrators.make_piano_score()
        >>> string = abjad.lilypond(score)
        >>> print(string)
        \context Score = "Score"
        <<
            \context PianoStaff = "Piano_Staff"
            <<
                \context Staff = "Treble_Staff"
                {
                    \context Voice = "Treble_Voice"
                    {
                    }
                }
                \context Staff = "Bass_Staff"
                {
                    \context Voice = "Bass_Voice"
                    {
                    }
                }
            >>
        >>