### PR TITLE
Update Sphinx 8

### DIFF
--- a/abjad/ext/sphinx.py
+++ b/abjad/ext/sphinx.py
@@ -16,7 +16,7 @@ from docutils.nodes import (
     literal_block,
 )
 from docutils.parsers.rst import Directive, directives
-from sphinx.util import FilenameUniqDict, logging
+from sphinx.util import logging
 from sphinx.util.console import brown  # type: ignore
 from sphinx.util.nodes import set_source_info
 from sphinx.util.osutil import copyfile, ensuredir
@@ -181,7 +181,7 @@ def visit_thumbnail_block_latex(self, node):
 
 
 def on_builder_inited(app):
-    app.env.thumbnails = FilenameUniqDict()  # separate so Sphinx doesn't purge it
+    app.env.thumbnails = {}  # separate so Sphinx doesn't purge it
     install_lightbox_static_files(app)
     (pathlib.Path(app.builder.outdir) / "_images").mkdir(exist_ok=True)
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ description = "Abjad is a Python API for building LilyPond files."
 with open("README.rst", "r") as file_pointer:
     long_description = file_pointer.read()
 
-author = ["Trevor Bača", "Joséphine Oberholtzer"]
+author = ["Trevor Bača", "Joséphine Wolf Oberholtzer"]
 
 author_email = [
     "trevor.baca@gmail.com",
@@ -45,6 +45,7 @@ extras_require = {
         "pytest>=8.1.1",
         "pytest-cov>=4.1.0",
         "pytest-helpers-namespace>=2021.12.29",
+        "sphinx>=8.1.3",
         "sphinx-rtd-theme>=1.0.0",
     ],
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import pathlib
 import shutil
 
 import pytest
-from sphinx.testing.path import path
 
 pytest_plugins = "sphinx.testing.fixtures"
 
@@ -25,5 +24,5 @@ def remove_sphinx_projects(sphinx_test_tempdir):
 
 @pytest.fixture()
 def rootdir(remove_sphinx_projects):
-    roots = path(os.path.dirname(__file__) or ".").abspath() / "roots"
+    roots = pathlib.Path(os.path.dirname(__file__) or ".").absolute() / "roots"
     yield roots


### PR DESCRIPTION
Adds sphinx>=8.1.3 to setup.py.

Removes sphinx.testing.path (deprecated in Sphinx 8).

Removes sphinx.util.FilenameUniqDict (deprecated in Sphinx 8).