### PR TITLE
CHANGE tweak tuplet bracket edge text manually

### DIFF
--- a/source/abjad/get.py
+++ b/source/abjad/get.py
@@ -912,6 +912,7 @@ def duration(
         Gets preprolated duration:
 
         >>> staff = abjad.Staff(r"\times 2/3 { c'4 ~ c' } \times 2/3 { d' ~ d' }")
+        >>> abjad.makers.tweak_tuplet_bracket_edge_height(staff)
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::

--- a/source/abjad/indicators.py
+++ b/source/abjad/indicators.py
@@ -7409,6 +7409,7 @@ class TimeSignature:
             Suppresses LilyPond "strange time signature" warning:
 
             >>> tuplet = abjad.Tuplet((2, 3), "c'4 d' e' f'")
+            >>> abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
             >>> staff = abjad.Staff([tuplet])
             >>> score = abjad.Score([staff], name="Score")
             >>> time_signature = abjad.TimeSignature((4, 3))

--- a/source/abjad/iterate.py
+++ b/source/abjad/iterate.py
@@ -658,6 +658,7 @@ def logical_ties(
         >>> string = r"c'4 ~ \times 2/3 { c'8 d'4 }"
         >>> string += r" e'4 ~ \times 2/3 { e'8 f' }"
         >>> staff = abjad.Staff(string)
+        >>> abjad.makers.tweak_tuplet_bracket_edge_height(staff)
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::

--- a/source/abjad/metricmodulation.py
+++ b/source/abjad/metricmodulation.py
@@ -196,6 +196,7 @@ class MetricModulation:
         >>> pitches = abjad.makers.make_pitches([0])
         >>> notes = abjad.makers.make_notes(pitches, durations)
         >>> tuplet = abjad.Tuplet((2, 3), notes)
+        >>> abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
         >>> metric_modulation = abjad.MetricModulation(
         ...     left_rhythm=abjad.Note("c'4"),
         ...     right_rhythm=tuplet,

--- a/source/abjad/mutate.py
+++ b/source/abjad/mutate.py
@@ -2694,6 +2694,7 @@ def wrap(argument, container):
         ...     tuplet = abjad.Tuplet((2, 3))
         ...     abjad.mutate.wrap(note, tuplet)
         ...
+        >>> abjad.makers.tweak_tuplet_bracket_edge_height(staff)
 
         ..  docs::
 

--- a/source/abjad/parsers/reduced.py
+++ b/source/abjad/parsers/reduced.py
@@ -97,6 +97,7 @@ class ReducedLyParser(Parser):
 
         >>> string = "2/3 { 4 4 3/5 { 8 8 8 } }"
         >>> tuplet = parser(string)
+        >>> abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
         >>> abjad.show(tuplet) # doctest: +SKIP
 
         ..  docs::

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -5065,6 +5065,7 @@ class Tuplet(Container):
 
         >>> second_tuplet = abjad.Tuplet("7:4", "g'4. ( a'16 )")
         >>> tuplet.insert(1, second_tuplet)
+        >>> abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
         >>> abjad.show(tuplet) # doctest: +SKIP
 
         ..  docs::
@@ -5094,6 +5095,7 @@ class Tuplet(Container):
             >>> third_tuplet = abjad.Tuplet("5:4", [])
             >>> third_tuplet.extend("e''32 [ ef''32 d''32 cs''32 cqs''32 ]")
             >>> second_tuplet.insert(1, third_tuplet)
+            >>> abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
         ..  docs::
@@ -5251,6 +5253,8 @@ class Tuplet(Container):
         "tweaks",
     )
 
+    tweak_edge_height_string = r"\tweak edge-height #'(0.7 . 0)"
+
     ### INITIALIZER ###
 
     def __init__(
@@ -5371,9 +5375,6 @@ class Tuplet(Container):
                 )
                 if fraction_command_string:
                     contributions.append(fraction_command_string)
-                edge_height_tweak_string = self._get_edge_height_tweak_string()
-                if edge_height_tweak_string:
-                    contributions.append(edge_height_tweak_string)
                 for tweak in sorted(self.tweaks):
                     strings = tweak._list_contributions()
                     contributions.extend(strings)
@@ -5399,12 +5400,6 @@ class Tuplet(Container):
         if not self:
             return f"{{ {d}:{n} }}"
         return f"{{ {d}:{n} {self._get_contents_summary()} }}"
-
-    def _get_edge_height_tweak_string(self):
-        duration = self._get_preprolated_duration()
-        denominator = duration.denominator
-        if not _math.is_nonnegative_integer_power_of_two(denominator):
-            return r"\tweak edge-height #'(0.7 . 0)"
 
     def _get_multiplier_fraction_string(self):
         numerator, denominator = self.multiplier
@@ -5952,6 +5947,7 @@ class Tuplet(Container):
                 }
 
             >>> tuplet.append(abjad.Note("e'4"))
+            >>> abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             ..  docs::
@@ -6124,6 +6120,7 @@ class Tuplet(Container):
 
             >>> notes = [abjad.Note("e'32"), abjad.Note("d'32"), abjad.Note("e'16")]
             >>> tuplet.extend(notes)
+            >>> abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             ..  docs::

--- a/tests/test_Container.py
+++ b/tests/test_Container.py
@@ -227,6 +227,7 @@ def test_Container___delitem___07():
 
     tuplet = abjad.Tuplet((2, 3), "c'8 [ d'8 e'8 ]")
     del tuplet[1]
+    abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""

--- a/tests/test_mutate_fuse.py
+++ b/tests/test_mutate_fuse.py
@@ -241,6 +241,7 @@ def test_mutate_fuse_08():
     tuplet_1 = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
     tuplet_2 = abjad.Tuplet((2, 3), "c'8 d'8 e'8 f'8 g'8")
     voice = abjad.Voice([tuplet_1, tuplet_2])
+    abjad.makers.tweak_tuplet_bracket_edge_height(voice)
     abjad.beam(tuplet_1[:])
     abjad.slur(tuplet_2[:])
 
@@ -273,6 +274,7 @@ def test_mutate_fuse_08():
 
     tuplets = voice[:]
     abjad.mutate.fuse(tuplets)
+    abjad.makers.tweak_tuplet_bracket_edge_height(voice)
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
@@ -318,6 +320,7 @@ def test_mutate_fuse_10():
     tuplet_1 = abjad.Tuplet((2, 3), "c'8")
     tuplet_2 = abjad.Tuplet((2, 3), "c'4")
     voice = abjad.Voice([tuplet_1, tuplet_2, abjad.Note("c'4")])
+    abjad.makers.tweak_tuplet_bracket_edge_height(voice)
     leaves = abjad.select.leaves(voice)
     abjad.slur(leaves)
 

--- a/tests/test_mutate_split.py
+++ b/tests/test_mutate_split.py
@@ -157,6 +157,7 @@ def test_mutate__set_leaf_duration_04():
     ), print(abjad.lilypond(voice))
 
     abjad.mutate._set_leaf_duration(voice[1], abjad.Duration(5, 48))
