### PR TITLE
Changed abjad.Accidental.symbol string for quartertones.

### DIFF
--- a/abjad/enumerate.py
+++ b/abjad/enumerate.py
@@ -1,5 +1,6 @@
 import functools
 import itertools
+import typing
 
 from . import math as _math
 from . import sequence as _sequence
@@ -430,7 +431,7 @@ def yield_partitions(argument):
         yield partition
 
 
-def yield_permutations(argument):
+def yield_permutations(argument) -> typing.Generator[typing.Any, None, None]:
     """
     Yields permutations of sequence.
 

--- a/abjad/label.py
+++ b/abjad/label.py
@@ -775,7 +775,7 @@ def with_durations(
                 c'4.
                 ^ \markup \fraction 3 8
                 d'8
-                ^ \markup \fraction 4 8
+                ^ \markup \fraction 1 2
                 ~
                 d'4.
                 e'16
@@ -821,8 +821,8 @@ def with_durations(
         pair = duration.pair
         if denominator is not None:
             pair = _duration.with_denominator(duration, denominator)
-        numerator, denominator = pair
-        label = _indicators.Markup(rf"\markup \fraction {numerator} {denominator}")
+        n, d = pair
+        label = _indicators.Markup(rf"\markup \fraction {n} {d}")
         _attach(label, logical_tie.head, direction=direction)
 
 

--- a/abjad/pcollections.py
+++ b/abjad/pcollections.py
@@ -1519,7 +1519,7 @@ class PitchSegment:
                 >>
 
         """
-        return dataclasses.replace(self, items=reversed(self))
+        return dataclasses.replace(self, items=list(reversed(self)))
 
     def rotate(self, n=0) -> "PitchSegment":
         r"""

--- a/abjad/pitch.py
+++ b/abjad/pitch.py
@@ -41,16 +41,16 @@ _accidental_abbreviation_to_semitones = {
     "ss": 2,
 }
 
-# TODO: possibly remove?
+# TODO: change to function; accommodate arbitrarily long abbreviations
 _accidental_abbreviation_to_symbol = {
     "ff": "bb",
-    "tqf": "b~",
+    "tqf": "tqf",
     "f": "b",
-    "qf": "~",
+    "qf": "qf",
     "": "",
-    "qs": "+",
+    "qs": "qs",
     "s": "#",
-    "tqs": "#+",
+    "tqs": "tqs",
     "ss": "##",
 }
 
@@ -924,7 +924,7 @@ class Accidental:
             'bb'
 
             >>> abjad.Accidental("tqf").symbol
-            'b~'
+            'tqf'
 
             >>> abjad.Accidental("f").symbol
             'b'
@@ -933,13 +933,13 @@ class Accidental:
             ''
 
             >>> abjad.Accidental("qs").symbol
-            '+'
+            'qs'
 
             >>> abjad.Accidental("s").symbol
             '#'
 
             >>> abjad.Accidental("tqs").symbol
-            '#+'
+            'tqs'
 
             >>> abjad.Accidental("ss").symbol
             '##'
@@ -5059,7 +5059,7 @@ class NamedPitch(Pitch):
             name = self._get_diatonic_pc_name().upper()
             return f"{name}{self.accidental.symbol}{self.octave.number}"
         else:
-            raise ValueError(f"must be 'us' or none: {locale!r}.")
+            raise ValueError(f'must be "us" or none: {locale!r}.')
 
     def invert(self, axis=None) -> "NamedPitch":
         """
@@ -5595,7 +5595,7 @@ class NumberedPitch(Pitch):
         """
         return super().from_hertz(hertz)
 
-    def get_name(self, locale=None) -> str:
+    def get_name(self, locale: str | None = None) -> str:
         """
         Gets name of numbered pitch name according to ``locale``.
 

--- a/abjad/scm/abjad-coloring.ily
+++ b/abjad/scm/abjad-coloring.ily
@@ -1,7 +1,7 @@
 %%% COLORED MUSIC %%%
 
 abjad-color-music = #(
-    define-music-function (parser location color music) (symbol? ly:music?)
+    define-music-function (color music) (symbol? ly:music?)
     #{
     \once \override Accidental.color = #(x11-color color)
     \once \override Beam.color = #(x11-color color)
@@ -18,9 +18,7 @@ abjad-color-music = #(
     )
 
 abjad-invisible-music = #(
