### PR TITLE
Remove typings.Duration

### DIFF
--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -12,7 +12,6 @@ from . import score as _score
 from . import sequence as _sequence
 from . import spanners as _spanners
 from . import tag as _tag
-from . import typings as _typings
 
 
 def _group_by_implied_prolation(durations):
@@ -201,8 +200,8 @@ def make_leaves(
     pitches,
     durations,
     *,
-    forbidden_note_duration: _typings.Duration | None = None,
-    forbidden_rest_duration: _typings.Duration | None = None,
+    forbidden_note_duration: _duration.Duration | None = None,
+    forbidden_rest_duration: _duration.Duration | None = None,
     skips_instead_of_rests: bool = False,
     increase_monotonic: bool = False,
     tag: _tag.Tag | None = None,
@@ -643,9 +642,9 @@ def make_leaves(
     if isinstance(durations, numbers.Number | tuple):
         durations = [durations]
     if forbidden_note_duration is not None:
-        forbidden_note_duration = _duration.Duration(forbidden_note_duration)
+        assert isinstance(forbidden_note_duration, _duration.Duration)
     if forbidden_rest_duration is not None:
-        forbidden_rest_duration = _duration.Duration(forbidden_rest_duration)
+        assert isinstance(forbidden_rest_duration, _duration.Duration)
     nonreduced_fractions = [_duration.Duration(_) for _ in durations]
     size = max(len(nonreduced_fractions), len(pitches))
     nonreduced_fractions = _sequence.repeat_to_length(nonreduced_fractions, size)
@@ -1571,12 +1570,12 @@ def tuplet_from_leaf_and_ratio(
 
 def tuplet_from_ratio_and_pair(
     ratio: tuple,
-    fraction: tuple,
+    pair: tuple,
     *,
     tag: _tag.Tag | None = None,
 ) -> _score.Tuplet:
     r"""
-    Makes tuplet from nonreduced ``ratio`` and nonreduced ``fraction``.
+    Makes tuplet from ``ratio`` and ``pair``.
 
     ..  container:: example
 
@@ -1744,10 +1743,10 @@ def tuplet_from_ratio_and_pair(
     """
     if not isinstance(ratio, tuple):
         raise ValueError(f"must be tuple, not {ratio!r}.")
-    if not isinstance(fraction, tuple):
-        raise ValueError(f"must be pair, not {fraction!r}.")
-    numerator, denominator = fraction
-    duration = _duration.Duration(fraction)
+    if not isinstance(pair, tuple):
+        raise ValueError(f"must be pair, not {pair!r}.")
+    numerator, denominator = pair
+    duration = _duration.Duration(pair)
     if len(ratio) == 1:
         if 0 < ratio[0]:
             try:

--- a/source/abjad/obgc.py
+++ b/source/abjad/obgc.py
@@ -13,7 +13,6 @@ from . import select as _select
 from . import spanners as _spanners
 from . import tag as _tag
 from . import tweaks as _tweaks
-from . import typings as _typings
 
 
 def _is_obgc_nongrace_voice(component):
@@ -118,7 +117,7 @@ class OnBeatGraceContainer(_score.Container):
         self,
         components: str | typing.Sequence[_score.Leaf] = (),
         *,
-        grace_leaf_duration: _typings.Duration | None = None,
+        grace_leaf_duration: _duration.Duration | None = None,
         identifier: str | None = None,
         name: str | None = None,
         tag: _tag.Tag | None = None,
@@ -294,7 +293,7 @@ def on_beat_grace_container(
     do_not_slash: bool = False,
     do_not_slur: bool = False,
     grace_font_size: int = -3,
-    grace_leaf_duration: _typings.Duration | None = None,
+    grace_leaf_duration: _duration.Duration | None = None,
     grace_polyphony_command: _indicators.VoiceNumber = _indicators.VoiceNumber(1),
     nongrace_polyphony_command: _indicators.VoiceNumber = _indicators.VoiceNumber(2),
     tag: _tag.Tag = _tag.Tag(),

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -20,7 +20,6 @@ from . import pitch as _pitch
 from . import tag as _tag
 from . import timespan as _timespan
 from . import tweaks as _tweaks
-from . import typings as _typings
 
 
 def _indent_strings(strings):
@@ -6196,7 +6195,7 @@ class Tuplet(Container):
 
     @staticmethod
     def from_duration(
-        duration: _typings.Duration, components, *, tag: _tag.Tag | None = None
+        duration: _duration.Duration, components, *, tag: _tag.Tag | None = None
     ) -> "Tuplet":
         r"""
         Makes tuplet from ``duration`` and ``components``.
@@ -6205,7 +6204,8 @@ class Tuplet(Container):
 
             Makes diminution:
 
-            >>> tuplet = abjad.Tuplet.from_duration((2, 8), "c'8 d' e'")
+            >>> duration = abjad.Duration(2, 8)
+            >>> tuplet = abjad.Tuplet.from_duration(duration, "c'8 d' e'")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             ..  docs::
@@ -6220,6 +6220,7 @@ class Tuplet(Container):
                 }
 
         """
+        assert isinstance(duration, _duration.Duration), repr(duration)
         if not len(components):
             raise Exception(f"components must be nonempty: {components!r}.")
         target_duration = _duration.Duration(duration)

--- a/source/abjad/typings.py
+++ b/source/abjad/typings.py
@@ -7,8 +7,6 @@ import typing
 
 from . import duration as _duration
 
-Duration: typing.TypeAlias = typing.Union[_duration.Duration, tuple[int, int]]
-
 Exclude: typing.TypeAlias = typing.Union[
     str | enum.Enum | typing.Sequence[str | enum.Enum]
 ]


### PR DESCRIPTION
OLD:

    abjad.makers.make_leaves():
        forbidden_note_duration keyword could be coerced from tuple to abjad.Duration
        forbidden_rest_duration keyword could be coerced from tuplet to abjad.Duration

NEW:

    abjad.makers.make_leaves():
        forbidden_note_duration keyword must be abjad.Duration; no coercion
        forbidden_rest_duration keyword must be abjad.Duration; no coercion

NEW: rmakers.durations() function.

    >>> rmakers.durations([(1, 8), (1, 2), (1, 16)])
    [Duration(1, 8), Duration(1, 2), Duration(1, 16)]