### PR TITLE
2024-12-update-1

### DIFF
--- a/abjad/illustrators.py
+++ b/abjad/illustrators.py
@@ -174,7 +174,7 @@ def _illustrate_pitch_class_segment(
         \override Flag.stencil = ##f
         \override Stem.stencil = ##f
         \override TimeSignature.stencil = ##f
-        proportionalNotationDuration = #(ly:make-moment 1 12)
+        proportionalNotationDuration = \musicLength 1*1/12
     }
 }
 
@@ -280,7 +280,7 @@ def components(
     \context
     {
         \Score
-        proportionalNotationDuration = #(ly:make-moment 1 24)
+        proportionalNotationDuration = \musicLength 1*1/24
     }
 }
 """

--- a/abjad/indicators.py
+++ b/abjad/indicators.py
@@ -278,35 +278,6 @@ class BarLine:
 
     context: typing.ClassVar[str] = "Score"
     # find_context_on_attach: typing.ClassVar[bool] = True
-    known_abbreviations: typing.ClassVar[tuple[str, ...]] = (
-        "",
-        "|",
-        ".",
-        "||",
-        ".|",
-        "..",
-        "|.|",
-        "|.",
-        ";",
-        "!",
-        ".|:",
-        ":..:",
-        ":|.|:",
-        ":|.:",
-        ":.|.:",
-        "[|:",
-        ":|][|:",
-        ":|]",
-        ":|.",
-        "'",
-    )
-
-    def __post_init__(self):
-        """
-        LilyPond fails to error on unknown bar-line abbreviation, so we check here.
-        """
-        if self.abbreviation not in self.known_abbreviations:
-            raise Exception(f"unknown bar-line abbreviation: {self.abbreviation!r}.")
 
     def _get_lilypond_format(self):
         return rf'\bar "{self.abbreviation}"'
@@ -2642,7 +2613,7 @@ class KeyCluster:
                 \once \override NoteHead.text =
                 \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
                 <c' e' g' b' d'' f''>8
-                ^ \markup \center-align \concat { \natural \flat }
+                ^ \markup \center-column { \natural \flat }
             }
 
     ..  container:: example
@@ -2668,7 +2639,7 @@ class KeyCluster:
                 \once \override NoteHead.text =
                 \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
                 <c' e' g' b' d'' f''>8
-                ^ \markup \center-align \concat { \natural \flat }
+                ^ \markup \center-column { \natural \flat }
             }
 
     ..  container:: example
@@ -2687,7 +2658,7 @@ class KeyCluster:
         \once \override NoteHead.text =
         \markup \filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25
         <c' e' g' b' d'' f''>8
-        ^ \markup \center-align \concat { \natural \flat }
+        ^ \markup \center-column { \natural \flat }
 
         The reason for this is that chords contain multiple note-heads: if key cluster
         formatted tweaks instead of overrides, the five format commands shown above would
@@ -2721,11 +2692,11 @@ class KeyCluster:
             "\\markup \\filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25"
         )
         if self.include_flat_markup and self.include_natural_markup:
-            string = r"\center-align \concat { \natural \flat }"
+            string = r"\center-column { \natural \flat }"
         elif self.include_flat_markup:
-            string = r"\center-align \flat"
+            string = r"\center-column \flat"
         else:
-            string = r"\center-align \natural"
+            string = r"\center-column \natural"
         string = rf"\markup {string}"
         if wrapper.direction is _enums.UP:
             string = rf"^ {string}"
@@ -4328,7 +4299,7 @@ class RepeatTie:
 
         >>> wrapper = abjad.get.indicator(voice[1], abjad.RepeatTie, unwrap=False)
         >>> wrapper.get_item()
-        Bundle(indicator=RepeatTie(), tweaks=(Tweak(string='- \\tweak color #blue', tag=None),))
+        Bundle(indicator=RepeatTie(), tweaks=(Tweak(string='- \\tweak color #blue', i=None, tag=None),))
 
         >>> for leaf in voice:
         ...     leaf, abjad.get.logical_tie(leaf)

--- a/abjad/scm/abjad-coloring.ily
+++ b/abjad/scm/abjad-coloring.ily
@@ -1,4 +1,6 @@
-%%% COLORED MUSIC %%%
+\version "2.25.16"
+
+% COLORED MUSIC
 
 abjad-color-music = #(
     define-music-function (color music) (symbol? ly:music?)

--- a/abjad/scm/abjad-hairpins.ily
+++ b/abjad/scm/abjad-hairpins.ily
@@ -1,3 +1,5 @@
+\version "2.25.16"
+
 %{
 
   LilyPond includes a \flared-hairpin command. The length of the flares created

--- a/abjad/scm/abjad-make-music-functions.ily
+++ b/abjad/scm/abjad-make-music-functions.ily
@@ -1,3 +1,5 @@
+\version "2.25.16"
+
 % Use these functions to make music inside markup functions.
 % Note that these are music functions and not markup functions.
 % But you can use these music functions within markup functions.

--- a/abjad/scm/abjad-metric-modulations.ily
+++ b/abjad/scm/abjad-metric-modulations.ily
@@ -1,3 +1,4 @@
+\version "2.25.16"
 \include "abjad-make-music-functions.ily"
 \include "abjad-metronome-marks.ily"
 

--- a/abjad/scm/abjad-metronome-marks.ily
+++ b/abjad/scm/abjad-metronome-marks.ily
@@ -1,4 +1,6 @@
-%%% METRONOME MARK FUNCTIONS %%%
+\version "2.25.16"
+
+% METRONOME MARK FUNCTIONS
 
 #(define-markup-command
     (abjad-metronome-mark-markup layout props

--- a/abjad/scm/abjad-spanners.ily
+++ b/abjad/scm/abjad-spanners.ily
@@ -1,4 +1,6 @@
-%%% GLISSANDO OVERRIDES %%%
+\version "2.25.16"
+
+% GLISSANDO OVERRIDES
 
 abjad-continuous-glissando = #(
     define-music-function (music) (ly:music?)

--- a/abjad/scm/abjad-text-spanner-line-styles.ily
+++ b/abjad/scm/abjad-text-spanner-line-styles.ily
@@ -1,4 +1,6 @@
-%%% GLISSANDO LINE STYLES %%%
+\version "2.25.16"
+
+% GLISSANDO LINE STYLES
 
 abjad-zero-padding-glissando = #(define-music-function (music) (ly:music?)
     #{
@@ -9,7 +11,7 @@ abjad-zero-padding-glissando = #(define-music-function (music) (ly:music?)
     #}
     )
 
-%%% TEXT SPANNER LINE STYLES %%%
+% TEXT SPANNER LINE STYLES
 
 abjad-dashed-line-with-arrow = #(define-music-function (music) (ly:music?)
     #{

--- a/abjad/scm/abjad.ily
+++ b/abjad/scm/abjad.ily
@@ -1,3 +1,4 @@
+\version "2.25.16"
 \include "abjad-coloring.ily"
 \include "abjad-hairpins.ily"
 \include "abjad-metric-modulations.ily"

--- a/abjad/scm/all-edo-markups-example.ily
+++ b/abjad/scm/all-edo-markups-example.ily
@@ -1,3 +1,4 @@
+\version "2.25.16"
 #(set-default-paper-size "letterportrait")
 #(set-global-staff-size 15)
 
@@ -21,7 +22,7 @@
     \override SpacingSpanner.uniform-stretching = ##t
 \context {
 	\Score
-	proportionalNotationDuration = #(ly:make-moment 1 30)
+	proportionalNotationDuration = \musicLength 1*1/30
 	barNumberVisibility = ##f
 }
 }

--- a/abjad/scm/default-et-accidental-markups.ily
+++ b/abjad/scm/default-et-accidental-markups.ily
@@ -1,17 +1,17 @@
-\version "2.19.84"
+\version "2.25.16"
 \include "fraction-accidental-markups.ily"
 \include "general-et-accidental-markups.ily"
 
-%%% one quarter tone down %%%
-one-quarter-flat-markup = \markup \musicglyph #"accidentals.mirroredflat"
+% one quarter tone down
+one-quarter-flat-markup = \markup \musicglyph "accidentals.mirroredflat"
 
-%%% three quarter tones down %%%
-three-quarters-flat-markup = \markup \musicglyph #"accidentals.mirroredflat.flat"
+% three quarter tones down
+three-quarters-flat-markup = \markup \musicglyph "accidentals.mirroredflat.flat"
 
-%%% three eighth tones down %%%
+% three eighth tones down
 three-eighths-flat-markup = \markup
     \combine
-    \musicglyph #"accidentals.mirroredflat"
+    \musicglyph "accidentals.mirroredflat"
     \path #0.15
       #'(
           (moveto 0.6 -0.65)
@@ -21,10 +21,10 @@ three-eighths-flat-markup = \markup
           (lineto 0.9 -0.7)
           )
 
-%%% seven eighth tones down %%%
+% seven eighth tones down
 seven-eighths-flat-markup = \markup
     \combine
-    \musicglyph #"accidentals.mirroredflat.flat"
+    \musicglyph "accidentals.mirroredflat.flat"
     \path #0.15
       #'(
           (moveto 0.79 -0.65)

--- a/abjad/scm/ekmelos-edo-accidental-markups.ily
+++ b/abjad/scm/ekmelos-edo-accidental-markups.ily
@@ -1,4 +1,4 @@
-\version "2.19.84"
+\version "2.25.16"
 \include "fraction-accidental-markups.ily"
 \include "general-edo-accidental-markups.ily"
 

--- a/abjad/scm/ekmelos-ji-accidental-markups.ily
+++ b/abjad/scm/ekmelos-ji-accidental-markups.ily
@@ -1,3 +1,4 @@
+\version "2.25.16"
 font-name = "ekmelos"
 \include "markup-functions.ily"
 
@@ -13,10 +14,10 @@ font-name = "ekmelos"
     #markup
     #}))
 
-% tempered accidentals %
+% tempered accidentals
 tempered-double-flat = \markup
     \combine
-    \musicglyph #"accidentals.flatflat"
+    \musicglyph "accidentals.flatflat"
     \path #0.15
       #'(
           (moveto 0.4 1.85)
@@ -38,7 +39,7 @@ tempered-three-quarters-flat = \markup
 
 tempered-flat = \markup
     \combine
-    \musicglyph #"accidentals.flat"
+    \musicglyph "accidentals.flat"
     \path #0.15
       #'(
           (moveto -0.25 1.85)
@@ -59,7 +60,7 @@ tempered-quarter-flat = \markup
 
 tempered-natural = \markup
     \combine
-    \musicglyph #"accidentals.natural"
+    \musicglyph "accidentals.natural"
     \path #0.15
       #'(
           (moveto -0.18 1.5)
@@ -69,7 +70,7 @@ tempered-natural = \markup
 
 tempered-quarter-sharp = \markup
     \combine
-    \musicglyph #"accidentals.sharp.slashslash.stem"
+    \musicglyph "accidentals.sharp.slashslash.stem"
     \path #0.15
       #'(
           (moveto 0.1 1.25)
@@ -79,7 +80,7 @@ tempered-quarter-sharp = \markup
 
 tempered-sharp = \markup
     \combine
-    \musicglyph #"accidentals.sharp"
+    \musicglyph "accidentals.sharp"
     \path #0.15
       #'(
           (moveto 0.55 1.5)
@@ -89,7 +90,7 @@ tempered-sharp = \markup
 
 tempered-three-quarters-sharp = \markup
     \combine
-    \musicglyph #"accidentals.sharp.slashslash.stemstemstem"
+    \musicglyph "accidentals.sharp.slashslash.stemstemstem"
     \path #0.15
       #'(
           (moveto 1 1.5)
@@ -99,7 +100,7 @@ tempered-three-quarters-sharp = \markup
 
 tempered-double-sharp = \markup
     \combine
-    \musicglyph #"accidentals.doublesharp"
+    \musicglyph "accidentals.doublesharp"
     \path #0.15
       #'(
           (moveto 0.5 0)

--- a/abjad/scm/fraction-accidental-markups.ily
+++ b/abjad/scm/fraction-accidental-markups.ily
@@ -1,4 +1,4 @@
-\version "2.19.84"
+\version "2.25.16"
 
 
 #(define-markup-command
@@ -19,7 +19,7 @@
 	\translate #'(0 . 2/3)
 	#den
 	\translate #'(0 . 25/16)
-	\musicglyph #"arrowheads.close.1M1"
+	\musicglyph "arrowheads.close.1M1"
 	}
     #}))
 
@@ -38,7 +38,7 @@
     \translate #'(-1 . 2)
 	\center-column {
 	\translate #'(0 . -1/12)
-	\musicglyph #"arrowheads.close.11"
+	\musicglyph "arrowheads.close.11"
     #num
 	\translate #'(0 . 2/3)
 	#den

--- a/abjad/scm/general-et-accidental-markups.ily
+++ b/abjad/scm/general-et-accidental-markups.ily
@@ -1,30 +1,30 @@
-\version "2.19.84"
+\version "2.25.16"
 
 
 abjad-natural-markup = \markup
-    \musicglyph #"accidentals.natural"
+    \musicglyph "accidentals.natural"
 
 abjad-sharp-markup = \markup
-    \musicglyph #"accidentals.sharp"
+    \musicglyph "accidentals.sharp"
 
 abjad-flat-markup = \markup
-    \musicglyph #"accidentals.flat"
+    \musicglyph "accidentals.flat"
 
 double-sharp-markup = \markup
-    \musicglyph #"accidentals.doublesharp"
+    \musicglyph "accidentals.doublesharp"
 
 double-flat-markup = \markup
-    \musicglyph #"accidentals.flatflat"
+    \musicglyph "accidentals.flatflat"
 
 one-quarter-sharp-markup = \markup
-    \musicglyph #"accidentals.sharp.slashslash.stem"
+    \musicglyph "accidentals.sharp.slashslash.stem"
 
 three-quarters-sharp-markup = \markup
-    \musicglyph #"accidentals.sharp.slashslash.stemstemstem"
+    \musicglyph "accidentals.sharp.slashslash.stemstemstem"
 
 one-eighth-sharp-markup = \markup
     \combine
-    \musicglyph #"accidentals.natural"
+    \musicglyph "accidentals.natural"
     \path #0.15
       #'(
           (moveto -0.22 0.9)
@@ -34,7 +34,7 @@ one-eighth-sharp-markup = \markup
 
 three-eighths-sharp-markup = \markup
     \combine
-    \musicglyph #"accidentals.sharp.slashslash.stem"
+    \musicglyph "accidentals.sharp.slashslash.stem"
     \path #0.15
       #'(
           (moveto 0.35 1.15)
@@ -46,7 +46,7 @@ three-eighths-sharp-markup = \markup
 
 five-eighths-sharp-markup = \markup
     \combine
-    \musicglyph #"accidentals.sharp"
+    \musicglyph "accidentals.sharp"
     \path #0.15
       #'(
           (moveto 0.8 1.15)
@@ -58,7 +58,7 @@ five-eighths-sharp-markup = \markup
 
 seven-eighths-sharp-markup = \markup
     \combine
-    \musicglyph #"accidentals.sharp.slashslash.stemstemstem"
+    \musicglyph "accidentals.sharp.slashslash.stemstemstem"
     \path #0.15
       #'(
           (moveto 1.25 1.15)
@@ -70,7 +70,7 @@ seven-eighths-sharp-markup = \markup
 
 one-eighth-flat-markup = \markup
     \combine
-    \musicglyph #"accidentals.natural"
+    \musicglyph "accidentals.natural"
     \path #0.15
       #'(
           (moveto 0.6 -0.95)
@@ -82,7 +82,7 @@ one-eighth-flat-markup = \markup
 
 five-eighths-flat-markup = \markup
     \combine
-    \musicglyph #"accidentals.flat"
+    \musicglyph "accidentals.flat"
     \path #0.15
       #'(
           (moveto 0.03 -0.65)

--- a/abjad/scm/harmonic-series-layout.ily
+++ b/abjad/scm/harmonic-series-layout.ily
@@ -1,19 +1,23 @@
-\layout {
-	indent = #1
-	ragged-last = ##t
-    ragged-right = ##t
-	\accidentalStyle "dodecaphonic"
-	\override Beam.transparent = ##t
-	\override Stem.transparent = ##t
-	\override Staff.BarLine.stencil = ##f
-	\override Flag.transparent = ##t
-	\override Staff.TimeSignature.stencil = ##f
-	\override SpacingSpanner.strict-grace-spacing = ##t
-	\override SpacingSpanner.uniform-stretching = ##t
-	\override SpacingSpanner.strict-note-spacing = ##t
-    \override SpacingSpanner.uniform-stretching = ##t
-\context {
-	\Score
-	proportionalNotationDuration = #(ly:make-moment 1 30)
-}
+\version "2.25.16"
+
+\layout
+{
+  indent = #1
+  ragged-last = ##t
+  ragged-right = ##t
+  \accidentalStyle dodecaphonic
+  \override Beam.transparent = ##t
+  \override Stem.transparent = ##t
+  \override Staff.BarLine.stencil = ##f
+  \override Flag.transparent = ##t
+  \override Staff.TimeSignature.stencil = ##f
+  \override SpacingSpanner.strict-grace-spacing = ##t
+  \override SpacingSpanner.uniform-stretching = ##t
+  \override SpacingSpanner.strict-note-spacing = ##t
+  \override SpacingSpanner.uniform-stretching = ##t
+  \context
+  {
+      \Score
+      proportionalNotationDuration = \musicLength 1*1/30
+  }
 }

--- a/abjad/scm/heji2-ji-accidental-markups.ily
+++ b/abjad/scm/heji2-ji-accidental-markups.ily
@@ -1,7 +1,9 @@
+\version "2.25.16"
 font-name = "HEJI2"
 \include "markup-functions.ily"
 
-% tempered accidentals %
+% tempered accidentals
+
 tempered-double-flat = \markup \letter-heji-accidental-markup #"A"
 tempered-three-quarters-flat = \markup \letter-heji-accidental-markup #"ia"
 tempered-flat = \markup \letter-heji-accidental-markup #"a"

--- a/abjad/scm/markup-functions.ily
+++ b/abjad/scm/markup-functions.ily
@@ -1,3 +1,5 @@
+\version "2.25.16"
+
 #(define-markup-command
     (heji-accidental-markup layout props point-code)
     (number?)
@@ -47,7 +49,7 @@
     #}))
 
 
-% diatonic accidentals %
+% diatonic accidentals
 abjad-natural = \markup \heji-accidental-markup ##x266e
 abjad-sharp = \markup \heji-accidental-markup ##xe262
 abjad-flat = \markup \heji-accidental-markup##xe260
@@ -55,35 +57,35 @@ double-sharp = \markup \heji-accidental-markup ##xe263
 double-flat = \markup \heji-accidental-markup ##xe264
 
 
-% natural syntonic commas %
+% natural syntonic commas
 natural-one-syntonic-comma-down = \markup \heji-accidental-markup ##xe2c2
 natural-two-syntonic-comma-down = \markup \heji-accidental-markup ##xe2cc
 natural-three-syntonic-comma-down = \markup \heji-accidental-markup ##xe2d6
 natural-one-syntonic-comma-up = \markup \heji-accidental-markup ##xe2c7
 natural-two-syntonic-comma-up = \markup \heji-accidental-markup ##xe2d1
 natural-three-syntonic-comma-up = \markup \heji-accidental-markup ##xe2db
-% sharp syntonic commas %
+% sharp syntonic commas
 sharp-one-syntonic-comma-down = \markup \heji-accidental-markup ##xe2c3
 sharp-two-syntonic-comma-down = \markup \heji-accidental-markup ##xe2cd
 sharp-three-syntonic-comma-down = \markup \heji-accidental-markup ##xe2d7
 sharp-one-syntonic-comma-up = \markup \heji-accidental-markup ##xe2c8
 sharp-two-syntonic-comma-up = \markup \heji-accidental-markup ##xe2d2
 sharp-three-syntonic-comma-up = \markup \heji-accidental-markup ##xe2dc
-% flat syntonic commas %
+% flat syntonic commas
 flat-one-syntonic-comma-down = \markup \heji-accidental-markup ##xe2c1
 flat-two-syntonic-comma-down = \markup \heji-accidental-markup ##xe2cb
 flat-three-syntonic-comma-down = \markup \heji-accidental-markup ##xe2d5
 flat-one-syntonic-comma-up = \markup \heji-accidental-markup ##xe2c6
 flat-two-syntonic-comma-up = \markup \heji-accidental-markup ##xe2d0
 flat-three-syntonic-comma-up = \markup \heji-accidental-markup ##xe2da
-% double sharp syntonic commas %
+% double sharp syntonic commas
 double-sharp-one-syntonic-comma-down = \markup \heji-accidental-markup ##xe2c4
 double-sharp-two-syntonic-comma-down = \markup \heji-accidental-markup ##xe2ce
 double-sharp-three-syntonic-comma-down = \markup \heji-accidental-markup ##xe2d8
 double-sharp-one-syntonic-comma-up = \markup \heji-accidental-markup ##xe2c9
 double-sharp-two-syntonic-comma-up = \markup \heji-accidental-markup ##xe2d3
 double-sharp-three-syntonic-comma-up = \markup \heji-accidental-markup ##xe2dd
-% double flat syntonic commas %
+% double flat syntonic commas
 double-flat-one-syntonic-comma-down = \markup \heji-accidental-markup ##xe2c0
 double-flat-two-syntonic-comma-down = \markup \heji-accidental-markup ##xe2ca
 double-flat-three-syntonic-comma-down = \markup \heji-accidental-markup ##xe2d4
@@ -101,7 +103,7 @@ two-septimal-comma-up = \markup \heji-accidental-markup ##xe2e1
 three-septimal-comma-up = \markup \heji-double-accidental-markup ##xe2df ##xe2e1 #0.125
 
 
-% undecimal quarter tones %
+% undecimal quarter tones
 one-undecimal-quarter-tone-down = \markup \heji-accidental-markup ##xe2e2
 two-undecimal-quarter-tone-down = \markup \heji-double-accidental-markup ##xe2e2 ##xe2e2 #0.035
 three-undecimal-quarter-tone-down = \markup \heji-triple-accidental-markup ##xe2e2 #0.035
@@ -111,7 +113,7 @@ two-undecimal-quarter-tone-up = \markup \heji-double-accidental-markup ##xe2e3 #
 three-undecimal-quarter-tone-up = \markup \heji-triple-accidental-markup ##xe2e3 #0.125
 
 
-% tridecimal third tones %
+% tridecimal third tones
 one-tridecimal-third-tone-down = \markup \heji-accidental-markup ##xe2e4
 two-tridecimal-third-tone-down = \markup \heji-double-accidental-markup ##xe2e4 ##xe2e4 #0.035
 three-tridecimal-third-tone-down = \markup \heji-triple-accidental-markup ##xe2e4 #0.035
@@ -120,7 +122,7 @@ two-tridecimal-third-tone-up = \markup \heji-double-accidental-markup ##xe2e5 ##
 three-tridecimal-third-tone-up = \markup \heji-triple-accidental-markup ##xe2e5 #0.125
 
 
-% seventeen-limit schismas %
+% seventeen-limit schismas
 one-seventeen-limit-schisma-down = \markup \heji-accidental-markup ##xe2e6
 two-seventeen-limit-schisma-down = \markup \heji-double-accidental-markup ##xe2e6 ##xe2e6 #0.125
 three-seventeen-limit-schisma-down = \markup \heji-triple-accidental-markup ##xe2e6 #0.125
@@ -129,7 +131,7 @@ two-seventeen-limit-schisma-up = \markup \heji-double-accidental-markup ##xe2e7 
 three-seventeen-limit-schisma-up = \markup \heji-triple-accidental-markup ##xe2e7 #0.125
 
 
-% nineteen-limit schismas %
+% nineteen-limit schismas
 one-nineteen-limit-schisma-down = \markup \heji-accidental-markup ##xe2e8
 two-nineteen-limit-schisma-down = \markup \heji-double-accidental-markup ##xe2e8 ##xe2e8 #0.125
 three-nineteen-limit-schisma-down = \markup \heji-triple-accidental-markup ##xe2e8 #0.125
@@ -138,7 +140,7 @@ two-nineteen-limit-schisma-up = \markup \heji-double-accidental-markup ##xe2e9 #
 three-nineteen-limit-schisma-up = \markup \heji-triple-accidental-markup ##xe2e9 #0.125
 
 
-% twenty-three-limit commas %
+% twenty-three-limit commas
 one-twenty-three-limit-comma-down = \markup \heji-accidental-markup ##xe2eb
 two-twenty-three-limit-comma-down = \markup \heji-double-accidental-markup ##xe2eb ##xe2eb #0.125
 three-twenty-three-limit-comma-down = \markup \heji-triple-accidental-markup ##xe2eb #0.125

--- a/abjad/scm/nalesnik-slash.ily
+++ b/abjad/scm/nalesnik-slash.ily
@@ -1,3 +1,5 @@
+\version "2.25.16"
+
 % FROM DAVID NALESNIK:
 %
 % http://lilypond.1069038.n5.nabble.com/So-slashed-beamed-grace-notes-td152817.html
@@ -7,7 +9,7 @@
 %    \slash
 
 slash = { 
-  #(remove-grace-property 'Voice 'Stem 'direction) 
+  $(remove-grace-property 'Voice 'Stem 'direction) 
   \once \override Stem.stencil = 
   #(lambda (grob) 
     (let* ((x-parent (ly:grob-parent grob X)) 

--- a/abjad/scm/nalesnik-text-spanner-id.ily
+++ b/abjad/scm/nalesnik-text-spanner-id.ily
@@ -1,3 +1,5 @@
+\version "2.25.16"
+
 % FROM DAVID NALESNIK:
 %
 % https://lists.gnu.org/archive/html/lilypond-user/2015-10/msg00545.html
@@ -13,8 +15,6 @@
 %    \stopTextSpanOne
 %    \stopTextSpanTwo
 %    \stopTextSpanThre
-
-\version "2.23.6"
 
 %% Incorporating some code from the rewrite in scheme of
 %% Text_spanner_engraver in input/regression/scheme-text-spanner.ly

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -3475,7 +3475,7 @@ class NoteHead:
         >>> note_head = abjad.NoteHead("cs''")
         >>> abjad.tweak(note_head, r"\tweak color #red")
         >>> note_head.tweaks
-        (Tweak(string='\\tweak color #red', tag=None),)
+        (Tweak(string='\\tweak color #red', i=None, tag=None),)
 
         >>> string = abjad.lilypond(note_head)
         >>> print(string)
@@ -4715,7 +4715,7 @@ class Skip(Leaf):
 
     __documentation_section__ = "Leaves"
 
-    __slots__ = ()
+    __slots__ = ("_hide_body", "_measure_initial_grace_note")
 
     def __init__(
         self,
@@ -4748,7 +4748,13 @@ class Skip(Leaf):
 
     def _get_body(self):
         result = []
-        result.append(f"s{self._get_formatted_duration()}")
+        if getattr(self, "_hide_body", False) is not True:
+            if getattr(self, "_measure_initial_grace_note", None) is not None:
+                grace_strings = self._measure_initial_grace_note
+                assert isinstance(grace_strings, list), repr(grace_strings)
+                assert "grace" in repr(grace_strings), repr(grace_strings)
+                result.extend(grace_strings)
+            result.append(f"s{self._get_formatted_duration()}")
         return result
 
     def _get_compact_representation(self):

--- a/abjad/select.py
+++ b/abjad/select.py
@@ -2221,7 +2221,7 @@ def group_by_measure(argument) -> list[list]:
         >>> staff = abjad.Staff("c'4 d' e' f' g' a' b' c''")
         >>> abjad.setting(staff).autoBeaming = False
         >>> score = abjad.Score([staff])
-        >>> string = "#(ly:make-moment 1 16)"
+        >>> string = r"\musicLength 16"
         >>> abjad.setting(score).proportionalNotationDuration = string
 
         >>> result = abjad.select.leaves(score)

--- a/abjad/spanners.py
+++ b/abjad/spanners.py
@@ -27,13 +27,14 @@ def _apply_tweaks(argument, tweaks, i=None, total=None):
         assert isinstance(total, int), repr(total)
     tweak_objects = []
     for item in tweaks:
-        if isinstance(item, tuple):
-            assert len(item) == 2
-            item, index = item
+        if isinstance(item, _tweaks.Tweak) and item.i is not None:
+            item, index = item, item.i
             if 0 <= index and index != i:
                 continue
             if index < 0 and index != -(total - i):
                 continue
+        elif isinstance(item, tuple):
+            raise Exception(f"use abjad.Tweak.i instead of tuple: {item}")
         assert isinstance(item, _tweaks.Tweak), repr(item)
         tweak_objects.append(item)
     bundle = _tweaks.bundle(argument, *tweak_objects)
@@ -982,8 +983,8 @@ def glissando(
         >>> voice = abjad.Voice("d'4 d' d' d'", name="Voice")
         >>> abjad.glissando(
         ...     voice[:],
-        ...     (abjad.Tweak(r"- \tweak color #red"), 0),
-        ...     (abjad.Tweak(r"- \tweak color #red"), -1),
+        ...     abjad.Tweak(r"- \tweak color #red", i=0),
+        ...     abjad.Tweak(r"- \tweak color #red", i=-1),
         ...     allow_repeats=True,
         ...     zero_padding=True,
         ... )

--- a/abjad/tweaks.py
+++ b/abjad/tweaks.py
@@ -11,10 +11,13 @@ class Tweak:
     """
 
     string: str
