### PR TITLE
Conforms tuple to list before assignment to fix mypy error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,18 +80,17 @@ mypy:
 project = abjad
 
 pytest:
-	pytest .
+	pytest
 
 pytest-coverage:
 	rm -Rf htmlcov/
 	pytest \
 	--cov-config=.coveragerc \
 	--cov-report=html \
-	--cov=${project} \
-	.
+	--cov=${project}
 
 pytest-x:
-	pytest -x .
+	pytest -x
 
 reformat:
 	make black-reformat

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -2577,7 +2577,7 @@ class Chord(Leaf):
             if isinstance(written_pitches, str):
                 written_pitches = [_ for _ in written_pitches.split() if _]
             elif isinstance(written_pitches, type(self)):
-                written_pitches = written_pitches.written_pitches
+                written_pitches = list(written_pitches.written_pitches)
         elif len(arguments) == 0:
             written_pitches = [_pitch.NamedPitch(_) for _ in [0, 4, 7]]
             written_duration = _duration.Duration(1, 4)


### PR DESCRIPTION
The new mypy (1.9.0) complains that
```
/tmp/abjad/abjad/score.py:2580: error: Incompatible types in assignment (expression has type "tuple[NamedPitch, ...]", variable has type "list[NamedPitch]")  [assignment]
```
See [this line](https://github.com/Abjad/abjad-ext-nauert/actions/runs/8304329606/job/22729832130?pr=71#step:8:34) for example


This PR is to fix this error.

Edit: Turns out there is another CI error with pytest as well. Hopefully my new commit fixes it.