### PR TITLE
Clean up docstrings

### DIFF
--- a/abjad/contextmanagers.py
+++ b/abjad/contextmanagers.py
@@ -183,10 +183,10 @@ class ForbidUpdate(ContextManager):
         r"""
         Enters context manager.
 
-        REGRESSION. Indicators need to be updated after swap; context manager
-        updates indicators before forbidding further updates:
-
         ..  container:: example
+
+            REGRESSION. Indicators need to be updated after swap; context
+            manager updates indicators before forbidding further updates:
 
             >>> staff = abjad.Staff(r"\times 1/1 { c'4 d' }")
             >>> abjad.attach(abjad.Clef("alto"), staff[0][0])

--- a/abjad/cyclictuple.py
+++ b/abjad/cyclictuple.py
@@ -68,18 +68,18 @@ class CyclicTuple:
         """
         Gets item or slice identified by ``argument``.
 
-        Gets slice open at right:
-
         ..  container:: example
+
+            Gets slice open at right:
 
             >>> items = [0, 1, 2, 3, 4, 5]
             >>> tuple_ = abjad.CyclicTuple(items=items)
             >>> tuple_[2:]
             (2, 3, 4, 5)
 
-        Gets slice closed at right:
-
         ..  container:: example
+
+            Gets slice closed at right:
 
             >>> items = [0, 1, 2, 3, 4, 5]
             >>> tuple_ = abjad.CyclicTuple(items=items)

--- a/abjad/duration.py
+++ b/abjad/duration.py
@@ -283,9 +283,9 @@ class Duration(fractions.Fraction):
 
         See https://bugs.python.org/issue4395#msg89533.
 
-        REGRESSION:
-
         ..  container:: example
+
+            REGRESSION:
 
             >>> offset_1 = abjad.Offset(1)
             >>> offset_2 = abjad.Offset(1, displacement=(-1, 16))
@@ -1066,9 +1066,9 @@ class Duration(fractions.Fraction):
         r"""
         Changes duration to clock string.
 
-        Changes duration to clock string:
-
         ..  container:: example
+
+            Changes duration to clock string:
 
             >>> note = abjad.Note("c'4")
             >>> duration = abjad.Duration(117)
@@ -1292,9 +1292,9 @@ class Offset(Duration):
         """
         Is true when offset equals ``argument``.
 
-        With equal numerators, denominators and displacement:
-
         ..  container:: example
+
+            With equal numerators, denominators and displacement:
 
             >>> offset_1 = abjad.Offset((1, 4), displacement=(-1, 16))
             >>> offset_2 = abjad.Offset((1, 4), displacement=(-1, 16))
@@ -1351,9 +1351,9 @@ class Offset(Duration):
         """
         Is true when offset is greater than or equal to ``argument``.
 
-        With equal numerators, denominators and displacement:
-
         ..  container:: example
+
+            With equal numerators, denominators and displacement:
 
             >>> offset_1 = abjad.Offset((1, 4), displacement=(-1, 16))
             >>> offset_2 = abjad.Offset((1, 4), displacement=(-1, 16))
@@ -1410,9 +1410,9 @@ class Offset(Duration):
         """
         Is true when offset is greater than ``argument``.
 
-        With equal numerators, denominators and displacement:
-
         ..  container:: example
+
+            With equal numerators, denominators and displacement:
 
             >>> offset_1 = abjad.Offset((1, 4), displacement=(-1, 16))
             >>> offset_2 = abjad.Offset((1, 4), displacement=(-1, 16))
@@ -1475,9 +1475,9 @@ class Offset(Duration):
         """
         Is true when offset is less than or equal to ``argument``.
 
-        With equal numerators, denominators and displacement:
-
         ..  container:: example
+
+            With equal numerators, denominators and displacement:
 
             >>> offset_1 = abjad.Offset((1, 4), displacement=(-1, 16))
             >>> offset_2 = abjad.Offset((1, 4), displacement=(-1, 16))

--- a/abjad/get.py
+++ b/abjad/get.py
@@ -1757,9 +1757,9 @@ def grace(argument) -> bool:
     Grace music defined equal to grace container, after-grace container and
     contents of those containers.
 
-    REGRESSION. Works with grace notes (and containers):
-
     ..  container:: example
+
+        REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
         >>> container = abjad.BeforeGraceContainer("cs'16")
@@ -1902,9 +1902,9 @@ def has_effective_indicator(
     r"""
     Is true when ``argument`` has effective indicator.
 
-    REGRESSION. Works with grace notes (and containers):
-
     ..  container:: example
+
+        REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
         >>> staff = abjad.Staff([music_voice])
