### PR TITLE
Added explicit contexts to tests and examples

### DIFF
--- a/abjad/bind.py
+++ b/abjad/bind.py
@@ -12,7 +12,7 @@ from . import tag as _tag
 from . import tweaks as _tweaks
 
 
-def _before_attach(indicator, deactivate, component):
+def _before_attach(indicator, context, deactivate, component):
     if getattr(indicator, "temporarily_do_not_check", False) is True:
         return
     if hasattr(indicator, "allowable_sites"):
@@ -26,13 +26,12 @@ def _before_attach(indicator, deactivate, component):
     if not hasattr(indicator, "context"):
         return
     if getattr(indicator, "find_context_on_attach", False) is True:
-        if hasattr(indicator, "context"):
-            context = Wrapper._find_correct_effective_context(
-                component, indicator.context
-            )
-            if context is None:
-                message = f"\n    {indicator} requires {indicator.context} context;"
-                message += f"\n    can not find {indicator.context}"
+        the_context = context or indicator.context
+        if the_context is not None:
+            context_ = Wrapper._find_correct_effective_context(component, the_context)
+            if context_ is None:
+                message = f"\n    {indicator} requires {the_context} context;"
+                message += f"\n    can not find {the_context}"
                 message += f" in parentage of {component!r}."
                 raise _exceptions.MissingContextError(message)
     if getattr(indicator, "nestable_spanner", False) is True:
