### PR TITLE
Changed abjad.StartTextSpan.style values.

### DIFF
--- a/abjad/indicators.py
+++ b/abjad/indicators.py
@@ -4323,7 +4323,7 @@ class StartTextSpan:
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
-        ...     style="solid-line-with-arrow",
+        ...     style=r"\abjad-solid-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
         >>> abjad.attach(bundle, voice[0])
@@ -4362,7 +4362,7 @@ class StartTextSpan:
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
-        ...     style="dashed-line-with-arrow",
+        ...     style=r"\abjad-dashed-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(
         ...     start_text_span,
@@ -4377,7 +4377,7 @@ class StartTextSpan:
         ...     command=r"\startTextSpanOne",
         ...     left_text=abjad.Markup(r"\upright A"),
         ...     right_text=abjad.Markup(r"\markup \upright B"),
-        ...     style="dashed-line-with-arrow",
+        ...     style=r"\abjad-dashed-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(
         ...     start_text_span,
@@ -4436,7 +4436,7 @@ class StartTextSpan:
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=left_text,
         ...     right_text=right_text,
-        ...     style='solid-line-with-arrow',
+        ...     style=r"\abjad-solid-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
         >>> abjad.attach(bundle, voice[0])
@@ -4471,7 +4471,7 @@ class StartTextSpan:
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
-        ...     style="dashed-line-with-arrow",
+        ...     style=r"\abjad-dashed-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
         >>> abjad.attach(bundle, voice[0])
@@ -4503,7 +4503,7 @@ class StartTextSpan:
         >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
-        ...     style="dashed-line-with-hook",
+        ...     style=r"\abjad-dashed-line-with-hook",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
         >>> abjad.attach(bundle, voice[0])
@@ -4535,7 +4535,7 @@ class StartTextSpan:
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
-        ...     style="invisible-line",
+        ...     style=r"\abjad-invisible-line",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
         >>> abjad.attach(bundle, voice[0])
@@ -4568,7 +4568,7 @@ class StartTextSpan:
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
-        ...     style="solid-line-with-arrow",
+        ...     style=r"\abjad-solid-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
         >>> abjad.attach(bundle, voice[0])
@@ -4600,7 +4600,7 @@ class StartTextSpan:
         >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
-        ...     style="solid-line-with-hook",
+        ...     style=r"\abjad-solid-line-with-hook",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
         >>> abjad.attach(bundle, voice[0])
@@ -4638,7 +4638,7 @@ class StartTextSpan:
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
-        ...     style="dashed-line-with-arrow",
+        ...     style=r"\abjad-dashed-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(
         ...     start_text_span,
@@ -4689,24 +4689,14 @@ class StartTextSpan:
     post_event: typing.ClassVar[bool] = True
     spanner_start: typing.ClassVar[bool] = True
 
-    _styles = (
-        "dashed-line-with-arrow",
-        "dashed-line-with-hook",
-        "dashed-line-with-up-hook",
-        "invisible-line",
-        "solid-line-with-arrow",
-        "solid-line-with-hook",
-        "solid-line-with-up-hook",
-    )
-
     def __post_init__(self):
         assert isinstance(self.command, str), repr(self.command)
+        assert isinstance(self.style, str | None), repr(self.style)
 
     def _get_contributions(self, *, component=None, wrapper=None):
         contributions = _contributions.ContributionsBySite()
         if self.style is not None:
-            string = rf"- \abjad-{self.style}"
-            contributions.after.spanner_starts.append(string)
+            contributions.after.spanner_starts.append(rf"- {self.style}")
         if self.left_text:
             string = self._get_left_text_directive()
             contributions.after.spanner_starts.append(string)
@@ -5644,7 +5634,7 @@ class StopTextSpan:
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
-        ...     style="dashed-line-with-arrow",
+        ...     style=r"\abjad-dashed-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
         >>> abjad.attach(bundle, voice[0])
@@ -5677,7 +5667,7 @@ class StopTextSpan:
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
-        ...     style="dashed-line-with-arrow",
+        ...     style=r"\abjad-dashed-line-with-arrow",
         ... )
         >>> bundle = abjad.bundle(start_text_span, r"- \tweak staff-padding 2.5")
         >>> abjad.attach(bundle, voice[0])

--- a/abjad/scm/abjad-text-spanner-line-styles.ily
+++ b/abjad/scm/abjad-text-spanner-line-styles.ily
@@ -19,7 +19,6 @@ abjad-dashed-line-with-arrow = #(
     (parser location music)
     (ly:music?)
     #{
-    - \tweak Y-extent ##f
     - \tweak arrow-width 0.25
     - \tweak bound-details.left-broken.text ##f
     - \tweak bound-details.left.stencil-align-dir-y #center
@@ -41,7 +40,6 @@ abjad-dashed-line-with-hook = #(
     (parser location music)
     (ly:music?)
     #{