@@ -2100,9 +2100,9 @@ def has_indicator(
     r"""
     Is true when ``argument`` has one or more indicators.
 
-    REGRESSION. Works with grace notes (and containers):
-
     ..  container:: example
+
+        REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
         >>> staff = abjad.Staff([music_voice])
@@ -2343,9 +2343,9 @@ def indicator(
     r"""
     Gets indicator.
 
-    REGRESSION. Works with grace notes (and containers):
-
     ..  container:: example
+
+        REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
         >>> staff = abjad.Staff([music_voice])
@@ -2494,9 +2494,9 @@ def indicators(
     r"""
     Get indicators.
 
-    REGRESSION. Works with grace notes (and containers):
-
     ..  container:: example
+
+        REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
         >>> staff = abjad.Staff([music_voice])
@@ -2987,9 +2987,9 @@ def lineage(argument) -> "Lineage":
     r"""
     Gets lineage.
 
-    REGRESSION. Works with grace notes (and containers):
-
     ..  container:: example
+
+        REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
         >>> container = abjad.BeforeGraceContainer("cs'16")
@@ -3191,9 +3191,9 @@ def logical_tie(argument) -> "_select.LogicalTie":
     r"""
     Gets logical tie.
 
-    REGRESSION. Works with grace notes (and containers):
-
     ..  container:: example
+
+        REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
         >>> container = abjad.BeforeGraceContainer("cs'16")
@@ -3383,9 +3383,9 @@ def measure_number(argument) -> int:
     r"""
     Gets measure number.
 
-    REGRESSION. Works with grace notes (and containers):
-
     ..  container:: example
+
+        REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
         >>> container = abjad.BeforeGraceContainer("cs'16")
@@ -3880,9 +3880,9 @@ def pitches(argument) -> set[_pitch.NamedPitch]:
     r"""
     Gets pitches.
 
-    REGRESSION. Works with grace notes (and containers):
-
     ..  container:: example
+
+        REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
         >>> container = abjad.BeforeGraceContainer("cs'16")
@@ -4138,9 +4138,9 @@ def timespan(argument, in_seconds: bool = False) -> _timespan.Timespan:
     r"""
     Gets timespan.
 
-    REGRESSION. Works with grace notes (and containers):
-
     ..  container:: example
+
+        REGRESSION. Works with grace notes (and containers):
 
         >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
         >>> container = abjad.BeforeGraceContainer("cs'16")

--- a/abjad/indicators.py
+++ b/abjad/indicators.py
@@ -952,9 +952,9 @@ class Clef:
         r"""
         Changes ``pitch`` to staff position.
 
-        Changes C#5 to absolute staff position:
-
         ..  container:: example
+
+            Changes C#5 to absolute staff position:
 
             >>> pitch = abjad.NamedPitch("C#5")
 

--- a/abjad/iterate.py
+++ b/abjad/iterate.py
@@ -245,9 +245,9 @@ def leaves(
     r"""
     Iterates leaves in ``argument``.
 
-    Set ``exclude=<annotation>`` to exclude leaves with annotation:
-
     ..  container:: example
+
+        Set ``exclude=<annotation>`` to exclude leaves with annotation:
 
         >>> staff = abjad.Staff()
         >>> score = abjad.Score([staff], name="Score")
@@ -488,9 +488,9 @@ def logical_ties(
     r"""
     Iterates logical ties in ``argument``.
 
-    Iterates logical ties:
-
     ..  container:: example
+
+        Iterates logical ties:
 
         >>> string = r"c'4 ~ \times 2/3 { c'16 d'8 } e'8 f'4 ~ f'16"
         >>> staff = abjad.Staff(string)
@@ -840,9 +840,9 @@ def pitches(argument) -> typing.Iterator[_pitch.NamedPitch]:
     r"""
     Iterates pitches in ``argument``.
 
-    Iterates pitches in container:
-
     ..  container:: example
+
+        Iterates pitches in container:
 
         >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
         >>> abjad.show(staff) # doctest: +SKIP
@@ -937,9 +937,9 @@ def timeline(
     r"""
     Iterates leaves in ``argument`` in timeline order.
 
-    Timeline-iterates leaves:
-
     ..  container:: example
+
+        Timeline-iterates leaves:
 
         >>> score = abjad.Score()
         >>> score.append(abjad.Staff("c'4 d'4 e'4 f'4"))

--- a/abjad/makers.py
+++ b/abjad/makers.py
@@ -706,10 +706,10 @@ def make_notes(
 
     Set ``durations`` to a single duration or a list of durations.
 
-    Cycles through ``pitches`` when the length of ``pitches`` is less than the length
-    of ``durations``:
-
     ..  container:: example
+
+        Cycles through ``pitches`` when the length of ``pitches`` is less than
+        the length of ``durations``:
 
         >>> pitches = [0]
         >>> durations = [(1, 16), (1, 8), (1, 8)]
@@ -930,9 +930,9 @@ def tuplet_from_duration_and_ratio(
     r"""
     Makes tuplet from ``duration`` and ``ratio``.
 
-    Makes tupletted leaves strictly without dots when all ``ratio`` equal ``1``:
-
     ..  container:: example
+
+        Makes tupletted leaves strictly without dots when all ``ratio`` equal ``1``:
 
         >>> tuplet = abjad.makers.tuplet_from_duration_and_ratio(
         ...     abjad.Duration(3, 16),

--- a/abjad/math.py
+++ b/abjad/math.py
@@ -583,9 +583,9 @@ def integer_equivalent_number_to_integer(number) -> int | float:
     """
     Changes integer-equivalent ``number`` to integer.
 
-    Returns integer-equivalent number as integer:
-
     ..  container:: example
+
+        Returns integer-equivalent number as integer:
 
         >>> abjad.math.integer_equivalent_number_to_integer(17.0)
         17
@@ -608,9 +608,9 @@ def integer_to_base_k_tuple(n, k) -> tuple[int, ...]:
     """
     Changes nonnegative integer ``n`` to base-`k` tuple.
 
-    Gets base-10 digits of 1066:
-
     ..  container:: example
+
+        Gets base-10 digits of 1066:
 
         >>> abjad.math.integer_to_base_k_tuple(1066, 10)
         (1, 0, 6, 6)
@@ -1148,9 +1148,9 @@ def sign(n) -> int:
     """
     Gets sign of ``n``.
 
-    Returns -1 on negative ``n``:
-
     ..  container:: example
+
+        Returns -1 on negative ``n``:
 
         >>> abjad.math.sign(-96.2)
         -1

--- a/abjad/mutate.py
+++ b/abjad/mutate.py
@@ -732,9 +732,9 @@ def copy(argument, n=1) -> list[_score.Component]:
     r"""
     Copies argument.
 
-    Copies explicit clefs:
-
     ..  container:: example
+
+        Copies explicit clefs:
 
         >>> staff = abjad.Staff("c'8 cs'8 d'8 ef'8 e'8 f'8 fs'8 g'8")
         >>> clef = abjad.Clef('treble')
@@ -867,9 +867,9 @@ def eject_contents(container: _score.Container) -> list[_score.Component]:
     r"""
     Ejects ``container`` contents.
 
-    Ejects leaves from container:
-
     ..  container:: example
+
+        Ejects leaves from container:
 
         >>> container = abjad.Container("c'4 ~ c'4 d'4 ~ d'4")
         >>> abjad.show(container) # doctest: +SKIP
@@ -1104,9 +1104,9 @@ def fuse(argument) -> _score.Tuplet | list[_score.Leaf]:
     r"""
     Fuses ``argument``.
 
-    Fuses in-score leaves:
-
     ..  container:: example
+
+        Fuses in-score leaves:
 
         >>> staff = abjad.Staff("c'8 d'8 e'8 f'8")
         >>> abjad.show(staff) # doctest: +SKIP
@@ -1394,10 +1394,10 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
     r"""
     Replaces ``argument`` (and contents of ``argument``) with ``recipients``.
 
-    Replaces in-score tuplet (and children of tuplet) with notes. Functions
-    exactly the same as container setitem:
-
     ..  container:: example
+
+        Replaces in-score tuplet (and children of tuplet) with notes. Functions
+        exactly the same as container setitem:
 
         >>> tuplet_1 = abjad.Tuplet((2, 3), "c'4 d'4 e'4")
         >>> tuplet_2 = abjad.Tuplet((2, 3), "d'4 e'4 f'4")
@@ -1639,9 +1639,9 @@ def scale(argument, multiplier) -> None:
     r"""
     Scales ``argument`` by ``multiplier``.
 
-    Scales note duration by dot-generating multiplier:
-
     ..  container:: example
+
+        Scales note duration by dot-generating multiplier:
 
         >>> staff = abjad.Staff("c'8 ( d'8 e'8 f'8 )")
         >>> abjad.show(staff) # doctest: +SKIP

--- a/abjad/parentage.py
+++ b/abjad/parentage.py
@@ -766,9 +766,9 @@ class Parentage(collections.abc.Sequence):
         r"""
         Gets number of ``prototype`` in parentage.
 
-        Gets tuplet count:
-
         ..  container:: example
+
+            Gets tuplet count:
 
             >>> staff = abjad.Staff(
             ...     r"\times 2/3 { c'2 \times 2/3 { d'8 e' f' } } \times 2/3 { c'4 d' e' }"
@@ -1254,9 +1254,9 @@ class Parentage(collections.abc.Sequence):
         r"""
         Gets logical voice.
 
-        Gets logical voice of note:
-
         ..  container:: example
+
+            Gets logical voice of note:
 
             >>> voice = abjad.Voice("c'4 d'4 e'4 f'4", name="MusicVoice")
             >>> staff = abjad.Staff([voice], name="Music_Staff")

--- a/abjad/pcollections.py
+++ b/abjad/pcollections.py
@@ -330,9 +330,9 @@ class PitchClassSet(frozenset):
         """
         Gets normal order.
 
-        Gets normal order of empty pitch-class set:
-
         ..  container:: example
+
+            Gets normal order of empty pitch-class set:
 
             >>> pc_set = abjad.PitchClassSet()
             >>> pc_set.get_normal_order()
@@ -388,9 +388,9 @@ class PitchClassSet(frozenset):
         """
         Gets prime form.
 
-        Gets prime form of empty pitch-class set:
-
         ..  container:: example
+
+            Gets prime form of empty pitch-class set:
 
             >>> pc_set = abjad.PitchClassSet()
             >>> pc_set.get_prime_form()
@@ -670,9 +670,9 @@ class PitchRange:
         """
         Is true when pitch range contains ``argument``.
 
-        Closed / closed range:
-
         ..  container:: example
+
+            Closed / closed range:
 
             >>> range_ = abjad.PitchRange("[A0, C8]")
 
@@ -2373,9 +2373,9 @@ class TwelveToneRow(PitchClassSegment):
         r"""
         Multiplies row by ``argument``.
 
-        Multiplies row:
-
         ..  container:: example
+
+            Multiplies row:
 
             >>> row = abjad.TwelveToneRow()
             >>> lilypond_file = abjad.illustrate(row)
@@ -2476,9 +2476,9 @@ class TwelveToneRow(PitchClassSegment):
         r"""
         Multiplies ``argument`` by row.
 
-        Multiplies integer by row:
-
         ..  container:: example
+
+            Multiplies integer by row:
 
             >>> row = abjad.TwelveToneRow()
             >>> lilypond_file = abjad.illustrate(row)
@@ -2590,9 +2590,9 @@ class TwelveToneRow(PitchClassSegment):
         r"""
         Inverts row about optional ``axis``.
 
-        Example row:
-
         ..  container:: example
+
+            Example row:
 
             >>> numbers = [1, 11, 9, 3, 6, 7, 5, 4, 10, 2, 8, 0]
             >>> row = abjad.TwelveToneRow(numbers)
@@ -2740,9 +2740,9 @@ class TwelveToneRow(PitchClassSegment):
         r"""
         Multiplies pitch-classes in row by ``n``.
 
-        Example row:
-
         ..  container:: example
+
+            Example row:
 
             >>> numbers = [1, 11, 9, 3, 6, 7, 5, 4, 10, 2, 8, 0]
             >>> row = abjad.TwelveToneRow(numbers)
@@ -2849,9 +2849,9 @@ class TwelveToneRow(PitchClassSegment):
         r"""
         Gets retrograde of row.
 
-        Example row:
-
         ..  container:: example
+
+            Example row:
 
             >>> numbers = [1, 11, 9, 3, 6, 7, 5, 4, 10, 2, 8, 0]
             >>> row = abjad.TwelveToneRow(numbers)
@@ -2930,9 +2930,9 @@ class TwelveToneRow(PitchClassSegment):
         r"""
         Rotates row by index ``n``.
 
-        Example row:
-
         ..  container:: example
+
+            Example row:
 
             >>> numbers = [1, 11, 9, 3, 6, 7, 5, 4, 10, 2, 8, 0]
             >>> row = abjad.TwelveToneRow(numbers)
@@ -3042,9 +3042,9 @@ class TwelveToneRow(PitchClassSegment):
         r"""
         Transposes row by index ``n``.
 
-        Example row:
-
         ..  container:: example
+
+            Example row:
 
             >>> numbers = [1, 11, 9, 3, 6, 7, 5, 4, 10, 2, 8, 0]
             >>> row = abjad.TwelveToneRow(numbers)

--- a/abjad/pitch.py
+++ b/abjad/pitch.py
@@ -620,7 +620,6 @@ class Accidental:
         >>> abjad.Accidental("ss").semitones
         2
 
-
     ..  container:: example
 
         >>> abjad.Accidental("ff").name
@@ -5190,9 +5189,9 @@ class NamedPitch(Pitch):
         """
         Transposes named pitch by index ``n``.
 
-        Transposes C4 up a minor second:
-
         ..  container:: example
+
+            Transposes C4 up a minor second:
 
             >>> abjad.NamedPitch("c'").transpose(n="m2")
             NamedPitch("df'")
@@ -5615,9 +5614,9 @@ class NumberedPitch(Pitch):
         """
         Interpolates between numbered pitch and ``stop_pitch`` by ``fraction``.
 
-        Interpolates from C4 to C5:
-
         ..  container:: example
+
+            Interpolates from C4 to C5:
 
             >>> start_pitch = abjad.NumberedPitch(0)
             >>> stop_pitch = abjad.NumberedPitch(12)
@@ -5677,9 +5676,9 @@ class NumberedPitch(Pitch):
         """
         Inverts numbered pitch around ``axis``.
 
-        Inverts pitch-class about pitch-class 0 explicitly:
-
         ..  container:: example
+
+            Inverts pitch-class about pitch-class 0 explicitly:
 
             >>> abjad.NumberedPitch(2).invert(0)
             NumberedPitch(-2)

--- a/abjad/rhythmtrees.py
+++ b/abjad/rhythmtrees.py
@@ -139,11 +139,12 @@ class RhythmTreeMixin:
         A sequence describing the relative durations of the nodes in a node's improper
         parentage.
 
-        The first item in the sequence is the preprolated_duration of the root node, and
-        subsequent items are pairs of the preprolated duration of the next node in the
-        parentage and the total preprolated_duration of that node and its siblings:
-
         ..  container:: example
+
+            The first item in the sequence is the preprolated_duration of the
+            root node, and subsequent items are pairs of the preprolated
+            duration of the next node in the parentage and the total
+            preprolated_duration of that node and its siblings:
 
             >>> a = abjad.rhythmtrees.RhythmTreeContainer(preprolated_duration=abjad.Duration(1))
             >>> b = abjad.rhythmtrees.RhythmTreeContainer(preprolated_duration=abjad.Duration(2))
@@ -488,7 +489,7 @@ class RhythmTreeContainer(RhythmTreeMixin, uqbar.containers.UniqueTreeList):
         RhythmTreeContainer c with the content of both a and b, and a
         preprolated_duration equal to the sum of the durations of a and b. The operation
         is non-commutative: the content of the first operand will be placed before the
-        content of the second operand:
+        content of the second operand.
 
         ..  container:: example
 
@@ -901,9 +902,9 @@ def parse_rtm_syntax(string: str) -> _score.Container | _score.Leaf | _score.Tup
     Creates rhythm tree from RTM ``string``; then calls rhythm tree on
     quarter-note pulse duration.
 
-    A single quarter note:
-
     ..  container:: example
+
+        A single quarter note:
 
         >>> result = abjad.rhythmtrees.parse_rtm_syntax("1")
         >>> result

--- a/abjad/score.py
+++ b/abjad/score.py
@@ -875,9 +875,9 @@ class Container(Component):
         r"""
         Deletes components(s) at index ``i`` in container.
 
-        Deletes first tuplet in voice:
-
         ..  container:: example
+
+            Deletes first tuplet in voice:
 
             >>> voice = abjad.Voice()
             >>> voice.append(abjad.Tuplet((4, 6), "c'4 d'4 e'4"))
@@ -1554,9 +1554,9 @@ class Container(Component):
         r"""
         Appends ``component`` to container.
 
-        Appends note to container:
-
         ..  container:: example
+
+            Appends note to container:
 
             >>> container = abjad.Container("c'4 ( d'4 f'4 )")
             >>> abjad.show(container) # doctest: +SKIP
@@ -1601,9 +1601,9 @@ class Container(Component):
         r"""
         Extends container with ``argument``.
 
-        Extends container with three notes:
-
         ..  container:: example
+
+            Extends container with three notes:
 
             >>> container = abjad.Container("c'4 ( d'4 f'4 )")
             >>> abjad.show(container) # doctest: +SKIP
@@ -1651,9 +1651,9 @@ class Container(Component):
         r"""
         Returns index of ``component`` in container.
 
-        Gets index of last element in container:
-
         ..  container:: example
+
+            Gets index of last element in container:
 
             >>> container = abjad.Container("c'4 d'4 f'4 e'4")
             >>> abjad.show(container) # doctest: +SKIP
@@ -1689,9 +1689,9 @@ class Container(Component):
         r"""
         Inserts ``component`` at index ``i`` in container.
 
-        Inserts note.
-
         ..  container:: example
+
+            Inserts note:
 
             >>> container = abjad.Container([])
             >>> container.extend("fs16 cs' e' a'")
@@ -1755,9 +1755,9 @@ class Container(Component):
         r"""
         Pops component from container at index ``i``.
 
-        Pops last element from container:
-
         ..  container:: example
+
+            Pops last element from container:
 
             >>> container = abjad.Container("c'4 ( d'4 f'4 ) e'4")
             >>> abjad.show(container) # doctest: +SKIP
@@ -1801,9 +1801,9 @@ class Container(Component):
         r"""
         Removes ``component`` from container.
 
-        Removes note from container:
-
         ..  container:: example
+
+            Removes note from container:
 
             >>> container = abjad.Container("c'4 d'4 f'4 e'4")
             >>> abjad.show(container) # doctest: +SKIP
@@ -4058,9 +4058,9 @@ class NoteHeadList(list):
         r"""
         Gets note-head by ``pitch``.
 
-        Gets note-head by pitch name:
-
         ..  container:: example
+
+            Gets note-head by pitch name:
 
             >>> chord = abjad.Chord("<e' cs'' f''>4")
             >>> abjad.show(chord) # doctest: +SKIP
@@ -5932,9 +5932,9 @@ class Tuplet(Container):
         r"""
         Appends ``component`` to tuplet.
 
-        Appends note to tuplet:
-
         ..  container:: example
+
+            Appends note to tuplet:
 
             >>> tuplet = abjad.Tuplet((2, 3), "c'4 ( d'4 f'4 )")
             >>> abjad.show(tuplet) # doctest: +SKIP
@@ -6021,9 +6021,9 @@ class Tuplet(Container):
         r"""
         Is true when tuplet multiplier is greater than ``1``.
 
-        Augmented tuplet:
-
         ..  container:: example
+
+            Augmented tuplet:
 
             >>> tuplet = abjad.Tuplet((4, 3), "c'8 d'8 e'8")
             >>> abjad.show(tuplet) # doctest: +SKIP
@@ -6061,9 +6061,9 @@ class Tuplet(Container):
         r"""
         Is true when tuplet multiplier is less than ``1``.
 
-        Augmented tuplet:
-
         ..  container:: example
+
+            Augmented tuplet:
 
             >>> tuplet = abjad.Tuplet((4, 3), "c'8 d'8 e'8")
             >>> abjad.show(tuplet) # doctest: +SKIP
@@ -6103,9 +6103,9 @@ class Tuplet(Container):
         r"""
         Extends tuplet with ``argument``.
 
-        Extends tuplet with three notes:
-
         ..  container:: example
+
+            Extends tuplet with three notes:
 
             >>> tuplet = abjad.Tuplet((2, 3), "c'4 ( d'4 f'4 )")
             >>> abjad.show(tuplet) # doctest: +SKIP
@@ -6201,9 +6201,9 @@ class Tuplet(Container):
         r"""
         Makes tuplet from ``duration`` and ``components``.
 
-        Makes diminution:
-
         ..  container:: example
+
+            Makes diminution:
 
             >>> tuplet = abjad.Tuplet.from_duration((2, 8), "c'8 d' e'")
             >>> abjad.show(tuplet) # doctest: +SKIP
@@ -6394,9 +6394,9 @@ class Tuplet(Container):
         r"""
         Rewrites dots.
 
-        Rewrites single dots as 3:2 prolation:
-
         ..  container:: example
+
+            Rewrites single dots as 3:2 prolation:
 
             >>> tuplet = abjad.Tuplet((1, 1), "c'8. c'8.")
             >>> abjad.show(tuplet) # doctest: +SKIP
@@ -6551,9 +6551,9 @@ class Tuplet(Container):
         r"""
         Sets preferred denominator of tuplet to at least ``denominator``.
 
-        Sets preferred denominator of tuplet to ``8`` at least:
-
         ..  container:: example
+
+            Sets preferred denominator of tuplet to ``8`` at least:
 
             >>> tuplet = abjad.Tuplet((3, 5), "c'4 d'8 e'8 f'4 g'2")
             >>> abjad.show(tuplet) # doctest: +SKIP
@@ -6604,9 +6604,9 @@ class Tuplet(Container):
         r"""
         Changes augmented tuplets to diminished; changes diminished tuplets to augmented.
 
-        Changes augmented tuplet to diminished:
-
         ..  container:: example
+
+            Changes augmented tuplet to diminished:
 
             >>> tuplet = abjad.Tuplet((4, 3), "c'8 d'8 e'8")
             >>> abjad.show(tuplet) # doctest: +SKIP

--- a/abjad/select.py
+++ b/abjad/select.py
@@ -254,9 +254,9 @@ def chord(
     r"""
     Selects chord ``n`` in ``argument``.
 
-    Selects chord -1:
-
     ..  container:: example
+
+        Selects chord -1:
 
         >>> tuplets = [
         ...     "r16 bf'16 <a'' b''>16 c'16 <d' e'>4 ~ <d' e'>16",
@@ -344,9 +344,9 @@ def chords(
     r"""
     Selects chords in ``argument``.
 
-    Selects chords:
-
     ..  container:: example
+
+        Selects chords:
 
         >>> tuplets = [
         ...     "r16 bf'16 <a'' b''>16 c'16 <d' e'>4 ~ <d' e'>16",
@@ -462,9 +462,9 @@ def components(
     r"""
     Selects components.
 
-    Selects notes:
-
     ..  container:: example
+
+        Selects notes:
 
         >>> staff = abjad.Staff("c'4 d'8 ~ d'16 e'16 ~ e'8 r4 g'8")
         >>> abjad.setting(staff).autoBeaming = False
@@ -840,9 +840,9 @@ def exclude(argument, indices: typing.Sequence[int], period: int | None = None) 
     r"""
     Excludes items at ``indices`` by ``period``.
 
-    Excludes every other leaf:
-
     ..  container:: example
+
+        Excludes every other leaf:
 
         >>> string = r"c'8 d'8 ~ d'8 e'8 ~ e'8 ~ e'8 r8 f'8"
         >>> staff = abjad.Staff(string)
@@ -995,9 +995,9 @@ def filter(argument, predicate=None) -> list:
     r"""
     Filters ``argument`` by ``predicate``.
 
-    Selects runs with duration equal to 2/8:
-
     ..  container:: example
+
+        Selects runs with duration equal to 2/8:
 
         >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
         >>> abjad.setting(staff).autoBeaming = False
@@ -1048,9 +1048,9 @@ def flatten(argument, depth: int = 1) -> list:
     r"""
     Flattens ``argument``.
 
-    Selects first two leaves of each tuplet:
-
     ..  container:: example
+
+        Selects first two leaves of each tuplet:
 
         >>> tuplets = [
         ...     "r16 bf'16 <a'' b''>16 c'16 <d' e'>4 ~ <d' e'>16",
@@ -1245,9 +1245,9 @@ def get(
     r"""
     Gets items in ``argument`` at ``indices`` according to ``period``.
 
-    Gets every other leaf:
-
     ..  container:: example
+
+        Gets every other leaf:
 
         >>> string = r"c'8 d'8 ~ d'8 e'8 ~ e'8 ~ e'8 r8 f'8"
         >>> staff = abjad.Staff(string)
@@ -1472,9 +1472,9 @@ def group_by(argument, predicate=None) -> list[list]:
     r'''
     Groups items in ``argument`` by ``predicate``.
 
-    Wraps selection in selection when ``predicate`` is none:
-
     ..  container:: example
+
+        Wraps selection in selection when ``predicate`` is none:
 
         >>> staff = abjad.Staff(r"""
         ...     c'8 ~ c'16 c'16 r8 c'16 c'16
@@ -1546,9 +1546,9 @@ def group_by_contiguity(argument) -> list[list]:
     r'''
     Groups items in ``argument`` by contiguity.
 
-    Groups pitched leaves by contiguity:
-
     ..  container:: example
+
+        Groups pitched leaves by contiguity:
 
         >>> string = r"c'8 d' r \times 2/3 { e' r f' } g' a' r"
         >>> staff = abjad.Staff(string)
@@ -1853,9 +1853,9 @@ def group_by_duration(argument) -> list[list]:
     r"""
     Groups items in ``argument`` by duration.
 
-    Groups logical ties by duration:
-
     ..  container:: example
+
+        Groups logical ties by duration:
 
         >>> string = "c'4 ~ c'16 d' ~ d' d' e'4 ~ e'16 f' ~ f' f'"
         >>> staff = abjad.Staff(string)
@@ -1925,9 +1925,9 @@ def group_by_length(argument) -> list[list]:
     r"""
     Groups items in ``argument`` by length.
 
-    Groups logical ties by length:
-
     ..  container:: example
+
+        Groups logical ties by length:
 
         >>> string = "c'4 ~ c'16 d' ~ d' d' e'4 ~ e'16 f' ~ f' f'"
         >>> staff = abjad.Staff(string)
@@ -1997,9 +1997,9 @@ def group_by_measure(argument) -> list[list]:
     r"""
     Groups items in ``argument`` by measure.
 
-    Groups leaves by measure:
-
     ..  container:: example
+
+        Groups leaves by measure:
 
         >>> staff = abjad.Staff("c'8 d' e' f' g' a' b' c''")
         >>> score = abjad.Score([staff], name="Score")
@@ -2364,9 +2364,9 @@ def group_by_pitch(argument) -> list[list]:
     r"""
     Groups items in ``argument`` by pitch.
 
-    Groups logical ties by pitches:
-
     ..  container:: example
+
+        Groups logical ties by pitches:
 
         >>> string = "c'4 ~ c'16 d' ~ d' d' e'4 ~ e'16 f' ~ f' f'"
         >>> staff = abjad.Staff(string)
@@ -2447,9 +2447,9 @@ def leaf(
     r"""
     Selects leaf ``n` in ``argument``.
 
-    Selects leaf -1:
-
     ..  container:: example
+
+        Selects leaf -1:
 
         >>> tuplets = [
         ...     "r16 bf'16 <a'' b''>16 c'16 <d' e'>4 ~ <d' e'>16",
@@ -3679,9 +3679,9 @@ def logical_ties(
     r'''
     Selects logical ties in ``argument``.
 
-    Selects logical ties:
-
     ..  container:: example
+
+        Selects logical ties:
 
         >>> staff = abjad.Staff("c'8 d' ~ { d' e' r f'~ } f' r")
         >>> abjad.setting(staff).autoBeaming = False
@@ -4301,9 +4301,9 @@ def nontrivial(argument) -> list:
     r"""
     Selects nontrivial items in ``argument``.
 
-    Selects nontrivial runs:
-
     ..  container:: example
+
+        Selects nontrivial runs:
 
         >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
         >>> abjad.setting(staff).autoBeaming = False
@@ -4360,9 +4360,9 @@ def note(
     r"""
     Selects note ``n`` in ``argument``.
 
-    Selects note -1:
-
     ..  container:: example
+
+        Selects note -1:
 
         >>> tuplets = [
         ...     "r16 bf'16 <a'' b''>16 c'16 <d' e'>4 ~ <d' e'>16",
@@ -4450,9 +4450,9 @@ def notes(
     r"""
     Selects notes in ``argument``.
 
-    Selects notes:
-
     ..  container:: example
+
+        Selects notes:
 
         >>> tuplets = [
         ...     "r16 bf'16 <a'' b''>16 c'16 <d' e'>4 ~ <d' e'>16",
@@ -4563,9 +4563,9 @@ def partition_by_counts(
     r"""
     Partitions items in ``argument`` by ``counts``.
 
-    Partitions leaves into a single part of length 3; truncates overhang:
-
     ..  container:: example
+
+        Partitions leaves into a single part of length 3; truncates overhang:
 
         >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
         >>> abjad.setting(staff).autoBeaming = False
@@ -5044,10 +5044,10 @@ def partition_by_durations(
     r"""
     Partitions items in ``argument`` by ``durations``.
 
-    Cyclically partitions leaves into parts equal to exactly 3/8; returns
-    overhang at end:
-
     ..  container:: example
+
+        Cyclically partitions leaves into parts equal to exactly 3/8; returns
+        overhang at end:
 
         >>> staff = abjad.Staff([
         ...     abjad.Container("c'8 d'"),
@@ -5910,9 +5910,9 @@ def partition_by_ratio(argument, ratio: tuple[int, ...]) -> list[list]:
     r"""
     Partitions items in ``argument`` by ``ratio``.
 
-    Partitions leaves by a ratio of 1:1:
-
     ..  container:: example
+
+        Partitions leaves by a ratio of 1:1:
 
         >>> string = r"c'8 d' r \times 2/3 { e' r f' } g' a' r"
         >>> staff = abjad.Staff(string)
@@ -6035,9 +6035,9 @@ def rest(
     r"""
     Selects rest ``n`` in ``argument``.
 
-    Selects rest -1:
-
     ..  container:: example
+
+        Selects rest -1:
 
         >>> tuplets = [
         ...     "r16 bf'16 <a'' b''>16 c'16 <d' e'>4 ~ <d' e'>16",
@@ -6125,9 +6125,9 @@ def rests(
     r"""
     Selects rests in ``argument``.
 
-    Selects rests:
-
     ..  container:: example
+
+        Selects rests:
 
         >>> tuplets = [
         ...     "r16 bf'16 <a'' b''>16 c'16 <d' e'>4 ~ <d' e'>16",
@@ -6226,9 +6226,9 @@ def run(
     r"""
     Selects run ``n`` in ``argument``.
 
-    Selects run -1:
-
     ..  container:: example
+
+        Selects run -1:
 
         >>> tuplets = [
         ...     "r16 c'16 c'16 c'16 <d' e'>4 ~ <d' e'>16",
@@ -6320,9 +6320,9 @@ def runs(
     r"""
     Selects runs in ``argument``.
 
-    Selects runs:
-
     ..  container:: example
+
+        Selects runs:
 
         >>> tuplets = [
         ...     "r16 c'16 c'16 c'16 <d' e'>4 ~ <d' e'>16",
@@ -6520,9 +6520,9 @@ def top(argument, *, exclude: _typings.Exclude | None = None) -> list[_score.Com
     r"""
     Selects top components in ``argument``.
 
-    Selects top components (up from leaves):
-
     ..  container:: example
+
+        Selects top components (up from leaves):
 
         >>> string = r"c'8 d' r \times 2/3 { e' r f' } g' a' r"
         >>> staff = abjad.Staff(string)
@@ -6600,9 +6600,9 @@ def tuplet(
     r"""
     Selects tuplet ``n`` in ``argument``.
 
-    Selects tuplet -1:
-
     ..  container:: example
+
+        Selects tuplet -1:
 
         >>> tuplets = [
         ...     "r16 bf'16 <a'' b''>16 c'16 <d' e'>4 ~ <d' e'>16",
@@ -6695,9 +6695,9 @@ def tuplets(
     r"""
     Selects tuplets in ``argument``.
 
-    Selects tuplets at every level:
-
     ..  container:: example
+
+        Selects tuplets at every level:
 
         >>> staff = abjad.Staff(
         ...     r"\times 2/3 { c'2 \times 2/3 { d'8 e' f' } } \times 2/3 { c'4 d' e' }"
@@ -6882,9 +6882,9 @@ def with_next_leaf(argument, *, grace: bool | None = None) -> list[_score.Leaf]:
     r"""
     Extends ``argument`` with next leaf.
 
-    Selects runs (each with next leaf):
-
     ..  container:: example
+
+        Selects runs (each with next leaf):
 
         >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
         >>> abjad.setting(staff).autoBeaming = False
@@ -7250,9 +7250,9 @@ def with_previous_leaf(argument) -> list[_score.Leaf]:
     r"""
     Extends ``argument`` with previous leaf.
 
-    Selects runs (each with previous leaf):
-
     ..  container:: example
+
+        Selects runs (each with previous leaf):
 
         >>> staff = abjad.Staff("c'8 r8 d'8 e'8 r8 f'8 g'8 a'8")
         >>> abjad.setting(staff).autoBeaming = False

--- a/abjad/sequence.py
+++ b/abjad/sequence.py
@@ -1105,9 +1105,9 @@ def split(
     r"""
     Splits ``sequence`` by ``weights``.
 
-    Splits sequence cyclically by weights with overhang:
-
     ..  container:: example
+
+        Splits sequence cyclically by weights with overhang:
 
         >>> sequence = list([10, -10, 10, -10])
 

--- a/abjad/setclass.py
+++ b/abjad/setclass.py
@@ -1037,9 +1037,9 @@ class SetClass:
         """
         Gets string representation.
 
-        Gets string of SG2 set-class with Forte rank:
-
         ..  container:: example
+
+            Gets string of SG2 set-class with Forte rank:
 
             >>> set_class = abjad.SetClass(4, 29)
             >>> print(set_class)

--- a/abjad/spanners.py
+++ b/abjad/spanners.py
@@ -1218,9 +1218,9 @@ def hairpin(
     r"""
     Attaches hairpin indicators.
 
-    With three-part string descriptor:
-
     ..  container:: example
+
+        With three-part string descriptor:
 
         >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> abjad.hairpin("p < f", voice[:], direction=abjad.UP)
@@ -1661,9 +1661,9 @@ def text_spanner(
     r"""
     Attaches text span indicators.
 
-    Single spanner:
-
     ..  container:: example
+
+        Single spanner:
 
         >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> start_text_span = abjad.StartTextSpan(

--- a/abjad/string.py
+++ b/abjad/string.py
@@ -9,9 +9,9 @@ def capitalize_start(string: str) -> str:
     """
     Capitalizes start of string.
 
-    Capitalizes only ``string[0]``; leaves noninitial characters unchanged:
-
     ..  container:: example
+
+        Capitalizes only ``string[0]``; leaves noninitial characters unchanged:
 
         >>> abjad.string.capitalize_start("violin I")
         'Violin I'

--- a/abjad/tag.py
+++ b/abjad/tag.py
@@ -248,9 +248,9 @@ def activate(text: str, tag: Tag | typing.Callable) -> tuple[str, int, int]:
     r"""
     Activates ``tag`` in ``text``.
 
-    Writes (deactivated) tag with ``"%@%"`` prefix into LilyPond input:
-
     ..  container:: example
+
+        Writes (deactivated) tag with ``"%@%"`` prefix into LilyPond input:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> markup = abjad.Markup(r"\markup { \with-color #red Allegro }")
@@ -399,9 +399,9 @@ def deactivate(
     r"""
     Deactivates ``tag`` in ``text``.
 
-    Writes (active) tag into LilyPond input:
-
     ..  container:: example
+
+        Writes (active) tag into LilyPond input:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> string = r"\markup { \with-color #red Allegro }"

--- a/abjad/timespan.py
+++ b/abjad/timespan.py
@@ -309,9 +309,9 @@ class Timespan:
         """
         Is true when timespan contains ``argument``.
 
-        Works with offsets:
-
         ..  container:: example
+
+            Works with offsets:
 
             >>> timespan = abjad.Timespan(0, (1, 4))
 
@@ -1011,9 +1011,9 @@ class Timespan:
         """
         Reflects timespan about ``axis``.
 
-        Reverse timespan about timespan axis:
-
         ..  container:: example
+
+            Reverse timespan about timespan axis:
 
             >>> abjad.Timespan(3, 6).reflect()
             Timespan(Offset((3, 1)), Offset((6, 1)))
@@ -1080,6 +1080,8 @@ class Timespan:
     def scale(self, multiplier, anchor=_enums.LEFT) -> "Timespan":
         """
         Scales timespan by ``multiplier``.
+
+        ..  container:: example
 
             >>> timespan = abjad.Timespan(3, 6)
 
@@ -1176,7 +1178,7 @@ class Timespan:
 
     def split_at_offset(self, offset) -> "TimespanList":
         """
-        Split into two parts when ``offset`` happens during timespan:
+        Split into two parts when ``offset`` happens during timespan.
 
         ..  container:: example
 
@@ -1213,7 +1215,7 @@ class Timespan:
 
     def split_at_offsets(self, offsets) -> "TimespanList":
         """
-        Split into one or more parts when ``offsets`` happens during timespan:
+        Split into one or more parts when ``offsets`` happens during timespan.
 
         ..  container:: example
 
@@ -1252,9 +1254,9 @@ class Timespan:
         """
         Stretches timespan by ``multiplier`` relative to ``anchor``.
 
-        Stretch relative to timespan start offset:
-
         .. container:: example
+
+            Stretch relative to timespan start offset:
 
             >>> abjad.Timespan(3, 10).stretch(abjad.Fraction(2))
             Timespan(Offset((3, 1)), Offset((17, 1)))
@@ -1448,9 +1450,9 @@ class TimespanList(list):
         """
         Keeps material that intersects ``timespan``.
 
-        Keeps material that intersects timespan:
-
         ..  container:: example
+
+            Keeps material that intersects timespan:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(0, 16),
@@ -1811,9 +1813,9 @@ class TimespanList(list):
         """
         Inverts timespans.
 
-        Inverts timespans:
-
         ..  container:: example
+
+            Inverts timespans:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(-2, 8),
@@ -1827,7 +1829,6 @@ class TimespanList(list):
             >>> for _ in ~timespans: _
             Timespan(Offset((8, 1)), Offset((15, 1)))
             Timespan(Offset((20, 1)), Offset((24, 1)))
-
 
         ..  container:: example
 
@@ -1854,9 +1855,9 @@ class TimespanList(list):
         """
         Deletes material that intersects ``timespan``.
 
-        Deletes material that intersects timespan:
-
         ..  container:: example
+
+            Deletes material that intersects timespan:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(0, 16),
@@ -2367,9 +2368,9 @@ class TimespanList(list):
         """
         Clips timespan durations.
 
-        Clips timespan durations:
-
         ..  container:: example
+
+            Clips timespan durations:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(0, 1),
@@ -2383,7 +2384,6 @@ class TimespanList(list):
             >>> for _ in timespans: _
             Timespan(Offset((0, 1)), Offset((5, 1)))
             Timespan(Offset((0, 1)), Offset((10, 1)))
-
 
         ..  container:: example
 
@@ -2401,7 +2401,6 @@ class TimespanList(list):
             >>> for _ in timespans: _
             Timespan(Offset((0, 1)), Offset((1, 1)))
             Timespan(Offset((0, 1)), Offset((5, 1)))
-
 
         ..  container:: example
 
@@ -2422,7 +2421,6 @@ class TimespanList(list):
             >>> for _ in timespans: _
             Timespan(Offset((0, 1)), Offset((3, 1)))
             Timespan(Offset((0, 1)), Offset((7, 1)))
-
 
         ..  container:: example
 
@@ -2485,9 +2483,9 @@ class TimespanList(list):
         """
         Computes logical AND of timespans.
 
-        Computes logical AND:
-
         ..  container:: example
+
+            Computes logical AND:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(0, 10),
@@ -2499,7 +2497,6 @@ class TimespanList(list):
 
             >>> for _ in timespans: _
             Timespan(Offset((0, 1)), Offset((10, 1)))
-
 
         ..  container:: example
 
@@ -2516,7 +2513,6 @@ class TimespanList(list):
 
             >>> for _ in timespans: _
             Timespan(Offset((5, 1)), Offset((10, 1)))
-
 
         ..  container:: example
 
@@ -2760,9 +2756,9 @@ class TimespanList(list):
         """
         Computes overlap factor of timespans.
 
-        Example timespan list:
-
         ..  container:: example
+
+            Example timespan list:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(0, 10),
@@ -2983,9 +2979,9 @@ class TimespanList(list):
         Explodes timespans into timespan lists, avoiding overlap, and
         distributing density as evenly as possible.
 
-        Example timespan list:
-
         ..  container:: example
+
+            Example timespan list:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(0, 3),
@@ -3317,9 +3313,9 @@ class TimespanList(list):
         """
         Reflects timespans.
 
-        Reflects timespans about timespan list axis:
-
         ..  container:: example
+
+            Reflects timespans about timespan list axis:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(0, 3),
@@ -3437,9 +3433,9 @@ class TimespanList(list):
         """
         Rotates by ``count`` contiguous timespans.
 
-        Rotates by one timespan to the left:
-
         ..  container:: example
+
+            Rotates by one timespan to the left:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(0, 3),
@@ -3601,9 +3597,9 @@ class TimespanList(list):
         """
         Scales timespan by ``multiplier`` relative to ``anchor``.
 
-        Scales timespans relative to timespan list start offset:
-
         ..  container:: example
+
+            Scales timespans relative to timespan list start offset:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(0, 3),
@@ -3833,9 +3829,9 @@ class TimespanList(list):
         """
         Translates timespans by ``translation``.
 
-        Translates timespan by offset ``50``:
-
         ..  container:: example
+
+            Translates timespan by offset ``50``:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(0, 3),
@@ -3863,9 +3859,9 @@ class TimespanList(list):
         Translates timespans by ``start_offset_translation`` and
         ``stop_offset_translation``.
 
-        Translates timespan start- and stop-offsets equally:
-
         ..  container:: example
+
+            Translates timespan start- and stop-offsets equally:
 
             >>> timespans = abjad.TimespanList([
             ...     abjad.Timespan(0, 3),

--- a/abjad/tweaks.py
+++ b/abjad/tweaks.py
@@ -181,9 +181,9 @@ def bundle(
     r"""
     Bundles ``indicator`` with ``tweaks``.
 
-    Bundles indicator:
-
     ..  container:: example
+
+        Bundles indicator:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> bundle = abjad.bundle(

--- a/abjad/wf.py
+++ b/abjad/wf.py
@@ -32,9 +32,9 @@ def check_beamed_lone_notes(argument) -> tuple[list, int]:
     r"""
     Checks beamed lone notes.
 
-    Beamed single notes are not wellformed:
-
     ..  container:: example
+
+        Beamed single notes are not wellformed:
 
         >>> voice = abjad.Voice("c'8 d' e' f'")
         >>> abjad.attach(abjad.StartBeam(), voice[0])
@@ -74,9 +74,9 @@ def check_beamed_long_notes(argument) -> tuple[list, int]:
     r"""
     Checks beamed long notes.
 
-    Beamed quarter notes are not wellformed:
-
     ..  container:: example
+
+        Beamed quarter notes are not wellformed:
 
         >>> voice = abjad.Voice("c'4 d'4 e'4 f'4")
         >>> abjad.attach(abjad.StartBeam(), voice[0])
@@ -348,9 +348,9 @@ def check_out_of_range_pitches(
     r"""
     Checks out-of-range notes.
 
-    Out of range:
-
     ..  container:: example
+
+        Out of range:
 
         >>> staff = abjad.Staff("c'8 r8 <d fs>8 r8")
         >>> violin = abjad.Violin()
@@ -657,9 +657,9 @@ def check_unmatched_stop_text_spans(argument) -> tuple[list, int]:
     r"""
     Checks unmatched stop text spans.
 
-    Unmatched stop text span is not wellformed:
-
     ..  container:: example
+
+        Unmatched stop text span is not wellformed:
 
         >>> voice = abjad.Voice("c'4 c'4 c'4 c'4")
         >>> stop_text_span = abjad.StopTextSpan()
@@ -734,9 +734,9 @@ def check_unterminated_hairpins(argument) -> tuple[list, int]:
     r"""
     Checks unterminated hairpins.
 
-    Unterminated crescendo is not wellformed:
-
     ..  container:: example
+
+        Unterminated crescendo is not wellformed:
 
         >>> voice = abjad.Voice("c'4 c'4 c'4 c'4")
         >>> start_hairpin = abjad.StartHairpin('<')
@@ -859,9 +859,9 @@ def check_unterminated_text_spanners(argument) -> tuple[list, int]:
     r"""
     Checks unterminated text spanners.
 
-    Unterminated text spanner is not wellformed:
-
     ..  container:: example
+
+        Unterminated text spanner is not wellformed:
 
         >>> voice = abjad.Voice("c'4 c'4 c'4 c'4")
         >>> start_text_span = abjad.StartTextSpan()


### PR DESCRIPTION
Cleans up several dozen docstrings that contain a reST `container` directive.

These docstrings were mangled by the Sphinx sphinx_autodoc_typehints extension for about the last two years.

This commit restores those docstrings now that sphinx_autodoc_typehints has been removed from Abjad's docs.