### PR TITLE
Clean up makers.py

### DIFF
--- a/docs/source/examples/enumeration.rst
+++ b/docs/source/examples/enumeration.rst
@@ -28,10 +28,9 @@ The following functions recreate Malt's results in Abjad:
     ...     lone_note_denominator = denominator * 4
     ...     lone_note_duration = (1, lone_note_denominator)
     ...     lone_note = abjad.Note("c'", lone_note_duration)
-    ...     duration = (outer, lone_note_denominator)
     ...     ratio = inner * (1,)
-    ...     maker = abjad.makers.tuplet_from_duration_and_ratio
-    ...     inner_tuplet = maker(duration, ratio)
+    ...     pair = (outer, lone_note_denominator)
+    ...     inner_tuplet = abjad.makers.tuplet_from_ratio_and_pair(ratio, pair)
     ...     multiplier = abjad.Fraction(*inner_tuplet.multiplier)
     ...     pair = abjad.duration.with_denominator(multiplier, inner)
     ...     inner_tuplet.multiplier = pair
@@ -112,4 +111,4 @@ Here's the rhythmic retrograde of the same:
     >>> lilypond_file = abjad.LilyPondFile([preamble, score])
     >>> abjad.show(lilypond_file)
 
-:author:`[Bača (1.1, 3.2)]`
+:author:`[Bača (1.1, 3.2, 3.24)]`

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -4,7 +4,6 @@ import math
 import numbers
 
 from . import duration as _duration
-from . import exceptions as _exceptions
 from . import math as _math
 from . import pitch as _pitch
 from . import score as _score
