### PR TITLE
Remove sphinx_autodoc_typehints

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
     "uqbar.sphinx.api",
     "uqbar.sphinx.book",
     "uqbar.sphinx.inheritance",

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ extras_require = {
         "pytest>=8.1.1",
         "pytest-cov>=4.1.0",
         "pytest-helpers-namespace>=2021.12.29",
-        "sphinx-autodoc-typehints>=1.22.0",
         "sphinx-rtd-theme>=1.0.0",
     ],
 }


### PR DESCRIPTION
`sphinx_autodoc_typehints` has had some long-running bugs related to the reST `container` directive.

The current bug is ...

    https://github.com/tox-dev/sphinx-autodoc-typehints/issues/513

... which mangles the formatting of docstrings that have a return-type annotation and a `container` directive.

This commit removes sphinx_autodoc_typethints. This prevents several dozen errors and warnings when Sphinx builds.

The extension doesn't look like it was providing much value to the docs anyway. Sphinx adds type annotations without `sphinx_autodoc_typehints`.