### PR TITLE
CHANGED. Changed \times to \tuplet.

### DIFF
--- a/abjad/get.py
+++ b/abjad/get.py
@@ -922,14 +922,14 @@ def duration(
             \new Staff
             {
                 \tweak edge-height #'(0.7 . 0)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     ~
                     c'4
                 }
                 \tweak edge-height #'(0.7 . 0)
-                \times 2/3
+                \tuplet 3/2
                 {
                     d'4
                     ~
@@ -4107,7 +4107,8 @@ def sustained(argument) -> bool:
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/2 {
+            \tuplet 2/3
+            {
                 c'4
                 ~
                 c'4

--- a/abjad/indicators.py
+++ b/abjad/indicators.py
@@ -7443,7 +7443,7 @@ class TimeSignature:
             \new Staff
             {
                 \tweak edge-height #'(0.7 . 0)
-                \times 2/3
+                \tuplet 3/2
                 {
                     #(ly:expect-warning "strange time signature found")
                     \time 4/3

--- a/abjad/iterate.py
+++ b/abjad/iterate.py
@@ -504,7 +504,7 @@ def logical_ties(
             {
                 c'4
                 ~
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'16
                     d'8
@@ -668,7 +668,7 @@ def logical_ties(
             {
                 c'4
                 ~
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     d'4
@@ -676,7 +676,7 @@ def logical_ties(
                 e'4
                 ~
                 \tweak edge-height #'(0.7 . 0)
-                \times 2/3
+                \tuplet 3/2
                 {
                     e'8
                     f'8
@@ -741,14 +741,14 @@ def logical_ties(
             {
                 c'4
                 ~
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     r4
                 }
                 d'4
                 ~
-                \times 2/3
+                \tuplet 3/2
                 {
                     d'8
                     r4

--- a/abjad/label.py
+++ b/abjad/label.py
@@ -983,7 +983,7 @@ def with_indices(argument, direction=_enums.UP, prototype=None) -> None:
                 \override TextScript.staff-padding = 2
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     ^ \markup 0
@@ -992,7 +992,7 @@ def with_indices(argument, direction=_enums.UP, prototype=None) -> None:
                     e'8
                     ]
                 }
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     ^ \markup 1
@@ -1001,7 +1001,7 @@ def with_indices(argument, direction=_enums.UP, prototype=None) -> None:
                     e'8
                     ]
                 }
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     ^ \markup 2
@@ -1010,7 +1010,7 @@ def with_indices(argument, direction=_enums.UP, prototype=None) -> None:
                     e'8
                     ]
                 }
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     ^ \markup 3
@@ -1755,7 +1755,7 @@ def with_start_offsets(
                 \override TupletBracket.staff-padding = 0
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     ^ \markup { 0 }

--- a/abjad/makers.py
+++ b/abjad/makers.py
@@ -383,7 +383,7 @@ def make_leaves(
             >>> print(string)
             \new Staff
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     d''2
                     d''2
@@ -534,7 +534,7 @@ def make_leaves(
             \new Staff
             {
                 \tweak edge-height #'(0.7 . 0)
-                \times 8/14
+                \tuplet 14/8
                 {
                     #(ly:expect-warning "strange time signature found")
                     \time 5/14
@@ -771,7 +771,7 @@ def make_notes(
             {
                 c'16
                 \tweak edge-height #'(0.7 . 0)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                 }
@@ -950,7 +950,7 @@ def tuplet_from_duration_and_ratio(
 
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
-            \times 4/5
+            \tuplet 5/4
             {
                 \time 3/16
                 c'32.
@@ -980,7 +980,7 @@ def tuplet_from_duration_and_ratio(
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 6/11
+            \tuplet 11/6
             {
                 \time 3/16
                 c'32
@@ -1009,7 +1009,7 @@ def tuplet_from_duration_and_ratio(
 
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
-            \times 8/11
+            \tuplet 11/8
             {
                 \time 3/16
                 c'16...
@@ -1037,7 +1037,7 @@ def tuplet_from_duration_and_ratio(
 
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
-            \times 4/5
+            \tuplet 5/4
             {
                 \time 3/16
                 c'32.
@@ -1066,7 +1066,7 @@ def tuplet_from_duration_and_ratio(
 
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
-            \times 8/11
+            \tuplet 11/8
             {
                 \time 3/16
                 c'16...
@@ -1096,7 +1096,7 @@ def tuplet_from_duration_and_ratio(
 
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
-            \times 4/5
+            \tuplet 5/4
             {
                 \time 3/16
                 c'32.
@@ -1126,7 +1126,7 @@ def tuplet_from_duration_and_ratio(
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 6/11
+            \tuplet 11/6
             {
                 \time 3/16
                 c'32
@@ -1155,7 +1155,7 @@ def tuplet_from_duration_and_ratio(
 
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
-            \times 8/11
+            \tuplet 11/8
             {
                 \time 3/16
                 c'16...
@@ -1183,7 +1183,7 @@ def tuplet_from_duration_and_ratio(
 
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
-            \times 4/5
+            \tuplet 5/4
             {
                 \time 3/16
                 c'32.
@@ -1212,7 +1212,7 @@ def tuplet_from_duration_and_ratio(
 
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
-            \times 8/11
+            \tuplet 11/8
             {
                 \time 3/16
                 c'16...
@@ -1275,7 +1275,7 @@ def tuplet_from_leaf_and_ratio(
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 1/1
+            \tuplet 1/1
             {
                 \time 3/16
                 c'8.
@@ -1297,7 +1297,7 @@ def tuplet_from_leaf_and_ratio(
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 1/1
+            \tuplet 1/1
             {
                 \time 3/16
                 c'16
@@ -1319,7 +1319,7 @@ def tuplet_from_leaf_and_ratio(
 
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
-            \times 4/5
+            \tuplet 5/4
             {
                 \time 3/16
                 c'32.
@@ -1343,7 +1343,7 @@ def tuplet_from_leaf_and_ratio(
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/4
+            \tuplet 4/3
             {
                 \time 3/16
                 c'32
@@ -1368,7 +1368,7 @@ def tuplet_from_leaf_and_ratio(
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 6/11
+            \tuplet 11/6
             {
                 \time 3/16
                 c'32
@@ -1393,7 +1393,7 @@ def tuplet_from_leaf_and_ratio(
 
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
-            \times 4/5
+            \tuplet 5/4
             {
                 \time 3/16
                 c'64
@@ -1420,7 +1420,7 @@ def tuplet_from_leaf_and_ratio(
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 1/1
+            \tuplet 1/1
             {
                 \time 3/16
                 c'8.
@@ -1442,7 +1442,7 @@ def tuplet_from_leaf_and_ratio(
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 1/1
+            \tuplet 1/1
             {
                 \time 3/16
                 c'16
@@ -1464,7 +1464,7 @@ def tuplet_from_leaf_and_ratio(
 
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
-            \times 4/5
+            \tuplet 5/4
             {
                 \time 3/16
                 c'32.
@@ -1488,7 +1488,7 @@ def tuplet_from_leaf_and_ratio(
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/4
+            \tuplet 4/3
             {
                 \time 3/16
                 c'32
@@ -1513,7 +1513,7 @@ def tuplet_from_leaf_and_ratio(
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 6/11
+            \tuplet 11/6
             {
                 \time 3/16
                 c'32
@@ -1538,7 +1538,7 @@ def tuplet_from_leaf_and_ratio(
 
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
-            \times 4/5
+            \tuplet 5/4
             {
                 \time 3/16
                 c'64
@@ -1594,7 +1594,7 @@ def tuplet_from_ratio_and_pair(
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 1/1
+            \tuplet 1/1
             {
                 \time 7/16
                 c'4..
@@ -1614,7 +1614,7 @@ def tuplet_from_ratio_and_pair(
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 7/6
+            \tuplet 6/7
             {
                 \time 7/16
                 c'8
@@ -1635,7 +1635,7 @@ def tuplet_from_ratio_and_pair(
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 1/1
+            \tuplet 1/1
             {
                 \time 7/16
                 c'16
@@ -1657,7 +1657,7 @@ def tuplet_from_ratio_and_pair(
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 7/8
+            \tuplet 8/7
             {
                 \time 7/16
                 c'16
@@ -1680,7 +1680,7 @@ def tuplet_from_ratio_and_pair(
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 7/10
+            \tuplet 10/7
             {
                 \time 7/16
                 c'16
@@ -1703,7 +1703,7 @@ def tuplet_from_ratio_and_pair(
 
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
-            \times 1/2
+            \tuplet 2/1
             {
                 \time 7/16
                 c'16
@@ -1730,7 +1730,7 @@ def tuplet_from_ratio_and_pair(
             >>> string = abjad.lilypond(staff[0])
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 5/8
+            \tuplet 8/5
             {
                 \time 7/16
                 c'4

--- a/abjad/meter.py
+++ b/abjad/meter.py
@@ -2010,11 +2010,13 @@ class Meter:
                         c'4
                         d'8.
                         ~
-                        \times 2/3 {
+                        \tuplet 3/2
+                        {
                             d'8.
                             ~
                             \tweak text #tuplet-number::calc-fraction-text
-                            \times 3/5 {
+                            \tuplet 5/3
+                            {
                                 d'16
                                 e'8.
                                 f'16
@@ -2055,13 +2057,15 @@ class Meter:
                         c'16
                         d'8.
                         ~
-                        \times 2/3 {
+                        \tuplet 3/2
+                        {
                             d'8
                             ~
                             d'16
                             ~
                             \tweak text #tuplet-number::calc-fraction-text
-                            \times 3/5 {
+                            \tuplet 5/3
+                            {
                                 d'16
                                 e'8
                                 ~
@@ -2175,12 +2179,14 @@ class Meter:
                     ~
                     c'8
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 6/7 {
+                    \tuplet 7/6
+                    {
                         c'4.
                         r16
                     }
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 6/7 {
+                    \tuplet 7/6
+                    {
                         r16
                         c'4.
                     }
@@ -2208,7 +2214,8 @@ class Meter:
                     \time 6/4
                     c'4.
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 6/7 {
+                    \tuplet 7/6
+                    {
                         c'8.
                         ~
                         c'8
@@ -2217,7 +2224,8 @@ class Meter:
                         r16
                     }
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 6/7 {
+                    \tuplet 7/6
+                    {
                         r16
                         c'8
                         ~
@@ -2251,12 +2259,14 @@ class Meter:
                     ~
                     c'8
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 6/7 {
+                    \tuplet 7/6
+                    {
                         c'4.
                         r16
                     }
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 6/7 {
+                    \tuplet 7/6
+                    {
                         r16
                         c'4.
                     }
@@ -2285,12 +2295,14 @@ class Meter:
                     \time 6/4
                     c'4.
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 6/7 {
+                    \tuplet 7/6
+                    {
                         c'4.
                         r16
                     }
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 6/7 {
+                    \tuplet 7/6
+                    {
                         r16
                         c'4.
                     }
@@ -3215,7 +3227,8 @@ class _MeterManager:
                     r8.
                     e'16
                     ~
-                    \times 2/3 {
+                    \tuplet 3/2
+                    {
                         e'8
                         ~
                         e'8

--- a/abjad/metricmodulation.py
+++ b/abjad/metricmodulation.py
@@ -272,7 +272,7 @@ class MetricModulation:
                         }
                         {
                             \tweak edge-height #'(0.7 . 0)
-                            \times 2/3
+                            \tuplet 3/2
                             {
                                 c'4
                                 ~

--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -952,7 +952,7 @@ def extract(argument):
                 \new Voice
                 {
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 3/2
+                    \tuplet 2/3
                     {
                         \time 3/4
                         c'4
@@ -961,7 +961,7 @@ def extract(argument):
                         e'4
                     }
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 3/2
+                    \tuplet 2/3
                     {
                         d'4
                         f'4
@@ -1017,7 +1017,7 @@ def extract(argument):
                 \new Voice
                 {
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 3/2
+                    \tuplet 2/3
                     {
                         \time 3/4
                         c'4
@@ -1026,7 +1026,7 @@ def extract(argument):
                         e'4
                     }
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 3/2
+                    \tuplet 2/3
                     {
                         d'4
                         f'4
@@ -1073,7 +1073,7 @@ def extract(argument):
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/2
+            \tuplet 2/3
             {
                 c'4
                 e'4
@@ -1089,7 +1089,7 @@ def extract(argument):
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/2
+            \tuplet 2/3
             {
                 c'4
                 e'4
@@ -1146,7 +1146,7 @@ def fuse(argument) -> _score.Tuplet | list[_score.Leaf]:
             {
                 \new Voice
                 {
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'8
                         [
@@ -1154,7 +1154,7 @@ def fuse(argument) -> _score.Tuplet | list[_score.Leaf]:
                         e'8
                         ]
                     }
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'16
                         (
@@ -1178,7 +1178,7 @@ def fuse(argument) -> _score.Tuplet | list[_score.Leaf]:
             {
                 \new Voice
                 {
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'8
                         [
@@ -1320,7 +1320,7 @@ def logical_tie_to_tuplet(
                     \p
                     \<
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 3/5
+                    \tuplet 5/3
                     {
                         c'8
                         c'16
@@ -1413,7 +1413,7 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
             >>> print(string)
             \new Voice
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     \p
@@ -1422,7 +1422,7 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
                     d'4
                     e'4
                 }
-                \times 2/3
+                \tuplet 3/2
                 {
                     d'4
                     e'4
@@ -1454,7 +1454,7 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
                 d'16
                 e'16
                 f'16
-                \times 2/3
+                \tuplet 3/2
                 {
                     d'4
                     e'4
@@ -1760,7 +1760,7 @@ def scale(argument, multiplier) -> None:
             >>> print(string)
             \new Staff
             {
-                \times 4/5
+                \tuplet 5/4
                 {
                     \time 4/8
                     c'8
@@ -1780,7 +1780,7 @@ def scale(argument, multiplier) -> None:
             >>> print(string)
             \new Staff
             {
-                \times 4/5
+                \tuplet 5/4
                 {
                     \time 4/8
                     c'4
@@ -2449,7 +2449,7 @@ def swap(argument, container):
             >>> print(string)
             \new Voice
             {
-                \times 4/6
+                \tuplet 6/4
                 {
                     \time 3/4
                     c'4
@@ -2616,7 +2616,7 @@ def wrap(argument, container):
                 e'8
                 )
                 ]
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     [
@@ -2641,7 +2641,7 @@ def wrap(argument, container):
 
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 d'8
@@ -2699,22 +2699,22 @@ def wrap(argument, container):
             \new Staff
             {
                 \tweak edge-height #'(0.7 . 0)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'1
                 }
                 \tweak edge-height #'(0.7 . 0)
-                \times 2/3
+                \tuplet 3/2
                 {
                     cs'1
                 }
                 \tweak edge-height #'(0.7 . 0)
-                \times 2/3
+                \tuplet 3/2
                 {
                     d'1
                 }
                 \tweak edge-height #'(0.7 . 0)
-                \times 2/3
+                \tuplet 3/2
                 {
                     ef'1
                 }

--- a/abjad/parentage.py
+++ b/abjad/parentage.py
@@ -591,7 +591,8 @@ class Parentage(collections.abc.Sequence):
                 {
                     \context Voice = "MusicVoice"
                     {
-                        \times 2/3 {
+                        \tuplet 3/2
+                        {
                             c'4
                             \grace {
                                 cs'16
@@ -599,7 +600,8 @@ class Parentage(collections.abc.Sequence):
                             d'4
                             e'4
                         }
-                        \times 2/3 {
+                        \tuplet 3/2
+                        {
                             <<
                                 \context Voice = "On_Beat_Grace_Container"
                                 {
@@ -779,15 +781,18 @@ class Parentage(collections.abc.Sequence):
                 >>> print(string)
                 \new Staff
                 {
-                    \times 2/3 {
+                    \tuplet 3/2
+                    {
                         c'2
-                        \times 2/3 {
+                        \tuplet 3/2
+                        {
                             d'8
                             e'8
                             f'8
                         }
                     }
-                    \times 2/3 {
+                    \tuplet 3/2
+                    {
                         c'4
                         d'4
                         e'4
@@ -1369,7 +1374,8 @@ class Parentage(collections.abc.Sequence):
                 <<
                     \new Staff
                     {
-                        \times 2/3 {
+                        \tuplet 3/2
+                        {
                             c''2
                             b'2
                             a'2

--- a/abjad/parsers/reduced.py
+++ b/abjad/parsers/reduced.py
@@ -104,13 +104,13 @@ class ReducedLyParser(Parser):
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3
+            \tuplet 3/2
             {
                 c'4
                 c'4
                 \tweak text #tuplet-number::calc-fraction-text
                 \tweak edge-height #'(0.7 . 0)
-                \times 3/5
+                \tuplet 5/3
                 {
                     c'8
                     c'8

--- a/abjad/rhythmtrees.py
+++ b/abjad/rhythmtrees.py
@@ -456,10 +456,10 @@ class RhythmTreeContainer(RhythmTreeMixin, uqbar.containers.UniqueTreeList):
 
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
-                \times 4/5
+                \tuplet 5/4
                 {
                     c'8.
                     c'8
@@ -540,10 +540,10 @@ class RhythmTreeContainer(RhythmTreeMixin, uqbar.containers.UniqueTreeList):
                 >>> print(string)
                 \new Staff
                 {
-                    \times 4/5
+                    \tuplet 5/4
                     {
                         c'16
-                        \times 2/3
+                        \tuplet 3/2
                         {
                             c'16
                             c'16
@@ -754,12 +754,12 @@ class RhythmTreeParser(Parser):
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/4
+            \tuplet 4/3
             {
                 c'2
-                \times 4/7
+                \tuplet 7/4
                 {
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'8
                         c'8
@@ -976,13 +976,13 @@ def parse_rtm_syntax(string: str) -> _score.Container | _score.Leaf | _score.Tup
                 c'4
                 c'8
                 \tweak edge-height #'(0.7 . 0)
-                \times 8/12
+                \tuplet 12/8
                 {
                     c'8
                 }
                 c'16
                 \tweak edge-height #'(0.7 . 0)
-                \times 16/20
+                \tuplet 20/16
                 {
                     c'16
                 }
@@ -1003,12 +1003,12 @@ def parse_rtm_syntax(string: str) -> _score.Container | _score.Leaf | _score.Tup
             {
                 c'4
                 \tweak edge-height #'(0.7 . 0)
-                \times 4/6
+                \tuplet 6/4
                 {
                     c'4
                 }
                 \tweak edge-height #'(0.7 . 0)
-                \times 16/20
+                \tuplet 20/16
                 {
                     c'8.
                 }
@@ -1062,7 +1062,7 @@ def parse_rtm_syntax(string: str) -> _score.Container | _score.Leaf | _score.Tup
 
             >>> string = abjad.lilypond(result)
             >>> print(string)
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 c'4
@@ -1116,7 +1116,7 @@ def parse_rtm_syntax(string: str) -> _score.Container | _score.Leaf | _score.Tup
 
             >>> string = abjad.lilypond(result)
             >>> print(string)
-            \times 2/3
+            \tuplet 3/2
             {
                 c'4
                 c'2
@@ -1142,7 +1142,7 @@ def parse_rtm_syntax(string: str) -> _score.Container | _score.Leaf | _score.Tup
                 c'4
                 c'8
                 c'8
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     c'4
@@ -1161,7 +1161,7 @@ def parse_rtm_syntax(string: str) -> _score.Container | _score.Leaf | _score.Tup
 
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 c'16
@@ -1182,12 +1182,12 @@ def parse_rtm_syntax(string: str) -> _score.Container | _score.Leaf | _score.Tup
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \times 9/17
+            \tuplet 17/9
             {
                 c'8
                 c'16
                 \tweak edge-height #'(0.7 . 0)
-                \times 8/15
+                \tuplet 15/8
                 {
                     c'8
                     r16

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -892,14 +892,14 @@ class Container(Component):
                 >>> print(string)
                 \new Voice
                 {
-                    \times 4/6
+                    \tuplet 6/4
                     {
                         c'4
                         (
                         d'4
                         e'4
                     }
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         e'4
                         d'4
@@ -924,7 +924,7 @@ class Container(Component):
                 >>> print(string)
                 \new Voice
                 {
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         e'4
                         (
@@ -948,7 +948,7 @@ class Container(Component):
 
                 >>> string = abjad.lilypond(tuplet_1)
                 >>> print(string)
-                \times 4/6
+                \tuplet 6/4
                 {
                     c'4
                     d'4
@@ -4795,7 +4795,7 @@ class Staff(Context):
             {
                 {
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 9/10
+                    \tuplet 10/9
                     {
                         r8
                         c'16
@@ -4808,7 +4808,7 @@ class Staff(Context):
                 }
                 {
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 9/10
+                    \tuplet 10/9
                     {
                         bf'16
                         e''16
@@ -4821,7 +4821,7 @@ class Staff(Context):
                     }
                 }
                 {
-                    \times 4/5
+                    \tuplet 5/4
                     {
                         a'16
                         r4
@@ -5047,7 +5047,7 @@ class Tuplet(Container):
 
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
-            \times 4/6
+            \tuplet 6/4
             {
                 c'8
                 d'8
@@ -5067,10 +5067,10 @@ class Tuplet(Container):
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak edge-height #'(0.7 . 0)
-            \times 4/6
+            \tuplet 6/4
             {
                 c'8
-                \times 4/7
+                \tuplet 7/4
                 {
                     g'4.
                     (
@@ -5096,15 +5096,15 @@ class Tuplet(Container):
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak edge-height #'(0.7 . 0)
-            \times 4/6
+            \tuplet 6/4
             {
                 c'8
                 \tweak edge-height #'(0.7 . 0)
-                \times 4/7
+                \tuplet 7/4
                 {
                     g'4.
                     (
-                    \times 4/5
+                    \tuplet 5/4
                     {
                         e''32
                         [
@@ -5141,7 +5141,7 @@ class Tuplet(Container):
             >>> print(string)
             \new Voice
             {
-                \times 4/6
+                \tuplet 6/4
                 {
                     c'4
                     d'4
@@ -5158,7 +5158,7 @@ class Tuplet(Container):
             >>> print(string)
             \new Voice
             {
-                \times 4/6
+                \tuplet 6/4
                 {
                     c'4
                     d'4
@@ -5202,11 +5202,11 @@ class Tuplet(Container):
                 \tweak text #tuplet-number::calc-fraction-text
                 \tweak color #blue
                 \tweak staff-padding 4
-                \times 5/4
+                \tuplet 4/5
                 {
                     \tweak color #red
                     \tweak staff-padding 2
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         \time 5/4
                         c'4
@@ -5217,7 +5217,7 @@ class Tuplet(Container):
                     }
                     \tweak color #green
                     \tweak staff-padding 2
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'4
                         (
@@ -5372,8 +5372,8 @@ class Tuplet(Container):
                 for tweak in sorted(self.tweaks):
                     strings = tweak._list_contributions()
                     contributions.extend(strings)
-                times_command_string = self._get_times_command_string()
-                contributions.append(times_command_string)
+                tuplet_command_string = self._get_tuplet_command_string()
+                contributions.append(tuplet_command_string)
                 contributions.append("{")
             if self.tag is not None:
                 contributions = _tag.double_tag(contributions, self.tag)
@@ -5442,6 +5442,15 @@ class Tuplet(Container):
         string = rf"\times {self._get_multiplier_fraction_string()}"
         return string
 
+    def _get_tuplet_command_string(self):
+        numerator, denominator = self.multiplier
+        if self.denominator is not None:
+            inverse_multiplier = fractions.Fraction(denominator, numerator)
+            pair = _duration.with_denominator(inverse_multiplier, self.denominator)
+            denominator, numerator = pair
+        string = rf"\tuplet {denominator}/{numerator}"
+        return string
+
     def _scale(self, multiplier):
         multiplier = fractions.Fraction(multiplier)
         for component in self[:]:
@@ -5465,7 +5474,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     d'4
@@ -5497,7 +5506,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     d'8
@@ -5515,7 +5524,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     d'8
@@ -5529,7 +5538,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 4/6
+                \tuplet 6/4
                 {
                     c'8
                     d'8
@@ -5577,19 +5586,19 @@ class Tuplet(Container):
                     \override TupletNumber.text = #tuplet-number::calc-denominator-text
                 }
                 {
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'4
                         d'4
                         e'4
                     }
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'4
                         d'4
                         e'4
                     }
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'4
                         d'4
@@ -5614,20 +5623,20 @@ class Tuplet(Container):
                     \override TupletNumber.text = #tuplet-number::calc-denominator-text
                 }
                 {
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'4
                         d'4
                         e'4
                     }
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'4
                         d'4
                         e'4
                     }
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'4
                         d'4
@@ -5690,7 +5699,7 @@ class Tuplet(Container):
                                 ragged-right = ##t
                             }
                         } }
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'8
                         d'8
@@ -5723,7 +5732,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     d'8
@@ -5746,13 +5755,13 @@ class Tuplet(Container):
                 >>> print(string)
                 \new Staff
                 {
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         c'4
                         d'4
                         e'4
                     }
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         d'4
                         e'4
@@ -5775,7 +5784,7 @@ class Tuplet(Container):
                         d'4
                         e'4
                     }
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         d'4
                         e'4
@@ -5854,7 +5863,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 4/3
+                \tuplet 3/4
                 {
                     c'8
                     d'8
@@ -5888,14 +5897,14 @@ class Tuplet(Container):
 
             >>> string = abjad.lilypond(tuplet, tags=True)
             >>> print(string)
-            %! RED
-            \times 2/3
-            %! RED
+              %! RED
+            \tuplet 3/2
+              %! RED
             {
                 c'4
                 d'4
                 e'4
-            %! RED
+              %! RED
             }
 
         """
@@ -5928,7 +5937,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     (
@@ -5945,7 +5954,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak edge-height #'(0.7 . 0)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     (
@@ -5966,7 +5975,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     (
@@ -5982,7 +5991,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 1/2
+                \tuplet 2/1
                 {
                     c'4
                     (
@@ -6099,7 +6108,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     (
@@ -6117,7 +6126,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak edge-height #'(0.7 . 0)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     (
@@ -6140,7 +6149,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     (
@@ -6157,7 +6166,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 4/7
+                \tuplet 7/4
                 {
                     c'4
                     (
@@ -6197,7 +6206,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     d'8
@@ -6227,7 +6236,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 1/3
+                \tuplet 3/1
                 {
                     c'4
                     d'4
@@ -6244,7 +6253,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     d'8
@@ -6264,7 +6273,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 8/3
+                \tuplet 3/8
                 {
                     c'32
                     d'32
@@ -6282,7 +6291,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 4/3
+                \tuplet 3/4
                 {
                     c'16
                     d'16
@@ -6302,7 +6311,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 5/12
+                \tuplet 12/5
                 {
                     c'4
                     d'4
@@ -6320,7 +6329,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 5/6
+                \tuplet 6/5
                 {
                     c'8
                     d'8
@@ -6362,7 +6371,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 3/2
+                \tuplet 2/3
                 {
                     r4
                     r4
@@ -6391,7 +6400,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 1/1
+                \tuplet 1/1
                 {
                     c'8.
                     c'8.
@@ -6405,7 +6414,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 3/2
+                \tuplet 2/3
                 {
                     c'8
                     c'8
@@ -6423,7 +6432,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 1/1
+                \tuplet 1/1
                 {
                     c'8..
                     c'8..
@@ -6437,7 +6446,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 7/4
+                \tuplet 4/7
                 {
                     c'8
                     c'8
@@ -6455,7 +6464,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 1/1
+                \tuplet 1/1
                 {
                     c'8.
                     d'8.
@@ -6470,7 +6479,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 1/1
+                \tuplet 1/1
                 {
                     c'8.
                     d'8.
@@ -6489,7 +6498,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 3/2
+                \tuplet 2/3
                 {
                     c'8
                     d'8
@@ -6504,7 +6513,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 3/2
+                \tuplet 2/3
                 {
                     c'8
                     d'8
@@ -6548,7 +6557,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 3/5
+                \tuplet 5/3
                 {
                     c'4
                     d'8
@@ -6565,7 +6574,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 6/10
+                \tuplet 10/6
                 {
                     c'4
                     d'8
@@ -6601,7 +6610,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 4/3
+                \tuplet 3/4
                 {
                     c'8
                     d'8
@@ -6615,7 +6624,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     d'4
@@ -6636,7 +6645,7 @@ class Tuplet(Container):
 
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'4
                     d'4
@@ -6651,7 +6660,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 4/3
+                \tuplet 3/4
                 {
                     c'8
                     d'8
@@ -6673,7 +6682,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 1/1
+                \tuplet 1/1
                 {
                     c'4
                     d'4
@@ -6688,7 +6697,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 1/1
+                \tuplet 1/1
                 {
                     c'4
                     d'4
@@ -6729,7 +6738,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 1/1
+                \tuplet 1/1
                 {
                     c'8
                     d'8
@@ -6753,7 +6762,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 1/1
+                \tuplet 1/1
                 {
                     c'8 * 3/2
                     d'8
@@ -6793,7 +6802,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 3/4
+                \tuplet 4/3
                 {
                     \time 3/8
                     c'4
@@ -6838,7 +6847,7 @@ class Tuplet(Container):
                 \new Staff
                 {
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 3/5
+                    \tuplet 5/3
                     {
                         \time 3/4
                         c'4
@@ -6871,7 +6880,7 @@ class Tuplet(Container):
                 \new Staff
                 {
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 3/4
+                    \tuplet 4/3
                     {
                         \time 3/4
                         c'2.
@@ -6907,7 +6916,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 3/4
+                \tuplet 4/3
                 {
                     c'2
                 }
@@ -6923,7 +6932,7 @@ class Tuplet(Container):
                 >>> string = abjad.lilypond(tuplet)
                 >>> print(string)
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 1/1
+                \tuplet 1/1
                 {
                     c'4.
                 }

--- a/abjad/select.py
+++ b/abjad/select.py
@@ -297,7 +297,7 @@ def chord(
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \time 7/4
                             r16
@@ -308,7 +308,7 @@ def chord(
                             ~
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             r16
                             bf'16
@@ -319,7 +319,7 @@ def chord(
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             r16
                             bf'16
@@ -397,7 +397,7 @@ def chords(
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \time 7/4
                             r16
@@ -411,7 +411,7 @@ def chords(
                             \abjad-color-music #'red
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             r16
                             bf'16
@@ -425,7 +425,7 @@ def chords(
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             r16
                             bf'16
@@ -1095,7 +1095,7 @@ def flatten(argument, depth: int = 1) -> list:
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \abjad-color-music #'red
                             \time 7/4
@@ -1108,7 +1108,7 @@ def flatten(argument, depth: int = 1) -> list:
                             ~
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             \abjad-color-music #'blue
                             r16
@@ -1121,7 +1121,7 @@ def flatten(argument, depth: int = 1) -> list:
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \abjad-color-music #'red
                             r16
@@ -1188,7 +1188,7 @@ def flatten(argument, depth: int = 1) -> list:
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \abjad-color-music #'red
                             \time 7/4
@@ -1201,7 +1201,7 @@ def flatten(argument, depth: int = 1) -> list:
                             ~
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             \abjad-color-music #'red
                             r16
@@ -1214,7 +1214,7 @@ def flatten(argument, depth: int = 1) -> list:
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \abjad-color-music #'red
                             r16
@@ -1584,7 +1584,7 @@ def group_by_contiguity(argument) -> list[list]:
                 \abjad-color-music #'red
                 d'8
                 r8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'blue
                     e'8
@@ -2490,7 +2490,7 @@ def leaf(
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \time 7/4
                             r16
@@ -2501,7 +2501,7 @@ def leaf(
                             ~
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             r16
                             bf'16
@@ -2512,7 +2512,7 @@ def leaf(
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             r16
                             bf'16
@@ -2658,7 +2658,7 @@ def leaves(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     r8
@@ -2675,7 +2675,7 @@ def leaves(
                 r8
                 \abjad-color-music #'red
                 f'8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'blue
                     e'8
@@ -2721,7 +2721,7 @@ def leaves(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     r8
                     \abjad-color-music #'red
@@ -2735,7 +2735,7 @@ def leaves(
                 r8
                 \abjad-color-music #'blue
                 f'8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     e'8
@@ -2785,7 +2785,7 @@ def leaves(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     r8
                     \abjad-color-music #'red
@@ -2802,7 +2802,7 @@ def leaves(
                 r8
                 \abjad-color-music #'blue
                 f'8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     e'8
@@ -2853,7 +2853,7 @@ def leaves(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     r8
                     \abjad-color-music #'red
@@ -2870,7 +2870,7 @@ def leaves(
                 r8
                 \abjad-color-music #'blue
                 f'8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     e'8
@@ -2921,7 +2921,7 @@ def leaves(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     c'8
@@ -2938,7 +2938,7 @@ def leaves(
                 r8
                 \abjad-color-music #'red
                 f'8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'blue
                     e'8
@@ -2985,7 +2985,7 @@ def leaves(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     r8
@@ -2998,7 +2998,7 @@ def leaves(
                 r8
                 r8
                 f'8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'blue
                     e'8
@@ -3043,7 +3043,7 @@ def leaves(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     r8
                     \abjad-color-music #'red
@@ -3055,7 +3055,7 @@ def leaves(
                 r8
                 r8
                 f'8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     e'8
@@ -3101,7 +3101,7 @@ def leaves(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     c'8
@@ -3114,7 +3114,7 @@ def leaves(
                 r8
                 r8
                 e'8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     d'8
@@ -3161,7 +3161,7 @@ def leaves(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     c'8
@@ -3174,7 +3174,7 @@ def leaves(
                 r8
                 r8
                 e'8
-                \times 2/3
+                \tuplet 3/2
                 {
                     d'8
                     ~
@@ -3219,7 +3219,7 @@ def leaves(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     <c' e' g'>8
@@ -3231,7 +3231,7 @@ def leaves(
                 r8
                 r8
                 <g d' fs'>8
-                \times 2/3
+                \tuplet 3/2
                 {
                     e'8
                     \abjad-color-music #'blue
@@ -3280,7 +3280,7 @@ def leaves(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     r8
@@ -3297,7 +3297,7 @@ def leaves(
                 r8
                 \abjad-color-music #'red
                 f'8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'blue
                     e'8
@@ -3866,7 +3866,7 @@ def logical_ties(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     c'8
@@ -3880,7 +3880,7 @@ def logical_ties(
                 e'8
                 f'8
                 ~
-                \times 2/3
+                \tuplet 3/2
                 {
                     f'8
                     \abjad-color-music #'blue
@@ -3893,7 +3893,7 @@ def logical_ties(
                 a'8
                 b'8
                 ~
-                \times 2/3
+                \tuplet 3/2
                 {
                     b'8
                     \abjad-color-music #'red
@@ -3936,7 +3936,7 @@ def logical_ties(
                 autoBeaming = ##f
             }
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'8
                     d'8
@@ -3946,7 +3946,7 @@ def logical_ties(
                 e'8
                 f'8
                 ~
-                \times 2/3
+                \tuplet 3/2
                 {
                     f'8
                     \abjad-color-music #'red
@@ -3959,7 +3959,7 @@ def logical_ties(
                 a'8
                 b'8
                 ~
-                \times 2/3
+                \tuplet 3/2
                 {
                     b'8
                     \abjad-color-music #'blue
@@ -4403,7 +4403,7 @@ def note(
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \time 7/4
                             r16
@@ -4414,7 +4414,7 @@ def note(
                             ~
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             r16
                             bf'16
@@ -4425,7 +4425,7 @@ def note(
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             r16
                             bf'16
@@ -4500,7 +4500,7 @@ def notes(
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \time 7/4
                             r16
@@ -4513,7 +4513,7 @@ def notes(
                             ~
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             r16
                             \abjad-color-music #'red
@@ -4526,7 +4526,7 @@ def notes(
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             r16
                             \abjad-color-music #'red
@@ -5946,7 +5946,7 @@ def partition_by_ratio(argument, ratio: tuple[int, ...]) -> list[list]:
                 d'8
                 \abjad-color-music #'red
                 r8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     e'8
@@ -6000,7 +6000,7 @@ def partition_by_ratio(argument, ratio: tuple[int, ...]) -> list[list]:
                 d'8
                 \abjad-color-music #'red
                 r8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'blue
                     e'8
@@ -6078,7 +6078,7 @@ def rest(
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \time 7/4
                             r16
@@ -6089,7 +6089,7 @@ def rest(
                             ~
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             r16
                             bf'16
@@ -6100,7 +6100,7 @@ def rest(
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \abjad-color-music #'green
                             r16
@@ -6172,7 +6172,7 @@ def rests(
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \abjad-color-music #'red
                             \time 7/4
@@ -6184,7 +6184,7 @@ def rests(
                             ~
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             \abjad-color-music #'blue
                             r16
@@ -6196,7 +6196,7 @@ def rests(
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \abjad-color-music #'red
                             r16
@@ -6269,7 +6269,7 @@ def run(
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \time 7/4
                             r16
@@ -6280,7 +6280,7 @@ def run(
                             ~
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             r16
                             d'16
@@ -6291,7 +6291,7 @@ def run(
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             r16
                             \abjad-color-music #'green
@@ -6367,7 +6367,7 @@ def runs(
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \time 7/4
                             r16
@@ -6383,7 +6383,7 @@ def runs(
                             \abjad-color-music #'red
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             r16
                             \abjad-color-music #'blue
@@ -6399,7 +6399,7 @@ def runs(
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             r16
                             \abjad-color-music #'red
@@ -6561,7 +6561,7 @@ def top(argument, *, exclude: _typings.Exclude | None = None) -> list[_score.Com
                 d'8
                 \abjad-color-music #'red
                 r8
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'blue
                     e'8
@@ -6643,7 +6643,7 @@ def tuplet(
                     \context Voice = "Voice"
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \time 7/4
                             r16
@@ -6654,7 +6654,7 @@ def tuplet(
                             ~
                             <d' e'>16
                         }
-                        \times 8/9
+                        \tuplet 9/8
                         {
                             r16
                             bf'16
@@ -6665,7 +6665,7 @@ def tuplet(
                             <e' fs'>16
                         }
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 10/9
+                        \tuplet 9/10
                         {
                             \abjad-color-music #'green
                             r16
@@ -6721,11 +6721,11 @@ def tuplets(
             >>> print(string)
             \new Staff
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     c'2
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         \abjad-color-music #'blue
                         \abjad-color-music #'red
@@ -6738,7 +6738,7 @@ def tuplets(
                         f'8
                     }
                 }
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     c'4
@@ -6774,10 +6774,10 @@ def tuplets(
             >>> print(string)
             \new Staff
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     c'2
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         \abjad-color-music #'red
                         d'8
@@ -6787,7 +6787,7 @@ def tuplets(
                         f'8
                     }
                 }
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'blue
                     c'4
@@ -6826,11 +6826,11 @@ def tuplets(
             >>> print(string)
             \new Staff
             {
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'red
                     c'2
-                    \times 2/3
+                    \tuplet 3/2
                     {
                         \abjad-color-music #'red
                         d'8
@@ -6840,7 +6840,7 @@ def tuplets(
                         f'8
                     }
                 }
-                \times 2/3
+                \tuplet 3/2
                 {
                     \abjad-color-music #'blue
                     c'4

--- a/abjad/verticalmoment.py
+++ b/abjad/verticalmoment.py
@@ -144,7 +144,7 @@ class VerticalMoment:
                     \new Staff
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 4/3
+                        \tuplet 3/4
                         {
                             d''8
                             c''8
@@ -243,7 +243,7 @@ class VerticalMoment:
                     \new Staff
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 4/3
+                        \tuplet 3/4
                         {
                             d''8
                             c''8
@@ -345,7 +345,7 @@ class VerticalMoment:
                     \new Staff
                     {
                         \tweak text #tuplet-number::calc-fraction-text
-                        \times 4/3
+                        \tuplet 3/4
                         {
                             d''8
                             c''8
@@ -517,7 +517,7 @@ def iterate_vertical_moments(components, reverse=None):
                 \new Staff
                 {
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 4/3
+                    \tuplet 3/4
                     {
                         d''8
                         c''8
@@ -583,7 +583,7 @@ def iterate_vertical_moments(components, reverse=None):
                 \new Staff
                 {
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 4/3
+                    \tuplet 3/4
                     {
                         d''8
                         c''8

--- a/tests/test_Component.py
+++ b/tests/test_Component.py
@@ -21,14 +21,14 @@ def test_Component__sibling_02():
 
 
 def test_Component__sibling_03():
-    staff = abjad.Staff(r"c'4 \times 2/3 { d'8 e'8 f'8 } g'2")
+    staff = abjad.Staff(r"c'4 \tuplet 3/2 { d'8 e'8 f'8 } g'2")
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
         r"""
         \new Staff
         {
             c'4
-            \times 2/3
+            \tuplet 3/2
             {
                 d'8
                 e'8

--- a/tests/test_Container.py
+++ b/tests/test_Container.py
@@ -231,7 +231,7 @@ def test_Container___delitem___07():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak edge-height #'(0.7 . 0)
-        \times 2/3
+        \tuplet 3/2
         {
             c'8
             [
@@ -645,7 +645,7 @@ def test_Container___setitem___04():
                 [
                 d'8
             }
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 d'8
@@ -1487,7 +1487,7 @@ def test_Container_append_02():
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
-        \times 4/7
+        \tuplet 7/4
         {
             c'8
             [

--- a/tests/test_Tuplet.py
+++ b/tests/test_Tuplet.py
@@ -10,7 +10,7 @@ def test_Tuplet___copy___01():
     assert abjad.lilypond(tuplet_1) == abjad.string.normalize(
         r"""
         \override NoteHead.color = #red
-        \times 2/3
+        \tuplet 3/2
         {
             c'8
             d'8
@@ -25,7 +25,7 @@ def test_Tuplet___copy___01():
     assert abjad.lilypond(tuplet_2) == abjad.string.normalize(
         r"""
         \override NoteHead.color = #red
-        \times 2/3
+        \tuplet 3/2
         {
         }
         \revert NoteHead.color
@@ -42,14 +42,14 @@ def test_Tuplet___init___01():
 
     tuplet = abjad.Tuplet()
 
-    assert abjad.lilypond(tuplet) == "\\times 2/3\n{\n}"
+    assert abjad.lilypond(tuplet) == "\\tuplet 3/2\n{\n}"
     assert tuplet.multiplier == (2, 3)
     assert not len(tuplet)
 
 
 # TODO: move to test_get_timespan.py
 def test_Tuplet_get_timespan_01():
-    staff = abjad.Staff(r"c'4 d'4 \times 2/3 { e'4 f'4 g'4 }")
+    staff = abjad.Staff(r"c'4 d'4 \tuplet 3/2 { e'4 f'4 g'4 }")
     leaves = abjad.select.leaves(staff)
     score = abjad.Score([staff])
     mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
@@ -64,7 +64,7 @@ def test_Tuplet_get_timespan_01():
                 \tempo 4=60
                 c'4
                 d'4
-                \times 2/3
+                \tuplet 3/2
                 {
                     e'4
                     f'4
@@ -88,7 +88,7 @@ def test_Tuplet_set_minimum_denominator_01():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/10
+        \tuplet 10/6
         {
             c'4
             d'8
@@ -109,7 +109,7 @@ def test_Tuplet_set_minimum_denominator_02():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 12/20
+        \tuplet 20/12
         {
             c'4
             d'8
@@ -130,7 +130,7 @@ def test_Tuplet_set_minimum_denominator_03():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/5
+        \tuplet 5/3
         {
             c'4
             d'8

--- a/tests/test_get_leaf.py
+++ b/tests/test_get_leaf.py
@@ -132,7 +132,7 @@ def test_get_leaf_05():
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
-        \times 2/3
+        \tuplet 3/2
         {
             c'8
             cs'8
@@ -203,13 +203,13 @@ def test_get_leaf_07():
         r"""
         \new Voice
         {
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 cs'8
                 d'8
             }
-            \times 2/3
+            \tuplet 3/2
             {
                 ef'8
                 e'8
@@ -661,14 +661,14 @@ def test_get_leaf_17():
         r"""
         \new Voice
         {
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 cs'8
                 d'8
             }
             ef'8
-            \times 2/3
+            \tuplet 3/2
             {
                 e'8
                 f'8
@@ -696,10 +696,10 @@ def test_get_leaf_18():
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
-        \times 2/3
+        \tuplet 3/2
         {
             c'4
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 c'8
@@ -1052,7 +1052,7 @@ def test__inspect_are_logical_voice_03():
     tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
 
     r"""
-    \times 2/3
+    \tuplet 3/2
     {
         c'8
         d'8
@@ -1157,13 +1157,13 @@ def test__inspect_are_logical_voice_07():
 
     voice = abjad.Voice(
         r"""
-        \times 2/3
+        \tuplet 3/2
         {
             c'8
             d'8
             e'8
         }
-        \times 2/3
+        \tuplet 3/2
         {
             f'8
             g'8
@@ -1176,13 +1176,13 @@ def test__inspect_are_logical_voice_07():
         r"""
         \new Voice
         {
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 d'8
                 e'8
             }
-            \times 2/3
+            \tuplet 3/2
             {
                 f'8
                 g'8

--- a/tests/test_get_timespan.py
+++ b/tests/test_get_timespan.py
@@ -351,7 +351,7 @@ def test_get_timespan_26():
 
 
 def test_Tuplet_timespan_01():
-    staff = abjad.Staff(r"c'4 d'4 \times 2/3 { e'4 f'4 g'4 }")
+    staff = abjad.Staff(r"c'4 d'4 \tuplet 3/2 { e'4 f'4 g'4 }")
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
         r"""
@@ -359,7 +359,7 @@ def test_Tuplet_timespan_01():
         {
             c'4
             d'4
-            \times 2/3
+            \tuplet 3/2
             {
                 e'4
                 f'4

--- a/tests/test_makers.py
+++ b/tests/test_makers.py
@@ -76,7 +76,7 @@ def test_makers_tuplet_from_ratio_and_pair_01():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/7
+        \tuplet 7/6
         {
             c'16
             c'8
@@ -92,7 +92,7 @@ def test_makers_tuplet_from_ratio_and_pair_02():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/4
+        \tuplet 4/3
         {
             c'16
             c'16
@@ -109,7 +109,7 @@ def test_makers_tuplet_from_ratio_and_pair_03():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 7/12
+        \tuplet 12/7
         {
             r8
             c'8.
@@ -124,7 +124,7 @@ def test_makers_tuplet_from_ratio_and_pair_04():
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
-        \times 16/19
+        \tuplet 19/16
         {
             c'16..
             c'16..
@@ -141,7 +141,7 @@ def test_makers_tuplet_from_ratio_and_pair_05():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5
+        \tuplet 5/6
         {
             c'8
             c'4
@@ -157,7 +157,7 @@ def test_makers_tuplet_from_ratio_and_pair_06():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5
+        \tuplet 5/6
         {
             c'8
             c'4
@@ -173,7 +173,7 @@ def test_makers_tuplet_from_ratio_and_pair_07():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/5
+        \tuplet 5/3
         {
             c'4
             c'2
@@ -189,7 +189,7 @@ def test_makers_tuplet_from_ratio_and_pair_08():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/5
+        \tuplet 5/3
         {
             c'4
             c'2
@@ -205,7 +205,7 @@ def test_makers_tuplet_from_ratio_and_pair_09():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/5
+        \tuplet 5/3
         {
             c'16
             c'8
@@ -221,7 +221,7 @@ def test_makers_tuplet_from_ratio_and_pair_10():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/5
+        \tuplet 5/3
         {
             c'8
             c'4
@@ -237,7 +237,7 @@ def test_makers_tuplet_from_ratio_and_pair_11():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5
+        \tuplet 5/6
         {
             c'8
             c'4
@@ -253,7 +253,7 @@ def test_makers_tuplet_from_ratio_and_pair_12():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5
+        \tuplet 5/6
         {
             c'4
             c'2
@@ -269,7 +269,7 @@ def test_makers_tuplet_from_ratio_and_pair_13():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5
+        \tuplet 5/6
         {
             c'2
             c'1
@@ -285,7 +285,7 @@ def test_makers_tuplet_from_ratio_and_pair_14():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5
+        \tuplet 5/6
         {
             c'4
             c'2
@@ -301,7 +301,7 @@ def test_makers_tuplet_from_ratio_and_pair_15():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5
+        \tuplet 5/6
         {
             c'8
             c'4
@@ -317,7 +317,7 @@ def test_makers_tuplet_from_ratio_and_pair_16():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 6/5
+        \tuplet 5/6
         {
             c'16
             c'8
@@ -333,7 +333,7 @@ def test_makers_tuplet_from_ratio_and_pair_17():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 1/1
+        \tuplet 1/1
         {
             c'16
             r16
@@ -349,7 +349,7 @@ def test_makers_tuplet_from_ratio_and_pair_18():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 1/1
+        \tuplet 1/1
         {
             c'16
             c'16
@@ -366,7 +366,7 @@ def test_makers_tuplet_from_ratio_and_pair_19():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 1/1
+        \tuplet 1/1
         {
             c'16
             c'16
@@ -384,7 +384,7 @@ def test_makers_tuplet_from_ratio_and_pair_20():
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 1/1
+        \tuplet 1/1
         {
             c'16
             c'16

--- a/tests/test_mutate_fuse.py
+++ b/tests/test_mutate_fuse.py
@@ -119,7 +119,7 @@ def test_mutate_fuse_06():
 
     assert abjad.lilypond(tuplet_1) == abjad.string.normalize(
         r"""
-        \times 2/3
+        \tuplet 3/2
         {
             c'8
             [
@@ -132,7 +132,7 @@ def test_mutate_fuse_06():
 
     assert abjad.lilypond(tuplet_2) == abjad.string.normalize(
         r"""
-        \times 2/3
+        \tuplet 3/2
         {
             c'16
             (
@@ -148,7 +148,7 @@ def test_mutate_fuse_06():
 
     assert abjad.lilypond(new) == abjad.string.normalize(
         r"""
-        \times 2/3
+        \tuplet 3/2
         {
             c'8
             [
@@ -186,7 +186,7 @@ def test_mutate_fuse_07():
         r"""
         \new Voice
         {
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 [
@@ -194,7 +194,7 @@ def test_mutate_fuse_07():
                 e'8
                 ]
             }
-            \times 2/3
+            \tuplet 3/2
             {
                 c'16
                 (
@@ -213,7 +213,7 @@ def test_mutate_fuse_07():
         r"""
         \new Voice
         {
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 [
@@ -248,7 +248,7 @@ def test_mutate_fuse_08():
         r"""
         \new Voice
         {
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 [
@@ -257,7 +257,7 @@ def test_mutate_fuse_08():
                 ]
             }
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 (
@@ -279,7 +279,7 @@ def test_mutate_fuse_08():
         \new Voice
         {
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 [
@@ -326,13 +326,13 @@ def test_mutate_fuse_10():
         \new Voice
         {
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 (
             }
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3
+            \tuplet 3/2
             {
                 c'4
             }
@@ -349,7 +349,7 @@ def test_mutate_fuse_10():
         r"""
         \new Voice
         {
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 (

--- a/tests/test_mutate_helpers.py
+++ b/tests/test_mutate_helpers.py
@@ -404,7 +404,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_07():
     Fuse leaves in logical tie with same immediate parent.
     """
 
-    voice = abjad.Voice(r"\times 8/13 { \time 4/4 c'8 ~ c'8 ~ c'16 ~ c'32 r16 } r4 r2")
+    voice = abjad.Voice(r"\tuplet 13/8 { \time 4/4 c'8 ~ c'8 ~ c'16 ~ c'32 r16 } r4 r2")
     logical_tie = abjad.get.logical_tie(voice[0][0])
     result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
     staff = abjad.Staff([voice])
@@ -416,7 +416,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_07():
         {
             \new Voice
             {
-                \times 8/13
+                \tuplet 13/8
                 {
                     \time 4/4
                     c'4
@@ -649,19 +649,19 @@ def test_mutate__immediately_precedes_05():
 
 
 def test_mutate__immediately_precedes_06():
-    voice = abjad.Voice(r"\times 2/3 { c'8 d'8 e'8 } \times 2/3 { f'8 e'8 d'8 }")
+    voice = abjad.Voice(r"\tuplet 3/2 { c'8 d'8 e'8 } \tuplet 3/2 { f'8 e'8 d'8 }")
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
         \new Voice
         {
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 d'8
                 e'8
             }
-            \times 2/3
+            \tuplet 3/2
             {
                 f'8
                 e'8

--- a/tests/test_mutate_split.py
+++ b/tests/test_mutate_split.py
@@ -165,7 +165,7 @@ def test_mutate__set_leaf_duration_04():
             c'8
             [
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3
+            \tuplet 3/2
             {
                 d'8
                 ~
@@ -213,7 +213,7 @@ def test_mutate__set_leaf_duration_05():
             c'8
             [
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3
+            \tuplet 3/2
             {
                 d'8
                 ]
@@ -467,7 +467,7 @@ def test_mutate__split_container_by_duration_02():
                 [
                 (
                 \tweak edge-height #'(0.7 . 0)
-                \times 4/5
+                \tuplet 5/4
                 {
                     d'16.
                     ~
@@ -475,7 +475,7 @@ def test_mutate__split_container_by_duration_02():
             }
             {
                 \tweak edge-height #'(0.7 . 0)
-                \times 4/5
+                \tuplet 5/4
                 {
                     d'16
                     ]
@@ -548,7 +548,7 @@ def test_mutate__split_leaf_by_durations_02():
     This test comes from #272 in GitHub.
     """
 
-    voice = abjad.Voice(r"\times 2/3 { c'8 [ d'8 e'8 ] }")
+    voice = abjad.Voice(r"\tuplet 3/2 { c'8 [ d'8 e'8 ] }")
     leaf = abjad.get.leaf(voice, 0)
     abjad.mutate._split_leaf_by_durations(leaf, [abjad.Duration(1, 20)])
 
@@ -556,9 +556,9 @@ def test_mutate__split_leaf_by_durations_02():
         r"""
         \new Voice
         {
-            \times 2/3
+            \tuplet 3/2
             {
-                \times 4/5
+                \tuplet 5/4
                 {
                     c'16.
                     [
@@ -1315,7 +1315,7 @@ def test_mutate_split_07():
         r"""
         \new Voice
         {
-            \times 2/3
+            \tuplet 3/2
             {
                 c'8
                 [
@@ -1323,12 +1323,12 @@ def test_mutate_split_07():
                 e'8
             }
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3
+            \tuplet 3/2
             {
                 f'8
             }
             \tweak edge-height #'(0.7 . 0)
-            \times 2/3
+            \tuplet 3/2
             {
                 g'8
                 a'8
@@ -1580,7 +1580,7 @@ def test_mutate_split_12():
     assert abjad.lilypond(left) == abjad.string.normalize(
         r"""
         \tweak edge-height #'(0.7 . 0)
-        \times 4/5
+        \tuplet 5/4
         {
             c'8
             [
@@ -1592,7 +1592,7 @@ def test_mutate_split_12():
     assert abjad.lilypond(right) == abjad.string.normalize(
         r"""
         \tweak edge-height #'(0.7 . 0)
-        \times 4/5
+        \tuplet 5/4
         {
             c'8
             c'8
@@ -1604,7 +1604,7 @@ def test_mutate_split_12():
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
-        \times 4/5
+        \tuplet 5/4
         {
         }
         """
@@ -1615,14 +1615,14 @@ def test_mutate_split_12():
         \new Voice
         {
             \tweak edge-height #'(0.7 . 0)
-            \times 4/5
+            \tuplet 5/4
             {
                 c'8
                 [
                 c'8
             }
             \tweak edge-height #'(0.7 . 0)
-            \times 4/5
+            \tuplet 5/4
             {
                 c'8
                 c'8
@@ -1640,14 +1640,14 @@ def test_mutate_split_12():
             \new Voice
             {
                 \tweak edge-height #'(0.7 . 0)
-                \times 4/5
+                \tuplet 5/4
                 {
                     c'8
                     [
                     c'8
                 }
                 \tweak edge-height #'(0.7 . 0)
-                \times 4/5
+                \tuplet 5/4
                 {
                     c'8
                     c'8
@@ -1800,7 +1800,7 @@ def test_mutate_split_15():
         r"""
         \new Staff
         {
-            \times 2/3
+            \tuplet 3/2
             {
                 c'4
                 ~

--- a/tests/test_mutate_swap.py
+++ b/tests/test_mutate_swap.py
@@ -42,7 +42,7 @@ def test_Mutation_swap_01():
         \new Voice
         {
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/4
+            \tuplet 4/3
             {
                 c'8
                 [
@@ -168,7 +168,7 @@ def test_Mutation_swap_03():
                 d'8
             }
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/4
+            \tuplet 4/3
             {
                 e'8
                 f'8

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -9,7 +9,7 @@ def test_Tuplet_grob_override_01():
         r"""
         \override Glissando.thickness = 3
         \tweak edge-height #'(0.7 . 0)
-        \times 2/3
+        \tuplet 3/2
         {
             c'8
             d'8

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -29,7 +29,7 @@ def test_LilyPondParser__containers__Tuplet_01():
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""
-        \times 2/3
+        \tuplet 3/2
         {
             c'8
             d'8
@@ -2415,19 +2415,19 @@ def test_parse_rtm_syntax_01():
     assert abjad.lilypond(result) == abjad.string.normalize(
         r"""
         \tweak text #tuplet-number::calc-fraction-text
-        \times 3/4
+        \tuplet 4/3
         {
             c'4
             \tweak text #tuplet-number::calc-fraction-text
-            \times 3/4
+            \tuplet 4/3
             {
                 c'4
                 \tweak text #tuplet-number::calc-fraction-text
-                \times 3/4
+                \tuplet 4/3
                 {
                     c'4
                     \tweak text #tuplet-number::calc-fraction-text
-                    \times 3/4
+                    \tuplet 4/3
                     {
                         c'4
                         c'4

--- a/tests/test_rhythmtrees.py
+++ b/tests/test_rhythmtrees.py
@@ -14,10 +14,10 @@ def test_RhythmTreeContainer___call___01():
     assert len(result) == 1
     assert abjad.lilypond(result[0]) == abjad.string.normalize(
         r"""
-        \times 4/5
+        \tuplet 5/4
         {
             c'16
-            \times 2/3
+            \tuplet 3/2
             {
                 c'16
                 c'16
@@ -40,7 +40,7 @@ def test_RhythmTreeContainer___call___02():
         \new Staff
         {
             \tweak text #tuplet-number::calc-fraction-text
-            \times 1/1
+            \tuplet 1/1
             {
                 c'16
                 c'32
@@ -406,10 +406,10 @@ def test_RhythmTreeNode___call___02():
     assert len(result) == 1
     assert abjad.lilypond(result[0]) == abjad.string.normalize(
         r"""
-        \times 4/5
+        \tuplet 5/4
         {
             c'16
-            \times 2/3
+            \tuplet 3/2
             {
                 c'16
                 c'16
@@ -427,7 +427,7 @@ def test_RhythmTreeNode___call___03():
     result = tree((1, 4))
     assert abjad.lilypond(result[0]) == abjad.string.normalize(
         r"""
-        \times 4/5
+        \tuplet 5/4
         {
             c'16
             c'32


### PR DESCRIPTION
OLD. Versions of Abjad earlier than 3.20 format Abjad tuplet objects with LilyPond's `\times` command:

    tuplet = abjad.Tuplet("3:2", "c'4 d' e'")
    string = abjad.lilypond(tuplet)
    print(string)
    \times 2/3
    {
        c'4
        d'4
        e'4
    }

NEW. Abjad 3.20 formats Abjad tuplet objects with LilyPond's `\tuplet` command:

    tuplet = abjad.Tuplet("3:2", "c'4 d' e'")
    string = abjad.lilypond(tuplet)
    print(string)
    \tuplet 3/2
    {
        c'4
        d'4
        e'4
    }

Closes #1586.