+    abjad.makers.tweak_tuplet_bracket_edge_height(voice)
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
@@ -205,6 +206,7 @@ def test_mutate__set_leaf_duration_05():
     ), print(abjad.lilypond(voice))
 
     abjad.mutate._set_leaf_duration(voice[1], abjad.Duration(1, 12))
+    abjad.makers.tweak_tuplet_bracket_edge_height(voice)
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
@@ -457,6 +459,7 @@ def test_mutate__split_container_by_duration_02():
     ), print(abjad.lilypond(voice))
 
     abjad.mutate._split_container_by_duration(voice[0], abjad.Duration(1, 5))
+    abjad.makers.tweak_tuplet_bracket_edge_height(voice)
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
@@ -1310,6 +1313,7 @@ def test_mutate_split_07():
 
     tuplets = voice[1:2]
     abjad.mutate.split(tuplets, [abjad.Duration(1, 12)])
+    abjad.makers.tweak_tuplet_bracket_edge_height(voice)
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
@@ -1573,6 +1577,7 @@ def test_mutate_split_12():
     abjad.beam(tuplet[:])
 
     result = abjad.mutate.split([tuplet], [abjad.Duration(1, 5)])
+    abjad.makers.tweak_tuplet_bracket_edge_height(voice)
 
     left = result[0][0]
     right = result[1][0]

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -4,6 +4,7 @@ import abjad
 def test_Tuplet_grob_override_01():
     tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8 f'8")
     abjad.override(tuplet).Glissando.thickness = 3
+    abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""


### PR DESCRIPTION
  OLD: Abjad automatically added ``\tweak edge-height #'(0.7 . 0)``
  to incomplete tuplets:

    >>> string = r"{ \tuplet 3/2 { c'4 d'4 } \tuplet 3/2 { c'4 d'4 e'4 } }"
    >>> staff = abjad.Staff(string)
    >>> abjad.makers.tweak_tuplet_bracket_edge_height(staff)
    >>> string = abjad.lilypond(staff)
    >>> print(string)
    \new Staff
    {
        {
            \tweak edge-height #'(0.7 . 0)
            \tuplet 3/2
            {
                c'4
                d'4
            }
            \tuplet 3/2
            {
                c'4
                d'4
                e'4
            }
        }
    }

  NEW: Abjad no longer does this:

    >>> print(string)
    \new Staff
    {
        {
            \tuplet 3/2
            {
                c'4
                d'4
            }
            \tuplet 3/2
            {
                c'4
                d'4
                e'4
            }
        }
    }

  Call the new ``abjad.makers.tweak_tuplet_bracket_edge_height()``
  function to iterate all tuplets and tweak the brackets of incomplete
  tuplets:

    >>> abjad.makers.tweak_tuplet_bracket_edge_height(staff)
    >>> print(string)
    \new Staff
    {
        {
            \tweak edge-height #'(0.7 . 0)
            \tuplet 3/2
            {
                c'4
                d'4
            }
            \tuplet 3/2
            {
                c'4
                d'4
                e'4
            }
        }
    }