@@ -1121,7 +1120,7 @@ def attach(
     assert not isinstance(nonbundle_attachable, _tweaks.Bundle)
     assert nonbundle_attachable is not None, repr(nonbundle_attachable)
     assert isinstance(target, _score.Component), repr(target)
-    _before_attach(nonbundle_attachable, deactivate, target)
+    _before_attach(nonbundle_attachable, context, deactivate, target)
     result = _unsafe_attach(
         attachable,
         target,

--- a/abjad/dynamic.py
+++ b/abjad/dynamic.py
@@ -130,19 +130,22 @@ class Dynamic:
 
         Tweaks:
 
-        >>> note = abjad.Note("c'4")
+        >>> voice = abjad.Voice("c'4")
         >>> dynamic = abjad.Dynamic("f")
         >>> bundle = abjad.bundle(dynamic, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, note)
-        >>> abjad.show(note) # doctest: +SKIP
+        >>> abjad.attach(bundle, voice[0])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(note)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            c'4
-            - \tweak color #blue
-            \f
+            \new Voice
+            {
+                c'4
+                - \tweak color #blue
+                \f
+            }
 
     ..  container:: example
 
@@ -163,16 +166,16 @@ class Dynamic:
 
         With ``direction`` unset:
 
-        >>> staff = abjad.Staff("c'2 c''2")
-        >>> abjad.attach(abjad.Dynamic("p"), staff[0])
-        >>> abjad.attach(abjad.Dynamic("f"), staff[1])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'2 c''2")
+        >>> abjad.attach(abjad.Dynamic("p"), voice[0])
+        >>> abjad.attach(abjad.Dynamic("f"), voice[1])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'2
                 \p
@@ -182,16 +185,16 @@ class Dynamic:
 
         With ``direction=abjad.UP``:
 
-        >>> staff = abjad.Staff("c'2 c''2")
-        >>> abjad.attach(abjad.Dynamic("p"), staff[0], direction=abjad.UP)
-        >>> abjad.attach(abjad.Dynamic("f"), staff[1], direction=abjad.UP)
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'2 c''2")
+        >>> abjad.attach(abjad.Dynamic("p"), voice[0], direction=abjad.UP)
+        >>> abjad.attach(abjad.Dynamic("f"), voice[1], direction=abjad.UP)
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'2
                 ^ \p
@@ -201,16 +204,16 @@ class Dynamic:
 
         With ``direction=abjad.DOWN``:
 
-        >>> staff = abjad.Staff("c'2 c''2")
-        >>> abjad.attach(abjad.Dynamic("p"), staff[0], direction=abjad.DOWN)
-        >>> abjad.attach(abjad.Dynamic("f"), staff[1], direction=abjad.DOWN)
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'2 c''2")
+        >>> abjad.attach(abjad.Dynamic("p"), voice[0], direction=abjad.DOWN)
+        >>> abjad.attach(abjad.Dynamic("f"), voice[1], direction=abjad.DOWN)
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'2
                 _ \p
@@ -222,16 +225,16 @@ class Dynamic:
 
         REGRESSION. Effort dynamics default to down:
 
-        >>> staff = abjad.Staff("c'2 c''2")
-        >>> abjad.attach(abjad.Dynamic('"p"'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('"f"'), staff[1])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'2 c''2")
+        >>> abjad.attach(abjad.Dynamic('"p"'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('"f"'), voice[1])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'2
                 _ #(make-dynamic-script
@@ -263,16 +266,16 @@ class Dynamic:
 
         And may be overriden:
 
-        >>> staff = abjad.Staff("c'2 c''2")
-        >>> abjad.attach(abjad.Dynamic('"p"'), staff[0], direction=abjad.UP)
-        >>> abjad.attach(abjad.Dynamic('"f"'), staff[1], direction=abjad.UP)
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'2 c''2")
+        >>> abjad.attach(abjad.Dynamic('"p"'), voice[0], direction=abjad.UP)
+        >>> abjad.attach(abjad.Dynamic('"f"'), voice[1], direction=abjad.UP)
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'2
                 ^ #(make-dynamic-script
@@ -342,21 +345,21 @@ class Dynamic:
 
         Without leaked stop dynamic:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_dynamic = abjad.Dynamic("mf")
         >>> start_hairpin = abjad.StartHairpin(">")
         >>> stop_dynamic = abjad.Dynamic("pp")
-        >>> abjad.attach(start_dynamic, staff[0])
-        >>> abjad.attach(start_hairpin, staff[0])
-        >>> abjad.attach(stop_dynamic, staff[-2])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(start_dynamic, voice[0])
+        >>> abjad.attach(start_hairpin, voice[0])
+        >>> abjad.attach(stop_dynamic, voice[-2])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4
@@ -373,21 +376,21 @@ class Dynamic:
 
         With leaked stop dynamic:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_dynamic = abjad.Dynamic("mf")
         >>> start_hairpin = abjad.StartHairpin(">")
         >>> stop_dynamic = abjad.Dynamic("pp", leak=True)
-        >>> abjad.attach(start_dynamic, staff[0])
-        >>> abjad.attach(start_hairpin, staff[0])
-        >>> abjad.attach(stop_dynamic, staff[-2])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(start_dynamic, voice[0])
+        >>> abjad.attach(start_hairpin, voice[0])
+        >>> abjad.attach(stop_dynamic, voice[-2])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4
@@ -407,21 +410,21 @@ class Dynamic:
 
         Leaks format after spanners:
 
-        >>> staff = abjad.Staff("c'8 [ d' e' ] f'")
+        >>> voice = abjad.Voice("c'8 [ d' e' ] f'")
         >>> start_dynamic = abjad.Dynamic("mf")
         >>> start_hairpin = abjad.StartHairpin(">")
         >>> stop_dynamic = abjad.Dynamic("pp", leak=True)
-        >>> abjad.attach(start_dynamic, staff[0])
-        >>> abjad.attach(start_hairpin, staff[0])
-        >>> abjad.attach(stop_dynamic, staff[-2])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(start_dynamic, voice[0])
+        >>> abjad.attach(start_hairpin, voice[0])
+        >>> abjad.attach(stop_dynamic, voice[-2])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4
@@ -443,16 +446,16 @@ class Dynamic:
 
         Leaked and nonleaked dynamic may be attached to the same leaf:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic("f"), staff[0])
-        >>> abjad.attach(abjad.Dynamic("p", leak=True), staff[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic("f"), voice[0])
+        >>> abjad.attach(abjad.Dynamic("p", leak=True), voice[0])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 \f
@@ -468,15 +471,15 @@ class Dynamic:
         Leaks and tweaks on the same dynamic format correctly; LilyPond empty chord
         ``<>`` symbol appears before postevents:
 
-        >>> staff = abjad.Staff("r4 d' e' f'")
+        >>> voice = abjad.Voice("r4 d' e' f'")
         >>> dynamic = abjad.Dynamic("f", leak=True)
         >>> bundle = abjad.bundle(dynamic, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(bundle, voice[0])
+        >>> abjad.show(voice) # doctest: +SKIP
 
-        >>> string = abjad.lilypond(staff)
+        >>> string = abjad.lilypond(voice)
         >>> print(string)
-        \new Staff
+        \new Voice
         {
             r4
             <>
@@ -660,6 +663,7 @@ class Dynamic:
 
     context: typing.ClassVar[str] = "Voice"
     directed: typing.ClassVar[bool] = True
+    # find_context_on_attach: typing.ClassVar[bool] = True
     parameter: typing.ClassVar[str] = "DYNAMIC"
     persistent: typing.ClassVar[bool] = True
     post_event: typing.ClassVar[bool] = True

--- a/abjad/illustrators.py
+++ b/abjad/illustrators.py
@@ -255,7 +255,7 @@ def components(
     )
     voice = _score.Voice(components, name="Voice")
     staff = _score.Staff([voice], name="Staff")
-    score = _score.Score([staff], name="Score")
+    score = _score.Score([staff], name="Score", simultaneous=False)
     if not time_signatures:
         duration = _get.duration(components)
         time_signature = _indicators.TimeSignature(duration.pair)

--- a/abjad/indicators.py
+++ b/abjad/indicators.py
@@ -1635,17 +1635,17 @@ class LilyPondLiteral:
 
         Dotted slur:
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-        >>> abjad.slur(staff[:])
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8")
+        >>> abjad.slur(voice[:])
         >>> literal = abjad.LilyPondLiteral(r"\slurDotted", site="before")
-        >>> abjad.attach(literal, staff[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(literal, voice[0])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 \slurDotted
                 c'8
@@ -1660,26 +1660,26 @@ class LilyPondLiteral:
 
         Use the absolute before and absolute after format sites like this:
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-        >>> abjad.slur(staff[:])
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8")
+        >>> abjad.slur(voice[:])
         >>> literal = abjad.LilyPondLiteral(r"\slurDotted", site="before")
-        >>> abjad.attach(literal, staff[0])
+        >>> abjad.attach(literal, voice[0])
         >>> literal = abjad.LilyPondLiteral("", site="absolute_before")
-        >>> abjad.attach(literal, staff[0])
+        >>> abjad.attach(literal, voice[0])
         >>> literal = abjad.LilyPondLiteral(
         ...     "% before all formatting",
         ...     site="absolute_before",
         ... )
-        >>> abjad.attach(literal, staff[0])
+        >>> abjad.attach(literal, voice[0])
         >>> literal = abjad.LilyPondLiteral("", site="absolute_after")
-        >>> abjad.attach(literal, staff[-1])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(literal, voice[-1])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
             <BLANKLINE>
                 % before all formatting
@@ -1697,15 +1697,15 @@ class LilyPondLiteral:
 
         LilyPond literals can be tagged:
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-        >>> abjad.slur(staff[:])
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8")
+        >>> abjad.slur(voice[:])
         >>> literal = abjad.LilyPondLiteral(r"\slurDotted", site="before")
-        >>> abjad.attach(literal, staff[0], tag=abjad.Tag("+PARTS"))
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(literal, voice[0], tag=abjad.Tag("+PARTS"))
+        >>> abjad.show(voice) # doctest: +SKIP
 
-        >>> string = abjad.lilypond(staff, tags=True)
+        >>> string = abjad.lilypond(voice, tags=True)
         >>> print(string)
-        \new Staff
+        \new Voice
         {
             %! +PARTS
             \slurDotted
@@ -1721,20 +1721,20 @@ class LilyPondLiteral:
 
         Multiline input is allowed:
 
-        >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-        >>> abjad.slur(staff[:])
+        >>> voice = abjad.Voice("c'8 d'8 e'8 f'8")
+        >>> abjad.slur(voice[:])
         >>> lines = [
         ...     r"\stopStaff",
         ...     r"\startStaff",
         ...     r"\once \override Staff.StaffSymbol.color = #red",
         ... ]
         >>> literal = abjad.LilyPondLiteral(lines, site="before")
-        >>> abjad.attach(literal, staff[2], tag=abjad.Tag("+PARTS"))
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(literal, voice[2], tag=abjad.Tag("+PARTS"))
+        >>> abjad.show(voice) # doctest: +SKIP
 
-        >>> string = abjad.lilypond(staff, tags=True)
+        >>> string = abjad.lilypond(voice, tags=True)
         >>> print(string)
-        \new Staff
+        \new Voice
         {
             c'8
             (
@@ -2505,6 +2505,7 @@ class MetronomeMark:
         should still determine effective metronome mark):
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> score = abjad.Score([staff])
         >>> metronome_mark_1 = abjad.MetronomeMark(abjad.Duration(1, 4), 72)
         >>> abjad.attach(metronome_mark_1, staff[0])
         >>> metronome_mark_2 = abjad.MetronomeMark(
@@ -2512,7 +2513,6 @@ class MetronomeMark:
         ...     hide=True,
         ... )
         >>> abjad.attach(metronome_mark_2, staff[2])
-        >>> score = abjad.Score([staff])
         >>> abjad.show(score) # doctest: +SKIP
 
         >>> string = abjad.lilypond(score)
@@ -3309,9 +3309,7 @@ class RepeatTie:
 
     """
 
-    context: typing.ClassVar[str] = "Voice"
     directed: typing.ClassVar[bool] = True
-    # find_context_on_attach: typing.ClassVar[bool] = True
     post_event: typing.ClassVar[bool] = True
 
     def _attachment_test_all(self, argument):
@@ -3496,19 +3494,19 @@ class StartBeam:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'8 d' e' f'")
+        >>> voice = abjad.Voice("c'8 d' e' f'")
         >>> start_beam = abjad.StartBeam()
         >>> bundle = abjad.bundle(start_beam, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_beam = abjad.StopBeam()
-        >>> abjad.attach(stop_beam, staff[-1])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_beam, voice[-1])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'8
                 - \tweak color #blue
@@ -3523,19 +3521,19 @@ class StartBeam:
 
         With ``direction=abjad.DOWN``:
 
-        >>> staff = abjad.Staff("c'8 d' e' f'")
+        >>> voice = abjad.Voice("c'8 d' e' f'")
         >>> start_beam = abjad.StartBeam()
         >>> bundle = abjad.bundle(start_beam, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0], direction=abjad.DOWN)
+        >>> abjad.attach(bundle, voice[0], direction=abjad.DOWN)
         >>> stop_beam = abjad.StopBeam()
-        >>> abjad.attach(stop_beam, staff[-1])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_beam, voice[-1])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'8
                 - \tweak color #blue
@@ -3575,19 +3573,19 @@ class StartGroup:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_group = abjad.StartGroup()
         >>> bundle = abjad.bundle(start_group, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_group = abjad.StopGroup()
-        >>> abjad.attach(stop_group, staff[-1])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_group, voice[-1])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -3620,18 +3618,18 @@ class StartHairpin:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic('p'), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('<'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('f'), staff[-1])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4.5
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic('p'), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('<'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('f'), voice[-1])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4.5
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4.5
@@ -3650,18 +3648,18 @@ class StartHairpin:
 
         Crescendo:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic('p'), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('<'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('f'), staff[-1])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4.5
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic('p'), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('<'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('f'), voice[-1])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4.5
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4.5
@@ -3678,18 +3676,18 @@ class StartHairpin:
 
         Crescendo dal niente:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic('niente', hide=True), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('o<'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('f'), staff[-1])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4.5
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic('niente', hide=True), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('o<'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('f'), voice[-1])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4.5
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4.5
@@ -3706,18 +3704,18 @@ class StartHairpin:
 
         Subito crescendo:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic('p'), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('<|'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('f'), staff[-1])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4.5
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic('p'), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('<|'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('f'), voice[-1])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4.5
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4.5
@@ -3735,18 +3733,18 @@ class StartHairpin:
 
         Subito crescendo dal niente:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic('niente', hide=True), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('o<|'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('f'), staff[-1])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4.5
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic('niente', hide=True), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('o<|'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('f'), voice[-1])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4.5
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4.5
@@ -3766,18 +3764,18 @@ class StartHairpin:
 
         Diminuendo:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic('f'), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('>'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('p'), staff[-1])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4.5
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic('f'), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('>'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('p'), voice[-1])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4.5
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4.5
@@ -3794,18 +3792,18 @@ class StartHairpin:
 
         Diminuendo al niente:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic('f'), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('>o'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('niente', command=r'\!'), staff[-1])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4.5
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic('f'), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('>o'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('niente', command=r'\!'), voice[-1])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4.5
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4.5
@@ -3823,18 +3821,18 @@ class StartHairpin:
 
         Subito diminuendo:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic('f'), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('|>'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('p'), staff[-1])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4.5
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic('f'), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('|>'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('p'), voice[-1])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4.5
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4.5
@@ -3852,18 +3850,18 @@ class StartHairpin:
 
         Subito diminuendo al niente:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic('f'), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('|>o'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('niente', command=r'\!'), staff[-1])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4.5
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic('f'), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('|>o'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('niente', command=r'\!'), voice[-1])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4.5
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4.5
@@ -3884,18 +3882,18 @@ class StartHairpin:
 
         Constante:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic('p'), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('--'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('f'), staff[-1])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4.5
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic('p'), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('--'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('f'), voice[-1])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4.5
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4.5
@@ -3915,20 +3913,20 @@ class StartHairpin:
 
         Tweaks:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.attach(abjad.Dynamic('p'), staff[0])
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.attach(abjad.Dynamic('p'), voice[0])
         >>> start_hairpin = abjad.StartHairpin('<')
         >>> bundle = abjad.bundle(start_hairpin, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
-        >>> abjad.attach(abjad.Dynamic('f'), staff[-1])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 4.5
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(bundle, voice[0])
+        >>> abjad.attach(abjad.Dynamic('f'), voice[-1])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 4.5
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 4.5
@@ -4036,19 +4034,19 @@ class StartPhrasingSlur:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_phrasing_slur = abjad.StartPhrasingSlur()
         >>> bundle = abjad.bundle(start_phrasing_slur, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_phrasing_slur = abjad.StopPhrasingSlur()
-        >>> abjad.attach(stop_phrasing_slur, staff[-1])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_phrasing_slur, voice[-1])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -4095,21 +4093,21 @@ class StartPianoPedal:
         ...     r"- \tweak color #blue",
         ...     r"- \tweak parent-alignment-X #center",
         ... )
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, staff[0], context="Staff")
         >>> stop_piano_pedal = abjad.StopPianoPedal()
-        >>> abjad.attach(stop_piano_pedal, staff[1])
+        >>> abjad.attach(stop_piano_pedal, staff[1], context="Staff")
 
         >>> start_piano_pedal = abjad.StartPianoPedal()
         >>> bundle = abjad.bundle(start_piano_pedal, r"- \tweak color #red")
-        >>> abjad.attach(bundle, staff[1])
+        >>> abjad.attach(bundle, staff[1], context="Staff")
         >>> stop_piano_pedal = abjad.StopPianoPedal()
-        >>> abjad.attach(stop_piano_pedal, staff[2])
+        >>> abjad.attach(stop_piano_pedal, staff[2], context="Staff")
 
         >>> start_piano_pedal = abjad.StartPianoPedal()
         >>> bundle = abjad.bundle(start_piano_pedal, r"- \tweak color #green")
-        >>> abjad.attach(bundle, staff[2])
+        >>> abjad.attach(bundle, staff[2], context="Staff")
         >>> stop_piano_pedal = abjad.StopPianoPedal()
-        >>> abjad.attach(stop_piano_pedal, staff[3])
+        >>> abjad.attach(stop_piano_pedal, staff[3], context="Staff")
 
         >>> abjad.override(staff).SustainPedalLineSpanner.staff_padding = 5
         >>> abjad.setting(staff).pedalSustainStyle = "#'mixed"
@@ -4176,19 +4174,19 @@ class StartSlur:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_slur = abjad.StartSlur()
         >>> bundle = abjad.bundle(start_slur, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_slur = abjad.StopSlur()
-        >>> abjad.attach(stop_slur, staff[-1])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_slur, voice[-1])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -4203,18 +4201,18 @@ class StartSlur:
 
         With ``direction`` unset:
 
-        >>> staff = abjad.Staff("c'8 d' e' f' c'' d'' e'' f''")
-        >>> abjad.attach(abjad.StartSlur(), staff[0])
-        >>> abjad.attach(abjad.StopSlur(), staff[3])
-        >>> abjad.attach(abjad.StartSlur(), staff[4])
-        >>> abjad.attach(abjad.StopSlur(), staff[7])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'8 d' e' f' c'' d'' e'' f''")
+        >>> abjad.attach(abjad.StartSlur(), voice[0])
+        >>> abjad.attach(abjad.StopSlur(), voice[3])
+        >>> abjad.attach(abjad.StartSlur(), voice[4])
+        >>> abjad.attach(abjad.StopSlur(), voice[7])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'8
                 (
@@ -4232,18 +4230,18 @@ class StartSlur:
 
         With ``direction=abjad.UP``:
 
-        >>> staff = abjad.Staff("c'8 d' e' f' c'' d'' e'' f''")
-        >>> abjad.attach(abjad.StartSlur(), staff[0], direction=abjad.UP)
-        >>> abjad.attach(abjad.StopSlur(), staff[3])
-        >>> abjad.attach(abjad.StartSlur(), staff[4], direction=abjad.UP)
-        >>> abjad.attach(abjad.StopSlur(), staff[7])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'8 d' e' f' c'' d'' e'' f''")
+        >>> abjad.attach(abjad.StartSlur(), voice[0], direction=abjad.UP)
+        >>> abjad.attach(abjad.StopSlur(), voice[3])
+        >>> abjad.attach(abjad.StartSlur(), voice[4], direction=abjad.UP)
+        >>> abjad.attach(abjad.StopSlur(), voice[7])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'8
                 ^ (
@@ -4261,18 +4259,18 @@ class StartSlur:
 
         With ``direction=abjad.DOWN``:
 
-        >>> staff = abjad.Staff("c'8 d' e' f' c'' d'' e'' f''")
-        >>> abjad.attach(abjad.StartSlur(), staff[0], direction=abjad.DOWN)
-        >>> abjad.attach(abjad.StopSlur(), staff[3])
-        >>> abjad.attach(abjad.StartSlur(), staff[4], direction=abjad.DOWN)
-        >>> abjad.attach(abjad.StopSlur(), staff[7])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'8 d' e' f' c'' d'' e'' f''")
+        >>> abjad.attach(abjad.StartSlur(), voice[0], direction=abjad.DOWN)
+        >>> abjad.attach(abjad.StopSlur(), voice[3])
+        >>> abjad.attach(abjad.StartSlur(), voice[4], direction=abjad.DOWN)
+        >>> abjad.attach(abjad.StopSlur(), voice[7])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'8
                 _ (
@@ -4317,24 +4315,24 @@ class StartTextSpan:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
         ...     style="solid-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_text_span = abjad.StopTextSpan()
-        >>> abjad.attach(stop_text_span, staff[-1])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.attach(stop_text_span, voice[-1])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak staff-padding 2.5
@@ -4355,7 +4353,7 @@ class StartTextSpan:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
 
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
@@ -4367,9 +4365,9 @@ class StartTextSpan:
         ...     r"- \tweak color #blue",
         ...     r"- \tweak staff-padding 2.5",
         ... )
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_text_span = abjad.StopTextSpan()
-        >>> abjad.attach(stop_text_span, staff[-1])
+        >>> abjad.attach(stop_text_span, voice[-1])
 
         >>> start_text_span = abjad.StartTextSpan(
         ...     command=r"\startTextSpanOne",
@@ -4382,21 +4380,21 @@ class StartTextSpan:
         ...     r"- \tweak color #red",
         ...     r"- \tweak staff-padding 6",
         ... )
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_text_span = abjad.StopTextSpan(command=r"\stopTextSpanOne")
-        >>> abjad.attach(stop_text_span, staff[-1])
+        >>> abjad.attach(stop_text_span, voice[-1])
 
         >>> markup = abjad.Markup(r"\markup SPACER")
         >>> bundle = abjad.bundle(markup, r"- \tweak transparent ##t")
-        >>> abjad.attach(bundle, staff[0], direction=abjad.UP)
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.attach(bundle, voice[0], direction=abjad.UP)
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak transparent ##t
@@ -4426,7 +4424,7 @@ class StartTextSpan:
 
         String literals are allowed in place of markup:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> left_text = r'- \tweak bound-details.left.text \markup'
         >>> left_text += r' \concat { \upright pont. \hspace #0.5 }'
         >>> right_text = r'- \tweak bound-details.right.text \markup'
@@ -4437,17 +4435,17 @@ class StartTextSpan:
         ...     style='solid-line-with-arrow',
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_text_span = abjad.StopTextSpan()
-        >>> abjad.attach(stop_text_span, staff[-1])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.attach(stop_text_span, voice[-1])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak staff-padding 2.5
@@ -4465,24 +4463,24 @@ class StartTextSpan:
 
         Styles:
 
-        >>> staff = abjad.Staff("c'4 d' e' fs'")
+        >>> voice = abjad.Voice("c'4 d' e' fs'")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
         ...     style="dashed-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_text_span = abjad.StopTextSpan()
-        >>> abjad.attach(stop_text_span, staff[-1])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.attach(stop_text_span, voice[-1])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak staff-padding 2.5
@@ -4498,23 +4496,23 @@ class StartTextSpan:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     style="dashed-line-with-hook",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_text_span = abjad.StopTextSpan()
-        >>> abjad.attach(stop_text_span, staff[-1])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.attach(stop_text_span, voice[-1])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak staff-padding 2.5
@@ -4529,24 +4527,24 @@ class StartTextSpan:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
         ...     style="invisible-line",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_text_span = abjad.StopTextSpan()
-        >>> abjad.attach(stop_text_span, staff[-1])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.attach(stop_text_span, voice[-1])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak staff-padding 2.5
@@ -4562,24 +4560,24 @@ class StartTextSpan:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
         ...     style="solid-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_text_span = abjad.StopTextSpan()
-        >>> abjad.attach(stop_text_span, staff[-1])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.attach(stop_text_span, voice[-1])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak staff-padding 2.5
@@ -4595,23 +4593,23 @@ class StartTextSpan:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     style="solid-line-with-hook",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_text_span = abjad.StopTextSpan()
-        >>> abjad.attach(stop_text_span, staff[-1])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.attach(stop_text_span, voice[-1])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak staff-padding 2.5
@@ -4758,19 +4756,19 @@ class StartTrillSpan:
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_trill_span = abjad.StartTrillSpan()
         >>> bundle = abjad.bundle(start_trill_span, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_trill_span = abjad.StopTrillSpan()
-        >>> abjad.attach(stop_trill_span, staff[-1])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_trill_span, voice[-1])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -4785,19 +4783,19 @@ class StartTrillSpan:
 
         With interval:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_trill_span = abjad.StartTrillSpan(interval=abjad.NamedInterval("M2"))
         >>> bundle = abjad.bundle(start_trill_span, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_trill_span = abjad.StopTrillSpan()
-        >>> abjad.attach(stop_trill_span, staff[-1])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_trill_span, voice[-1])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 \pitchedTrill
                 c'4
@@ -4813,19 +4811,19 @@ class StartTrillSpan:
 
         With pitch:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_trill_span = abjad.StartTrillSpan(pitch=abjad.NamedPitch("C#4"))
         >>> bundle = abjad.bundle(start_trill_span, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_trill_span = abjad.StopTrillSpan()
-        >>> abjad.attach(stop_trill_span, staff[-1])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_trill_span, voice[-1])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 \pitchedTrill
                 c'4
@@ -4973,19 +4971,19 @@ class StopBeam:
 
         Without leak:
 
-        >>> staff = abjad.Staff("c'8 d' e' r")
+        >>> voice = abjad.Voice("c'8 d' e' r")
         >>> start_beam = abjad.StartBeam()
         >>> bundle = abjad.bundle(start_beam, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_beam = abjad.StopBeam()
-        >>> abjad.attach(stop_beam, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_beam, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'8
                 - \tweak color #blue
@@ -4998,19 +4996,19 @@ class StopBeam:
 
         With leak:
 
-        >>> staff = abjad.Staff("c'8 d' e' r")
+        >>> voice = abjad.Voice("c'8 d' e' r")
         >>> start_beam = abjad.StartBeam()
         >>> bundle = abjad.bundle(start_beam, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_beam = abjad.StopBeam(leak=True)
-        >>> abjad.attach(stop_beam, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_beam, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'8
                 - \tweak color #blue
@@ -5052,19 +5050,19 @@ class StopGroup:
 
         Without leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_group = abjad.StartGroup()
         >>> bundle = abjad.bundle(start_group, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_group = abjad.StopGroup()
-        >>> abjad.attach(stop_group, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_group, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -5077,19 +5075,19 @@ class StopGroup:
 
         With leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_group = abjad.StartGroup()
         >>> bundle = abjad.bundle(start_group, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_group = abjad.StopGroup(leak=True)
-        >>> abjad.attach(stop_group, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_group, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -5105,20 +5103,20 @@ class StopGroup:
 
         REGRESSION. Leaked contributions appear last in postevent format site:
 
-        >>> staff = abjad.Staff("c'8 d' e' f' r2")
-        >>> abjad.beam(staff[:4])
+        >>> voice = abjad.Voice("c'8 d' e' f' r2")
+        >>> abjad.beam(voice[:4])
         >>> start_group = abjad.StartGroup()
         >>> bundle = abjad.bundle(start_group, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_group = abjad.StopGroup(leak=True)
-        >>> abjad.attach(stop_group, staff[3])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_group, voice[3])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'8
                 [
@@ -5165,19 +5163,19 @@ class StopHairpin:
 
         Without leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_hairpin = abjad.StartHairpin('<')
         >>> bundle = abjad.bundle(start_hairpin, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_hairpin = abjad.StopHairpin()
-        >>> abjad.attach(stop_hairpin, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_hairpin, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -5190,19 +5188,19 @@ class StopHairpin:
 
         With leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_hairpin = abjad.StartHairpin('<')
         >>> bundle = abjad.bundle(start_hairpin, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_hairpin = abjad.StopHairpin(leak=True)
-        >>> abjad.attach(stop_hairpin, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_hairpin, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -5244,19 +5242,19 @@ class StopPhrasingSlur:
 
         Without leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_phrasing_slur = abjad.StartPhrasingSlur()
         >>> bundle = abjad.bundle(start_phrasing_slur, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_phrasing_slur = abjad.StopPhrasingSlur()
-        >>> abjad.attach(stop_phrasing_slur, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_phrasing_slur, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -5269,19 +5267,19 @@ class StopPhrasingSlur:
 
         With leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_phrasing_slur = abjad.StartPhrasingSlur()
         >>> bundle = abjad.bundle(start_phrasing_slur, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_phrasing_slur = abjad.StopPhrasingSlur(leak=True)
-        >>> abjad.attach(stop_phrasing_slur, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_phrasing_slur, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -5297,20 +5295,20 @@ class StopPhrasingSlur:
 
         REGRESSION. Leaked contributions appear last in postevent format site:
 
-        >>> staff = abjad.Staff("c'8 d' e' f' r2")
-        >>> abjad.beam(staff[:4])
+        >>> voice = abjad.Voice("c'8 d' e' f' r2")
+        >>> abjad.beam(voice[:4])
         >>> start_phrasing_slur = abjad.StartPhrasingSlur()
         >>> bundle = abjad.bundle(start_phrasing_slur, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_phrasing_slur = abjad.StopPhrasingSlur(leak=True)
-        >>> abjad.attach(stop_phrasing_slur, staff[3])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_phrasing_slur, voice[3])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'8
                 [
@@ -5363,14 +5361,14 @@ class StopPianoPedal:
         ...     r"- \tweak color #blue",
         ...     r"- \tweak parent-alignment-X #center",
         ... )
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, staff[0], context="Staff")
         >>> stop_piano_pedal = abjad.StopPianoPedal()
         >>> bundle = abjad.bundle(
         ...     stop_piano_pedal,
         ...     r"- \tweak color #red",
         ...     r"- \tweak parent-alignment-X #center",
         ... )
-        >>> abjad.attach(bundle, staff[-2])
+        >>> abjad.attach(bundle, staff[-2], context="Staff")
         >>> abjad.override(staff).SustainPedalLineSpanner.staff_padding = 5
         >>> abjad.show(staff) # doctest: +SKIP
 
@@ -5405,14 +5403,14 @@ class StopPianoPedal:
         ...     r"- \tweak color #blue",
         ...     r"- \tweak parent-alignment-X #center",
         ... )
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, staff[0], context="Staff")
         >>> stop_piano_pedal = abjad.StopPianoPedal(leak=True)
         >>> bundle = abjad.bundle(
         ...     stop_piano_pedal,
         ...     r"- \tweak color #red",
         ...     r"- \tweak parent-alignment-X #center",
         ... )
-        >>> abjad.attach(bundle, staff[-2])
+        >>> abjad.attach(bundle, staff[-2], context="Staff")
         >>> abjad.override(staff).SustainPedalLineSpanner.staff_padding = 5
         >>> abjad.show(staff) # doctest: +SKIP
 
@@ -5482,19 +5480,19 @@ class StopSlur:
 
         Without leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_slur = abjad.StartSlur()
         >>> bundle = abjad.bundle(start_slur, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_slur = abjad.StopSlur()
-        >>> abjad.attach(stop_slur, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_slur, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -5507,19 +5505,19 @@ class StopSlur:
 
         With leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_slur = abjad.StartSlur()
         >>> bundle = abjad.bundle(start_slur, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_slur = abjad.StopSlur(leak=True)
-        >>> abjad.attach(stop_slur, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_slur, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -5536,20 +5534,20 @@ class StopSlur:
         REGRESSION. Leaked contributions appear last in postevent format site.
         The leaked text spanner above does not inadvertantly leak the beam:
 
-        >>> staff = abjad.Staff("c'8 d' e' f' r2")
-        >>> abjad.beam(staff[:4])
+        >>> voice = abjad.Voice("c'8 d' e' f' r2")
+        >>> abjad.beam(voice[:4])
         >>> start_slur = abjad.StartSlur()
         >>> bundle = abjad.bundle(start_slur, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_slur = abjad.StopSlur(leak=True)
-        >>> abjad.attach(stop_slur, staff[3])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_slur, voice[3])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'8
                 [
@@ -5598,24 +5596,24 @@ class StopTextSpan:
 
         Without leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
         ...     style="dashed-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_text_span = abjad.StopTextSpan()
-        >>> abjad.attach(stop_text_span, staff[-2])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.attach(stop_text_span, voice[-2])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak staff-padding 2.5
@@ -5631,24 +5629,24 @@ class StopTextSpan:
 
         With leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
         ...     style="dashed-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_text_span = abjad.StopTextSpan(leak=True)
-        >>> abjad.attach(stop_text_span, staff[-2])
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.attach(stop_text_span, voice[-2])
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak staff-padding 2.5
@@ -5700,19 +5698,19 @@ class StopTrillSpan:
 
         Without leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_trill_span = abjad.StartTrillSpan()
         >>> bundle = abjad.bundle(start_trill_span, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_trill_span = abjad.StopTrillSpan()
-        >>> abjad.attach(stop_trill_span, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_trill_span, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -5725,19 +5723,19 @@ class StopTrillSpan:
 
         With leak:
 
-        >>> staff = abjad.Staff("c'4 d' e' r")
+        >>> voice = abjad.Voice("c'4 d' e' r")
         >>> start_trill_span = abjad.StartTrillSpan()
         >>> bundle = abjad.bundle(start_trill_span, r"- \tweak color #blue")
-        >>> abjad.attach(bundle, staff[0])
+        >>> abjad.attach(bundle, voice[0])
         >>> stop_trill_span = abjad.StopTrillSpan(leak=True)
-        >>> abjad.attach(stop_trill_span, staff[-2])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(stop_trill_span, voice[-2])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 - \tweak color #blue
@@ -5876,7 +5874,6 @@ class Tie:
 
     """
 
-    context: typing.ClassVar[str] = "Voice"
     directed: typing.ClassVar[bool] = True
     post_event: typing.ClassVar[bool] = True
 

--- a/abjad/instruments.py
+++ b/abjad/instruments.py
@@ -67,14 +67,14 @@ Instruments.
     Two instruments active on a single staff:
 
     >>> voice_1 = abjad.Voice("e'8 g'8 f'8 a'8")
+    >>> voice_2 = abjad.Voice("c'2")
+    >>> staff = abjad.Staff([voice_1, voice_2], simultaneous=True)
     >>> flute = abjad.Flute()
     >>> abjad.attach(flute, voice_1[0], context="Voice")
     >>> abjad.attach(abjad.VoiceNumber(1), voice_1[0])
-    >>> voice_2 = abjad.Voice("c'2")
     >>> abjad.attach(abjad.VoiceNumber(2), voice_2[0])
     >>> viola = abjad.Viola()
     >>> abjad.attach(viola, voice_2[0], context="Voice")
-    >>> staff = abjad.Staff([voice_1, voice_2], simultaneous=True)
     >>> abjad.show(staff) # doctest: +SKIP
 
     ..  docs::
@@ -129,6 +129,7 @@ class Instrument:
 
     clefs: tuple[str, ...] = ()
     context: str = "Staff"
+    # find_context_on_attach: typing.ClassVar[bool] = True
     middle_c_sounding_pitch: _pitch.NamedPitch = _pitch.NamedPitch("C4")
     pitch_range: _pcollections.PitchRange = _pcollections.PitchRange("[-inf, +inf]")
 

--- a/abjad/iterate.py
+++ b/abjad/iterate.py
@@ -851,7 +851,6 @@ def pitches(argument) -> typing.Iterator[_pitch.NamedPitch]:
     ..  container:: example
 
         >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
-        >>> abjad.beam(staff[:])
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -861,11 +860,9 @@ def pitches(argument) -> typing.Iterator[_pitch.NamedPitch]:
             \new Staff
             {
                 c'8
-                [
                 d'8
                 e'8
                 f'8
-                ]
             }
 
         >>> for pitch in abjad.iterate.pitches(staff):

--- a/abjad/label.py
+++ b/abjad/label.py
@@ -124,7 +124,6 @@ def color_leaves(argument, color="#red", *, deactivate=False, tag=None) -> None:
     ..  container:: example
 
         >>> staff = abjad.Staff("cs'8. r8. s8. <c' cs' a'>8.")
-        >>> abjad.beam(staff[:])
         >>> abjad.label.color_leaves(staff, "#red")
         >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
@@ -137,14 +136,12 @@ def color_leaves(argument, color="#red", *, deactivate=False, tag=None) -> None:
             {
                 \abjad-color-music #'red
                 cs'8.
-                [
                 \abjad-color-music #'red
                 r8.
                 % red
                 s8.
                 \abjad-color-music #'red
                 <c' cs' a'>8.
-                ]
             }
 
     """

--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -937,10 +937,11 @@ def extract(argument):
 
         Extract tuplets:
 
-        >>> staff = abjad.Staff()
-        >>> staff.append(abjad.Tuplet((3, 2), "c'4 e'4"))
-        >>> staff.append(abjad.Tuplet((3, 2), "d'4 f'4"))
-        >>> leaves = abjad.select.leaves(staff)
+        >>> voice = abjad.Voice()
+        >>> voice.append(abjad.Tuplet((3, 2), "c'4 e'4"))
+        >>> voice.append(abjad.Tuplet((3, 2), "d'4 f'4"))
+        >>> leaves = abjad.select.leaves(voice)
+        >>> staff = abjad.Staff([voice])
         >>> score = abjad.Score([staff], name="Score")
         >>> time_signature = abjad.TimeSignature((3, 4))
         >>> abjad.attach(time_signature, leaves[0])
@@ -953,26 +954,29 @@ def extract(argument):
             >>> print(string)
             \new Staff
             {
-                \tweak text #tuplet-number::calc-fraction-text
-                \times 3/2
+                \new Voice
                 {
-                    \time 3/4
-                    c'4
-                    \p
-                    \<
-                    e'4
-                }
-                \tweak text #tuplet-number::calc-fraction-text
-                \times 3/2
-                {
-                    d'4
-                    f'4
-                    \f
+                    \tweak text #tuplet-number::calc-fraction-text
+                    \times 3/2
+                    {
+                        \time 3/4
+                        c'4
+                        \p
+                        \<
+                        e'4
+                    }
+                    \tweak text #tuplet-number::calc-fraction-text
+                    \times 3/2
+                    {
+                        d'4
+                        f'4
+                        \f
+                    }
                 }
             }
 
-        >>> empty_tuplet = abjad.mutate.extract(staff[-1])
-        >>> empty_tuplet = abjad.mutate.extract(staff[0])
+        >>> empty_tuplet = abjad.mutate.extract(voice[-1])
+        >>> empty_tuplet = abjad.mutate.extract(voice[0])
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -981,23 +985,27 @@ def extract(argument):
             >>> print(string)
             \new Staff
             {
-                \time 3/4
-                c'4
-                \p
-                \<
-                e'4
-                d'4
-                f'4
-                \f
+                \new Voice
+                {
+                    \time 3/4
+                    c'4
+                    \p
+                    \<
+                    e'4
+                    d'4
+                    f'4
+                    \f
+                }
             }
 
     ..  container:: example
 
         Scales tuplet contents and then extracts tuplet:
 
-        >>> staff = abjad.Staff()
-        >>> staff.append(abjad.Tuplet((3, 2), "c'4 e'4"))
-        >>> staff.append(abjad.Tuplet((3, 2), "d'4 f'4"))
+        >>> voice = abjad.Voice()
+        >>> staff = abjad.Staff([voice])
+        >>> voice.append(abjad.Tuplet((3, 2), "c'4 e'4"))
+        >>> voice.append(abjad.Tuplet((3, 2), "d'4 f'4"))
         >>> score = abjad.Score([staff], name="Score")
         >>> leaves = abjad.select.leaves(staff)
         >>> abjad.hairpin('p < f', leaves)
@@ -1011,29 +1019,32 @@ def extract(argument):
             >>> print(string)
             \new Staff
             {
-                \tweak text #tuplet-number::calc-fraction-text
-                \times 3/2
+                \new Voice
                 {
-                    \time 3/4
-                    c'4
-                    \p
-                    \<
-                    e'4
-                }
-                \tweak text #tuplet-number::calc-fraction-text
-                \times 3/2
-                {
-                    d'4
-                    f'4
-                    \f
+                    \tweak text #tuplet-number::calc-fraction-text
+                    \times 3/2
+                    {
+                        \time 3/4
+                        c'4
+                        \p
+                        \<
+                        e'4
+                    }
+                    \tweak text #tuplet-number::calc-fraction-text
+                    \times 3/2
+                    {
+                        d'4
+                        f'4
+                        \f
+                    }
                 }
             }
 
-        >>> abjad.mutate.scale(staff[-1], abjad.Fraction(3, 2))
-        >>> empty_tuplet = abjad.mutate.extract(staff[-1])
-        >>> abjad.mutate.scale(staff[0], abjad.Fraction(3, 2))
-        >>> empty_tuplet = abjad.mutate.extract(staff[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.mutate.scale(voice[-1], abjad.Fraction(3, 2))
+        >>> empty_tuplet = abjad.mutate.extract(voice[-1])
+        >>> abjad.mutate.scale(voice[0], abjad.Fraction(3, 2))
+        >>> empty_tuplet = abjad.mutate.extract(voice[0])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
@@ -1041,14 +1052,17 @@ def extract(argument):
             >>> print(string)
             \new Staff
             {
-                \time 3/4
-                c'4.
-                \p
-                \<
-                e'4.
-                d'4.
-                f'4.
-                \f
+                \new Voice
+                {
+                    \time 3/4
+                    c'4.
+                    \p
+                    \<
+                    e'4.
+                    d'4.
+                    f'4.
+                    \f
+                }
             }
 
     ..  container:: example
@@ -1122,10 +1136,11 @@ def fuse(argument) -> _score.Tuplet | list[_score.Leaf]:
         Fuses parent-contiguous tuplets in selection:
 
         >>> tuplet_1 = abjad.Tuplet((2, 3), "c'8 d' e'")
-        >>> abjad.beam(tuplet_1[:])
         >>> tuplet_2 = abjad.Tuplet((2, 3), "c'16 d' e'")
+        >>> voice = abjad.Voice([tuplet_1, tuplet_2])
+        >>> staff = abjad.Staff([voice])
+        >>> abjad.beam(tuplet_1[:])
         >>> abjad.slur(tuplet_2[:])
-        >>> staff = abjad.Staff([tuplet_1, tuplet_2])
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -1134,25 +1149,28 @@ def fuse(argument) -> _score.Tuplet | list[_score.Leaf]:
             >>> print(string)
             \new Staff
             {
-                \times 2/3
+                \new Voice
                 {
-                    c'8
-                    [
-                    d'8
-                    e'8
-                    ]
-                }
-                \times 2/3
-                {
-                    c'16
-                    (
-                    d'16
-                    e'16
-                    )
+                    \times 2/3
+                    {
+                        c'8
+                        [
+                        d'8
+                        e'8
+                        ]
+                    }
+                    \times 2/3
+                    {
+                        c'16
+                        (
+                        d'16
+                        e'16
+                        )
+                    }
                 }
             }
 
-        >>> tuplets = staff[:]
+        >>> tuplets = voice[:]
         >>> abjad.mutate.fuse(tuplets)
         Tuplet('3:2', "c'8 d'8 e'8 c'16 d'16 e'16")
         >>> abjad.show(staff) #doctest: +SKIP
@@ -1163,18 +1181,21 @@ def fuse(argument) -> _score.Tuplet | list[_score.Leaf]:
             >>> print(string)
             \new Staff
             {
-                \times 2/3
+                \new Voice
                 {
-                    c'8
-                    [
-                    d'8
-                    e'8
-                    ]
-                    c'16
-                    (
-                    d'16
-                    e'16
-                    )
+                    \times 2/3
+                    {
+                        c'8
+                        [
+                        d'8
+                        e'8
+                        ]
+                        c'16
+                        (
+                        d'16
+                        e'16
+                        )
+                    }
                 }
             }
 
@@ -1248,14 +1269,15 @@ def logical_tie_to_tuplet(
 
     ..  container:: example
 
-        >>> staff = abjad.Staff(r"df'8 c'8 ~ c'16 cqs''4")
+        >>> voice = abjad.Voice(r"df'8 c'8 ~ c'16 cqs''4")
+        >>> staff = abjad.Staff([voice])
         >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.Dynamic('p'), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('<'), staff[0])
-        >>> abjad.attach(abjad.Dynamic('f'), staff[-1])
+        >>> abjad.attach(abjad.Dynamic('p'), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('<'), voice[0])
+        >>> abjad.attach(abjad.Dynamic('f'), voice[-1])
         >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 3
         >>> time_signature = abjad.TimeSignature((9, 16))
-        >>> abjad.attach(time_signature, staff[0])
+        >>> abjad.attach(time_signature, voice[0])
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -1268,18 +1290,21 @@ def logical_tie_to_tuplet(
                 \override DynamicLineSpanner.staff-padding = 3
             }
             {
-                \time 9/16
-                df'8
-                \p
-                \<
-                c'8
-                ~
-                c'16
-                cqs''4
-                \f
+                \new Voice
+                {
+                    \time 9/16
+                    df'8
+                    \p
+                    \<
+                    c'8
+                    ~
+                    c'16
+                    cqs''4
+                    \f
+                }
             }
 
-        >>> logical_tie = abjad.select.logical_tie(staff[1])
+        >>> logical_tie = abjad.select.logical_tie(voice[1])
         >>> abjad.mutate.logical_tie_to_tuplet(logical_tie, [2, 1, 1, 1])
         Tuplet('5:3', "c'8 c'16 c'16 c'16")
 
@@ -1293,32 +1318,36 @@ def logical_tie_to_tuplet(
                 \override DynamicLineSpanner.staff-padding = 3
             }
             {
-                \time 9/16
-                df'8
-                \p
-                \<
-                \tweak text #tuplet-number::calc-fraction-text
-                \times 3/5
+                \new Voice
                 {
-                    c'8
-                    c'16
-                    c'16
-                    c'16
+                    \time 9/16
+                    df'8
+                    \p
+                    \<
+                    \tweak text #tuplet-number::calc-fraction-text
+                    \times 3/5
+                    {
+                        c'8
+                        c'16
+                        c'16
+                        c'16
+                    }
+                    cqs''4
+                    \f
                 }
-                cqs''4
-                \f
             }
 
         >>> abjad.show(staff) # doctest: +SKIP
 
     ..  container:: example
 
-        >>> staff = abjad.Staff(r"c'8 ~ c'16 cqs''4")
+        >>> voice = abjad.Voice(r"c'8 ~ c'16 cqs''4")
+        >>> staff = abjad.Staff([voice])
         >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.hairpin('p < f', staff[:])
+        >>> abjad.hairpin('p < f', voice[:])
         >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 3
         >>> time_signature = abjad.TimeSignature((7, 16))
-        >>> abjad.attach(time_signature, staff[0])
+        >>> abjad.attach(time_signature, voice[0])
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -1331,14 +1360,17 @@ def logical_tie_to_tuplet(
                 \override DynamicLineSpanner.staff-padding = 3
             }
             {
-                \time 7/16
-                c'8
-                \p
-                \<
-                ~
-                c'16
-                cqs''4
-                \f
+                \new Voice
+                {
+                    \time 7/16
+                    c'8
+                    \p
+                    \<
+                    ~
+                    c'16
+                    cqs''4
+                    \f
+                }
             }
 
     """
@@ -1374,17 +1406,17 @@ def replace(argument, recipients, wrappers=False):
 
         >>> tuplet_1 = abjad.Tuplet((2, 3), "c'4 d'4 e'4")
         >>> tuplet_2 = abjad.Tuplet((2, 3), "d'4 e'4 f'4")
-        >>> staff = abjad.Staff([tuplet_1, tuplet_2])
-        >>> leaves = abjad.select.leaves(staff)
+        >>> voice = abjad.Voice([tuplet_1, tuplet_2])
+        >>> leaves = abjad.select.leaves(voice)
         >>> abjad.hairpin('p < f', leaves)
         >>> abjad.slur(leaves)
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 \times 2/3
                 {
@@ -1407,15 +1439,15 @@ def replace(argument, recipients, wrappers=False):
 
         >>> notes = abjad.makers.make_notes("c' d' e' f' c' d' e' f'", (1, 16))
         >>> abjad.mutate.replace([tuplet_1], notes)
-        >>> abjad.attach(abjad.Dynamic('p'), staff[0])
-        >>> abjad.attach(abjad.StartHairpin('<'), staff[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.attach(abjad.Dynamic('p'), voice[0])
+        >>> abjad.attach(abjad.StartHairpin('<'), voice[0])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'16
                 \p
@@ -1808,16 +1840,16 @@ def split(argument, durations, *, cyclic=False, tag=None):
 
         Splits leaves cyclically and ties split notes:
 
-        >>> staff = abjad.Staff("c'1 d'1")
-        >>> abjad.hairpin('p < f', staff[:])
-        >>> abjad.override(staff).DynamicLineSpanner.staff_padding = 3
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'1 d'1")
+        >>> abjad.hairpin('p < f', voice[:])
+        >>> abjad.override(voice).DynamicLineSpanner.staff_padding = 3
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 3
@@ -1832,17 +1864,17 @@ def split(argument, durations, *, cyclic=False, tag=None):
 
         >>> durations = [(3, 4)]
         >>> result = abjad.mutate.split(
-        ...     staff[:],
+        ...     voice[:],
         ...     durations,
         ...     cyclic=True,
         ...     )
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override DynamicLineSpanner.staff-padding = 3
@@ -2311,22 +2343,23 @@ def swap(argument, container):
 
         Swaps containers for tuplet:
 
-        >>> staff = abjad.Staff()
+        >>> voice = abjad.Voice()
+        >>> staff = abjad.Staff([voice])
         >>> score = abjad.Score([staff], name="Score")
-        >>> staff.append(abjad.Container("c'4 d'4 e'4"))
-        >>> staff.append(abjad.Container("d'4 e'4 f'4"))
-        >>> abjad.attach(abjad.TimeSignature((3, 4)), staff[0][0])
-        >>> leaves = abjad.select.leaves(staff)
+        >>> voice.append(abjad.Container("c'4 d'4 e'4"))
+        >>> voice.append(abjad.Container("d'4 e'4 f'4"))
+        >>> abjad.attach(abjad.TimeSignature((3, 4)), voice[0][0])
+        >>> leaves = abjad.select.leaves(voice)
         >>> abjad.hairpin('p < f', leaves)
-        >>> measures = staff[:]
+        >>> measures = voice[:]
         >>> abjad.slur(leaves)
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 {
                     \time 3/4
@@ -2346,17 +2379,17 @@ def swap(argument, container):
                 }
             }
 
-        >>> containers = staff[:]
+        >>> containers = voice[:]
         >>> tuplet = abjad.Tuplet((2, 3), [])
         >>> tuplet.denominator = 4
         >>> abjad.mutate.swap(containers, tuplet)
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 \times 4/6
                 {
@@ -2378,11 +2411,11 @@ def swap(argument, container):
         REGRESSION: context indicators survive swap:
 
         >>> prototype = abjad.TimeSignature
-        >>> for component in abjad.iterate.components(staff):
+        >>> for component in abjad.iterate.components(voice):
         ...     time_signature = abjad.get.effective(component, prototype)
         ...     print(component, time_signature)
         ...
-        Staff("{ 2/3 c'4 d'4 e'4 d'4 e'4 f'4 }") TimeSignature(pair=(3, 4), hide=False, partial=None)
+        Voice("{ 2/3 c'4 d'4 e'4 d'4 e'4 f'4 }") TimeSignature(pair=(3, 4), hide=False, partial=None)
         Tuplet('3:2', "c'4 d'4 e'4 d'4 e'4 f'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
         Note("c'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
         Note("d'4") TimeSignature(pair=(3, 4), hide=False, partial=None)

--- a/abjad/parsers/reduced.py
+++ b/abjad/parsers/reduced.py
@@ -392,7 +392,7 @@ class ReducedLyParser(Parser):
         p[0] = p[1]
         if p[2]:
             annotation = {"post events": p[2]}
-            _bind.attach(annotation, p[0])
+            _bind._unsafe_attach(annotation, p[0])
 
     def p_leaf_body__chord_body(self, p):
         """
@@ -422,10 +422,10 @@ class ReducedLyParser(Parser):
         leaf = _iterlib._get_leaf(measure, 0)
         time_signature = _indicators.TimeSignature(p[2])
         try:
-            _bind.attach(time_signature, leaf)
+            _bind._unsafe_attach(time_signature, leaf)
         except _exceptions.MissingContextError:
             score = _score.Score([measure])
-            _bind.attach(time_signature, leaf)
+            _bind._unsafe_attach(time_signature, leaf)
             score[:] = []
         p[0] = measure
 
@@ -612,18 +612,18 @@ class ReducedLyParser(Parser):
                     _indicators.StopSlur,
                 ):
                     indicator = current_class()
-                    _bind.attach(indicator, leaf)
+                    _bind._unsafe_attach(indicator, leaf)
                     continue
                 if current_class in (
                     _indicators.StartBeam,
                     _indicators.StopBeam,
                 ):
                     indicator = current_class()
-                    _bind.attach(indicator, leaf)
+                    _bind._unsafe_attach(indicator, leaf)
                     continue
                 if current_class is _indicators.Tie:
                     indicator = current_class()
-                    _bind.attach(indicator, leaf)
+                    _bind._unsafe_attach(indicator, leaf)
                     continue
 
     def _cleanup(self, parsed):

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -1650,8 +1650,6 @@ class Container(Component):
             >>> container.extend("fs16 cs' e' a'")
             >>> container.extend("cs''16 e'' cs'' a'")
             >>> container.extend("fs'16 e' cs' fs")
-            >>> start_slur = abjad.StartSlur()
-            >>> abjad.slur(container[:], direction=abjad.DOWN, start_slur=start_slur)
             >>> abjad.show(container) # doctest: +SKIP
 
             ..  docs::
@@ -1660,7 +1658,6 @@ class Container(Component):
                 >>> print(string)
                 {
                     fs16
-                    _ (
                     cs'16
                     e'16
                     a'16
@@ -1672,7 +1669,6 @@ class Container(Component):
                     e'16
                     cs'16
                     fs16
-                    )
                 }
 
             >>> container.insert(-4, abjad.Note("e'4"))
@@ -1684,7 +1680,6 @@ class Container(Component):
                 >>> print(string)
                 {
                     fs16
-                    _ (
                     cs'16
                     e'16
                     a'16
@@ -1697,7 +1692,6 @@ class Container(Component):
                     e'16
                     cs'16
                     fs16
-                    )
                 }
 
         """

--- a/abjad/select.py
+++ b/abjad/select.py
@@ -284,7 +284,7 @@ def chord(
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -331,7 +331,7 @@ def chord(
                         }
                     }
                 }
-            >>
+            }
 
     """
     return chords(argument, exclude=exclude, grace=grace)[n]
@@ -384,7 +384,7 @@ def chords(
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -439,7 +439,7 @@ def chords(
                         }
                     }
                 }
-            >>
+            }
 
     """
     items = []
@@ -931,7 +931,7 @@ def flatten(argument, depth: int = 1) -> list:
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -983,7 +983,7 @@ def flatten(argument, depth: int = 1) -> list:
                         }
                     }
                 }
-            >>
+            }
 
     ..  container:: example
 
@@ -1024,7 +1024,7 @@ def flatten(argument, depth: int = 1) -> list:
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -1076,7 +1076,7 @@ def flatten(argument, depth: int = 1) -> list:
                         }
                     }
                 }
-            >>
+            }
 
     """
     items = _sequence.flatten(argument, depth=depth)
@@ -2326,7 +2326,7 @@ def leaf(
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -2373,7 +2373,7 @@ def leaf(
                         }
                     }
                 }
-            >>
+            }
 
     """
     return leaves(
@@ -3952,7 +3952,7 @@ def note(
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -3999,7 +3999,7 @@ def note(
                         }
                     }
                 }
-            >>
+            }
 
     """
     return notes(argument, exclude=exclude, grace=grace)[n]
@@ -4049,7 +4049,7 @@ def notes(
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -4101,7 +4101,7 @@ def notes(
                         }
                     }
                 }
-            >>
+            }
 
     """
     items = []
@@ -5627,7 +5627,7 @@ def rest(
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -5674,7 +5674,7 @@ def rest(
                         }
                     }
                 }
-            >>
+            }
 
     """
     return rests(argument, exclude=exclude, grace=grace)[n]
@@ -5721,7 +5721,7 @@ def rests(
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -5770,7 +5770,7 @@ def rests(
                         }
                     }
                 }
-            >>
+            }
 
     """
     items = []
@@ -5818,7 +5818,7 @@ def run(
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -5869,7 +5869,7 @@ def run(
                         }
                     }
                 }
-            >>
+            }
 
     """
     return runs(argument, exclude=exclude)[n]
@@ -5916,7 +5916,7 @@ def runs(
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -5977,7 +5977,7 @@ def runs(
                         }
                     }
                 }
-            >>
+            }
 
     ..  container:: example
 
@@ -6194,7 +6194,7 @@ def tuplet(
             >>> string = abjad.lilypond(score)
             >>> print(string)
             \context Score = "Score"
-            <<
+            {
                 \context Staff = "Staff"
                 \with
                 {
@@ -6246,7 +6246,7 @@ def tuplet(
                         }
                     }
                 }
-            >>
+            }
 
     """
     return tuplets(argument, exclude=exclude, level=level)[n]