-    - \tweak Y-extent ##f
     - \tweak dash-fraction 0.25
     - \tweak dash-period 1.5
     - \tweak bound-details.left.stencil-align-dir-y #center
@@ -60,7 +58,6 @@ abjad-dashed-line-with-up-hook = #(
     (parser location music)
     (ly:music?)
     #{
-    - \tweak Y-extent ##f
     - \tweak dash-fraction 0.25
     - \tweak dash-period 1.5
     - \tweak bound-details.left.stencil-align-dir-y #center
@@ -79,7 +76,6 @@ abjad-invisible-line = #(
     (parser location music)
     (ly:music?)
     #{
-    - \tweak Y-extent ##f
     - \tweak dash-period 0
     - \tweak bound-details.left.stencil-align-dir-y #center
     - \tweak bound-details.left-broken.text ##f
@@ -96,7 +92,6 @@ abjad-solid-line-with-arrow = #(
     (parser location music)
     (ly:music?)
     #{
-    - \tweak Y-extent ##f
     - \tweak arrow-width 0.25
     - \tweak bound-details.left-broken.text ##f
     - \tweak bound-details.left.stencil-align-dir-y #center
@@ -116,7 +111,6 @@ abjad-solid-line-with-hook = #(
     (parser location music)
     (ly:music?)
     #{
-    - \tweak Y-extent ##f
     - \tweak dash-fraction 1
     - \tweak bound-details.left.stencil-align-dir-y #center
     - \tweak bound-details.left-broken.text ##f
@@ -134,7 +128,6 @@ abjad-solid-line-with-up-hook = #(
     (parser location music)
     (ly:music?)
     #{
-    - \tweak Y-extent ##f
     - \tweak dash-fraction 1
     - \tweak bound-details.left.stencil-align-dir-y #center
     - \tweak bound-details.left-broken.text ##f

--- a/abjad/spanners.py
+++ b/abjad/spanners.py
@@ -1570,7 +1570,7 @@ def text_spanner(
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
         ...     right_text=abjad.Markup(r"\markup \upright tasto"),
-        ...     style="solid-line-with-arrow",
+        ...     style=r"\abjad-solid-line-with-arrow",
         ... )
         >>> abjad.text_spanner(
         ...     voice[:], direction=abjad.UP, start_text_span=start_text_span
@@ -1604,13 +1604,13 @@ def text_spanner(
         >>> voice = abjad.Voice("c'4 d' e' f' r")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
-        ...     style="dashed-line-with-arrow",
+        ...     style=r"\abjad-dashed-line-with-arrow",
         ... )
         >>> abjad.text_spanner(voice[:3], start_text_span=start_text_span)
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright tasto"),
         ...     right_text=abjad.Markup(r"\markup \upright pont."),
-        ...     style="dashed-line-with-arrow",
+        ...     style=r"\abjad-dashed-line-with-arrow",
         ... )
         >>> abjad.text_spanner(voice[-3:], start_text_span=start_text_span)
         >>> abjad.override(voice).TextSpanner.staff_padding = 4
@@ -1646,12 +1646,12 @@ def text_spanner(
         >>> voice = abjad.Voice("c'4 d' e' f' r")
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright pont."),
-        ...     style="dashed-line-with-arrow",
+        ...     style=r"\abjad-dashed-line-with-arrow",
         ... )
         >>> abjad.text_spanner(voice[:3], start_text_span=start_text_span)
         >>> start_text_span = abjad.StartTextSpan(
         ...     left_text=abjad.Markup(r"\upright tasto"),
-        ...     style="solid-line-with-hook",
+        ...     style=r"\abjad-solid-line-with-hook",
         ... )
         >>> abjad.text_spanner(voice[-3:], start_text_span=start_text_span)
         >>> abjad.override(voice).TextSpanner.staff_padding = 4


### PR DESCRIPTION
    OLD:

        style="dashed-line-with-arrow"
        style="dashed-line-with-hook"
        style="dashed-line-with-up-hook"
        style="solid-line-with-arrow"
        style="solid-line-with-hook"
        style="solid-line-with-up-hook"
        style="invisible-line"

    NEW:

        style=r"\abjad-dashed-line-with-arrow"
        style=r"\abjad-dashed-line-with-hook"
        style=r"\abjad-dashed-line-with-up-hook"
        style=r"\abjad-solid-line-with-arrow"
        style=r"\abjad-solid-line-with-hook"
        style=r"\abjad-solid-line-with-up-hook"
        style=r"\abjad-invisible-line"

CHANGED: the definitions of abjad-dashed-line-with-arrow, etc., no longer include "- \tweak Y-extent ##f".

NEW: abjad.StartTextSpan.style can be set to a custom line-style definition:

    style=r"\custom-dashed-line-with-hook"