### PR TITLE
Bump Sphinx from 8.2.1 to 8.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     "pytest-cov==6.0.0",
     "pytest-helpers-namespace==2021.12.29",
     "setuptools==75.8.2",
-    "sphinx==8.2.1",
+    "sphinx==8.1.3",
     "sphinx-rtd-theme==3.0.2",
     "twine==6.1.0"
 ]


### PR DESCRIPTION
Sphinx 8.2.x introduces this bug:

https://github.com/sphinx-doc/sphinx/issues/13410

Sphinx 8.1.3 doesn't have this bug.

So this PR pins Sphinx to 8.1.3 for Abjad 3.22.