@@ -6565,7 +6565,7 @@ def with_next_leaf(argument, *, grace: bool | None = None) -> list[_score.Leaf]:
         [Note("f'8")]
 
         >>> for item in result:
-        ...     abjad.piano_pedal(item)
+        ...     abjad.piano_pedal(item, context="Staff")
         ...
 
         >>> abjad.label.by_selector(result, True)

--- a/abjad/spanners.py
+++ b/abjad/spanners.py
@@ -59,15 +59,15 @@ def beam(
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'8 d' e' f'")
-        >>> abjad.beam(staff[:], direction=abjad.UP)
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'8 d' e' f'")
+        >>> abjad.beam(voice[:], direction=abjad.UP)
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'8
                 ^ [
@@ -1176,16 +1176,16 @@ def hairpin(
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.hairpin("p < f", staff[:], direction=abjad.UP)
-        >>> abjad.override(staff[0]).DynamicLineSpanner.staff_padding = 4
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.hairpin("p < f", voice[:], direction=abjad.UP)
+        >>> abjad.override(voice[0]).DynamicLineSpanner.staff_padding = 4
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 \once \override DynamicLineSpanner.staff-padding = 4
                 c'4
@@ -1201,16 +1201,16 @@ def hairpin(
 
         With two-part string descriptor:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.hairpin("< !", staff[:])
-        >>> abjad.override(staff[0]).DynamicLineSpanner.staff_padding = 4
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.hairpin("< !", voice[:])
+        >>> abjad.override(voice[0]).DynamicLineSpanner.staff_padding = 4
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 \once \override DynamicLineSpanner.staff-padding = 4
                 c'4
@@ -1225,20 +1225,20 @@ def hairpin(
 
         With dynamic objects:
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_dynamic = abjad.Dynamic("niente", command=r"\!")
         >>> start_hairpin = abjad.StartHairpin("o<|")
         >>> bundle = abjad.bundle(start_hairpin, r"- \tweak color #blue")
         >>> stop_dynamic = abjad.Dynamic('"f"')
-        >>> abjad.hairpin([start_dynamic, bundle, stop_dynamic], staff[:])
-        >>> abjad.override(staff[0]).DynamicLineSpanner.staff_padding = 4
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> abjad.hairpin([start_dynamic, bundle, stop_dynamic], voice[:])
+        >>> abjad.override(voice[0]).DynamicLineSpanner.staff_padding = 4
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 \once \override DynamicLineSpanner.staff-padding = 4
                 c'4
@@ -1333,15 +1333,15 @@ def horizontal_bracket(
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.horizontal_bracket(staff[:])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.horizontal_bracket(voice[:])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 \startGroup
@@ -1420,15 +1420,15 @@ def phrasing_slur(
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.phrasing_slur(staff[:], direction=abjad.UP)
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.phrasing_slur(voice[:], direction=abjad.UP)
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 ^ \(
@@ -1456,6 +1456,7 @@ def phrasing_slur(
 def piano_pedal(
     argument: _score.Component | typing.Sequence[_score.Component],
     *,
+    context: str | None = None,
     selector: typing.Callable = lambda _: _select.leaves(_),
     start_piano_pedal: _indicators.StartPianoPedal | None = None,
     stop_piano_pedal: _indicators.StopPianoPedal | None = None,
@@ -1467,7 +1468,7 @@ def piano_pedal(
     ..  container:: example
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.piano_pedal(staff[:])
+        >>> abjad.piano_pedal(staff[:], context="Staff")
         >>> abjad.setting(staff).pedalSustainStyle = "#'mixed"
         >>> abjad.override(staff).SustainPedalLineSpanner.staff_padding = 5
         >>> abjad.show(staff) # doctest: +SKIP
@@ -1499,8 +1500,8 @@ def piano_pedal(
     leaves = _select.leaves(argument)
     start_leaf = leaves[0]
     stop_leaf = leaves[-1]
-    _bind.attach(start_piano_pedal, start_leaf, tag=tag)
-    _bind.attach(stop_piano_pedal, stop_leaf, tag=tag)
+    _bind.attach(start_piano_pedal, start_leaf, context=context, tag=tag)
+    _bind.attach(stop_piano_pedal, stop_leaf, context=context, tag=tag)
 
 
 def slur(
@@ -1517,15 +1518,15 @@ def slur(
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.slur(staff[:], direction=abjad.UP)
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.slur(voice[:], direction=abjad.UP)
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 ^ (
@@ -1564,24 +1565,24 @@ def text_spanner(
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
         ...     style="solid-line-with-arrow",
         ... )
         >>> abjad.text_spanner(
-        ...     staff[:], direction=abjad.UP, start_text_span=start_text_span
+        ...     voice[:], direction=abjad.UP, start_text_span=start_text_span
         ... )
-        >>> abjad.override(staff[0]).TextSpanner.staff_padding = 4
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.override(voice[0]).TextSpanner.staff_padding = 4
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 \once \override TextSpanner.staff-padding = 4
                 c'4
@@ -1599,27 +1600,27 @@ def text_spanner(
 
         Enchained spanners:
 
-        >>> staff = abjad.Staff("c'4 d' e' f' r")
+        >>> voice = abjad.Voice("c'4 d' e' f' r")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     style="dashed-line-with-arrow",
         ... )
-        >>> abjad.text_spanner(staff[:3], start_text_span=start_text_span)
+        >>> abjad.text_spanner(voice[:3], start_text_span=start_text_span)
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright tasto"),
         ...     right_text=abjad.Markup(r"\markup \upright pont."),
         ...     style="dashed-line-with-arrow",
         ... )
-        >>> abjad.text_spanner(staff[-3:], start_text_span=start_text_span)
-        >>> abjad.override(staff).TextSpanner.staff_padding = 4
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.text_spanner(voice[-3:], start_text_span=start_text_span)
+        >>> abjad.override(voice).TextSpanner.staff_padding = 4
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override TextSpanner.staff-padding = 4
@@ -1641,26 +1642,26 @@ def text_spanner(
                 \stopTextSpan
             }
 
-        >>> staff = abjad.Staff("c'4 d' e' f' r")
+        >>> voice = abjad.Voice("c'4 d' e' f' r")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     style="dashed-line-with-arrow",
         ... )
-        >>> abjad.text_spanner(staff[:3], start_text_span=start_text_span)
+        >>> abjad.text_spanner(voice[:3], start_text_span=start_text_span)
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright tasto"),
         ...     style="solid-line-with-hook",
         ... )
-        >>> abjad.text_spanner(staff[-3:], start_text_span=start_text_span)
-        >>> abjad.override(staff).TextSpanner.staff_padding = 4
-        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+        >>> abjad.text_spanner(voice[-3:], start_text_span=start_text_span)
+        >>> abjad.override(voice).TextSpanner.staff_padding = 4
+        >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', voice])
         >>> abjad.show(lilypond_file) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             \with
             {
                 \override TextSpanner.staff-padding = 4
@@ -1937,15 +1938,15 @@ def trill_spanner(
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.trill_spanner(staff[:])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> voice = abjad.Voice("c'4 d' e' f'")
+        >>> abjad.trill_spanner(voice[:])
+        >>> abjad.show(voice) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff)
+            >>> string = abjad.lilypond(voice)
             >>> print(string)
-            \new Staff
+            \new Voice
             {
                 c'4
                 \startTrillSpan

--- a/abjad/wf.py
+++ b/abjad/wf.py
@@ -582,6 +582,8 @@ def check_overlapping_text_spanners(argument) -> tuple[list, int]:
         wrappers.sort(key=key)
         open_spanners: dict = {}
         for wrapper in wrappers:
+            if wrapper.deactivate is True:
+                continue
             if isinstance(wrapper.unbundle_indicator(), _indicators.StartTextSpan):
                 total += 1
                 command = wrapper.unbundle_indicator().command
@@ -861,6 +863,8 @@ def check_unterminated_text_spanners(argument) -> tuple[list, int]:
         wrappers.sort(key=lambda _: _.leaked_start_offset)
         open_spanners: dict = {}
         for wrapper in wrappers:
+            if wrapper.deactivate is True:
+                continue
             if isinstance(wrapper.unbundle_indicator(), _indicators.StartTextSpan):
                 total += 1
                 command = wrapper.unbundle_indicator().command

--- a/tests/test_Container___setitem__.py
+++ b/tests/test_Container___setitem__.py
@@ -462,14 +462,14 @@ def test_Container___setitem___09():
 def test_Container___setitem___10():
     r"""Sets leaf between spanned compoennts."""
 
-    staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    abjad.beam(staff[:])
+    voice = abjad.Voice("c'8 d'8 e'8 f'8")
+    abjad.beam(voice[:])
     note = abjad.Note("g'8")
-    staff[2:2] = [note]
+    voice[2:2] = [note]
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -480,13 +480,15 @@ def test_Container___setitem___10():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_Container___setitem___11():
-    r"""Sets multiple leaves between spanned components."""
+    r"""
+    Sets multiple leaves between spanned components.
+    """
 
     notes = [
         abjad.Note("c'8"),
@@ -501,12 +503,12 @@ def test_Container___setitem___11():
     middle = notes[2:4]
     end = notes[4:]
 
-    staff = abjad.Staff(beginning + end)
-    abjad.beam(staff[:])
+    voice = abjad.Voice(beginning + end)
+    abjad.beam(voice[:])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -516,13 +518,13 @@ def test_Container___setitem___11():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    staff[2:2] = middle
+    voice[2:2] = middle
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -534,22 +536,24 @@ def test_Container___setitem___11():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_Container___setitem___12():
-    r"""Replaces multiple spanned leaves with with single leaf."""
+    r"""
+    Replaces multiple spanned leaves with with single leaf.
+    """
 
-    staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    abjad.beam(staff[:])
+    voice = abjad.Voice("c'8 d'8 e'8 f'8")
+    abjad.beam(voice[:])
     note = abjad.Note("c''8")
-    staff[1:3] = [note]
+    voice[1:3] = [note]
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -558,22 +562,24 @@ def test_Container___setitem___12():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_Container___setitem___13():
-    r"""Replaces three spanned leaves with three different leaves."""
+    """
+    Replaces three spanned leaves with three different leaves.
+    """
 
-    staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    abjad.beam(staff[:])
+    voice = abjad.Voice("c'8 d'8 e'8 f'8")
+    abjad.beam(voice[:])
     notes = [abjad.Note("b'8"), abjad.Note("a'8"), abjad.Note("g'8")]
-    staff[1:3] = notes
+    voice[1:3] = notes
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -584,9 +590,9 @@ def test_Container___setitem___13():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_Container___setitem___14():

--- a/tests/test_Container_append.py
+++ b/tests/test_Container_append.py
@@ -37,6 +37,7 @@ def test_Container_append_02():
     """
 
     tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+    abjad.Voice([tuplet])
     abjad.beam(tuplet[:])
     tuplet.append(abjad.Note(5, (1, 16)), preserve_duration=True)
 

--- a/tests/test_Container_insert.py
+++ b/tests/test_Container_insert.py
@@ -50,14 +50,14 @@ def test_Container_insert_02():
 
 
 def test_Container_insert_03():
-    staff = abjad.Staff([abjad.Note(n, (1, 8)) for n in range(4)])
-    abjad.beam(staff[:])
-    staff.insert(4, abjad.Rest((1, 4)))
+    voice = abjad.Voice([abjad.Note(n, (1, 8)) for n in range(4)])
+    abjad.beam(voice[:])
+    voice.insert(4, abjad.Rest((1, 4)))
 
-    assert abjad.wf.wellformed(staff)
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.wf.wellformed(voice)
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -76,14 +76,14 @@ def test_Container_insert_04():
     Insert works with really big positive values.
     """
 
-    staff = abjad.Staff([abjad.Note(n, (1, 8)) for n in range(4)])
-    abjad.beam(staff[:])
-    staff.insert(1000, abjad.Rest((1, 4)))
+    voice = abjad.Voice([abjad.Note(n, (1, 8)) for n in range(4)])
+    abjad.beam(voice[:])
+    voice.insert(1000, abjad.Rest((1, 4)))
 
-    assert abjad.wf.wellformed(staff)
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.wf.wellformed(voice)
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -167,14 +167,14 @@ def test_Container_insert_07():
 
 
 def test_Container_insert_08():
-    staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    abjad.beam(staff[:])
-    staff.insert(1, abjad.Note("cs'8"))
+    voice = abjad.Voice("c'8 d'8 e'8 f'8")
+    abjad.beam(voice[:])
+    voice.insert(1, abjad.Note("cs'8"))
 
-    assert abjad.wf.wellformed(staff)
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.wf.wellformed(voice)
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [

--- a/tests/test_Container_pop.py
+++ b/tests/test_Container_pop.py
@@ -55,13 +55,13 @@ def test_Container_pop_02():
     Containers pop nested containers correctly.
     """
 
-    staff = abjad.Staff("{ c'8 d'8 } { e'8 f'8 }")
-    leaves = abjad.select.leaves(staff)
+    voice = abjad.Voice("{ c'8 d'8 } { e'8 f'8 }")
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -75,13 +75,13 @@ def test_Container_pop_02():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    sequential = staff.pop()
+    sequential = voice.pop()
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -90,9 +90,9 @@ def test_Container_pop_02():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
     assert abjad.lilypond(sequential) == abjad.string.normalize(
         r"""

--- a/tests/test_Container_remove.py
+++ b/tests/test_Container_remove.py
@@ -61,14 +61,14 @@ def test_Container_remove_02():
     abjad.Container returns after removal.
     """
 
-    staff = abjad.Staff("{ c'8 d'8 } { e'8 f'8 }")
-    leaves = abjad.select.leaves(staff)
-    sequential = staff[0]
+    voice = abjad.Voice("{ c'8 d'8 } { e'8 f'8 }")
+    leaves = abjad.select.leaves(voice)
+    sequential = voice[0]
     abjad.beam(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -84,11 +84,11 @@ def test_Container_remove_02():
         """
     )
 
-    staff.remove(sequential)
+    voice.remove(sequential)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 e'8
@@ -99,7 +99,7 @@ def test_Container_remove_02():
         """
     )
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
     assert abjad.lilypond(sequential) == abjad.string.normalize(
         r"""

--- a/tests/test_LilyPondParser__indicators__Dynamic.py
+++ b/tests/test_LilyPondParser__indicators__Dynamic.py
@@ -2,7 +2,7 @@ import abjad
 
 
 def test_LilyPondParser__indicators__Dynamic_01():
-    target = abjad.Staff("c2 c2 c2 c2 c2 c2")
+    target = abjad.Voice("c2 c2 c2 c2 c2 c2")
     dynamic = abjad.Dynamic("ppp")
     abjad.attach(dynamic, target[0], direction=abjad.DOWN)
     dynamic = abjad.Dynamic("mp")
@@ -18,7 +18,7 @@ def test_LilyPondParser__indicators__Dynamic_01():
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c2
             _ \ppp
@@ -36,7 +36,7 @@ def test_LilyPondParser__indicators__Dynamic_01():
         """
     )
 
-    string = r"""\new Staff { c2 _ \ppp c ^ \mp c2\rfz c\mf c2\spp c\ff }"""
+    string = r"""\new Voice { c2 _ \ppp c ^ \mp c2\rfz c\mf c2\spp c\ff }"""
     parser = abjad.parser.LilyPondParser()
     result = parser(string)
     assert abjad.lilypond(target) == abjad.lilypond(result)

--- a/tests/test_LilyPondParser__misc__chord_repetition.py
+++ b/tests/test_LilyPondParser__misc__chord_repetition.py
@@ -29,7 +29,7 @@ def test_LilyPondParser__misc__chord_repetition_01():
 
 
 def test_LilyPondParser__misc__chord_repetition_02():
-    target = abjad.Staff(
+    target = abjad.Voice(
         [
             abjad.Chord([0, 4, 7], (1, 8)),
             abjad.Chord([0, 4, 7], (1, 8)),
@@ -51,7 +51,7 @@ def test_LilyPondParser__misc__chord_repetition_02():
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             <c' e' g'>8
             \p
@@ -67,7 +67,7 @@ def test_LilyPondParser__misc__chord_repetition_02():
         """
     )
 
-    string = r"""\new Staff { <c' e' g'>8\p q q4-! q8.^"text" q16 q4-! }"""
+    string = r"""\new Voice { <c' e' g'>8\p q q4-! q8.^"text" q16 q4-! }"""
     parser = abjad.parser.LilyPondParser()
     result = parser(string)
     assert abjad.lilypond(target) == abjad.lilypond(result) and target is not result

--- a/tests/test_LilyPondParser__spanners__Beam.py
+++ b/tests/test_LilyPondParser__spanners__Beam.py
@@ -4,12 +4,13 @@ import abjad
 
 
 def test_LilyPondParser__spanners__Beam_01():
-    target = abjad.Container(abjad.makers.make_notes([0] * 4, [(1, 8)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 4, [(1, 8)]))
     abjad.beam(target[0:3])
     abjad.beam(target[3:], beam_lone_notes=True)
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'8
             [
@@ -29,12 +30,13 @@ def test_LilyPondParser__spanners__Beam_01():
 
 
 def test_LilyPondParser__spanners__Beam_02():
-    target = abjad.Container(abjad.makers.make_notes([0] * 4, [(1, 8)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 4, [(1, 8)]))
     abjad.beam(target[:])
     abjad.beam(target[1:3])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'8
             [
@@ -53,12 +55,13 @@ def test_LilyPondParser__spanners__Beam_02():
 
 
 def test_LilyPondParser__spanners__Beam_03():
-    target = abjad.Container(abjad.makers.make_notes([0] * 4, [(1, 8)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 4, [(1, 8)]))
     abjad.beam(target[:3])
     abjad.beam(target[2:])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'8
             [
@@ -87,7 +90,7 @@ def test_LilyPondParser__spanners__Beam_05():
     With direction.
     """
 
-    target = abjad.Container(abjad.makers.make_notes(4 * [0], [(1, 8)]))
+    target = abjad.Voice(abjad.makers.make_notes(4 * [0], [(1, 8)]))
     start_beam = abjad.StartBeam()
     abjad.attach(start_beam, target[0], direction=abjad.UP)
     stop_beam = abjad.StopBeam()
@@ -99,6 +102,7 @@ def test_LilyPondParser__spanners__Beam_05():
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'8
             ^ [

--- a/tests/test_LilyPondParser__spanners__Hairpin.py
+++ b/tests/test_LilyPondParser__spanners__Hairpin.py
@@ -4,13 +4,13 @@ import abjad
 
 
 def test_LilyPondParser__spanners__Hairpin_01():
-    target = abjad.Staff(abjad.makers.make_notes([0] * 5, [(1, 4)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 5, [(1, 4)]))
     abjad.hairpin("< !", target[:3])
     abjad.hairpin("> ppp", target[2:])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'4
             \<
@@ -35,13 +35,13 @@ def test_LilyPondParser__spanners__Hairpin_02():
     Dynamics can terminate hairpins.
     """
 
-    target = abjad.Staff(abjad.makers.make_notes([0] * 3, [(1, 4)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 3, [(1, 4)]))
     abjad.hairpin("<", target[0:2])
     abjad.hairpin("p > f", target[1:])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'4
             \<
@@ -54,7 +54,7 @@ def test_LilyPondParser__spanners__Hairpin_02():
         """
     )
 
-    string = r"\new Staff \relative c' { c \< c \p \> c \f }"
+    string = r"\new Voice \relative c' { c \< c \p \> c \f }"
     parser = abjad.parser.LilyPondParser()
     result = parser(string)
     assert abjad.lilypond(target) == abjad.lilypond(result) and target is not result
@@ -94,7 +94,7 @@ def test_LilyPondParser__spanners__Hairpin_06():
     With direction.
     """
 
-    target = abjad.Staff(abjad.makers.make_notes([0] * 5, [(1, 4)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 5, [(1, 4)]))
     start_hairpin = abjad.StartHairpin("<")
     abjad.attach(start_hairpin, target[0], direction=abjad.UP)
     stop_hairpin = abjad.StopHairpin()
@@ -106,7 +106,7 @@ def test_LilyPondParser__spanners__Hairpin_06():
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'4
             ^ \<

--- a/tests/test_LilyPondParser__spanners__HorizontalBracket.py
+++ b/tests/test_LilyPondParser__spanners__HorizontalBracket.py
@@ -4,13 +4,14 @@ import abjad
 
 
 def test_LilyPondParser__spanners__HorizontalBracket_01():
-    target = abjad.Container(abjad.makers.make_notes([0] * 4, [(1, 4)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 4, [(1, 4)]))
     abjad.horizontal_bracket(target[:])
     abjad.horizontal_bracket(target[:2])
     abjad.horizontal_bracket(target[2:])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'4
             \startGroup

--- a/tests/test_LilyPondParser__spanners__PhrasingSlur.py
+++ b/tests/test_LilyPondParser__spanners__PhrasingSlur.py
@@ -8,12 +8,13 @@ def test_LilyPondParser__spanners__PhrasingSlur_01():
     Successful slurs, showing single leaf overlap.
     """
 
-    target = abjad.Container(abjad.makers.make_notes([0] * 4, [(1, 4)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 4, [(1, 4)]))
     abjad.phrasing_slur(target[2:])
     abjad.phrasing_slur(target[:3])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'4
             \(
@@ -37,12 +38,13 @@ def test_LilyPondParser__spanners__PhrasingSlur_02():
     Swapped start and stop.
     """
 
-    target = abjad.Container(abjad.makers.make_notes([0] * 4, [(1, 4)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 4, [(1, 4)]))
     abjad.phrasing_slur(target[2:])
     abjad.phrasing_slur(target[:3])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'4
             \(
@@ -56,7 +58,7 @@ def test_LilyPondParser__spanners__PhrasingSlur_02():
         """
     )
 
-    string = r"\relative c' { c \( c c \( \) c \) }"
+    string = r"\new Voice \relative c' { c \( c c \( \) c \) }"
 
     parser = abjad.parser.LilyPondParser()
     result = parser(string)

--- a/tests/test_LilyPondParser__spanners__Slur.py
+++ b/tests/test_LilyPondParser__spanners__Slur.py
@@ -8,12 +8,13 @@ def test_LilyPondParser__spanners__Slur_01():
     Successful slurs, showing single leaf overlap.
     """
 
-    target = abjad.Container(abjad.makers.make_notes([0] * 4, [(1, 4)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 4, [(1, 4)]))
     abjad.slur(target[2:])
     abjad.slur(target[:3])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'4
             (
@@ -37,12 +38,13 @@ def test_LilyPondParser__spanners__Slur_02():
     Swapped start and stop.
     """
 
-    target = abjad.Container(abjad.makers.make_notes([0] * 4, [(1, 4)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 4, [(1, 4)]))
     abjad.slur(target[2:])
     abjad.slur(target[:3])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'4
             (
@@ -56,8 +58,7 @@ def test_LilyPondParser__spanners__Slur_02():
         """
     )
 
-    string = r"\relative c' { c ( c c () c ) }"
-
+    string = r"\new Voice \relative c' { c ( c c () c ) }"
     parser = abjad.parser.LilyPondParser()
     result = parser(string)
     assert abjad.lilypond(target) == abjad.lilypond(result) and target is not result
@@ -108,7 +109,7 @@ def test_LilyPondParser__spanners__Slur_07():
     With direction.
     """
 
-    target = abjad.Container(abjad.makers.make_notes([0] * 4, [(1, 4)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 4, [(1, 4)]))
     start_slur = abjad.StartSlur()
     abjad.slur(target[:3], direction=abjad.DOWN, start_slur=start_slur)
     start_slur = abjad.StartSlur()
@@ -116,6 +117,7 @@ def test_LilyPondParser__spanners__Slur_07():
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'4
             _ (

--- a/tests/test_LilyPondParser__spanners__Text.py
+++ b/tests/test_LilyPondParser__spanners__Text.py
@@ -8,12 +8,13 @@ def test_LilyPondParser__spanners__Text_01():
     Successful text spanners, showing single leaf overlap.
     """
 
-    container = abjad.Container(abjad.makers.make_notes([0] * 4, [(1, 4)]))
+    container = abjad.Voice(abjad.makers.make_notes([0] * 4, [(1, 4)]))
     abjad.text_spanner(container[2:])
     abjad.text_spanner(container[:3])
 
     assert abjad.lilypond(container) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'4
             \startTextSpan
@@ -39,12 +40,13 @@ def test_LilyPondParser__spanners__Text_02():
     Swapped start and stop.
     """
 
-    target = abjad.Container(abjad.makers.make_notes([0] * 4, [(1, 4)]))
+    target = abjad.Voice(abjad.makers.make_notes([0] * 4, [(1, 4)]))
     abjad.text_spanner(target[2:])
     abjad.text_spanner(target[:3])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'4
             \startTextSpan
@@ -59,10 +61,9 @@ def test_LilyPondParser__spanners__Text_02():
     )
 
     string = (
-        r"\relative c' { c \startTextSpan c c \startTextSpan \stopTextSpan c"
+        r"\new Voice \relative c' { c \startTextSpan c c \startTextSpan \stopTextSpan c"
         r" \stopTextSpan }"
     )
-
     parser = abjad.parser.LilyPondParser()
     result = parser(string)
     assert abjad.lilypond(target) == abjad.lilypond(result) and target is not result

--- a/tests/test_LilyPondParser__spanners__Trill.py
+++ b/tests/test_LilyPondParser__spanners__Trill.py
@@ -9,12 +9,13 @@ def test_LilyPondParser__spanners__Trill_01():
     """
 
     notes = abjad.makers.make_notes(4 * [0], [(1, 4)])
-    target = abjad.Container(notes)
+    target = abjad.Voice(notes)
     abjad.trill_spanner(target[2:])
     abjad.trill_spanner(target[:3])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'4
             \startTrillSpan
@@ -39,12 +40,13 @@ def test_LilyPondParser__spanners__Trill_02():
     """
 
     notes = abjad.makers.make_notes(4 * [0], [(1, 4)])
-    target = abjad.Container(notes)
+    target = abjad.Voice(notes)
     abjad.trill_spanner(target[2:])
     abjad.trill_spanner(target[:3])
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
+        \new Voice
         {
             c'4
             \startTrillSpan
@@ -59,10 +61,9 @@ def test_LilyPondParser__spanners__Trill_02():
     )
 
     string = (
-        r"\relative c' { c \startTrillSpan c c \startTrillSpan \stopTrillSpan c"
+        r"\new Voice \relative c' { c \startTrillSpan c c \startTrillSpan \stopTrillSpan c"
         r" \stopTrillSpan }"
     )
-
     parser = abjad.parser.LilyPondParser()
     result = parser(string)
     assert abjad.lilypond(target) == abjad.lilypond(result) and target is not result

--- a/tests/test_Note___init__.py
+++ b/tests/test_Note___init__.py
@@ -95,9 +95,9 @@ def test_Note___init___08():
 
     chord = abjad.Chord([2, 3, 4], (1, 8))
     chords = abjad.mutate.copy(chord, 3)
-    staff = abjad.Staff(chords)
-    abjad.beam(staff[:])
-    note = abjad.Note(staff[0])
+    voice = abjad.Voice(chords)
+    abjad.beam(voice[:])
+    note = abjad.Note(voice[0])
 
     assert abjad.lilypond(note) == abjad.string.normalize(
         r"""
@@ -147,15 +147,15 @@ def test_Note___init___11():
     Initializes note from beamed rest.
     """
 
-    staff = abjad.Staff(
+    voice = abjad.Voice(
         [abjad.Note(0, (1, 8)), abjad.Rest((1, 8)), abjad.Note(0, (1, 8))]
     )
-    abjad.beam(staff[:])
-    note = abjad.Note(staff[1])
+    abjad.beam(voice[:])
+    note = abjad.Note(voice[1])
 
-    assert isinstance(staff[1], abjad.Rest)
+    assert isinstance(voice[1], abjad.Rest)
     assert isinstance(note, abjad.Note)
-    assert staff[1]._parent is staff
+    assert voice[1]._parent is voice
     assert note._parent is None
 
 
@@ -196,15 +196,15 @@ def test_Note___init___14():
     Initializes note from beamed skip.
     """
 
-    staff = abjad.Staff(
+    voice = abjad.Voice(
         [abjad.Note(0, (1, 8)), abjad.Skip((1, 8)), abjad.Note(0, (1, 8))]
     )
-    abjad.beam(staff[:])
-    note = abjad.Note(staff[1])
+    abjad.beam(voice[:])
+    note = abjad.Note(voice[1])
 
-    assert isinstance(staff[1], abjad.Skip)
+    assert isinstance(voice[1], abjad.Skip)
     assert isinstance(note, abjad.Note)
-    assert staff[1]._parent is staff
+    assert voice[1]._parent is voice
     assert note._parent is None
 
 

--- a/tests/test_Rest___init__.py
+++ b/tests/test_Rest___init__.py
@@ -66,9 +66,9 @@ def test_Rest___init___05():
 
     chord = abjad.Chord([2, 3, 4], abjad.Duration(1, 8))
     chords = abjad.mutate.copy(chord, 3)
-    staff = abjad.Staff(chords)
-    abjad.beam(staff[:])
-    rest = abjad.Rest(staff[0])
+    voice = abjad.Voice(chords)
+    abjad.beam(voice[:])
+    rest = abjad.Rest(voice[0])
 
     assert abjad.lilypond(rest) == abjad.string.normalize(
         r"""

--- a/tests/test_Skip___init__.py
+++ b/tests/test_Skip___init__.py
@@ -87,12 +87,12 @@ def test_Skip___init___07():
     Initialize skip from beamed note.
     """
 
-    staff = abjad.Staff("c'8 c'8 c'8")
-    abjad.beam(staff[:])
-    skip = abjad.Skip(staff[0])
-    assert isinstance(staff[0], abjad.Note)
+    voice = abjad.Voice("c'8 c'8 c'8")
+    abjad.beam(voice[:])
+    skip = abjad.Skip(voice[0])
+    assert isinstance(voice[0], abjad.Note)
     assert isinstance(skip, abjad.Skip)
-    assert staff[0]._parent is staff
+    assert voice[0]._parent is voice
 
 
 def test_Skip___init___08():
@@ -131,12 +131,12 @@ def test_Skip___init___10():
     Initialize skip from spanned rest.
     """
 
-    staff = abjad.Staff(
+    voice = abjad.Voice(
         [abjad.Note(0, (1, 8)), abjad.Rest((1, 8)), abjad.Note(0, (1, 8))]
     )
-    abjad.beam(staff[:])
-    skip = abjad.Skip(staff[1])
+    abjad.beam(voice[:])
+    skip = abjad.Skip(voice[1])
     assert isinstance(skip, abjad.Skip)
-    assert isinstance(staff[1], abjad.Rest)
-    assert staff[1]._parent is staff
+    assert isinstance(voice[1], abjad.Rest)
+    assert voice[1]._parent is voice
     assert skip._parent is None

--- a/tests/test_get_duration.py
+++ b/tests/test_get_duration.py
@@ -9,11 +9,11 @@ def test_get_duration_01():
     """
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
+    score = abjad.Score([staff])
     mark = abjad.MetronomeMark(abjad.Duration(1, 4), 38)
     abjad.attach(mark, staff[0])
     mark = abjad.MetronomeMark(abjad.Duration(1, 4), 42)
     abjad.attach(mark, staff[2])
-    score = abjad.Score([staff])
 
     assert abjad.lilypond(score) == abjad.string.normalize(
         r"""
@@ -51,11 +51,11 @@ def test_get_duration_03():
     """
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
+    abjad.Score([staff])
     mark = abjad.MetronomeMark(abjad.Duration(1, 4), 38)
     abjad.attach(mark, staff[0])
     mark = abjad.MetronomeMark(abjad.Duration(1, 4), 42)
     abjad.attach(mark, staff[2])
-    abjad.Score([staff])
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
         r"""

--- a/tests/test_get_indicators.py
+++ b/tests/test_get_indicators.py
@@ -2,16 +2,16 @@ import abjad
 
 
 def test_get_indicators_01():
-    staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    abjad.slur(staff[:])
+    voice = abjad.Voice("c'8 d'8 e'8 f'8")
+    abjad.slur(voice[:])
     command_1 = abjad.LilyPondLiteral(r"\slurDotted", site="before")
-    abjad.attach(command_1, staff[0])
+    abjad.attach(command_1, voice[0])
     command_2 = abjad.LilyPondLiteral(r"\slurUp", site="before")
-    abjad.attach(command_2, staff[0])
+    abjad.attach(command_2, voice[0])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             \slurDotted
             \slurUp
@@ -23,36 +23,40 @@ def test_get_indicators_01():
             )
         }
         """
-    ), abjad.lilypond(staff)
+    ), abjad.lilypond(voice)
 
-    indicators = abjad.get.indicators(staff[0], abjad.LilyPondLiteral)
+    indicators = abjad.get.indicators(voice[0], abjad.LilyPondLiteral)
     assert command_1 in indicators
     assert command_2 in indicators
     assert len(indicators) == 2
 
 
 def test_get_indicators_02():
-    staff = abjad.Staff("c'8 d'8 e'8 f'8")
+    voice = abjad.Voice("c'8 d'8 e'8 f'8")
+    staff = abjad.Staff([voice])
     clef = abjad.Clef("treble")
-    abjad.attach(clef, staff[0])
+    abjad.attach(clef, voice[0])
     dynamic = abjad.Dynamic("p")
-    abjad.attach(dynamic, staff[0])
+    abjad.attach(dynamic, voice[0])
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
         r"""
         \new Staff
         {
-            \clef "treble"
-            c'8
-            \p
-            d'8
-            e'8
-            f'8
+            \new Voice
+            {
+                \clef "treble"
+                c'8
+                \p
+                d'8
+                e'8
+                f'8
+            }
         }
         """
     ), abjad.lilypond(staff)
 
-    indicators = abjad.get.indicators(staff[0])
+    indicators = abjad.get.indicators(voice[0])
     assert len(indicators) == 2
 
 

--- a/tests/test_iterpitches_transpose_from_sounding_pitch.py
+++ b/tests/test_iterpitches_transpose_from_sounding_pitch.py
@@ -2,29 +2,31 @@ import abjad
 
 
 def test_transpose_from_sounding_pitch_01():
-    staff = abjad.Staff("c'4 c'4 c'4 c'4")
+    voice = abjad.Voice("c'4 c'4 c'4 c'4")
+    staff = abjad.Staff([voice])
     trill_pitch = abjad.NamedPitch("d'")
     start_trill_span = abjad.StartTrillSpan(pitch=trill_pitch)
-    abjad.attach(start_trill_span, staff[1])
+    abjad.attach(start_trill_span, voice[1])
     stop_trill_span = abjad.StopTrillSpan()
-    abjad.attach(stop_trill_span, staff[2])
+    abjad.attach(stop_trill_span, voice[2])
     instrument = abjad.AltoSaxophone()
-    abjad.attach(instrument, staff[0])
-
-    abjad.iterpitches.transpose_from_sounding_pitch(staff)
-
+    abjad.attach(instrument, voice[0])
+    abjad.iterpitches.transpose_from_sounding_pitch(voice)
     string = abjad.lilypond(staff)
     assert string == abjad.string.normalize(
         r"""
         \new Staff
         {
-            a'4
-            \pitchedTrill
-            a'4
-            \startTrillSpan b'
-            a'4
-            \stopTrillSpan
-            a'4
+            \new Voice
+            {
+                a'4
+                \pitchedTrill
+                a'4
+                \startTrillSpan b'
+                a'4
+                \stopTrillSpan
+                a'4
+            }
         }
         """
     )

--- a/tests/test_iterpitches_transpose_from_written_pitch.py
+++ b/tests/test_iterpitches_transpose_from_written_pitch.py
@@ -2,29 +2,31 @@ import abjad
 
 
 def test_transpose_from_written_pitch_01():
-    staff = abjad.Staff("a'4 a'4 a'4 a'4")
+    voice = abjad.Voice("a'4 a'4 a'4 a'4")
+    staff = abjad.Staff([voice])
     trill_pitch = abjad.NamedPitch("b'")
     start_trill_span = abjad.StartTrillSpan(pitch=trill_pitch)
-    abjad.attach(start_trill_span, staff[1])
+    abjad.attach(start_trill_span, voice[1])
     stop_trill_span = abjad.StopTrillSpan()
-    abjad.attach(stop_trill_span, staff[2])
+    abjad.attach(stop_trill_span, voice[2])
     instrument = abjad.AltoSaxophone()
-    abjad.attach(instrument, staff[0])
-
-    abjad.iterpitches.transpose_from_written_pitch(staff)
-
+    abjad.attach(instrument, voice[0])
+    abjad.iterpitches.transpose_from_written_pitch(voice)
     string = abjad.lilypond(staff)
     assert string == abjad.string.normalize(
         r"""
         \new Staff
         {
-            c'4
-            \pitchedTrill
-            c'4
-            \startTrillSpan d'
-            c'4
-            \stopTrillSpan
-            c'4
+            \new Voice
+            {
+                c'4
+                \pitchedTrill
+                c'4
+                \startTrillSpan d'
+                c'4
+                \stopTrillSpan
+                c'4
+            }
         }
         """
     )

--- a/tests/test_mutate__fuse_leaves_by_immediate_parent.py
+++ b/tests/test_mutate__fuse_leaves_by_immediate_parent.py
@@ -151,7 +151,6 @@ def test_mutate__fuse_leaves_by_immediate_parent_06():
     """
 
     voice = abjad.Voice(r"c'16 ~ c'16 ~ c'16 ~ c'16 ~ c'16 r16 r16 r16 r4 r4")
-    abjad.attach(abjad.MetronomeMark(abjad.Duration(1, 4), 120), voice[0])
     logical_tie = abjad.get.logical_tie(voice[0])
     result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
 
@@ -159,7 +158,6 @@ def test_mutate__fuse_leaves_by_immediate_parent_06():
         r"""
         \new Voice
         {
-            \tempo 4=120
             c'4
             ~
             c'16
@@ -264,12 +262,13 @@ def test_mutate__fuse_leaves_by_immediate_parent_09():
     the end of the logical tie after fusing.
     """
 
-    staff = abjad.Staff(r"d'8 c'8 ~ c'32 r16 r16 r16 r4")
+    voice = abjad.Voice(r"d'8 c'8 ~ c'32 r16 r16 r16 r4")
+    staff = abjad.Staff([voice])
     abjad.Score([staff], name="Score")
 
     indicators = (abjad.TimeSignature((3, 4)), abjad.StartBeam())
     for indicator in indicators:
-        abjad.attach(indicator, staff[0])
+        abjad.attach(indicator, voice[0])
 
     indicators = (
         abjad.BeforeGraceContainer("b'16"),
@@ -278,31 +277,34 @@ def test_mutate__fuse_leaves_by_immediate_parent_09():
         abjad.StopBeam(),
     )
     for indicator in indicators:
-        abjad.attach(indicator, staff[1])
+        abjad.attach(indicator, voice[1])
 
-    logical_tie = abjad.get.logical_tie(staff[1])
+    logical_tie = abjad.get.logical_tie(voice[1])
     result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
         r"""
         \new Staff
         {
-            \time 3/4
-            d'8
-            [
-            \grace {
-                b'16
+            \new Voice
+            {
+                \time 3/4
+                d'8
+                [
+                \grace {
+                    b'16
+                }
+                c'8
+                - \accent
+                - \staccato
+                ~
+                c'32
+                ]
+                r16
+                r16
+                r16
+                r4
             }
-            c'8
-            - \accent
-            - \staccato
-            ~
-            c'32
-            ]
-            r16
-            r16
-            r16
-            r4
         }
         """
     ), print(abjad.lilypond(staff))

--- a/tests/test_mutate__split_container_by_duration.py
+++ b/tests/test_mutate__split_container_by_duration.py
@@ -7,17 +7,17 @@ def test_mutate__split_container_by_duration_01():
     Adds tie after split.
     """
 
-    staff = abjad.Staff()
-    staff.append(abjad.Container("c'8 d'8"))
-    staff.append(abjad.Container("e'8 f'8"))
-    leaves = abjad.select.leaves(staff)
+    voice = abjad.Voice()
+    voice.append(abjad.Container("c'8 d'8"))
+    voice.append(abjad.Container("e'8 f'8"))
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves[:2])
     abjad.beam(leaves[-2:])
     abjad.slur(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -35,13 +35,13 @@ def test_mutate__split_container_by_duration_01():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    abjad.mutate._split_container_by_duration(staff[0], abjad.Duration(1, 32))
+    abjad.mutate._split_container_by_duration(voice[0], abjad.Duration(1, 32))
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'32
@@ -63,9 +63,9 @@ def test_mutate__split_container_by_duration_01():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_mutate__split_container_by_duration_02():
@@ -73,17 +73,17 @@ def test_mutate__split_container_by_duration_02():
     Split in-score container at split offset with non-power-of-two denominator.
     """
 
-    staff = abjad.Staff()
-    staff.append(abjad.Container("c'8 d'8"))
-    staff.append(abjad.Container("e'8 f'8"))
-    leaves = abjad.select.leaves(staff)
+    voice = abjad.Voice()
+    voice.append(abjad.Container("c'8 d'8"))
+    voice.append(abjad.Container("e'8 f'8"))
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves[:2])
     abjad.beam(leaves[-2:])
     abjad.slur(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -101,13 +101,13 @@ def test_mutate__split_container_by_duration_02():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    abjad.mutate._split_container_by_duration(staff[0], abjad.Duration(1, 5))
+    abjad.mutate._split_container_by_duration(voice[0], abjad.Duration(1, 5))
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -137,6 +137,6 @@ def test_mutate__split_container_by_duration_02():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)

--- a/tests/test_mutate__split_leaf_by_durations.py
+++ b/tests/test_mutate__split_leaf_by_durations.py
@@ -54,13 +54,13 @@ def test_mutate__split_leaf_by_durations_02():
     This test comes from #272 in GitHub.
     """
 
-    staff = abjad.Staff(r"\times 2/3 { c'8 [ d'8 e'8 ] }")
-    leaf = abjad.get.leaf(staff, 0)
+    voice = abjad.Voice(r"\times 2/3 { c'8 [ d'8 e'8 ] }")
+    leaf = abjad.get.leaf(voice, 0)
     abjad.mutate._split_leaf_by_durations(leaf, [abjad.Duration(1, 20)])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             \times 2/3
             {
@@ -77,9 +77,9 @@ def test_mutate__split_leaf_by_durations_02():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_mutate__split_leaf_by_durations_03():
@@ -243,17 +243,17 @@ def test_mutate__split_leaf_by_durations_10():
     Ties after split.
     """
 
-    staff = abjad.Staff()
-    staff.append(abjad.Container("c'8 d'8"))
-    staff.append(abjad.Container("e'8 f'8"))
-    leaves = abjad.select.leaves(staff)
+    voice = abjad.Voice()
+    voice.append(abjad.Container("c'8 d'8"))
+    voice.append(abjad.Container("e'8 f'8"))
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves[:2])
     abjad.beam(leaves[-2:])
     abjad.slur(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -271,13 +271,13 @@ def test_mutate__split_leaf_by_durations_10():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
     abjad.mutate._split_leaf_by_durations(leaves[0], [abjad.Duration(1, 32)])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'32
@@ -297,6 +297,6 @@ def test_mutate__split_leaf_by_durations_10():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)

--- a/tests/test_mutate_copy.py
+++ b/tests/test_mutate_copy.py
@@ -7,25 +7,27 @@ def test_mutate_copy_01():
     Returns Python list of copied components.
     """
 
-    staff = abjad.Staff(
+    voice = abjad.Voice(
         [
             abjad.Container("c'8 d'"),
             abjad.Container("e'8 f'"),
             abjad.Container("g'8 a'"),
-        ]
+        ],
+        name="Voice",
     )
-    abjad.Score([staff], name="Score")
-    for container in staff:
+    staff = abjad.Staff([voice], name="Staff")
+    score = abjad.Score([staff], name="Score")
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.slur(leaves)
     abjad.trill_spanner(leaves)
     abjad.beam(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Voice"
         {
             {
                 \time 2/8
@@ -50,7 +52,7 @@ def test_mutate_copy_01():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
     result = abjad.mutate.copy(leaves[2:4])
     new = abjad.Staff(result)
@@ -67,7 +69,7 @@ def test_mutate_copy_01():
         """,
         print(abjad.lilypond(new)),
     )
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(score)
     assert abjad.wf.wellformed(new)
 
 
@@ -76,25 +78,27 @@ def test_mutate_copy_02():
     Copy one measure.
     """
 
-    staff = abjad.Staff(
+    voice = abjad.Voice(
         [
             abjad.Container("c'8 d'"),
             abjad.Container("e'8 f'"),
             abjad.Container("g'8 a'"),
-        ]
+        ],
+        name="Voice",
     )
+    staff = abjad.Staff([voice], name="Staff")
     abjad.Score([staff], name="Score")
-    for container in staff:
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.slur(leaves)
     abjad.trill_spanner(leaves)
     abjad.beam(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Voice"
         {
             {
                 \time 2/8
@@ -119,15 +123,15 @@ def test_mutate_copy_02():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    result = abjad.mutate.copy(staff[1:2])
-    new = abjad.Staff(result)
+    result = abjad.mutate.copy(voice[1:2])
+    new = abjad.Voice(result, name="Foo")
     abjad.Score([new], name="Score")
 
     assert abjad.lilypond(new) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Foo"
         {
             {
                 \time 2/8
@@ -138,7 +142,7 @@ def test_mutate_copy_02():
         """
     ), print(abjad.lilypond(new))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
     assert abjad.wf.wellformed(new)
 
 
@@ -147,25 +151,27 @@ def test_mutate_copy_03():
     Three notes crossing measure boundaries.
     """
 
-    staff = abjad.Staff(
+    voice = abjad.Voice(
         [
             abjad.Container("c'8 d'"),
             abjad.Container("e'8 f'"),
             abjad.Container("g'8 a'"),
-        ]
+        ],
+        name="Voice",
     )
+    staff = abjad.Staff([voice], name="Staff")
     abjad.Score([staff], name="Score")
-    for container in staff:
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.slur(leaves)
     abjad.trill_spanner(leaves)
     abjad.beam(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Voice"
         {
             {
                 \time 2/8
@@ -190,15 +196,15 @@ def test_mutate_copy_03():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
     result = abjad.mutate.copy(leaves[-3:])
-    new = abjad.Staff(result)
+    new = abjad.Voice(result, name="Foo")
     abjad.Score([new], name="Score")
 
     assert abjad.lilypond(new) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Foo"
         {
             f'8
             \time 2/8
@@ -211,30 +217,29 @@ def test_mutate_copy_03():
         """
     ), print(abjad.lilypond(new))
 
-    assert abjad.wf.wellformed(staff)
-    assert abjad.wf.wellformed(new)
-
 
 def test_mutate_copy_04():
-    staff = abjad.Staff(
+    voice = abjad.Voice(
         [
             abjad.Container("c'8 d'"),
             abjad.Container("e'8 f'"),
             abjad.Container("g'8 a'"),
             abjad.Container("b'8 c''"),
-        ]
+        ],
+        name="Voice",
     )
+    staff = abjad.Staff([voice], name="Staff")
     abjad.Score([staff], name="Score")
-    for container in staff:
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves)
     abjad.slur(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Voice"
         {
             {
                 \time 2/8
@@ -262,14 +267,15 @@ def test_mutate_copy_04():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    new_staff = abjad.mutate.copy(staff)
+    new_voice = abjad.mutate.copy(voice)
+    new_staff = abjad.Staff([new_voice], name="New_Staff")
     abjad.Score([new_staff], name="Score")
 
-    assert abjad.lilypond(new_staff) == abjad.string.normalize(
+    assert abjad.lilypond(new_voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Voice"
         {
             {
                 \time 2/8
@@ -297,31 +303,33 @@ def test_mutate_copy_04():
             }
         }
         """
-    ), print(abjad.lilypond(new_staff))
+    ), print(abjad.lilypond(new_voice))
 
-    assert abjad.wf.wellformed(new_staff)
+    assert abjad.wf.wellformed(new_voice)
 
 
 def test_mutate_copy_05():
-    staff = abjad.Staff(
+    voice = abjad.Voice(
         [
             abjad.Container("c'8 d'"),
             abjad.Container("e'8 f'"),
             abjad.Container("g'8 a'"),
             abjad.Container("b'8 c''"),
-        ]
+        ],
+        name="Voice",
     )
+    staff = abjad.Staff([voice], name="Staff")
     abjad.Score([staff], name="Score")
-    for container in staff:
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves)
     abjad.slur(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Voice"
         {
             {
                 \time 2/8
@@ -349,15 +357,16 @@ def test_mutate_copy_05():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    result = abjad.mutate.copy(staff[1:])
-    new_staff = abjad.Staff(result)
+    result = abjad.mutate.copy(voice[1:])
+    new_voice = abjad.Voice(result, name="New_Voice")
+    new_staff = abjad.Staff([new_voice], name="New_Staff")
     abjad.Score([new_staff], name="Score")
 
-    assert abjad.lilypond(new_staff) == abjad.string.normalize(
+    assert abjad.lilypond(new_voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "New_Voice"
         {
             {
                 \time 2/8
@@ -378,32 +387,33 @@ def test_mutate_copy_05():
             }
         }
         """
-    ), print(abjad.lilypond(new_staff))
+    ), print(abjad.lilypond(new_voice))
 
-    assert abjad.wf.wellformed(staff)
-    assert abjad.wf.wellformed(new_staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_mutate_copy_06():
-    staff = abjad.Staff(
+    voice = abjad.Voice(
         [
             abjad.Container("c'8 d'"),
             abjad.Container("e'8 f'"),
             abjad.Container("g'8 a'"),
             abjad.Container("b'8 c''"),
-        ]
+        ],
+        name="Voice",
     )
+    staff = abjad.Staff([voice], name="Staff")
     abjad.Score([staff], name="Score")
-    for container in staff:
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves)
     abjad.slur(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Voice"
         {
             {
                 \time 2/8
@@ -431,15 +441,16 @@ def test_mutate_copy_06():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
     result = abjad.mutate.copy(leaves[:6])
-    new_staff = abjad.Staff(result)
-    abjad.Score([new_staff], name="Score")
+    new_voice = abjad.Voice(result, name="New_Voice")
+    new_staff = abjad.Staff([new_voice], name="New_Staff")
+    abjad.Score([new_staff], name="New_Score")
 
-    assert abjad.lilypond(new_staff) == abjad.string.normalize(
+    assert abjad.lilypond(new_voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "New_Voice"
         {
             \time 2/8
             c'8
@@ -454,32 +465,31 @@ def test_mutate_copy_06():
             a'8
         }
         """
-    ), print(abjad.lilypond(new_staff))
-
-    assert abjad.wf.wellformed(staff)
-    assert abjad.wf.wellformed(new_staff)
+    ), print(abjad.lilypond(new_voice))
 
 
 def test_mutate_copy_07():
-    staff = abjad.Staff(
+    voice = abjad.Voice(
         [
             abjad.Container("c'8 d'"),
             abjad.Container("e'8 f'"),
             abjad.Container("g'8 a'"),
             abjad.Container("b'8 c''"),
-        ]
+        ],
+        name="Voice",
     )
+    staff = abjad.Staff([voice], name="Staff")
     abjad.Score([staff], name="Score")
-    for container in staff:
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves)
     abjad.slur(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Voice"
         {
             {
                 \time 2/8
@@ -507,15 +517,16 @@ def test_mutate_copy_07():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    result = abjad.mutate.copy(staff[-2:])
-    new_staff = abjad.Staff(result)
-    abjad.Score([new_staff], name="Score")
+    result = abjad.mutate.copy(voice[-2:])
+    new_voice = abjad.Voice(result, name="New_Voice")
+    new_staff = abjad.Staff([new_voice], name="New_Staff")
+    abjad.Score([new_staff], name="New_Score")
 
-    assert abjad.lilypond(new_staff) == abjad.string.normalize(
+    assert abjad.lilypond(new_voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "New_Voice"
         {
             {
                 \time 2/8
@@ -531,10 +542,7 @@ def test_mutate_copy_07():
             }
         }
         """
-    ), print(abjad.lilypond(new_staff))
-
-    assert abjad.wf.wellformed(staff)
-    assert abjad.wf.wellformed(new_staff)
+    ), print(abjad.lilypond(new_voice))
 
 
 def test_mutate_copy_08():
@@ -542,12 +550,12 @@ def test_mutate_copy_08():
     Copies hairpin.
     """
 
-    staff = abjad.Staff("c'8 cs'8 d'8 ef'8 e'8 f'8 fs'8 g'8")
-    abjad.hairpin("< !", staff[:4])
+    voice = abjad.Voice("c'8 cs'8 d'8 ef'8 e'8 f'8 fs'8 g'8", name="Voice")
+    abjad.hairpin("< !", voice[:4])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Voice"
         {
             c'8
             \<
@@ -563,13 +571,13 @@ def test_mutate_copy_08():
         """
     )
 
-    new_notes = abjad.mutate.copy(staff[:4])
-    staff.extend(new_notes)
-    abjad.Score([staff], name="Score")
+    new_notes = abjad.mutate.copy(voice[:4])
+    voice.extend(new_notes)
+    # abjad.Score([staff], name="Score")
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \context Voice = "Voice"
         {
             c'8
             \<
@@ -590,7 +598,7 @@ def test_mutate_copy_08():
         }
         """
     )
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_mutate_copy_09():

--- a/tests/test_mutate_extract.py
+++ b/tests/test_mutate_extract.py
@@ -102,15 +102,15 @@ def test_mutate_extract_03():
     Extracts container.
     """
 
-    staff = abjad.Staff()
-    staff.append(abjad.Container("c'8 d'8"))
-    staff.append(abjad.Container("e'8 f'8"))
-    leaves = abjad.select.leaves(staff)
+    voice = abjad.Voice()
+    voice.append(abjad.Container("c'8 d'8"))
+    voice.append(abjad.Container("e'8 f'8"))
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -124,14 +124,14 @@ def test_mutate_extract_03():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    container = staff[0]
+    container = voice[0]
     abjad.mutate.extract(container)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -143,10 +143,10 @@ def test_mutate_extract_03():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
     assert not container
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_mutate_extract_04():

--- a/tests/test_mutate_fuse.py
+++ b/tests/test_mutate_fuse.py
@@ -109,9 +109,12 @@ def test_mutate_fuse_06():
     Fuses two tuplets with same multiplier.
     """
 
+    voice = abjad.Voice()
     tuplet_1 = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+    voice.append(tuplet_1)
     abjad.beam(tuplet_1[:])
     tuplet_2 = abjad.Tuplet((2, 3), "c'16 d'16 e'16")
+    voice.append(tuplet_2)
     abjad.slur(tuplet_2[:])
 
     assert abjad.lilypond(tuplet_1) == abjad.string.normalize(
@@ -172,11 +175,12 @@ def test_mutate_fuse_07():
     Fuses tuplets with same multiplier in score.
     """
 
+    voice = abjad.Voice()
     tuplet_1 = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
-    abjad.beam(tuplet_1[:])
     tuplet_2 = abjad.Tuplet((2, 3), "c'16 d'16 e'16")
-    abjad.slur(tuplet_2[:])
     voice = abjad.Voice([tuplet_1, tuplet_2])
+    abjad.beam(tuplet_1[:])
+    abjad.slur(tuplet_2[:])
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
@@ -235,10 +239,10 @@ def test_mutate_fuse_08():
     """
 
     tuplet_1 = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
-    abjad.beam(tuplet_1[:])
     tuplet_2 = abjad.Tuplet((2, 3), "c'8 d'8 e'8 f'8 g'8")
-    abjad.slur(tuplet_2[:])
     voice = abjad.Voice([tuplet_1, tuplet_2])
+    abjad.beam(tuplet_1[:])
+    abjad.slur(tuplet_2[:])
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""

--- a/tests/test_mutate_replace.py
+++ b/tests/test_mutate_replace.py
@@ -8,14 +8,14 @@ def test_mutate_replace_01():
     Equivalent to staff[1:3] = new_notes.
     """
 
-    staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    abjad.beam(staff[:2])
-    abjad.beam(staff[2:])
-    abjad.hairpin("< !", staff[:])
+    voice = abjad.Voice("c'8 d'8 e'8 f'8")
+    abjad.beam(voice[:2])
+    abjad.beam(voice[2:])
+    abjad.hairpin("< !", voice[:])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -29,9 +29,9 @@ def test_mutate_replace_01():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    old_notes = staff[1:3]
+    old_notes = voice[1:3]
     new_notes = [
         abjad.Note("c''16"),
         abjad.Note("c''16"),
@@ -42,9 +42,9 @@ def test_mutate_replace_01():
 
     abjad.mutate.replace(old_notes, new_notes)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -59,25 +59,25 @@ def test_mutate_replace_01():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_mutate_replace_02():
     """
     Moves parentage from one old note to five new notes.
 
-    Equivalent to staff[:1] = new_notes.
+    Equivalent to voice[:1] = new_notes.
     """
 
-    staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    abjad.beam(staff[:2])
-    abjad.beam(staff[2:])
+    voice = abjad.Voice("c'8 d'8 e'8 f'8")
+    abjad.beam(voice[:2])
+    abjad.beam(voice[2:])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -89,9 +89,9 @@ def test_mutate_replace_02():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    old_notes = staff[:1]
+    old_notes = voice[:1]
     new_notes = [
         abjad.Note("c''16"),
         abjad.Note("c''16"),
@@ -100,12 +100,14 @@ def test_mutate_replace_02():
         abjad.Note("c''16"),
     ]
     abjad.mutate.replace(old_notes, new_notes)
+    abjad.attach(abjad.StartBeam(), voice[0])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c''16
+            [
             c''16
             c''16
             c''16
@@ -118,25 +120,25 @@ def test_mutate_replace_02():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_mutate_replace_03():
     """
     Moves parentage from two old notes to five new notes.
 
-    Equivalent to staff[:2] = new_notes.
+    Equivalent to voice[:2] = new_notes.
     """
 
-    staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    abjad.beam(staff[:2])
-    abjad.beam(staff[2:])
+    voice = abjad.Voice("c'8 d'8 e'8 f'8")
+    abjad.beam(voice[:2])
+    abjad.beam(voice[2:])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -148,9 +150,9 @@ def test_mutate_replace_03():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    old_notes = staff[:2]
+    old_notes = voice[:2]
     new_notes = [
         abjad.Note("c''16"),
         abjad.Note("c''16"),
@@ -160,9 +162,9 @@ def test_mutate_replace_03():
     ]
     abjad.mutate.replace(old_notes, new_notes)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c''16
             c''16
@@ -175,25 +177,25 @@ def test_mutate_replace_03():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_mutate_replace_04():
     """
     Moves parentage from three old notes to five new notes.
 
-    "Equivalent to staff[:3] = new_notes."
+    Equivalent to voice[:3] = new_notes.
     """
 
-    staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    abjad.beam(staff[:2])
-    abjad.beam(staff[2:])
+    voice = abjad.Voice("c'8 d'8 e'8 f'8")
+    abjad.beam(voice[:2])
+    abjad.beam(voice[2:])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -205,9 +207,9 @@ def test_mutate_replace_04():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    old_notes = staff[:3]
+    old_notes = voice[:3]
     new_notes = [
         abjad.Note("c''16"),
         abjad.Note("c''16"),
@@ -216,12 +218,14 @@ def test_mutate_replace_04():
         abjad.Note("c''16"),
     ]
     abjad.mutate.replace(old_notes, new_notes)
+    abjad.attach(abjad.StartBeam(), voice[0])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c''16
+            [
             c''16
             c''16
             c''16
@@ -230,25 +234,25 @@ def test_mutate_replace_04():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_mutate_replace_05():
     """
     Moves parentage from four old notes to five new notes.
 
-    Equivalent to staff[:] = new_notes.
+    Equivalent to voice[:] = new_notes.
     """
 
-    staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    abjad.beam(staff[:2])
-    abjad.beam(staff[2:])
+    voice = abjad.Voice("c'8 d'8 e'8 f'8")
+    abjad.beam(voice[:2])
+    abjad.beam(voice[2:])
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c'8
             [
@@ -260,9 +264,9 @@ def test_mutate_replace_05():
             ]
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    old_notes = staff[:]
+    old_notes = voice[:]
     new_notes = [
         abjad.Note("c''16"),
         abjad.Note("c''16"),
@@ -272,9 +276,9 @@ def test_mutate_replace_05():
     ]
     abjad.mutate.replace(old_notes, new_notes)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             c''16
             c''16
@@ -283,9 +287,9 @@ def test_mutate_replace_05():
             c''16
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_mutate_replace_06():

--- a/tests/test_mutate_split.py
+++ b/tests/test_mutate_split.py
@@ -6,17 +6,17 @@ def test_mutate_split_01():
     Cyclically splits note in score.
     """
 
-    staff = abjad.Staff()
-    staff.append(abjad.Container("c'8 d'8"))
-    staff.append(abjad.Container("e'8 f'8"))
-    leaves = abjad.select.leaves(staff)
+    voice = abjad.Voice()
+    voice.append(abjad.Container("c'8 d'8"))
+    voice.append(abjad.Container("e'8 f'8"))
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves[:2])
     abjad.beam(leaves[-2:])
     abjad.slur(leaves)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -34,14 +34,14 @@ def test_mutate_split_01():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    notes = staff[0][1:2]
+    notes = voice[0][1:2]
     result = abjad.mutate.split(notes, [abjad.Duration(3, 64)], cyclic=True)
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -63,9 +63,9 @@ def test_mutate_split_01():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
     assert len(result) == 3
 
 
@@ -74,12 +74,13 @@ def test_mutate_split_02():
     Cyclically splits consecutive notes in score.
     """
 
-    staff = abjad.Staff([abjad.Container("c'8 d'"), abjad.Container("e'8 f'")])
+    voice = abjad.Voice([abjad.Container("c'8 d'"), abjad.Container("e'8 f'")])
+    staff = abjad.Staff([voice])
     abjad.Score([staff], name="Score")
-    for container in staff:
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves[:2])
     abjad.beam(leaves[-2:])
     abjad.slur(leaves)
@@ -88,21 +89,24 @@ def test_mutate_split_02():
         r"""
         \new Staff
         {
+            \new Voice
             {
-                \time 2/8
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
+                {
+                    \time 2/8
+                    c'8
+                    [
+                    (
+                    d'8
+                    ]
+                }
+                {
+                    \time 2/8
+                    e'8
+                    [
+                    f'8
+                    )
+                    ]
+                }
             }
         }
         """
@@ -114,29 +118,32 @@ def test_mutate_split_02():
         r"""
         \new Staff
         {
+            \new Voice
             {
-                \time 2/8
-                c'16.
-                [
-                (
-                ~
-                c'32
-                d'16
-                ~
-                d'16
-                ]
-            }
-            {
-                \time 2/8
-                e'32
-                [
-                ~
-                e'16.
-                f'16.
-                ~
-                f'32
-                )
-                ]
+                {
+                    \time 2/8
+                    c'16.
+                    [
+                    (
+                    ~
+                    c'32
+                    d'16
+                    ~
+                    d'16
+                    ]
+                }
+                {
+                    \time 2/8
+                    e'32
+                    [
+                    ~
+                    e'16.
+                    f'16.
+                    ~
+                    f'32
+                    )
+                    ]
+                }
             }
         }
         """
@@ -151,12 +158,13 @@ def test_mutate_split_03():
     Cyclically splits note in score.
     """
 
-    staff = abjad.Staff([abjad.Container("c'8 d'"), abjad.Container("e'8 f'")])
+    voice = abjad.Voice([abjad.Container("c'8 d'"), abjad.Container("e'8 f'")])
+    staff = abjad.Staff([voice])
     abjad.Score([staff], name="Score")
-    for container in staff:
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves[:2])
     abjad.beam(leaves[-2:])
     abjad.slur(leaves)
@@ -165,54 +173,60 @@ def test_mutate_split_03():
         r"""
         \new Staff
         {
+            \new Voice
             {
-                \time 2/8
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
+                {
+                    \time 2/8
+                    c'8
+                    [
+                    (
+                    d'8
+                    ]
+                }
+                {
+                    \time 2/8
+                    e'8
+                    [
+                    f'8
+                    )
+                    ]
+                }
             }
         }
         """
     ), print(abjad.lilypond(staff))
 
-    notes = staff[0][1:]
+    notes = voice[0][1:]
     result = abjad.mutate.split(notes, [abjad.Duration(1, 32)], cyclic=True)
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
         r"""
         \new Staff
         {
+            \new Voice
             {
-                \time 2/8
-                c'8
-                [
-                (
-                d'32
-                ~
-                d'32
-                ~
-                d'32
-                ~
-                d'32
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
+                {
+                    \time 2/8
+                    c'8
+                    [
+                    (
+                    d'32
+                    ~
+                    d'32
+                    ~
+                    d'32
+                    ~
+                    d'32
+                    ]
+                }
+                {
+                    \time 2/8
+                    e'8
+                    [
+                    f'8
+                    )
+                    ]
+                }
             }
         }
         """
@@ -227,12 +241,13 @@ def test_mutate_split_04():
     Cyclically splits consecutive notes in score.
     """
 
-    staff = abjad.Staff([abjad.Container("c'8 d'"), abjad.Container("e'8 f'")])
+    voice = abjad.Voice([abjad.Container("c'8 d'"), abjad.Container("e'8 f'")])
+    staff = abjad.Staff([voice])
     abjad.Score([staff], name="Score")
-    for container in staff:
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves[:2])
     abjad.beam(leaves[-2:])
     abjad.slur(leaves)
@@ -241,21 +256,24 @@ def test_mutate_split_04():
         r"""
         \new Staff
         {
+            \new Voice
             {
-                \time 2/8
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
+                {
+                    \time 2/8
+                    c'8
+                    [
+                    (
+                    d'8
+                    ]
+                }
+                {
+                    \time 2/8
+                    e'8
+                    [
+                    f'8
+                    )
+                    ]
+                }
             }
         }
         """
@@ -267,29 +285,32 @@ def test_mutate_split_04():
         r"""
         \new Staff
         {
+            \new Voice
             {
-                \time 2/8
-                c'16
-                [
-                (
-                ~
-                c'16
-                d'16
-                ~
-                d'16
-                ]
-            }
-            {
-                \time 2/8
-                e'16
-                [
-                ~
-                e'16
-                f'16
-                ~
-                f'16
-                )
-                ]
+                {
+                    \time 2/8
+                    c'16
+                    [
+                    (
+                    ~
+                    c'16
+                    d'16
+                    ~
+                    d'16
+                    ]
+                }
+                {
+                    \time 2/8
+                    e'16
+                    [
+                    ~
+                    e'16
+                    f'16
+                    ~
+                    f'16
+                    )
+                    ]
+                }
             }
         }
         """
@@ -304,12 +325,13 @@ def test_mutate_split_05():
     Cyclically splits measure in score.
     """
 
-    staff = abjad.Staff([abjad.Container("c'8 d'"), abjad.Container("e'8 f'")])
+    voice = abjad.Voice([abjad.Container("c'8 d'"), abjad.Container("e'8 f'")])
+    staff = abjad.Staff([voice])
     abjad.Score([staff], name="Score")
-    for container in staff:
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves[:2])
     abjad.beam(leaves[-2:])
     abjad.slur(leaves)
@@ -318,58 +340,64 @@ def test_mutate_split_05():
         r"""
         \new Staff
         {
+            \new Voice
             {
-                \time 2/8
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
+                {
+                    \time 2/8
+                    c'8
+                    [
+                    (
+                    d'8
+                    ]
+                }
+                {
+                    \time 2/8
+                    e'8
+                    [
+                    f'8
+                    )
+                    ]
+                }
             }
         }
         """
     ), print(abjad.lilypond(staff))
 
-    measures = staff[:1]
+    measures = voice[:1]
     result = abjad.mutate.split(measures, [abjad.Duration(1, 16)], cyclic=True)
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
         r"""
         \new Staff
         {
+            \new Voice
             {
-                \time 2/8
-                c'16
-                [
-                (
-                ~
-            }
-            {
-                c'16
-            }
-            {
-                d'16
-                ~
-            }
-            {
-                d'16
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
+                {
+                    \time 2/8
+                    c'16
+                    [
+                    (
+                    ~
+                }
+                {
+                    c'16
+                }
+                {
+                    d'16
+                    ~
+                }
+                {
+                    d'16
+                    ]
+                }
+                {
+                    \time 2/8
+                    e'8
+                    [
+                    f'8
+                    )
+                    ]
+                }
             }
         }
         """
@@ -384,12 +412,13 @@ def test_mutate_split_06():
     Cyclically splits consecutive measures in score.
     """
 
-    staff = abjad.Staff([abjad.Container("c'8 d'"), abjad.Container("e'8 f'")])
+    voice = abjad.Voice([abjad.Container("c'8 d'"), abjad.Container("e'8 f'")])
+    staff = abjad.Staff([voice])
     abjad.Score([staff], name="Score")
-    for container in staff:
+    for container in voice:
         time_signature = abjad.TimeSignature((2, 8))
         abjad.attach(time_signature, container[0])
-    leaves = abjad.select.leaves(staff)
+    leaves = abjad.select.leaves(voice)
     abjad.beam(leaves[:2])
     abjad.beam(leaves[-2:])
     abjad.slur(leaves)
@@ -398,66 +427,72 @@ def test_mutate_split_06():
         r"""
         \new Staff
         {
+            \new Voice
             {
-                \time 2/8
-                c'8
-                [
-                (
-                d'8
-                ]
-            }
-            {
-                \time 2/8
-                e'8
-                [
-                f'8
-                )
-                ]
+                {
+                    \time 2/8
+                    c'8
+                    [
+                    (
+                    d'8
+                    ]
+                }
+                {
+                    \time 2/8
+                    e'8
+                    [
+                    f'8
+                    )
+                    ]
+                }
             }
         }
         """
     ), print(abjad.lilypond(staff))
 
-    measures = staff[:]
+    measures = voice[:]
     result = abjad.mutate.split(measures, [abjad.Duration(3, 32)], cyclic=True)
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
         r"""
         \new Staff
         {
+            \new Voice
             {
-                \time 2/8
-                c'16.
-                [
-                (
-                ~
-            }
-            {
-                c'32
-                d'16
-                ~
-            }
-            {
-                d'16
-                ]
-            }
-            {
-                \time 2/8
-                e'32
-                [
-                ~
-            }
-            {
-                e'16.
-            }
-            {
-                f'16.
-                ~
-            }
-            {
-                f'32
-                )
-                ]
+                {
+                    \time 2/8
+                    c'16.
+                    [
+                    (
+                    ~
+                }
+                {
+                    c'32
+                    d'16
+                    ~
+                }
+                {
+                    d'16
+                    ]
+                }
+                {
+                    \time 2/8
+                    e'32
+                    [
+                    ~
+                }
+                {
+                    e'16.
+                }
+                {
+                    f'16.
+                    ~
+                }
+                {
+                    f'32
+                    )
+                    ]
+                }
             }
         }
         """
@@ -656,19 +691,19 @@ def test_mutate_split_11():
     Splits container in score.
     """
 
-    staff = abjad.Staff([abjad.Container("c'8 d'8 e'8 f'8")])
-    voice = staff[0]
-    leaves = abjad.select.leaves(staff)
+    voice = abjad.Voice([abjad.Container("c'8 d'8 e'8 f'8")])
+    container = voice[0]
+    leaves = abjad.select.leaves(container)
     abjad.beam(leaves)
 
-    result = abjad.mutate.split([voice], [abjad.Duration(1, 4)])
+    result = abjad.mutate.split([container], [abjad.Duration(1, 4)])
 
     left = result[0][0]
     right = result[1][0]
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -682,7 +717,7 @@ def test_mutate_split_11():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
     assert abjad.lilypond(left) == abjad.string.normalize(
         r"""
@@ -704,16 +739,16 @@ def test_mutate_split_11():
         """
     ), print(abjad.lilypond(right))
 
-    assert abjad.lilypond(voice) == abjad.string.normalize(
+    assert abjad.lilypond(container) == abjad.string.normalize(
         r"""
         {
         }
         """
-    ), print(abjad.lilypond(voice))
+    ), print(abjad.lilypond(container))
 
-    assert abjad.lilypond(staff) == abjad.string.normalize(
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Staff
+        \new Voice
         {
             {
                 c'8
@@ -727,9 +762,9 @@ def test_mutate_split_11():
             }
         }
         """
-    ), print(abjad.lilypond(staff))
+    ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.wellformed(voice)
 
 
 def test_mutate_split_12():


### PR DESCRIPTION
Many Abjad indicators are contexted: `abjad.Dynamic` is contexted to the voice; `abjad.Clef` is contexted to the staff; `abjad.Violin` is contexted to the staff; `abjad.Piano` is contexted to the staff group; and so on.

This commit changes many tests and examples to make sure that all examples with an `abjad.Dynamic` attach to a score with an explicit `abjad.Voice`, and that all examples with an `abjad.Clef` attach to a score with an explicit `abjad.Staff`, and so on.

Cleaned up abjad.illustrators.components().
Taught text-spanner wellformedness checks about deactivated wrappers.