@@ -918,362 +917,6 @@ def make_notes(
     return result
 
 
-def tuplet_from_duration_and_ratio(
-    duration: _duration.Duration,
-    ratio: tuple[int, ...],
-    *,
-    increase_monotonic: bool = False,
-    tag: _tag.Tag | None = None,
-) -> _score.Tuplet:
-    r"""
-    Makes tuplet from ``duration`` and ``ratio``.
-
-    ..  container:: example
-
-        Helper function:
-
-        >>> def make_score(duration, ratio, *, increase_monotonic=False):
-        ...     tuplet = abjad.makers.tuplet_from_duration_and_ratio(
-        ...         duration, ratio, increase_monotonic=increase_monotonic
-        ...     )
-        ...     staff = abjad.Staff([tuplet], lilypond_type="RhythmicStaff")
-        ...     score = abjad.Score([staff], name="Score")
-        ...     pair = duration.pair
-        ...     time_signature = abjad.TimeSignature(pair)
-        ...     leaf = abjad.select.leaf(staff, 0)
-        ...     abjad.attach(time_signature, leaf)
-        ...     return score
-
-    ..  container:: example
-
-        Divides duration of 3/16 into increasing number of parts:
-
-        >>> score = make_score(abjad.Duration(3, 16), (1, 2, 2))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 5/4
-            {
-                \time 3/16
-                c'32.
-                c'16.
-                c'16.
-            }
-
-        >>> score = make_score(abjad.Duration(3, 16), (1, 2, 2, 3))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 4/3
-            {
-                \time 3/16
-                c'32
-                c'16
-                c'16
-                c'16.
-            }
-
-        >>> score = make_score(abjad.Duration(3, 16), (1, 2, 2, 3, 3))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 11/6
-            {
-                \time 3/16
-                c'32
-                c'16
-                c'16
-                c'16.
-                c'16.
-            }
-
-        >>> score = make_score(abjad.Duration(3, 16), (1, 2, 2, 3, 3, 4))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 5/4
-            {
-                \time 3/16
-                c'64
-                c'32
-                c'32
-                c'32.
-                c'32.
-                c'16
-            }
-
-    ..  container:: example
-
-        Divides duration of 7/16 into increasing number of parts:
-
-        >>> score = make_score(abjad.Duration(7, 16), (1,))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 7/16
-                c'4..
-            }
-
-        >>> score = make_score(abjad.Duration(7, 16), (1, 2))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 3/2
-            {
-                \time 7/16
-                c'8..
-                c'4..
-            }
-
-        >>> score = make_score(abjad.Duration(7, 16), (1, 2, 4))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 7/16
-                c'16
-                c'8
-                c'4
-            }
-
-        >>> score = make_score(abjad.Duration(7, 16), (1, 2, 4, 1))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 7/16
-                c'32..
-                c'16..
-                c'8..
-                c'32..
-            }
-
-        >>> score = make_score(abjad.Duration(7, 16), (1, 2, 4, 1, 2))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 5/4
-            {
-                \time 7/16
-                c'32..
-                c'16..
-                c'8..
-                c'32..
-                c'16..
-            }
-
-        >>> score = make_score(abjad.Duration(7, 16), (1, 2, 4, 1, 2, 4))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 7/16
-                c'32
-                c'16
-                c'8
-                c'32
-                c'16
-                c'8
-            }
-
-    ..  container:: example
-
-        Interprets negative integers in ``ratio`` as rests:
-
-        >>> score = make_score(abjad.Duration(1, 4), (1, 1, 1, -1, 1))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 5/4
-            {
-                \time 1/4
-                c'16
-                c'16
-                c'16
-                r16
-                c'16
-            }
-
-        >>> score = make_score(abjad.Duration(1, 4), (3, -2, 2))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 7/4
-            {
-                \time 1/4
-                c'8.
-                r8
-                c'8
-            }
-
-    ..  container:: example
-
-        Spells nonassignable durations in monotonically decreasing parts by default:
-
-        >>> score = make_score(abjad.Duration(1, 4), (5, -2))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 7/4
-            {
-                \time 1/4
-                c'4
-                ~
-                c'16
-                r8
-            }
-
-        Set ``increase_monotonic=True`` to spell nonassignable durations
-        in monotonically increasing parts:
-
-        >>> score = make_score(abjad.Duration(1, 4), (5, -2), increase_monotonic=True)
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 7/4
-            {
-                \time 1/4
-                c'16
-                ~
-                c'4
-                r8
-            }
-
-    ..  container:: example
-
-        Reduces integers in ``ratio`` relative to each other:
-
-        >>> score = make_score(abjad.Duration(1, 4), (1, 1, 1))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 3/2
-            {
-                \time 1/4
-                c'8
-                c'8
-                c'8
-            }
-
-        >>> score = make_score(abjad.Duration(1, 4), (4, 4, 4))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 3/2
-            {
-                \time 1/4
-                c'8
-                c'8
-                c'8
-            }
-
-    """
-    assert isinstance(duration, _duration.Duration), repr(duration)
-    assert isinstance(ratio, tuple), repr(ratio)
-    assert all(isinstance(_, int) for _ in ratio), repr(ratio)
-    basic_prolated_duration = duration / _math.weight(ratio)
-    basic_written_duration = basic_prolated_duration.equal_or_greater_assignable
-    written_durations = [x * basic_written_duration for x in ratio]
-    components: list[_score.Leaf | _score.Tuplet] = []
-    try:
-        for written_duration in written_durations:
-            if 0 < written_duration:
-                note = _score.Note(0, written_duration, tag=tag)
-                components.append(note)
-            else:
-                rest = _score.Rest(abs(written_duration), tag=tag)
-                components.append(rest)
-    except _exceptions.AssignabilityError:
-        denominator = duration.denominator
-        note_durations = [_duration.Duration(x, denominator) for x in ratio]
-        pitches = [None if note_duration < 0 else 0 for note_duration in note_durations]
-        leaf_durations = [abs(note_duration) for note_duration in note_durations]
-        components = make_leaves(
-            pitches,
-            leaf_durations,
-            increase_monotonic=increase_monotonic,
-            tag=tag,
-        )
-    tuplet = _score.Tuplet.from_duration(duration, components, tag=tag)
-    tuplet.normalize_multiplier()
-    return tuplet
-
-
 def tuplet_from_ratio_and_pair(
     ratio: tuple[int, ...],
     pair: tuple[int, int],
@@ -1298,7 +941,7 @@ def tuplet_from_ratio_and_pair(
 
     ..  container:: example
 
-        COMPARISON. Divides duration of 3/16 into increasing number of parts:
+        Divides duration of 3/16 into increasing number of parts:
 
         >>> score = make_score((1, 2, 2), (3, 16))
         >>> abjad.show(score) # doctest: +SKIP
@@ -1375,7 +1018,7 @@ def tuplet_from_ratio_and_pair(
 
     ..  container:: example
 
-        COMPARISON. Divides duration of 7/16 into increasing number of parts:
+        Divides duration of 7/16 into increasing number of parts:
 
         >>> score = make_score((1,), (7, 16))
         >>> abjad.show(score) # doctest: +SKIP
@@ -1483,7 +1126,7 @@ def tuplet_from_ratio_and_pair(
 
     ..  container:: example
 
-        COMPARISON. Interprets negative integers in ``ratio`` as rests:
+        Interprets negative integers in ``ratio`` as rests:
 
         >>> score = make_score((1, 1, 1, -1, 1), (1, 4))
         >>> abjad.show(score) # doctest: +SKIP
@@ -1544,7 +1187,7 @@ def tuplet_from_ratio_and_pair(
 
     ..  container:: example
 
-        COMPARISON. Reduces integers in ``ratio`` relative to each other:
+        Reduces integers in ``ratio`` relative to each other:
 
         >>> score = make_score((1, 1, 1), (1, 4))
         >>> abjad.show(score) # doctest: +SKIP

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -1022,6 +1022,113 @@ def tuplet_from_duration_and_ratio(
 
     ..  container:: example
 
+        Divides duration of 7/16 into increasing number of parts:
+
+        >>> score = make_score(abjad.Duration(7, 16), (1,))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tweak text #tuplet-number::calc-fraction-text
+            \tuplet 1/1
+            {
+                \time 7/16
+                c'4..
+            }
+
+        >>> score = make_score(abjad.Duration(7, 16), (1, 2))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tuplet 3/2
+            {
+                \time 7/16
+                c'8..
+                c'4..
+            }
+
+        >>> score = make_score(abjad.Duration(7, 16), (1, 2, 4))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tweak text #tuplet-number::calc-fraction-text
+            \tuplet 1/1
+            {
+                \time 7/16
+                c'16
+                c'8
+                c'4
+            }
+
+        >>> score = make_score(abjad.Duration(7, 16), (1, 2, 4, 1))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tweak text #tuplet-number::calc-fraction-text
+            \tuplet 1/1
+            {
+                \time 7/16
+                c'32..
+                c'16..
+                c'8..
+                c'32..
+            }
+
+        >>> score = make_score(abjad.Duration(7, 16), (1, 2, 4, 1, 2))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tuplet 5/4
+            {
+                \time 7/16
+                c'32..
+                c'16..
+                c'8..
+                c'32..
+                c'16..
+            }
+
+        >>> score = make_score(abjad.Duration(7, 16), (1, 2, 4, 1, 2, 4))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tweak text #tuplet-number::calc-fraction-text
+            \tuplet 1/1
+            {
+                \time 7/16
+                c'32
+                c'16
+                c'8
+                c'32
+                c'16
+                c'8
+            }
+
+    ..  container:: example
+
         Interprets negative integers in ``ratio`` as rests:
 
         >>> score = make_score(abjad.Duration(1, 4), (1, 1, 1, -1, 1))
@@ -1191,7 +1298,84 @@ def tuplet_from_ratio_and_pair(
 
     ..  container:: example
 
-        Divides duration of 7/16 into increasing number of parts:
+        COMPARISON. Divides duration of 3/16 into increasing number of parts:
+
+        >>> score = make_score((1, 2, 2), (3, 16))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tweak text #tuplet-number::calc-fraction-text
+            \tuplet 5/3
+            {
+                \time 3/16
+                c'16
+                c'8
+                c'8
+            }
+
+        >>> score = make_score((1, 2, 2, 3), (3, 16))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tweak text #tuplet-number::calc-fraction-text
+            \tuplet 4/3
+            {
+                \time 3/16
+                c'32
+                c'16
+                c'16
+                c'16.
+            }
+
+        >>> score = make_score((1, 2, 2, 3, 3), (3, 16))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tweak text #tuplet-number::calc-fraction-text
+            \tuplet 11/6
+            {
+                \time 3/16
+                c'32
+                c'16
+                c'16
+                c'16.
+                c'16.
+            }
+
+        >>> score = make_score((1, 2, 2, 3, 3, 4), (3, 16))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tuplet 5/4
+            {
+                \time 3/16
+                c'64
+                c'32
+                c'32
+                c'32.
+                c'32.
+                c'16
+            }
+
+    ..  container:: example
+
+        COMPARISON. Divides duration of 7/16 into increasing number of parts:
 
         >>> score = make_score((1,), (7, 16))
         >>> abjad.show(score) # doctest: +SKIP
@@ -1299,6 +1483,44 @@ def tuplet_from_ratio_and_pair(
 
     ..  container:: example
 
+        COMPARISON. Interprets negative integers in ``ratio`` as rests:
+
+        >>> score = make_score((1, 1, 1, -1, 1), (1, 4))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tuplet 5/4
+            {
+                \time 1/4
+                c'16
+                c'16
+                c'16
+                r16
+                c'16
+            }
+
+        >>> score = make_score((3, -2, 2), (1, 4))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tuplet 7/4
+            {
+                \time 1/4
+                c'8.
+                r8
+                c'8
+            }
+
+    ..  container:: example
+
         Works with nonassignable rests:
 
         >>> score = make_score((11, -5), (7, 16))
@@ -1318,6 +1540,42 @@ def tuplet_from_ratio_and_pair(
                 c'16.
                 r8
                 r32
+            }
+
+    ..  container:: example
+
+        COMPARISON. Reduces integers in ``ratio`` relative to each other:
+
+        >>> score = make_score((1, 1, 1), (1, 4))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tuplet 3/2
+            {
+                \time 1/4
+                c'8
+                c'8
+                c'8
+            }
+
+        >>> score = make_score((4, 4, 4), (1, 4))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tuplet 3/2
+            {
+                \time 1/4
+                c'8
+                c'8
+                c'8
             }
 
     """

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -938,7 +938,6 @@ def tuplet_from_duration_and_ratio(
         ...         duration, ratio, increase_monotonic=increase_monotonic
         ...     )
         ...     staff = abjad.Staff([tuplet], lilypond_type="RhythmicStaff")
-        ...     staff.name = "Staff"
         ...     score = abjad.Score([staff], name="Score")
         ...     pair = duration.pair
         ...     time_signature = abjad.TimeSignature(pair)
@@ -1031,7 +1030,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> string = abjad.lilypond(score["Staff"][0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tuplet 5/4
             {
@@ -1048,7 +1048,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> string = abjad.lilypond(score["Staff"][0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tuplet 7/4
             {
@@ -1067,7 +1068,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> string = abjad.lilypond(score["Staff"][0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tuplet 7/4
             {
@@ -1086,7 +1088,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> string = abjad.lilypond(score["Staff"][0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tuplet 7/4
             {
@@ -1106,7 +1109,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> string = abjad.lilypond(score["Staff"][0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tuplet 3/2
             {
@@ -1121,7 +1125,8 @@ def tuplet_from_duration_and_ratio(
 
         ..  docs::
 
-            >>> string = abjad.lilypond(score["Staff"][0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tuplet 3/2
             {
@@ -1164,8 +1169,8 @@ def tuplet_from_duration_and_ratio(
 
 
 def tuplet_from_ratio_and_pair(
-    ratio: tuple,
-    pair: tuple,
+    ratio: tuple[int, ...],
+    pair: tuple[int, int],
     *,
     tag: _tag.Tag | None = None,
 ) -> _score.Tuplet:
@@ -1174,18 +1179,28 @@ def tuplet_from_ratio_and_pair(
 
     ..  container:: example
 
-        >>> tuplet = abjad.makers.tuplet_from_ratio_and_pair((1,), (7, 16))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((7, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        Helper function:
+
+        >>> def make_score(ratio, pair):
+        ...     tuplet = abjad.makers.tuplet_from_ratio_and_pair(ratio, pair)
+        ...     staff = abjad.Staff([tuplet], lilypond_type="RhythmicStaff")
+        ...     score = abjad.Score([staff], name="Score")
+        ...     time_signature = abjad.TimeSignature(pair)
+        ...     leaf = abjad.select.leaf(staff, 0)
+        ...     abjad.attach(time_signature, leaf)
+        ...     return score
+
+    ..  container:: example
+
+        Divides duration of 7/16 into increasing number of parts:
+
+        >>> score = make_score((1,), (7, 16))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \tuplet 1/1
@@ -1194,18 +1209,13 @@ def tuplet_from_ratio_and_pair(
                 c'4..
             }
 
-        >>> tuplet = abjad.makers.tuplet_from_ratio_and_pair((1, 2), (7, 16))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((7, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score((1, 2), (7, 16))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \tuplet 6/7
@@ -1215,18 +1225,13 @@ def tuplet_from_ratio_and_pair(
                 c'4
             }
 
-        >>> tuplet = abjad.makers.tuplet_from_ratio_and_pair((1, 2, 4), (7, 16))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((7, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score((1, 2, 4), (7, 16))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \tuplet 1/1
@@ -1237,18 +1242,13 @@ def tuplet_from_ratio_and_pair(
                 c'4
             }
 
-        >>> tuplet = abjad.makers.tuplet_from_ratio_and_pair((1, 2, 4, 1), (7, 16))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((7, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score((1, 2, 4, 1), (7, 16))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \tuplet 8/7
@@ -1260,18 +1260,13 @@ def tuplet_from_ratio_and_pair(
                 c'16
             }
 
-        >>> tuplet = abjad.makers.tuplet_from_ratio_and_pair((1, 2, 4, 1, 2), (7, 16))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((7, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score((1, 2, 4, 1, 2), (7, 16))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
             \tuplet 10/7
@@ -1284,18 +1279,13 @@ def tuplet_from_ratio_and_pair(
                 c'8
             }
 
-        >>> tuplet = abjad.makers.tuplet_from_ratio_and_pair((1, 2, 4, 1, 2, 4), (7, 16))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((7, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score((1, 2, 4, 1, 2, 4), (7, 16))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tuplet 2/1
             {
@@ -1308,23 +1298,20 @@ def tuplet_from_ratio_and_pair(
                 c'4
             }
 
+    ..  container:: example
+
         Works with nonassignable rests:
 
-        >>> tuplet = abjad.makers.tuplet_from_ratio_and_pair((11, -5), (5, 16))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((7, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score((11, -5), (7, 16))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 8/5
+            \tuplet 8/7
             {
                 \time 7/16
                 c'4
@@ -1334,12 +1321,11 @@ def tuplet_from_ratio_and_pair(
                 r32
             }
 
-    Interprets ``d`` as tuplet denominator.
     """
-    if not isinstance(ratio, tuple):
-        raise ValueError(f"must be tuple, not {ratio!r}.")
-    if not isinstance(pair, tuple):
-        raise ValueError(f"must be pair, not {pair!r}.")
+    assert isinstance(ratio, tuple), repr(ratio)
+    assert all(isinstance(_, int) for _ in ratio), repr(ratio)
+    assert isinstance(pair, tuple), repr(pair)
+    assert all(isinstance(_, int) for _ in pair), repr(pair)
     numerator, denominator = pair
     duration = _duration.Duration(pair)
     if len(ratio) == 1:

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -948,40 +948,78 @@ def tuplet_from_duration_and_ratio(
 
     ..  container:: example
 
-        Divides duration of a quarter note into equal parts:
+        Divides duration of 3/16 into increasing number of parts:
 
-        >>> score = make_score(abjad.Duration(1, 4), (1, 1, 1, 1, 1))
+        >>> score = make_score(abjad.Duration(3, 16), (1, 2, 2))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(score["Staff"][0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
             \tuplet 5/4
             {
-                \time 1/4
-                c'16
-                c'16
-                c'16
-                c'16
-                c'16
+                \time 3/16
+                c'32.
+                c'16.
+                c'16.
             }
 
-        Divides duration of a quarter note into unequal parts:
-
-        >>> score = make_score(abjad.Duration(1, 4), (3, 2, 2))
+        >>> score = make_score(abjad.Duration(3, 16), (1, 2, 2, 3))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(score["Staff"][0])
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
             >>> print(string)
-            \tuplet 7/4
+            \tweak text #tuplet-number::calc-fraction-text
+            \tuplet 4/3
             {
-                \time 1/4
-                c'8.
-                c'8
-                c'8
+                \time 3/16
+                c'32
+                c'16
+                c'16
+                c'16.
+            }
+
+        >>> score = make_score(abjad.Duration(3, 16), (1, 2, 2, 3, 3))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tweak text #tuplet-number::calc-fraction-text
+            \tuplet 11/6
+            {
+                \time 3/16
+                c'32
+                c'16
+                c'16
+                c'16.
+                c'16.
+            }
+
+        >>> score = make_score(abjad.Duration(3, 16), (1, 2, 2, 3, 3, 4))
+        >>> abjad.show(score) # doctest: +SKIP
+
+        ..  docs::
+
+            >>> tuplet = score[0][0]
+            >>> string = abjad.lilypond(tuplet)
+            >>> print(string)
+            \tuplet 5/4
+            {
+                \time 3/16
+                c'64
+                c'32
+                c'32
+                c'32.
+                c'32.
+                c'16
             }
 
     ..  container:: example
@@ -1022,7 +1060,7 @@ def tuplet_from_duration_and_ratio(
 
     ..  container:: example
 
-        Spells nonassignable durations monotonically decreasing by default:
+        Spells nonassignable durations in monotonically decreasing parts by default:
 
         >>> score = make_score(abjad.Duration(1, 4), (5, -2))
         >>> abjad.show(score) # doctest: +SKIP
@@ -1041,7 +1079,7 @@ def tuplet_from_duration_and_ratio(
             }
 
         Set ``increase_monotonic=True`` to spell nonassignable durations
-        monotonically increasing:
+        in monotonically increasing parts:
 
         >>> score = make_score(abjad.Duration(1, 4), (5, -2), increase_monotonic=True)
         >>> abjad.show(score) # doctest: +SKIP
@@ -1121,324 +1159,6 @@ def tuplet_from_duration_and_ratio(
             tag=tag,
         )
     tuplet = _score.Tuplet.from_duration(duration, components, tag=tag)
-    tuplet.normalize_multiplier()
-    return tuplet
-
-
-def tuplet_from_leaf_and_ratio(
-    leaf: _score.Leaf, ratio: tuple[int, ...]
-) -> _score.Tuplet:
-    r"""
-    Makes tuplet from ``leaf`` and ``ratio``.
-
-    >>> note = abjad.Note("c'8.")
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1,))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 3/16
-                c'8.
-            }
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1, 2))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 3/16
-                c'16
-                c'8
-            }
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1, 2, 2))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 5/4
-            {
-                \time 3/16
-                c'32.
-                c'16.
-                c'16.
-            }
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1, 2, 2, 3))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 4/3
-            {
-                \time 3/16
-                c'32
-                c'16
-                c'16
-                c'16.
-            }
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1, 2, 2, 3, 3))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 11/6
-            {
-                \time 3/16
-                c'32
-                c'16
-                c'16
-                c'16.
-                c'16.
-            }
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1, 2, 2, 3, 3, 4))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 5/4
-            {
-                \time 3/16
-                c'64
-                c'32
-                c'32
-                c'32.
-                c'32.
-                c'16
-            }
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1,))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 3/16
-                c'8.
-            }
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1, 2))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 3/16
-                c'16
-                c'8
-            }
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1, 2, 2))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 5/4
-            {
-                \time 3/16
-                c'32.
-                c'16.
-                c'16.
-            }
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1, 2, 2, 3))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 4/3
-            {
-                \time 3/16
-                c'32
-                c'16
-                c'16
-                c'16.
-            }
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1, 2, 2, 3, 3))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 11/6
-            {
-                \time 3/16
-                c'32
-                c'16
-                c'16
-                c'16.
-                c'16.
-            }
-
-    ..  container:: example
-
-        >>> tuplet = abjad.makers.tuplet_from_leaf_and_ratio(note, (1, 2, 2, 3, 3, 4))
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 5/4
-            {
-                \time 3/16
-                c'64
-                c'32
-                c'32
-                c'32.
-                c'32.
-                c'16
-            }
-
-    """
-    assert isinstance(ratio, tuple), repr(ratio)
-    target_duration = leaf.written_duration
-    basic_prolated_duration = target_duration / sum(ratio)
-    basic_written_duration = basic_prolated_duration.equal_or_greater_assignable
-    written_durations = [_ * basic_written_duration for _ in ratio]
-    notes: list[_score.Note | _score.Tuplet]
-    try:
-        notes = [_score.Note(0, x) for x in written_durations]
-    except _exceptions.AssignabilityError:
-        denominator = target_duration.denominator
-        note_durations = [_duration.Duration(_, denominator) for _ in ratio]
-        notes = make_notes(0, note_durations)
-    contents_duration = _getlib._get_duration(notes)
-    multiplier = target_duration / contents_duration
-    tuplet = _score.Tuplet(_duration.pair(multiplier), notes)
     tuplet.normalize_multiplier()
     return tuplet
 

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -920,7 +920,7 @@ def make_notes(
 
 
 def tuplet_from_duration_and_ratio(
-    duration,
+    duration: _duration.Duration,
     ratio: tuple[int, ...],
     *,
     increase_monotonic: bool = False,
@@ -931,321 +931,196 @@ def tuplet_from_duration_and_ratio(
 
     ..  container:: example
 
-        Makes tupletted leaves strictly without dots when all ``ratio`` equal ``1``:
+        Helper function:
 
-        >>> tuplet = abjad.makers.tuplet_from_duration_and_ratio(
-        ...     abjad.Duration(3, 16),
-        ...     (1, 1, 1, -1, -1),
-        ... )
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> def make_score(duration, ratio, *, increase_monotonic=False):
+        ...     tuplet = abjad.makers.tuplet_from_duration_and_ratio(
+        ...         duration, ratio, increase_monotonic=increase_monotonic
+        ...     )
+        ...     staff = abjad.Staff([tuplet], lilypond_type="RhythmicStaff")
+        ...     staff.name = "Staff"
+        ...     score = abjad.Score([staff], name="Score")
+        ...     pair = duration.pair
+        ...     time_signature = abjad.TimeSignature(pair)
+        ...     leaf = abjad.select.leaf(staff, 0)
+        ...     abjad.attach(time_signature, leaf)
+        ...     return score
+
+    ..  container:: example
+
+        Divides duration of a quarter note into equal parts:
+
+        >>> score = make_score(abjad.Duration(1, 4), (1, 1, 1, 1, 1))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> string = abjad.lilypond(score["Staff"][0])
             >>> print(string)
             \tuplet 5/4
             {
-                \time 3/16
-                c'32.
-                c'32.
-                c'32.
-                r32.
-                r32.
+                \time 1/4
+                c'16
+                c'16
+                c'16
+                c'16
+                c'16
             }
 
-        Allows tupletted leaves to return with dots when some ``ratio`` do not equal
-        ``1``:
+        Divides duration of a quarter note into unequal parts:
 
-        >>> tuplet = abjad.makers.tuplet_from_duration_and_ratio(
-        ...     abjad.Duration(3, 16),
-        ...     (1, -2, -2, 3, 3),
-        ... )
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score(abjad.Duration(1, 4), (3, 2, 2))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> string = abjad.lilypond(score["Staff"][0])
             >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 11/6
+            \tuplet 7/4
             {
-                \time 3/16
-                c'32
-                r16
-                r16
-                c'16.
-                c'16.
-            }
-
-        Interprets nonassignable ``ratio`` according to ``increase_monotonic``:
-
-        >>> tuplet = abjad.makers.tuplet_from_duration_and_ratio(
-        ...     abjad.Duration(3, 16),
-        ...     (5, -1, 5),
-        ...     increase_monotonic=True,
-        ... )
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(staff[0])
-            >>> print(string)
-            \tuplet 11/8
-            {
-                \time 3/16
-                c'16...
-                r64.
-                c'16...
+                \time 1/4
+                c'8.
+                c'8
+                c'8
             }
 
     ..  container:: example
 
-        Makes augmented tuplet from ``duration`` and ``ratio`` and encourages dots:
+        Interprets negative integers in ``ratio`` as rests:
 
-        >>> tuplet = abjad.makers.tuplet_from_duration_and_ratio(
-        ...     abjad.Duration(3, 16),
-        ...     (1, 1, 1, -1, -1),
-        ... )
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score(abjad.Duration(1, 4), (1, 1, 1, -1, 1))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> string = abjad.lilypond(score["Staff"][0])
             >>> print(string)
             \tuplet 5/4
             {
-                \time 3/16
-                c'32.
-                c'32.
-                c'32.
-                r32.
-                r32.
+                \time 1/4
+                c'16
+                c'16
+                c'16
+                r16
+                c'16
             }
 
-        Interprets nonassignable ``ratio`` according to ``increase_monotonic``:
-
-        >>> tuplet = abjad.makers.tuplet_from_duration_and_ratio(
-        ...     abjad.Duration(3, 16),
-        ...     (5, -1, 5),
-        ...     increase_monotonic=True,
-        ... )
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score(abjad.Duration(1, 4), (3, -2, 2))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> string = abjad.lilypond(score["Staff"][0])
             >>> print(string)
-            \tuplet 11/8
+            \tuplet 7/4
             {
-                \time 3/16
-                c'16...
-                r64.
-                c'16...
+                \time 1/4
+                c'8.
+                r8
+                c'8
             }
 
     ..  container:: example
 
-        Makes diminished tuplet from ``duration`` and nonzero integer ``ratio``.
+        Spells nonassignable durations monotonically decreasing by default:
 
-        Makes tupletted leaves strictly without dots when all ``ratio`` equal ``1``:
-
-        >>> tuplet = abjad.makers.tuplet_from_duration_and_ratio(
-        ...     abjad.Duration(3, 16),
-        ...     (1, 1, 1, -1, -1),
-        ... )
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score(abjad.Duration(1, 4), (5, -2))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> string = abjad.lilypond(score["Staff"][0])
             >>> print(string)
-            \tuplet 5/4
+            \tuplet 7/4
             {
-                \time 3/16
-                c'32.
-                c'32.
-                c'32.
-                r32.
-                r32.
+                \time 1/4
+                c'4
+                ~
+                c'16
+                r8
             }
 
-        Allows tupletted leaves to return with dots when some ``ratio`` do not equal
-        ``1``:
+        Set ``increase_monotonic=True`` to spell nonassignable durations
+        monotonically increasing:
 
-        >>> tuplet = abjad.makers.tuplet_from_duration_and_ratio(
-        ...     abjad.Duration(3, 16),
-        ...     (1, -2, -2, 3, 3),
-        ... )
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score(abjad.Duration(1, 4), (5, -2), increase_monotonic=True)
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> string = abjad.lilypond(score["Staff"][0])
             >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 11/6
+            \tuplet 7/4
             {
-                \time 3/16
-                c'32
-                r16
-                r16
-                c'16.
-                c'16.
-            }
-
-        Interprets nonassignable ``ratio`` according to ``increase_monotonic``:
-
-        >>> tuplet = abjad.makers.tuplet_from_duration_and_ratio(
-        ...     abjad.Duration(3, 16),
-        ...     (5, -1, 5),
-        ...     increase_monotonic=True,
-        ... )
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(staff[0])
-            >>> print(string)
-            \tuplet 11/8
-            {
-                \time 3/16
-                c'16...
-                r64.
-                c'16...
+                \time 1/4
+                c'16
+                ~
+                c'4
+                r8
             }
 
     ..  container:: example
 
-        Makes diminished tuplet from ``duration`` and ``ratio`` and encourages dots:
+        Reduces integers in ``ratio`` relative to each other:
 
-        >>> tuplet = abjad.makers.tuplet_from_duration_and_ratio(
-        ...     abjad.Duration(3, 16),
-        ...     (1, 1, 1, -1, -1),
-        ... )
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score(abjad.Duration(1, 4), (1, 1, 1))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> string = abjad.lilypond(score["Staff"][0])
             >>> print(string)
-            \tuplet 5/4
+            \tuplet 3/2
             {
-                \time 3/16
-                c'32.
-                c'32.
-                c'32.
-                r32.
-                r32.
+                \time 1/4
+                c'8
+                c'8
+                c'8
             }
 
-        Interprets nonassignable ``ratio`` according to ``direction``:
-
-        >>> tuplet = abjad.makers.tuplet_from_duration_and_ratio(
-        ...     abjad.Duration(3, 16),
-        ...     (5, -1, 5),
-        ...     increase_monotonic=True,
-        ... )
-        >>> staff = abjad.Staff(
-        ...     [tuplet],
-        ...     lilypond_type="RhythmicStaff",
-        ... )
-        >>> score = abjad.Score([staff], name="Score")
-        >>> abjad.attach(abjad.TimeSignature((3, 16)), tuplet[0])
-        >>> abjad.show(staff) # doctest: +SKIP
+        >>> score = make_score(abjad.Duration(1, 4), (4, 4, 4))
+        >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
 
-            >>> string = abjad.lilypond(staff[0])
+            >>> string = abjad.lilypond(score["Staff"][0])
             >>> print(string)
-            \tuplet 11/8
+            \tuplet 3/2
             {
-                \time 3/16
-                c'16...
-                r64.
-                c'16...
+                \time 1/4
+                c'8
+                c'8
+                c'8
             }
 
-    Reduces ``ratio`` relative to each other.
-
-    Interprets negative ``ratio`` as rests.
     """
-    duration = _duration.Duration(duration)
+    assert isinstance(duration, _duration.Duration), repr(duration)
     assert isinstance(ratio, tuple), repr(ratio)
+    assert all(isinstance(_, int) for _ in ratio), repr(ratio)
     basic_prolated_duration = duration / _math.weight(ratio)
     basic_written_duration = basic_prolated_duration.equal_or_greater_assignable
     written_durations = [x * basic_written_duration for x in ratio]
-    notes: list[_score.Leaf | _score.Tuplet]
+    components: list[_score.Leaf | _score.Tuplet] = []
     try:
-        notes = [
-            _score.Note(0, x, tag=tag) if 0 < x else _score.Rest(abs(x), tag=tag)
-            for x in written_durations
-        ]
+        for written_duration in written_durations:
+            if 0 < written_duration:
+                note = _score.Note(0, written_duration, tag=tag)
+                components.append(note)
+            else:
+                rest = _score.Rest(abs(written_duration), tag=tag)
+                components.append(rest)
     except _exceptions.AssignabilityError:
         denominator = duration.denominator
         note_durations = [_duration.Duration(x, denominator) for x in ratio]
         pitches = [None if note_duration < 0 else 0 for note_duration in note_durations]
         leaf_durations = [abs(note_duration) for note_duration in note_durations]
-        notes = make_leaves(
+        components = make_leaves(
             pitches,
             leaf_durations,
             increase_monotonic=increase_monotonic,
             tag=tag,
         )
-    tuplet = _score.Tuplet.from_duration(duration, notes, tag=tag)
+    tuplet = _score.Tuplet.from_duration(duration, components, tag=tag)
     tuplet.normalize_multiplier()
     return tuplet
 


### PR DESCRIPTION
REMOVE abjad.makers.tuplet_from_duration_and_ratio()

    OLD: the very old abjad.makers.tuplet_from_duration_and_ratio()
    function frequently spelled tuplets with unexpected dotted note
    values; the function is no longer supported and has been removed:

        >>> duration = abjad.Duration(5, 4)
        >>> abjad.makers.tuplet_from_duration_and_ratio(duration, (1, 1))
        Tuplet('6:5', "c'2. c'2.")

    NEW: use abjad.makers.tuplet_from_ratio_and_pair() instead; this
    results in better tuplet spelling:

        >>> abjad.makers.tuplet_from_ratio_and_pair((1, 1), (5, 4))
        Tuplet('4:5', "c'2 c'2")

REMOVE abjad.makers.tuplet_from_leaf_and_ratio()

    OLD: abjad.makers.tuplet_from_leaf_and_ratio(leaf, ratio)
    NEW: abjad.makers.tuplet_from_duration_and_ratio(leaf.written_duration, ratio)