+    i: int | None = None
     tag: _tag.Tag | None = None
 
     def __post_init__(self):
         assert isinstance(self.string, str), repr(self.string)
+        if self.i is not None:
+            assert isinstance(self.i, int), repr(self.i)
         if self.tag is not None:
             assert isinstance(self.tag, _tag.Tag), repr(self.tag)
         self._parse()
@@ -125,7 +128,7 @@ class Bundle:
             ...     r"- \tweak font-size 3",
             ... )
             >>> bundle.get_attribute("color")
-            Tweak(string='- \\tweak color #red', tag=None)
+            Tweak(string='- \\tweak color #red', i=None, tag=None)
 
             >>> bundle.get_attribute("style") is None
             True
@@ -154,7 +157,7 @@ class Bundle:
 
             >>> bundle_3 = abjad.bundle(bundle_2, r"- \tweak color #blue")
             >>> bundle_3.tweaks
-            (Tweak(string='- \\tweak color #blue', tag=None),)
+            (Tweak(string='- \\tweak color #blue', i=None, tag=None),)
 
         """
         assert tweak in self.tweaks, repr(tweak)
@@ -236,8 +239,8 @@ def bundle(
         Traceback (most recent call last):
             ...
         Exception: duplicate 'color' attribute:
-        Tweak(string='- \\tweak color #blue', tag=None)
-        Tweak(string='- \\tweak color #red', tag=None)
+        Tweak(string='- \\tweak color #blue', i=None, tag=None)
+        Tweak(string='- \\tweak color #red', i=None, tag=None)
 
         Unless ``overwrite=True``:
 
@@ -248,7 +251,7 @@ def bundle(
         ...     overwrite=True,
         ... )
         >>> for _ in bundle.tweaks: _
-        Tweak(string='- \\tweak color #red', tag=None)
+        Tweak(string='- \\tweak color #red', i=None, tag=None)
 
     ..  container:: example
 
@@ -265,8 +268,8 @@ def bundle(
         Traceback (most recent call last):
             ...
         Exception: duplicate 'color' attribute:
-        OLD: Tweak(string='- \\tweak color #blue', tag=None)
-        NEW: Tweak(string='- \\tweak color #red', tag=None)
+        OLD: Tweak(string='- \\tweak color #blue', i=None, tag=None)
+        NEW: Tweak(string='- \\tweak color #red', i=None, tag=None)
 
         Unless ``overwrite=True``:
 
@@ -280,7 +283,7 @@ def bundle(
         ...     overwrite=True,
         ... )
         >>> for _ in bundle.tweaks: _
-        Tweak(string='- \\tweak color #red', tag=None)
+        Tweak(string='- \\tweak color #red', i=None, tag=None)
 
     """
     input_tweaks: list[Tweak] = []