-    define-music-function
-    (parser location music)
-    (ly:music?)
+    define-music-function (music) (ly:music?)
     #{
     \once \override Accidental.transparent = ##t
     \once \override Dots.transparent = ##t
@@ -35,9 +33,7 @@ abjad-invisible-music = #(
     )
 
 abjad-invisible-music-coloring = #(
-    define-music-function
-    (parser location music)
-    (ly:music?)
+    define-music-function (music) (ly:music?)
     #{
     \abjad-color-music #'salmon
     $music

--- a/abjad/scm/abjad-make-music-functions.ily
+++ b/abjad/scm/abjad-make-music-functions.ily
@@ -3,10 +3,7 @@
 % But you can use these music functions within markup functions.
 
 
-abjad-make-note = #(
-    define-music-function
-    (parser location length dots)
-    (number? number?)
+abjad-make-note = #(define-music-function (length dots) (number? number?)
     (make-music
         'SequentialMusic
         'elements
@@ -19,9 +16,7 @@ abjad-make-note = #(
     )
 
 abjad-make-tuplet-monad = #(
-    define-music-function
-    (parser location length dots n d)
-    (number? number? number? number?)
+    define-music-function (length dots n d) (number? number? number? number?)
     (make-music
         'SequentialMusic
         'elements

--- a/abjad/scm/abjad-spanners.ily
+++ b/abjad/scm/abjad-spanners.ily
@@ -1,7 +1,7 @@
 %%% GLISSANDO OVERRIDES %%%
 
 abjad-continuous-glissando = #(
-    define-music-function (parser location music) (ly:music?)
+    define-music-function (music) (ly:music?)
     #{
     \override Glissando.bound-details.left.padding = -1
     \override Glissando.bound-details.left.start-at-dot = ##f
@@ -11,7 +11,7 @@ abjad-continuous-glissando = #(
     )
 
 abjad-revert-continuous-glissando = #(
-    define-music-function (parser location music) (ly:music?)
+    define-music-function (music) (ly:music?)
     #{
     \revert Glissando.bound-details.left.padding
     \revert Glissando.bound-details.left.start-at-dot

--- a/abjad/scm/abjad-text-spanner-line-styles.ily
+++ b/abjad/scm/abjad-text-spanner-line-styles.ily
@@ -1,9 +1,6 @@
 %%% GLISSANDO LINE STYLES %%%
 
-abjad-zero-padding-glissando = #(
-    define-music-function
-    (parser location music)
-    (ly:music?)
+abjad-zero-padding-glissando = #(define-music-function (music) (ly:music?)
     #{
     - \tweak bound-details.left.padding 0
     - \tweak bound-details.left.start-at-dot ##f
@@ -14,10 +11,7 @@ abjad-zero-padding-glissando = #(
 
 %%% TEXT SPANNER LINE STYLES %%%
 
-abjad-dashed-line-with-arrow = #(
-    define-music-function
-    (parser location music)
-    (ly:music?)
+abjad-dashed-line-with-arrow = #(define-music-function (music) (ly:music?)
     #{
     - \tweak arrow-width 0.25
     - \tweak bound-details.left-broken.text ##f
@@ -35,10 +29,7 @@ abjad-dashed-line-with-arrow = #(
     #}
     )
 
-abjad-dashed-line-with-hook = #(
-    define-music-function
-    (parser location music)
-    (ly:music?)
+abjad-dashed-line-with-hook = #(define-music-function (music) (ly:music?)
     #{
     - \tweak dash-fraction 0.25
     - \tweak dash-period 1.5
@@ -53,10 +44,7 @@ abjad-dashed-line-with-hook = #(
     #}
     )
 
-abjad-dashed-line-with-up-hook = #(
-    define-music-function
-    (parser location music)
-    (ly:music?)
+abjad-dashed-line-with-up-hook = #(define-music-function (music) (ly:music?)
     #{
     - \tweak dash-fraction 0.25
     - \tweak dash-period 1.5
@@ -71,10 +59,7 @@ abjad-dashed-line-with-up-hook = #(
     #}
     )
     
-abjad-invisible-line = #(
-    define-music-function
-    (parser location music)
-    (ly:music?)
+abjad-invisible-line = #(define-music-function (music) (ly:music?)
     #{
     - \tweak dash-period 0
     - \tweak bound-details.left.stencil-align-dir-y #center
@@ -87,10 +72,7 @@ abjad-invisible-line = #(
     #}
     )
     