--- a/docs/source/_mothballed/accumulation.rst
+++ b/docs/source/_mothballed/accumulation.rst
@@ -121,7 +121,7 @@ The functions we'll use:
     ...         \override TupletBracket.springs-and-rods = #ly:spanner::set-spacing-rods
     ...         \override TupletNumber.text = #tuplet-number::calc-fraction-text
     ...         autoBeaming = ##f
-    ...         proportionalNotationDuration = #(ly:make-moment 1 8)
+    ...         proportionalNotationDuration = \musicLength 8
     ...         tupletFullLength = ##t
     ...     }
     ...     \context {

--- a/docs/source/_mothballed/pitch-conventions.rst
+++ b/docs/source/_mothballed/pitch-conventions.rst
@@ -45,7 +45,7 @@ Abjad numbers pitches like this:
     ...         \override Stem.stencil = ##f
     ...         \override TextScript.staff-padding = #6
     ...         \override TimeSignature.stencil = ##f
-    ...         proportionalNotationDuration = #(ly:make-moment 1 56)
+    ...         proportionalNotationDuration = \musicLength 1*1/56
     ...     }
     ... }"""
 

--- a/docs/source/_pending/hexachordal-recombination-all-interval.rst
+++ b/docs/source/_pending/hexachordal-recombination-all-interval.rst
@@ -75,7 +75,7 @@ this. Then we write some LilyPond code to beautify the example:
     ... \layout {
     ...     \context {
     ...         \Score
-    ...         proportionalNotationDuration = #(ly:make-moment 1 16)
+    ...         proportionalNotationDuration = \musicLength 16
     ...         \override SpacingSpanner.uniform-stretching = ##t
     ...     }
     ... }"""

--- a/docs/source/_pending/rotation-by-row-index.rst
+++ b/docs/source/_pending/rotation-by-row-index.rst
@@ -84,7 +84,7 @@ Rotation, by row index
     ...             (basic-distance . 10) (minimum-distance . 10) (padding . 2))
     ...         \override Stem.stencil = ##f
     ...         \override TimeSignature.stencil = ##f
-    ...         proportionalNotationDuration = #(ly:make-moment 1 25)
+    ...         proportionalNotationDuration = \musicLength 1*1/25
     ...     }
     ... }"""
 

--- a/docs/source/_pending/row-derivation-by-trichord.rst
+++ b/docs/source/_pending/row-derivation-by-trichord.rst
@@ -24,7 +24,7 @@ First we define functions to illustrate the examples that follow:
     ...     abjad.override(treble_staff).SpanBar.stencil = False
     ...     abjad.override(treble_staff).Stem.stencil = False
     ...     abjad.override(treble_staff).TimeSignature.stencil = False
-    ...     string = "#(ly:make-moment 1 25)"
+    ...     string = r"\musicLength 1*1/25"
     ...     abjad.setting(treble_staff).proportionalNotationDuration = string
     ...     string = "#(set-global-staff-size 16)"
     ...     lilypond_file = abjad.LilyPondFile([string, treble_staff])

--- a/docs/source/_pending/scale-derivation-by-sieve.rst
+++ b/docs/source/_pending/scale-derivation-by-sieve.rst
@@ -26,7 +26,7 @@ First we define a function to illustrate the examples that follow:
     ...     abjad.override(score).SpanBar.stencil = False
     ...     abjad.override(score).Stem.stencil = False
     ...     abjad.override(score).TimeSignature.stencil = False
-    ...     abjad.setting(score).proportionalNotationDuration = "#(ly:make-moment 1 25)"
+    ...     abjad.setting(score).proportionalNotationDuration = r"\musicLength 1*1/25"
     ...     lilypond_file = abjad.LilyPondFile(
     ...         items=[
     ...             "#(set-global-staff-size 16)",

--- a/docs/source/_pending/superimposition-of-partials.rst
+++ b/docs/source/_pending/superimposition-of-partials.rst
@@ -64,7 +64,7 @@ First we define functions to illustrate the examples that follow:
     ...     abjad.override(score).SpanBar.stencil = False
     ...     abjad.override(score).Stem.stencil = False
     ...     abjad.override(score).TimeSignature.stencil = False
-    ...     abjad.setting(score).proportionalNotationDuration = "#(ly:make-moment 1 25)"
+    ...     abjad.setting(score).proportionalNotationDuration = r"\musicLength 1*1/25"
     ...     string = "#(set-global-staff-size 16)"
     ...     lilypond_file = abjad.LilyPondFile([string, score])
     ...     return lilypond_file

--- a/docs/source/_pending/tone-clock-tesselation.rst
+++ b/docs/source/_pending/tone-clock-tesselation.rst
@@ -23,7 +23,7 @@ Tone-clock tesselation in Jenny McLeod's `Tone Clock Piece I`.
     ...     abjad.override(score).BarLine.stencil = False
     ...     abjad.override(score).BarNumber.stencil = False
     ...     abjad.override(score).SpanBar.stencil = False
-    ...     abjad.setting(score).proportionalNotationDuration = "#(ly:make-moment 1 5)"
+    ...     abjad.setting(score).proportionalNotationDuration = r"\musicLength 1*1/25"
     ...     string = "#(set-global-staff-size 16)"
     ...     lilypond_file = abjad.LilyPondFile([string, score])
     ...     return lilypond_file

--- a/docs/source/_pending/trichord-definition-by-ratio.rst
+++ b/docs/source/_pending/trichord-definition-by-ratio.rst
@@ -138,7 +138,7 @@ Define helper functions:
     ...     abjad.override(score).Rest.stencil = False
     ...     abjad.override(score).SpacingSpanner.strict_note_spacing = True
     ...     abjad.override(score).TimeSignature.stencil = False
-    ...     abjad.setting(score).proportionalNotationDuration = "#(ly:make-moment 1 5)"
+    ...     abjad.setting(score).proportionalNotationDuration = r"\musicLength 1*1/5"
     ...     items = [score, abjad.Block(name="layout"), abjad.Block(name="paper")]
     ...     string = "#(set-global-staff-size 16)"
     ...     items.insert(0, string)

--- a/docs/source/appendices/best-practices.rst
+++ b/docs/source/appendices/best-practices.rst
@@ -85,7 +85,7 @@ than defining them with Abjad.
 
     Not so good: ::
 
-        abjad.setting(score).proportional_notation_duration = "#(ly:make-moment 1 32)"
+        abjad.setting(score).proportional_notation_duration = r"\musicLength 32"
         abjad.setting(score).spacing_spanner.strict_grace_spacing = True
         abjad.setting(score).spacing_spanner.strict_note_spacing = True
         abjad.setting(score).spacing_spanner.uniform_stretching = True
@@ -94,7 +94,7 @@ than defining them with Abjad.
 
         \context {
             \Score
-            proportionalNotationDuration = #(ly:make-moment 1 32)
+            proportionalNotationDuration = \musicLength 32
             \override SpacingSpanner.strict-grace-spacing = ##t
             \override SpacingSpanner.strict-note-spacing = ##t
             \override SpacingSpanner.uniform-stretching = ##t

--- a/docs/source/examples/design-by-dyads.rst
+++ b/docs/source/examples/design-by-dyads.rst
@@ -58,7 +58,7 @@ LilyPond settings to format examples:
     ...         \override SpanBar.stencil = ##f
     ...         \override Stem.stencil = ##f
     ...         \override TimeSignature.transparent = ##t
-    ...         proportionalNotationDuration = #(ly:make-moment 1 16)
+    ...         proportionalNotationDuration = \musicLength 16
     ...     }
     ... }
     ... """