-abjad-solid-line-with-arrow = #(
-    define-music-function
-    (parser location music)
-    (ly:music?)
+abjad-solid-line-with-arrow = #(define-music-function (music) (ly:music?)
     #{
     - \tweak arrow-width 0.25
     - \tweak bound-details.left-broken.text ##f
@@ -106,10 +88,7 @@ abjad-solid-line-with-arrow = #(
     #}
     )
     
-abjad-solid-line-with-hook = #(
-    define-music-function
-    (parser location music)
-    (ly:music?)
+abjad-solid-line-with-hook = #(define-music-function (music) (ly:music?)
     #{
     - \tweak dash-fraction 1
     - \tweak bound-details.left.stencil-align-dir-y #center
@@ -123,10 +102,7 @@ abjad-solid-line-with-hook = #(
     #}
     )
 
-abjad-solid-line-with-up-hook = #(
-    define-music-function
-    (parser location music)
-    (ly:music?)
+abjad-solid-line-with-up-hook = #(define-music-function (music) (ly:music?)
     #{
     - \tweak dash-fraction 1
     - \tweak bound-details.left.stencil-align-dir-y #center

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -392,6 +392,12 @@ class Component:
             assert isinstance(self._tag, _tag.Tag), repr(self._tag)
         return self._tag
 
+    @tag.setter
+    def tag(self, argument):
+        if argument is not None:
+            assert isinstance(argument, _tag.Tag), repr(argument)
+        self._tag = argument
+
 
 class Leaf(Component):
     """
@@ -3202,6 +3208,10 @@ class Context(Container):
         """
         return super().tag
 
+    @tag.setter
+    def tag(self, argument) -> None:
+        self._tag = argument
+
 
 class MultimeasureRest(Leaf):
     r"""
@@ -3298,6 +3308,10 @@ class MultimeasureRest(Leaf):
 
         """
         return super().tag
+
+    @tag.setter
+    def tag(self, argument) -> None:
+        self._tag = argument
 
 
 @functools.total_ordering
@@ -4501,6 +4515,10 @@ class Score(Context):
 
         """
         return super().tag
+
+    @tag.setter
+    def tag(self, argument) -> None:
+        self._tag = argument
 
 
 class Skip(Leaf):
@@ -5737,6 +5755,10 @@ class Tuplet(Container):
 
         """
         return super().tag
+
+    @tag.setter
+    def tag(self, argument) -> None:
+        self._tag = argument
 
     ### PUBLIC METHODS ###
 
@@ -7161,3 +7183,7 @@ class Voice(Context):
 
         """
         return super().tag
+
+    @tag.setter
+    def tag(self, argument) -> None:
+        self._tag = argument

--- a/abjad/tag.py
+++ b/abjad/tag.py
@@ -2,6 +2,7 @@ import dataclasses
 import typing
 
 from . import _indentlib
+from . import string as _string
 
 
 @dataclasses.dataclass(frozen=True, order=True, slots=True, unsafe_hash=True)
@@ -176,6 +177,28 @@ class Tag:
                 return Tag(word)
         else:
             return None
+
+    def retain_shoutcase(self) -> "Tag":
+        """
+        Retains shoutcase.
+
+        ..  container:: example
+
+            >>> tag = abjad.Tag("-PARTS:DEFAULT_CLEF:_apply_clef()")
+            >>> tag.retain_shoutcase()
+            Tag(string='-PARTS:DEFAULT_CLEF')
+
+            >>> tag = abjad.Tag("_debug_function()")
+            >>> tag.retain_shoutcase()
+            Tag(string='')
+
+        """
+        words = []
+        for word in self.words():
+            if _string.is_shout_case(word) or word[0] in ("-", "+"):
+                words.append(word)
+        string = ":".join(words)
+        return type(self)(string)
 
     def words(self) -> list[str]:
         """


### PR DESCRIPTION
OLD:

    >>> abjad.Accidental("qf").symbol
    "~"
    >>> abjad.Accidental("tqf").symbol
    "b~"
    >>> abjad.Accidental("qs").symbol
    "+"
    >>> abjad.Accidental("tqs").symbol
    "#+"

NEW:

    >>> abjad.Accidental("qf").symbol
    "qf
    >>> abjad.Accidental("tqf").symbol
    "tqf"
    >>> abjad.Accidental("qs").symbol
    "qs"
    >>> abjad.Accidental("tqs").symbol
    "tqs"

Made component tags settable.

Removed "parser" and "location" variables from LilyPond music functions.