--- a/docs/source/examples/enumeration.rst
+++ b/docs/source/examples/enumeration.rst
@@ -90,7 +90,7 @@ The following functions recreate Malt's results in Abjad:
     ...         \override TextScript.staff-padding = #6
     ...         \override TimeSignature.stencil = ##f
     ...         \override TupletNumber.text = #tuplet-number::calc-fraction-text
-    ...         proportionalNotationDuration = #(ly:make-moment 1 40)
+    ...         proportionalNotationDuration = \musicLength 1*1/40
     ...         tupletFullLength = ##t
     ...     }
     ... }

--- a/docs/source/examples/magic-square-from-twelve-tone-row.rst
+++ b/docs/source/examples/magic-square-from-twelve-tone-row.rst
@@ -67,7 +67,7 @@ example:
     ...         \override TextScript.color = #blue
     ...         \override TextScript.staff-padding = 5
     ...         \override TimeSignature.transparent = ##t
-    ...         proportionalNotationDuration = #(ly:make-moment 1 16)
+    ...         proportionalNotationDuration = \musicLength 16
     ...     }
     ... }
     ... """

--- a/ly/contexts.ly
+++ b/ly/contexts.ly
@@ -1,4 +1,4 @@
-\version "2.19.24"
+\version "2.25.19"
 
 #
 (load "helpers.scm")

--- a/ly/current_module.ly
+++ b/ly/current_module.ly
@@ -1,4 +1,4 @@
-\version "2.19.24"
+\version "2.25.19"
 
 #(define current-module-sorted
   (sort

--- a/ly/engravers.ly
+++ b/ly/engravers.ly
@@ -1,4 +1,4 @@
-\version "2.19.24"
+\version "2.25.19"
 
 #
 (load-from-path "lily-sort")

--- a/ly/grob_interfaces.ly
+++ b/ly/grob_interfaces.ly
@@ -1,4 +1,4 @@
-\version "2.19.24"
+\version "2.25.19"
 
 #(load "helpers.scm")
 

--- a/ly/guile_interpreter.ly
+++ b/ly/guile_interpreter.ly
@@ -1,4 +1,4 @@
-\version "2.19.24"
+\version "2.25.19"
 
 #(module-define! (resolve-module '(guile-user))
                  'lilypond-module (current-module))

--- a/ly/interface_properties.ly
+++ b/ly/interface_properties.ly
@@ -1,4 +1,4 @@
-\version "2.19.24"
+\version "2.25.19"
 
 #(load "helpers.scm")
 

--- a/ly/language_pitch_names.ly
+++ b/ly/language_pitch_names.ly
@@ -1,4 +1,4 @@
-\version "2.19.24"
+\version "2.25.19"
 
 %%% DEFINITIONS %%%
 

--- a/ly/markup_functions.ly
+++ b/ly/markup_functions.ly
@@ -1,4 +1,4 @@
-\version "2.19.24"
+\version "2.25.19"
 
 
 #(define (markup-function? func)

--- a/ly/music_glyphs.ly
+++ b/ly/music_glyphs.ly
@@ -1,4 +1,4 @@
-\version "2.19.24"
+\version "2.25.19"
 
 #(load "helpers.scm")
 

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -319,16 +319,6 @@ def test_allowable_sites():
     assert "allows only" in str(e)
 
 
-def test_BarLine_01():
-    """
-    Errors on unknown abbreviation.
-    """
-
-    with pytest.raises(Exception) as e:
-        abjad.BarLine("foo")
-    assert "unknown bar-line abbreviation" in str(e)
-
-
 def test_StartTrillSpan_01():
     """
     Set force_trill_pitch_head_accidental=True to force trill pitch head accidental.

--- a/tests/test_setting.py
+++ b/tests/test_setting.py
@@ -10,14 +10,14 @@ def test_setting_01():
 
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     score = abjad.Score([staff])
-    abjad.setting(score).tempoWholesPerMinute = "#(ly:make-moment 24 1)"
+    abjad.setting(score).tempoWholesPerMinute = r"\musicLength 1*24"
 
     assert abjad.lilypond(score) == abjad.string.normalize(
         r"""
         \new Score
         \with
         {
-            tempoWholesPerMinute = #(ly:make-moment 24 1)
+            tempoWholesPerMinute = \musicLength 1*24
         }
         <<
             \new Staff
@@ -42,7 +42,7 @@ def test_setting_02():
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     score = abjad.Score([staff])
     leaves = abjad.select.leaves(score)
-    abjad.setting(leaves[1]).Score.tempoWholesPerMinute = "#(ly:make-moment 24 1)"
+    abjad.setting(leaves[1]).Score.tempoWholesPerMinute = r"\musicLength 1*24"
 
     assert abjad.lilypond(score) == abjad.string.normalize(
         r"""
@@ -51,7 +51,7 @@ def test_setting_02():
             \new Staff
             {
                 c'8
-                \set Score.tempoWholesPerMinute = #(ly:make-moment 24 1)
+                \set Score.tempoWholesPerMinute = \musicLength 1*24
                 d'8
                 e'8
                 f'8


### PR DESCRIPTION
2024-12 update 1.

Change #(ly:make-moment n d) to \musicLength 1*n/d.

Clean up abjad.KeyCluster markup.

Remove abjad.BarLine.known_abbreviations.

Run convert-ly through 2.25.19.