### PR TITLE
Clean up a bunch of tuplet docstrings

### DIFF
--- a/docs/source/_mothballed/working-with-tuplets.rst
+++ b/docs/source/_mothballed/working-with-tuplets.rst
@@ -10,7 +10,7 @@ You can create tuplets from a LilyPond input string:
 
 ::
 
-    >>> tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+    >>> tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
     >>> abjad.show(tuplet)
 
 
@@ -22,7 +22,7 @@ You can also make tuplets from a list of other components:
 ::
 
     >>> leaves = [abjad.Note("fs'8"), abjad.Note("g'8"), abjad.Rest('r8')]
-    >>> tuplet = abjad.Tuplet((2, 3), leaves)
+    >>> tuplet = abjad.Tuplet("3:2", leaves)
     >>> abjad.show(tuplet)
 
 Understanding the interpreter representation of a tuplet

--- a/docs/source/_mothballed/written-duration.rst
+++ b/docs/source/_mothballed/written-duration.rst
@@ -30,7 +30,7 @@ But now consider this measure:
 
 ::
 
-    >>> tuplet = abjad.Tuplet((4, 5), r"\time 4/16 c16 [ c c c c ]")
+    >>> tuplet = abjad.Tuplet("5:4", r"\time 4/16 c16 [ c c c c ]")
     >>> staff = abjad.Staff([tuplet], lilypond_type="RhythmicStaff")
     >>> leaves = abjad.select.leaves(staff)
 

--- a/source/abjad/configuration.py
+++ b/source/abjad/configuration.py
@@ -1,4 +1,3 @@
-import collections
 import configparser
 import importlib
 import os
@@ -657,30 +656,13 @@ def list_all_functions(modules="abjad"):
 configuration = Configuration()
 
 
-def yield_all_modules(paths=None):
+def yield_all_modules(package_name: str = "abjad") -> typing.Iterator[types.ModuleType]:
     """
-    Yields all modules encountered in ``path``.
-
-    Returns generator.
+    Yields all submodules in the package named ``package_name``.
     """
-    _paths = []
-    if not paths:
-        _paths = configuration.abjad_directory
-    elif isinstance(paths, str):
-        module = importlib.import_module(paths)
-        _paths.extend(module.__path__)
-    elif isinstance(paths, types.ModuleType):
-        _paths.extend(paths.__path__)
-    elif isinstance(paths, collections.abc.Iterable):
-        for path in paths:
-            if isinstance(path, types.ModuleType):
-                _paths.extend(path.__path__)
-            elif isinstance(path, str):
-                module = importlib.import_module(path)
-                _paths.extend(module.__path__)
-            else:
-                raise ValueError(module)
-    for path in _paths:
-        for source_path in uqbar.apis.collect_source_paths([path]):
+    assert isinstance(package_name, str), repr(package_name)
+    module = importlib.import_module(package_name)
+    for path_string in module.__path__:
+        for source_path in uqbar.apis.collect_source_paths([path_string]):
             package_path = uqbar.apis.source_path_to_package_path(source_path)
             yield importlib.import_module(package_path)

--- a/source/abjad/enumerate.py
+++ b/source/abjad/enumerate.py
@@ -6,7 +6,7 @@ from . import math as _math
 from . import sequence as _sequence
 
 
-def _is_restricted_growth_function(sequence):
+def _is_restricted_growth_function(sequence) -> bool:
     """
     Is true when ``sequence`` is a restricted growth function.
 
@@ -38,8 +38,6 @@ def _is_restricted_growth_function(sequence):
 
     A restricted growth function is a sequence ``l`` such that ``l[0] == 1`` and such
     that ``l[i] <= max(l[:i]) + 1`` for ``1 <= i <= len(l)``.
-
-    Returns true or false.
     """
     try:
         for i, n in enumerate(sequence):
@@ -54,7 +52,7 @@ def _is_restricted_growth_function(sequence):
         return False
 
 
-def _partition_by_rgf(sequence, rgf):
+def _partition_by_rgf(sequence, rgf: list[int]) -> list[list]:
     """
     Partitions ``sequence`` by restricted growth function ``rgf``.
 
@@ -64,7 +62,6 @@ def _partition_by_rgf(sequence, rgf):
     >>> abjad.enumerate._partition_by_rgf(sequence, rgf)
     [[0, 1, 4], [2, 3, 5, 8], [6, 7], [9]]
 
-    Returns list of lists.
     """
     rgf = list(rgf)
     if not _is_restricted_growth_function(rgf):
@@ -73,17 +70,17 @@ def _partition_by_rgf(sequence, rgf):
         raise ValueError("lengths must be equal.")
     partition = []
     for part_index in range(max(rgf)):
-        part = []
+        part: list = []
         partition.append(part)
     for n, part_number in zip(sequence, rgf):
         part_index = part_number - 1
         part = partition[part_index]
         part.append(n)
     partition = [type(sequence)(_) for _ in partition]
-    return type(sequence)(partition)
+    return partition
 
 
-def _yield_restricted_growth_functions(length):
+def _yield_restricted_growth_functions(length) -> typing.Iterator[list[int]]:
     """
     Yields restricted growth functions of ``length``.
 
@@ -93,30 +90,28 @@ def _yield_restricted_growth_functions(length):
         >>> for rgf in rgfs:
         ...     rgf
         ...
-        (1, 1, 1, 1)
-        (1, 1, 1, 2)
-        (1, 1, 2, 1)
-        (1, 1, 2, 2)
-        (1, 1, 2, 3)
-        (1, 2, 1, 1)
-        (1, 2, 1, 2)
-        (1, 2, 1, 3)
-        (1, 2, 2, 1)
-        (1, 2, 2, 2)
-        (1, 2, 2, 3)
-        (1, 2, 3, 1)
-        (1, 2, 3, 2)
-        (1, 2, 3, 3)
-        (1, 2, 3, 4)
+        [1, 1, 1, 1]
+        [1, 1, 1, 2]
+        [1, 1, 2, 1]
+        [1, 1, 2, 2]
+        [1, 1, 2, 3]
+        [1, 2, 1, 1]
+        [1, 2, 1, 2]
+        [1, 2, 1, 3]
+        [1, 2, 2, 1]
+        [1, 2, 2, 2]
+        [1, 2, 2, 3]
+        [1, 2, 3, 1]
+        [1, 2, 3, 2]
+        [1, 2, 3, 3]
+        [1, 2, 3, 4]
 
-    Returns restricted growth functions in lex order.
-
-    Returns generator of tuples.
+    Yields restricted growth functions in lex order.
     """
     assert _math.is_positive_integer(length), repr(length)
     last_rgf = list(range(1, length + 1))
     rgf = length * [1]
-    yield tuple(rgf)
+    yield list(rgf)
     while not rgf == last_rgf:
         for i, x in enumerate(reversed(rgf)):
             stop = -(i + 1)
@@ -125,7 +120,7 @@ def _yield_restricted_growth_functions(length):
                 increased_part = [rgf[stop] + 1]
                 trailing_ones = i * [1]
                 rgf = first_part + increased_part + trailing_ones
-                yield tuple(rgf)
+                yield list(rgf)
                 break
 
 
@@ -206,7 +201,9 @@ def outer_product(argument):
     return result
 
 
-def yield_combinations(argument, minimum_length=None, maximum_length=None):
+def yield_combinations(
+    argument, minimum_length=None, maximum_length=None
+) -> typing.Iterator:
     """
     Yields combinations of sequence items.
 
@@ -305,8 +302,6 @@ def yield_combinations(argument, minimum_length=None, maximum_length=None):
         'text'
 
     Yields combinations in binary string order.
-
-    Returns sequence generator.
     """
     length = len(argument)
     for i in range(2**length):
@@ -330,7 +325,7 @@ def yield_combinations(argument, minimum_length=None, maximum_length=None):
                 yield type(argument)(sublist)
 
 
-def yield_pairs(argument):
+def yield_pairs(argument) -> typing.Iterator:
     """
     Yields pairs sequence items.
 
@@ -375,7 +370,6 @@ def yield_pairs(argument):
         ...     pair
         ...
 
-    Returns generator of length-2 sequences.
     """
     for i, item in enumerate(argument):
         start = i + 1
@@ -384,7 +378,7 @@ def yield_pairs(argument):
             yield type(argument)(pair)
 
 
-def yield_partitions(argument):
+def yield_partitions(argument) -> typing.Iterator:
     """
     Yields partitions of sequence.
 
@@ -412,7 +406,6 @@ def yield_partitions(argument):
         [[0], [1], [2, 3]]
         [[0], [1], [2], [3]]
 
-    Returns generator of nested sequences.
     """
     length = len(argument) - 1
     for i in range(2**length):
@@ -431,7 +424,7 @@ def yield_partitions(argument):
         yield partition
 
 
-def yield_permutations(argument) -> typing.Generator[typing.Any, None, None]:
+def yield_permutations(argument) -> typing.Iterator:
     """
     Yields permutations of sequence.
 
@@ -447,7 +440,6 @@ def yield_permutations(argument) -> typing.Generator[typing.Any, None, None]:
         [3, 1, 2]
         [3, 2, 1]
 
-    Returns sequence generator.
     """
     _argument = list(argument)
     length = len(_argument)
@@ -456,7 +448,7 @@ def yield_permutations(argument) -> typing.Generator[typing.Any, None, None]:
         yield _sequence.permute(argument, permutation)
 
 
-def yield_set_partitions(argument):
+def yield_set_partitions(argument) -> typing.Iterator[list[list]]:
     """
     Yields set partitions of sequence.
 
@@ -482,8 +474,6 @@ def yield_set_partitions(argument):
         [[21], [22], [23], [24]]
 
     Returns set partitions in order of restricted growth function.
-
-    Returns generator of list of lists.
     """
     _argument = list(argument)
     length = len(_argument)
@@ -492,7 +482,9 @@ def yield_set_partitions(argument):
         yield partition
 
 
-def yield_subsequences(argument, minimum_length=0, maximum_length=None):
+def yield_subsequences(
+    argument, minimum_length=0, maximum_length=None
+) -> typing.Iterator:
     """
     Yields subsequences of ``sequence``.
 
@@ -559,7 +551,6 @@ def yield_subsequences(argument, minimum_length=0, maximum_length=None):
         [1, 2, 3]
         [2, 3, 4]
 
-    Returns sequence generator.
     """
     _argument = argument
     length = len(_argument)

--- a/source/abjad/get.py
+++ b/source/abjad/get.py
@@ -4099,7 +4099,7 @@ def sustained(argument) -> bool:
 
     ..  container:: example
 
-        >>> tuplet = abjad.Tuplet((3, 2), "c'4 ~ c' ~ c'")
+        >>> tuplet = abjad.Tuplet("2:3", "c'4 ~ c' ~ c'")
         >>> abjad.makers.tweak_tuplet_number_text(tuplet)
         >>> abjad.show(tuplet) # doctest: +SKIP
 

--- a/source/abjad/label.py
+++ b/source/abjad/label.py
@@ -953,7 +953,7 @@ def with_indices(argument, direction=_enums.UP, prototype=None) -> None:
 
         Labels tuplet indices:
 
-        >>> tuplet = abjad.Tuplet((2, 3), "c'8 [ d'8 e'8 ]")
+        >>> tuplet = abjad.Tuplet("3:2", "c'8 [ d'8 e'8 ]")
         >>> tuplets = abjad.mutate.copy(tuplet, 4)
         >>> staff = abjad.Staff(tuplets)
         >>> abjad.label.with_indices(staff, prototype=abjad.Tuplet)

--- a/source/abjad/metricmodulation.py
+++ b/source/abjad/metricmodulation.py
@@ -39,7 +39,7 @@ class MetricModulation:
         With tuplets:
 
         >>> metric_modulation = abjad.MetricModulation(
-        ...     left_rhythm=abjad.Tuplet((4, 5), "c'4"),
+        ...     left_rhythm=abjad.Tuplet("5:4", "c'4"),
         ...     right_rhythm=abjad.Note("c'4"),
         ... )
 
@@ -56,7 +56,7 @@ class MetricModulation:
 
         >>> metric_modulation = abjad.MetricModulation(
         ...     left_rhythm=abjad.Note("c'4"),
-        ...     right_rhythm=abjad.Tuplet((4, 5), "c'4"),
+        ...     right_rhythm=abjad.Tuplet("5:4", "c'4"),
         ... )
 
         >>> lilypond_file = abjad.LilyPondFile(
@@ -76,7 +76,7 @@ class MetricModulation:
 
         >>> metric_modulation = abjad.MetricModulation(
         ...     left_rhythm=abjad.Note("c16."),
-        ...     right_rhythm=abjad.Tuplet((2, 3), "c8"),
+        ...     right_rhythm=abjad.Tuplet("3:2", "c8"),
         ... )
 
         >>> lilypond_file = abjad.LilyPondFile(
@@ -195,7 +195,7 @@ class MetricModulation:
         >>> durations = abjad.makers.make_durations([(5, 16)])
         >>> pitches = abjad.makers.make_pitches([0])
         >>> notes = abjad.makers.make_notes(pitches, durations)
-        >>> tuplet = abjad.Tuplet((2, 3), notes)
+        >>> tuplet = abjad.Tuplet("3:2", notes)
         >>> abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
         >>> metric_modulation = abjad.MetricModulation(
         ...     left_rhythm=abjad.Note("c'4"),
@@ -367,7 +367,7 @@ class MetricModulation:
             ...     right_rhythm=abjad.Note("c'4."),
             ... )
             >>> metric_modulation_2 = abjad.MetricModulation(
-            ...     left_rhythm=abjad.Tuplet((2, 3), [abjad.Note("c'4")]),
+            ...     left_rhythm=abjad.Tuplet("3:2", [abjad.Note("c'4")]),
             ...     right_rhythm=abjad.Note("c'4"),
             ... )
             >>> durations = abjad.makers.make_durations([(5, 16)])
@@ -567,7 +567,7 @@ class MetricModulation:
         ..  container:: example
 
             >>> metric_modulation = abjad.MetricModulation(
-            ...     left_rhythm=abjad.Tuplet((2, 3), [abjad.Note("c'4")]),
+            ...     left_rhythm=abjad.Tuplet("3:2", [abjad.Note("c'4")]),
             ...     right_rhythm=abjad.Note("c'4"),
             ... )
             >>> metric_modulation.ratio

--- a/source/abjad/mutate.py
+++ b/source/abjad/mutate.py
@@ -933,8 +933,8 @@ def extract(argument):
         Extract tuplets:
 
         >>> voice = abjad.Voice()
-        >>> voice.append(abjad.Tuplet((3, 2), "c'4 e'4"))
-        >>> voice.append(abjad.Tuplet((3, 2), "d'4 f'4"))
+        >>> voice.append(abjad.Tuplet("2:3", "c'4 e'4"))
+        >>> voice.append(abjad.Tuplet("2:3", "d'4 f'4"))
         >>> abjad.makers.tweak_tuplet_number_text(voice)
         >>> leaves = abjad.select.leaves(voice)
         >>> staff = abjad.Staff([voice])
@@ -1000,8 +1000,8 @@ def extract(argument):
 
         >>> voice = abjad.Voice()
         >>> staff = abjad.Staff([voice])
-        >>> voice.append(abjad.Tuplet((3, 2), "c'4 e'4"))
-        >>> voice.append(abjad.Tuplet((3, 2), "d'4 f'4"))
+        >>> voice.append(abjad.Tuplet("2:3", "c'4 e'4"))
+        >>> voice.append(abjad.Tuplet("2:3", "d'4 f'4"))
         >>> abjad.makers.tweak_tuplet_number_text(voice)
         >>> score = abjad.Score([staff], name="Score")
         >>> leaves = abjad.select.leaves(staff)
@@ -1067,7 +1067,7 @@ def extract(argument):
         Extracting out-of-score component does nothing and returns
         component:
 
-        >>> tuplet = abjad.Tuplet((3, 2), "c'4 e'4")
+        >>> tuplet = abjad.Tuplet("2:3", "c'4 e'4")
         >>> abjad.makers.tweak_tuplet_number_text(tuplet)
         >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -1133,8 +1133,8 @@ def fuse(argument) -> _score.Tuplet | list[_score.Leaf]:
 
         Fuses parent-contiguous tuplets in selection:
 
-        >>> tuplet_1 = abjad.Tuplet((2, 3), "c'8 d' e'")
-        >>> tuplet_2 = abjad.Tuplet((2, 3), "c'16 d' e'")
+        >>> tuplet_1 = abjad.Tuplet("3:2", "c'8 d' e'")
+        >>> tuplet_2 = abjad.Tuplet("3:2", "c'16 d' e'")
         >>> voice = abjad.Voice([tuplet_1, tuplet_2])
         >>> staff = abjad.Staff([voice])
         >>> abjad.beam(tuplet_1[:])
@@ -1405,8 +1405,8 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
         Replaces in-score tuplet (and children of tuplet) with notes. Functions
         exactly the same as container setitem:
 
-        >>> tuplet_1 = abjad.Tuplet((2, 3), "c'4 d'4 e'4")
-        >>> tuplet_2 = abjad.Tuplet((2, 3), "d'4 e'4 f'4")
+        >>> tuplet_1 = abjad.Tuplet("3:2", "c'4 d'4 e'4")
+        >>> tuplet_2 = abjad.Tuplet("3:2", "d'4 e'4 f'4")
         >>> voice = abjad.Voice([tuplet_1, tuplet_2])
         >>> leaves = abjad.select.leaves(voice)
         >>> abjad.hairpin('p < f', leaves)
@@ -1753,7 +1753,7 @@ def scale(argument, multiplier) -> None:
 
         >>> staff = abjad.Staff()
         >>> score = abjad.Score([staff], name="Score")
-        >>> tuplet = abjad.Tuplet((4, 5), "c'8 d'8 e'8 f'8 g'8")
+        >>> tuplet = abjad.Tuplet("5:4", "c'8 d'8 e'8 f'8 g'8")
         >>> staff.append(tuplet)
         >>> time_signature = abjad.TimeSignature((4, 8))
         >>> leaf = abjad.get.leaf(staff, 0)
@@ -2444,7 +2444,7 @@ def swap(argument, container):
             }
 
         >>> containers = voice[:]
-        >>> tuplet = abjad.Tuplet((4, 6), [])
+        >>> tuplet = abjad.Tuplet("6:4", [])
         >>> abjad.mutate.swap(containers, tuplet)
         >>> abjad.show(voice) # doctest: +SKIP
 
@@ -2604,7 +2604,7 @@ def wrap(argument, container):
                 ]
             }
 
-        >>> tuplet = abjad.Tuplet((2, 3), [])
+        >>> tuplet = abjad.Tuplet("3:2", [])
         >>> abjad.mutate.wrap(staff[-3:], tuplet)
         >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2640,7 +2640,7 @@ def wrap(argument, container):
         >>> pitches = abjad.makers.make_pitches([0, 2, 4])
         >>> durations = [abjad.Duration(1, 8)]
         >>> notes = abjad.makers.make_notes(pitches, durations)
-        >>> tuplet = abjad.Tuplet((2, 3), [])
+        >>> tuplet = abjad.Tuplet("3:2", [])
         >>> abjad.mutate.wrap(notes, tuplet)
         >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -2695,7 +2695,7 @@ def wrap(argument, container):
         >>> notes = [abjad.Note(n, (1, 1)) for n in range(4)]
         >>> staff = abjad.Staff(notes)
         >>> for note in staff:
-        ...     tuplet = abjad.Tuplet((2, 3))
+        ...     tuplet = abjad.Tuplet("3:2")
         ...     abjad.mutate.wrap(note, tuplet)
         ...
         >>> abjad.makers.tweak_tuplet_bracket_edge_height(staff)
@@ -2734,7 +2734,7 @@ def wrap(argument, container):
 
         >>> import pytest
         >>> staff = abjad.Staff("c'8 [ ( d' e' ] ) c' [ ( d' e' ] )")
-        >>> tuplet = abjad.Tuplet((2, 3), "g'8 a' fs'")
+        >>> tuplet = abjad.Tuplet("3:2", "g'8 a' fs'")
         >>> abjad.mutate.wrap(staff[-3:], tuplet)
         Traceback (most recent call last):
             ...

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -879,8 +879,8 @@ class Container(Component):
             Deletes first tuplet in voice:
 
             >>> voice = abjad.Voice()
-            >>> voice.append(abjad.Tuplet((4, 6), "c'4 d'4 e'4"))
-            >>> voice.append(abjad.Tuplet((2, 3), "e'4 d'4 c'4"))
+            >>> voice.append(abjad.Tuplet("6:4", "c'4 d'4 e'4"))
+            >>> voice.append(abjad.Tuplet("3:2", "e'4 d'4 c'4"))
             >>> leaves = abjad.select.leaves(voice)
             >>> abjad.slur(leaves)
             >>> abjad.show(voice) # doctest: +SKIP
@@ -1005,7 +1005,7 @@ class Container(Component):
         """
         return ([],)
 
-    def __iter__(self):
+    def __iter__(self) -> typing.Iterator:
         """
         Iterates container.
 
@@ -1028,8 +1028,6 @@ class Container(Component):
             False
 
         Yields container elements.
-
-        Returns generator.
         """
         return iter(self.components)
 
@@ -5062,143 +5060,24 @@ class Tuplet(Container):
 
     ..  container:: example
 
-        A nested tuplet:
-
-        >>> second_tuplet = abjad.Tuplet("7:4", "g'4. ( a'16 )")
-        >>> tuplet.insert(1, second_tuplet)
-        >>> abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
-        >>> abjad.show(tuplet) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak edge-height #'(0.7 . 0)
-            \tuplet 6/4
-            {
-                c'8
-                \tuplet 7/4
-                {
-                    g'4.
-                    (
-                    a'16
-                    )
-                }
-                d'8
-                e'8
-            }
-
-
-    ..  container:: example
-
-        A doubly nested tuplet:
-
-            >>> third_tuplet = abjad.Tuplet("5:4", [])
-            >>> third_tuplet.extend("e''32 [ ef''32 d''32 cs''32 cqs''32 ]")
-            >>> second_tuplet.insert(1, third_tuplet)
-            >>> abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
-            >>> abjad.show(tuplet) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak edge-height #'(0.7 . 0)
-            \tuplet 6/4
-            {
-                c'8
-                \tweak edge-height #'(0.7 . 0)
-                \tuplet 7/4
-                {
-                    g'4.
-                    (
-                    \tuplet 5/4
-                    {
-                        e''32
-                        [
-                        ef''32
-                        d''32
-                        cs''32
-                        cqs''32
-                        ]
-                    }
-                    a'16
-                    )
-                }
-                d'8
-                e'8
-            }
-
-    ..  container:: example
-
-        Selects language:
-
-        >>> abjad.Tuplet("6:4", "do'2 dod' re'", language="français")
-        Tuplet('6:4', "c'2 cs'2 d'2")
-
-    ..  container:: example
-
-        Tuplets can be entered as LilyPond input:
-
-        >>> voice = abjad.Voice(r"\tuplet 6/4 { c'4 d' e' }")
-        >>> abjad.show(voice) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(voice)
-            >>> print(string)
-            \new Voice
-            {
-                \tuplet 6/4
-                {
-                    c'4
-                    d'4
-                    e'4
-                }
-            }
-
-        >>> voice = abjad.Voice(r"\times 4/6 { c'4 d' e' }")
-        >>> abjad.show(voice) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> string = abjad.lilypond(voice)
-            >>> print(string)
-            \new Voice
-            {
-                \tuplet 6/4
-                {
-                    c'4
-                    d'4
-                    e'4
-                }
-            }
-
-    ..  container:: example
-
         Tweak tuplets like this:
 
-        >>> tuplet_1 = abjad.Tuplet((2, 3), "c'4 ( d'4 e'4 )")
+        >>> tuplet_1 = abjad.Tuplet("3:2", "c'4 ( d'4 e'4 )")
         >>> abjad.tweak(tuplet_1, r"\tweak color #red")
         >>> abjad.tweak(tuplet_1, r"\tweak staff-padding 2")
 
-        >>> tuplet_2 = abjad.Tuplet((2, 3), "c'4 ( d'4 e'4 )")
+        >>> tuplet_2 = abjad.Tuplet("3:2", "c'4 ( d'4 e'4 )")
         >>> abjad.tweak(tuplet_2, r"\tweak color #green")
         >>> abjad.tweak(tuplet_2, r"\tweak staff-padding 2")
 
-        >>> tuplet_3 = abjad.Tuplet((5, 4), [tuplet_1, tuplet_2])
+        >>> tuplet_3 = abjad.Tuplet("4:5", [tuplet_1, tuplet_2])
         >>> abjad.tweak(tuplet_3, r"\tweak color #blue")
         >>> abjad.tweak(tuplet_3, r"\tweak staff-padding 4")
 
-        >>> staff = abjad.Staff([tuplet_3])
+        >>> staff = abjad.Staff(r"\time 6/4 r4")
+        >>> staff.append(tuplet_3)
         >>> score = abjad.Score([staff], name="Score")
         >>> abjad.makers.tweak_tuplet_number_text(score)
-        >>> leaves = abjad.select.leaves(staff)
-        >>> abjad.attach(abjad.TimeSignature((5, 4)), leaves[0])
-        >>> literal = abjad.LilyPondLiteral(
-        ...     r"\set tupletFullLength = ##t", site="opening"
-        ... )
-        >>> abjad.attach(literal, staff)
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -5207,7 +5086,8 @@ class Tuplet(Container):
             >>> print(string)
             \new Staff
             {
-                \set tupletFullLength = ##t
+                \time 6/4
+                r4
                 \tweak color #blue
                 \tweak staff-padding 4
                 \tweak text #tuplet-number::calc-fraction-text
@@ -5217,7 +5097,6 @@ class Tuplet(Container):
                     \tweak staff-padding 2
                     \tuplet 3/2
                     {
-                        \time 5/4
                         c'4
                         (
                         d'4
@@ -5236,10 +5115,6 @@ class Tuplet(Container):
                     }
                 }
             }
-
-        ..  todo:: Report LilyPond bug that results from removing tupletFullLength
-            in the example above: blue tuplet bracket shrinks to encompass only the
-            second underlying tuplet.
 
     """
 
@@ -5540,7 +5415,7 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+            >>> tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             ..  docs::
@@ -5559,8 +5434,8 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet_1 = abjad.Tuplet((2, 3), "c'4 d'4 e'4")
-            >>> tuplet_2 = abjad.Tuplet((2, 3), "d'4 e'4 f'4")
+            >>> tuplet_1 = abjad.Tuplet("3:2", "c'4 d'4 e'4")
+            >>> tuplet_2 = abjad.Tuplet("3:2", "d'4 e'4 f'4")
             >>> staff = abjad.Staff([tuplet_1, tuplet_2])
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -5623,7 +5498,7 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+            >>> tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             >>> tuplet.implied_prolation
@@ -5639,7 +5514,7 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+            >>> tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
 
             >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -5660,7 +5535,7 @@ class Tuplet(Container):
 
             Gets tuplet multiplier:
 
-            >>> tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+            >>> tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             >>> tuplet.multiplier
@@ -5706,9 +5581,7 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet = abjad.Tuplet(
-            ...     (2, 3), "c'4 d' e'", tag=abjad.Tag('RED')
-            ... )
+            >>> tuplet = abjad.Tuplet("3:2", "c'4 d' e'", tag=abjad.Tag('RED'))
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             >>> string = abjad.lilypond(tuplet, tags=True)
@@ -5746,7 +5619,7 @@ class Tuplet(Container):
 
             Appends note to tuplet:
 
-            >>> tuplet = abjad.Tuplet((2, 3), "c'4 ( d'4 f'4 )")
+            >>> tuplet = abjad.Tuplet("3:2", "c'4 ( d'4 f'4 )")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             ..  docs::
@@ -5783,39 +5656,50 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            Appends note to tuplet and preserves tuplet duration:
+            Appends note to tuplet and changes tuplet multiplier to preserve
+            tuplet duration:
 
-            >>> tuplet = abjad.Tuplet((2, 3), "c'4 ( d'4 f'4 )")
-            >>> abjad.show(tuplet) # doctest: +SKIP
+            >>> tuplet = abjad.Tuplet("3:2", "c'4 ( d'4 f'4 )")
+            >>> abjad.tweak(tuplet, r"\tweak text #tuplet-number::calc-fraction-text")
+            >>> voice = abjad.Voice([tuplet])
+            >>> abjad.show(voice) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(tuplet)
+                >>> string = abjad.lilypond(voice)
                 >>> print(string)
-                \tuplet 3/2
+                \new Voice
                 {
-                    c'4
-                    (
-                    d'4
-                    f'4
-                    )
+                    \tweak text #tuplet-number::calc-fraction-text
+                    \tuplet 3/2
+                    {
+                        c'4
+                        (
+                        d'4
+                        f'4
+                        )
+                    }
                 }
 
             >>> tuplet.append(abjad.Note("e'4"), preserve_duration=True)
-            >>> abjad.show(tuplet) # doctest: +SKIP
+            >>> abjad.show(voice) # doctest: +SKIP
 
             ..  docs::
 
-                >>> string = abjad.lilypond(tuplet)
+                >>> string = abjad.lilypond(voice)
                 >>> print(string)
-                \tuplet 2/1
+                \new Voice
                 {
-                    c'4
-                    (
-                    d'4
-                    f'4
-                    )
-                    e'4
+                    \tweak text #tuplet-number::calc-fraction-text
+                    \tuplet 2/1
+                    {
+                        c'4
+                        (
+                        d'4
+                        f'4
+                        )
+                        e'4
+                    }
                 }
 
         """
@@ -5836,7 +5720,7 @@ class Tuplet(Container):
 
             Augmented tuplet:
 
-            >>> tuplet = abjad.Tuplet((4, 3), "c'8 d'8 e'8")
+            >>> tuplet = abjad.Tuplet("3:4", "c'8 d'8 e'8")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             >>> tuplet.augmentation()
@@ -5846,7 +5730,7 @@ class Tuplet(Container):
 
             Diminished tuplet:
 
-            >>> tuplet = abjad.Tuplet((2, 3), "c'4 d'4 e'4")
+            >>> tuplet = abjad.Tuplet("3:2", "c'4 d'4 e'4")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             >>> tuplet.augmentation()
@@ -5856,7 +5740,7 @@ class Tuplet(Container):
 
             Trivial tuplet:
 
-            >>> tuplet = abjad.Tuplet((1, 1), "c'8. d'8. e'8.")
+            >>> tuplet = abjad.Tuplet("1:1", "c'8. d'8. e'8.")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             >>> tuplet.augmentation()
@@ -5876,7 +5760,7 @@ class Tuplet(Container):
 
             Augmented tuplet:
 
-            >>> tuplet = abjad.Tuplet((4, 3), "c'8 d'8 e'8")
+            >>> tuplet = abjad.Tuplet("3:4", "c'8 d'8 e'8")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             >>> tuplet.diminution()
@@ -5886,7 +5770,7 @@ class Tuplet(Container):
 
             Diminished tuplet:
 
-            >>> tuplet = abjad.Tuplet((2, 3), "c'4 d'4 e'4")
+            >>> tuplet = abjad.Tuplet("3:2", "c'4 d'4 e'4")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             >>> tuplet.diminution()
@@ -5896,7 +5780,7 @@ class Tuplet(Container):
 
             Trivial tuplet:
 
-            >>> tuplet = abjad.Tuplet((1, 1), "c'8. d'8. e'8.")
+            >>> tuplet = abjad.Tuplet("1:1", "c'8. d'8. e'8.")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             >>> tuplet.diminution()
@@ -5941,7 +5825,7 @@ class Tuplet(Container):
 
             Extends tuplet with three notes:
 
-            >>> tuplet = abjad.Tuplet((2, 3), "c'4 ( d'4 f'4 )")
+            >>> tuplet = abjad.Tuplet("3:2", "c'4 ( d'4 f'4 )")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             ..  docs::
@@ -5983,7 +5867,7 @@ class Tuplet(Container):
 
             Extends tuplet with three notes and preserves tuplet duration:
 
-            >>> tuplet = abjad.Tuplet((2, 3), "c'4 ( d'4 f'4 )")
+            >>> tuplet = abjad.Tuplet("3:2", "c'4 ( d'4 f'4 )")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             ..  docs::
@@ -6068,7 +5952,7 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet = abjad.Tuplet((1, 3), "c'4 d' e'")
+            >>> tuplet = abjad.Tuplet("3:1", "c'4 d' e'")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             ..  docs::
@@ -6104,7 +5988,7 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet = abjad.Tuplet((8, 3), "c'32 d'32 e'32")
+            >>> tuplet = abjad.Tuplet("3:8", "c'32 d'32 e'32")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -6143,7 +6027,7 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet = abjad.Tuplet((5, 12), "c'4 d'4 e'4")
+            >>> tuplet = abjad.Tuplet("12:5", "c'4 d'4 e'4")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -6201,7 +6085,7 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet = abjad.Tuplet((3, 2), "r4 r r")
+            >>> tuplet = abjad.Tuplet("2:3", "r4 r r")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -6231,7 +6115,7 @@ class Tuplet(Container):
 
             Rewrites single dots as 3:2 prolation:
 
-            >>> tuplet = abjad.Tuplet((1, 1), "c'8. c'8.")
+            >>> tuplet = abjad.Tuplet("1:1", "c'8. c'8.")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -6264,7 +6148,7 @@ class Tuplet(Container):
 
             Rewrites double dots as 7:4 prolation:
 
-            >>> tuplet = abjad.Tuplet((1, 1), "c'8.. c'8..")
+            >>> tuplet = abjad.Tuplet("1:1", "c'8.. c'8..")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -6297,7 +6181,7 @@ class Tuplet(Container):
 
             Does nothing when dot counts differ:
 
-            >>> tuplet = abjad.Tuplet((1, 1), "c'8. d'8. e'8")
+            >>> tuplet = abjad.Tuplet("1:1", "c'8. d'8. e'8")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -6332,7 +6216,7 @@ class Tuplet(Container):
 
             Does nothing when leaves carry no dots:
 
-            >>> tuplet = abjad.Tuplet((3, 2), "c'8 d' e'")
+            >>> tuplet = abjad.Tuplet("2:3", "c'8 d' e'")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -6392,7 +6276,7 @@ class Tuplet(Container):
 
             Changes augmented tuplet to diminished:
 
-            >>> tuplet = abjad.Tuplet((4, 3), "c'8 d'8 e'8")
+            >>> tuplet = abjad.Tuplet("3:4", "c'8 d'8 e'8")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -6430,7 +6314,7 @@ class Tuplet(Container):
 
             Changes diminished tuplet to augmented:
 
-            >>> tuplet = abjad.Tuplet((2, 3), "c'4 d'4 e'4")
+            >>> tuplet = abjad.Tuplet("3:2", "c'4 d'4 e'4")
             >>> abjad.show(tuplet) # doctest: +SKIP
 
             ..  docs::
@@ -6467,7 +6351,7 @@ class Tuplet(Container):
 
             REGRESSION. Leaves trivial tuplets unchanged:
 
-            >>> tuplet = abjad.Tuplet((1, 1), "c'4 d'4 e'4")
+            >>> tuplet = abjad.Tuplet("1:1", "c'4 d'4 e'4")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -6524,7 +6408,7 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet = abjad.Tuplet((1, 1), "c'8 d'8 e'8")
+            >>> tuplet = abjad.Tuplet("1:1", "c'8 d'8 e'8")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 
@@ -6547,7 +6431,7 @@ class Tuplet(Container):
 
             Tuplet is not trivial when multipliers attach to tuplet leaves:
 
-            >>> tuplet = abjad.Tuplet((1, 1), "c'8 d'8 e'8")
+            >>> tuplet = abjad.Tuplet("1:1", "c'8 d'8 e'8")
             >>> tuplet[0].multiplier = (3, 2)
             >>> tuplet[-1].multiplier = (1, 2)
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
@@ -6587,7 +6471,7 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet = abjad.Tuplet((3, 4), "c'4 c'4")
+            >>> tuplet = abjad.Tuplet("4:3", "c'4 c'4")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> staff = abjad.Staff([tuplet])
             >>> score = abjad.Score([staff], name="Score")
@@ -6631,7 +6515,7 @@ class Tuplet(Container):
 
             Nontrivializable tuplet:
 
-            >>> tuplet = abjad.Tuplet((3, 5), "c'4 c'4 c'4 c'4 c'4")
+            >>> tuplet = abjad.Tuplet("5:3", "c'4 c'4 c'4 c'4 c'4")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> staff = abjad.Staff([tuplet])
             >>> score = abjad.Score([staff], name="Score")
@@ -6665,7 +6549,7 @@ class Tuplet(Container):
 
             REGRESSION. Nontrivializable tuplet:
 
-            >>> tuplet = abjad.Tuplet((3, 4), "c'2. c4")
+            >>> tuplet = abjad.Tuplet("4:3", "c'2. c4")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> staff = abjad.Staff([tuplet])
             >>> score = abjad.Score([staff], name="Score")
@@ -6707,7 +6591,7 @@ class Tuplet(Container):
 
         ..  container:: example
 
-            >>> tuplet = abjad.Tuplet((3, 4), "c'2")
+            >>> tuplet = abjad.Tuplet("4:3", "c'2")
             >>> abjad.makers.tweak_tuplet_number_text(tuplet)
             >>> abjad.show(tuplet) # doctest: +SKIP
 

--- a/source/abjad/sequence.py
+++ b/source/abjad/sequence.py
@@ -1551,11 +1551,7 @@ def join(sequence):
 
     ..  container:: example
 
-        >>> items = [(1, 2, 3), (), (4, 5), (), (6,)]
-        >>> sequence = list(items)
-        >>> sequence
-        [(1, 2, 3), (), (4, 5), (), (6,)]
-
+        >>> sequence = [(1, 2, 3), (), (4, 5), (), (6,)]
         >>> abjad.sequence.join(sequence)
         [(1, 2, 3, 4, 5, 6)]
 
@@ -1665,8 +1661,6 @@ def nwise(
         [3, 4]
         [4, 5]
 
-        Returns infinite generator.
-
         Iterates items 3 at a time. Cycles indefinitely:
 
         >>> sequence = list(range(10))
@@ -1689,8 +1683,6 @@ def nwise(
         [2, 3, 4]
         [3, 4, 5]
         [4, 5, 6]
-
-        Returns infinite generator.
 
         Iterates items 1 at a time:
 

--- a/source/abjad/verticalmoment.py
+++ b/source/abjad/verticalmoment.py
@@ -1,6 +1,9 @@
+import typing
+
 from . import enumerate as _enumerate
 from . import iterate as _iterate
 from . import parentage as _parentage
+from . import pitch as _pitch
 from . import score as _score
 from . import select as _select
 from . import sequence as _sequence
@@ -667,7 +670,7 @@ def iterate_vertical_moments(components, reverse=None):
     return tuple(moments)
 
 
-def iterate_leaf_pairs(components):
+def iterate_leaf_pairs(components) -> typing.Iterator:
     r"""
     Iterates leaf pairs.
 
@@ -721,8 +724,6 @@ def iterate_leaf_pairs(components):
         [Note("g'4"), Note('g,4')]
 
     Iterates leaf pairs left-to-right and top-to-bottom.
-
-    Returns generator.
     """
     vertical_moments = iterate_vertical_moments(components)
     for moment_1, moment_2 in _sequence.nwise(vertical_moments):
@@ -736,7 +737,9 @@ def iterate_leaf_pairs(components):
             yield list(pair)
 
 
-def iterate_pitch_pairs(components):
+def iterate_pitch_pairs(
+    components,
+) -> typing.Iterator[tuple[_pitch.NamedPitch, _pitch.NamedPitch]]:
     r"""
     Iterates pitch pairs.
 
@@ -821,7 +824,6 @@ def iterate_pitch_pairs(components):
         (NamedPitch("e'"), NamedPitch("g''"))
         (NamedPitch("f''"), NamedPitch("g''"))
 
-    Returns generator.
     """
     for leaf_pair in iterate_leaf_pairs(components):
         pitches = sorted(_iterate.pitches(leaf_pair[0]))

--- a/tests/test_Chord.py
+++ b/tests/test_Chord.py
@@ -265,7 +265,7 @@ def test_Chord___init___09():
     Initialize chord from tupletized skip.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "s8 s8 s8")
+    tuplet = abjad.Tuplet("3:2", "s8 s8 s8")
     chord = abjad.Chord(tuplet[0])
 
     assert abjad.lilypond(chord) == "<>8"
@@ -318,7 +318,7 @@ def test_Chord___init___13():
     Initialize chord from tupletized rest.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "r8 r8 r8")
+    tuplet = abjad.Tuplet("3:2", "r8 r8 r8")
     chord = abjad.Chord(tuplet[1])
 
     assert abjad.lilypond(chord) == "<>8"
@@ -345,7 +345,7 @@ def test_Chord___init___15():
     Initialize chord from tupletized note.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "c'8 c'8 c'8")
+    tuplet = abjad.Tuplet("3:2", "c'8 c'8 c'8")
     chord = abjad.Chord(tuplet[1])
 
     assert abjad.lilypond(chord) == "<c'>8"

--- a/tests/test_Container.py
+++ b/tests/test_Container.py
@@ -225,7 +225,7 @@ def test_Container___delitem___07():
     Deletes leaf from tuplet.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "c'8 [ d'8 e'8 ]")
+    tuplet = abjad.Tuplet("3:2", "c'8 [ d'8 e'8 ]")
     del tuplet[1]
     abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
 
@@ -635,7 +635,7 @@ def test_Container___setitem___04():
         """
     ), print(abjad.lilypond(voice))
 
-    voice[1] = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+    voice[1] = abjad.Tuplet("3:2", "c'8 d'8 e'8")
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
@@ -1481,7 +1481,7 @@ def test_Container_append_02():
     Append leaf to tuplet.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+    tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
     abjad.Voice([tuplet])
     abjad.beam(tuplet[:])
     tuplet.append(abjad.Note(5, (1, 16)), preserve_duration=True)

--- a/tests/test_Note.py
+++ b/tests/test_Note.py
@@ -252,7 +252,7 @@ def test_Note___init___07():
 
     chord = abjad.Chord([2, 3, 4], (1, 4))
     chords = abjad.mutate.copy(chord, 3)
-    tuplet = abjad.Tuplet((2, 3), chords)
+    tuplet = abjad.Tuplet("3:2", chords)
     note = abjad.Note(tuplet[0])
 
     assert abjad.lilypond(note) == abjad.string.normalize(
@@ -307,7 +307,7 @@ def test_Note___init___10():
     Initializes note from tupletized rest.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "r8 r8 r8")
+    tuplet = abjad.Tuplet("3:2", "r8 r8 r8")
     duration = tuplet[0].written_duration
     note = abjad.Note(tuplet[0])
 
@@ -356,7 +356,7 @@ def test_Note___init___13():
     Initializes note from tupletized skip.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "s8 s8 s8")
+    tuplet = abjad.Tuplet("3:2", "s8 s8 s8")
     duration = tuplet[0].written_duration
     note = abjad.Note(tuplet[0])
 

--- a/tests/test_Rest.py
+++ b/tests/test_Rest.py
@@ -114,7 +114,7 @@ def test_Rest___init___04():
 
     chord = abjad.Chord([2, 3, 4], abjad.Duration(1, 4))
     chords = abjad.mutate.copy(chord, 3)
-    tuplet = abjad.Tuplet((2, 3), chords)
+    tuplet = abjad.Tuplet("3:2", chords)
     rest = abjad.Rest(tuplet[0])
 
     assert abjad.lilypond(rest) == abjad.string.normalize(
@@ -169,7 +169,7 @@ def test_Rest___init___07():
     Initialize rest from tupletted skip.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "s4 s4 s4")
+    tuplet = abjad.Tuplet("3:2", "s4 s4 s4")
     rest = abjad.Rest(tuplet[0])
 
     assert abjad.lilypond(rest) == abjad.string.normalize(
@@ -220,7 +220,7 @@ def test_Rest___init___10():
     Initialize rest from tupletized note.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "c'4 d'4 e'4")
+    tuplet = abjad.Tuplet("3:2", "c'4 d'4 e'4")
     rest = abjad.Rest(tuplet[0])
 
     assert abjad.lilypond(rest) == abjad.string.normalize(

--- a/tests/test_Skip.py
+++ b/tests/test_Skip.py
@@ -90,7 +90,7 @@ def test_Skip___init___03():
 
     chord = abjad.Chord([2, 3, 4], (1, 4))
     chords = abjad.mutate.copy(chord, 3)
-    tuplet = abjad.Tuplet((2, 3), chords)
+    tuplet = abjad.Tuplet("3:2", chords)
     duration = tuplet[0].written_duration
     skip = abjad.Skip(tuplet[0])
     assert isinstance(tuplet[0], abjad.Chord)
@@ -130,7 +130,7 @@ def test_Skip___init___05():
 
 
 def test_Skip___init___06():
-    tuplet = abjad.Tuplet((2, 3), "c'8 c'8 c'8")
+    tuplet = abjad.Tuplet("3:2", "c'8 c'8 c'8")
     duration = tuplet[0].written_duration
     skip = abjad.Skip(tuplet[0])
     assert isinstance(tuplet[0], abjad.Note)
@@ -173,7 +173,7 @@ def test_Skip___init___09():
     Initialize skip from tupletized rest.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "r8 r8 r8")
+    tuplet = abjad.Tuplet("3:2", "r8 r8 r8")
     duration = tuplet[0].written_duration
     skip = abjad.Skip(tuplet[0])
     assert isinstance(skip, abjad.Skip)

--- a/tests/test_Staff.py
+++ b/tests/test_Staff.py
@@ -38,7 +38,7 @@ def test_Staff___delitem___01():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -77,7 +77,7 @@ def test_Staff___delitem___02():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -116,7 +116,7 @@ def test_Staff___delitem___03():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -155,7 +155,7 @@ def test_Staff___getitem___01():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -180,7 +180,7 @@ def test_Staff___getitem___02():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -198,7 +198,7 @@ def test_Staff___getitem___03():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -219,7 +219,7 @@ def test_Staff___getitem___04():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -240,7 +240,7 @@ def test_Staff___getitem___05():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -263,7 +263,7 @@ def test_Staff___getitem___06():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -286,7 +286,7 @@ def test_Staff___getitem___07():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -309,7 +309,7 @@ def test_Staff___getitem___08():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -360,7 +360,7 @@ def test_Staff___setitem___01():
             abjad.Rest((1, 4)),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
-            abjad.Tuplet((4, 5), "c'16 c'16 c'16 c'16"),
+            abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
 
@@ -387,7 +387,7 @@ def test_Staff___setitem___01():
     assert isinstance(staff[2], abjad.Chord)
     assert isinstance(staff[3], abjad.Skip)
     assert isinstance(staff[4], abjad.Tuplet)
-    staff[-2] = abjad.Tuplet((2, 3), "c'8 c'8 c'8")
+    staff[-2] = abjad.Tuplet("3:2", "c'8 c'8 c'8")
     assert len(staff) == 5
     assert abjad.wf.wellformed(staff)
     assert isinstance(staff[0], abjad.Rest)
@@ -502,7 +502,7 @@ def test_Staff___setitem___09():
     """
 
     staff = abjad.Staff("c'8 c'8 c'8 c'8 c'8 c'8 c'8 c'8")
-    tuplet = abjad.Tuplet((2, 3), "c'8 c'8 c'8")
+    tuplet = abjad.Tuplet("3:2", "c'8 c'8 c'8")
     tuplets = abjad.mutate.copy(tuplet, 2)
     staff[0:4] = tuplets
     assert len(staff) == 6
@@ -544,7 +544,7 @@ def test_Staff_append_03():
     """
 
     staff = abjad.Staff("c'4 c'4 c'4 c'4")
-    staff.append(abjad.Tuplet((2, 3), "c'8 c'8 c'8"))
+    staff.append(abjad.Tuplet("3:2", "c'8 c'8 c'8"))
     assert abjad.wf.wellformed(staff)
     assert len(staff) == 5
     assert staff._get_contents_duration() == abjad.Duration(5, 4)

--- a/tests/test_Tuplet.py
+++ b/tests/test_Tuplet.py
@@ -4,7 +4,7 @@ import abjad
 
 
 def test_Tuplet___copy___01():
-    tuplet_1 = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+    tuplet_1 = abjad.Tuplet("3:2", "c'8 d'8 e'8")
     abjad.override(tuplet_1).NoteHead.color = "#red"
 
     assert abjad.lilypond(tuplet_1) == abjad.string.normalize(
@@ -47,35 +47,23 @@ def test_Tuplet___init___01():
     assert not len(tuplet)
 
 
-# TODO: move to test_get_timespan.py
-def test_Tuplet_get_timespan_01():
-    staff = abjad.Staff(r"c'4 d'4 \tuplet 3/2 { e'4 f'4 g'4 }")
-    leaves = abjad.select.leaves(staff)
-    score = abjad.Score([staff])
-    mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
-    abjad.attach(mark, leaves[0])
+def test_Tuplet___init__02():
+    r"""
+    Abjad parses LilyPond's \tuplet command.
+    """
 
-    assert abjad.lilypond(score) == abjad.string.normalize(
+    voice = abjad.Voice(r"\tuplet 6/4 { c'4 d' e' }")
+
+    assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
-        \new Score
-        <<
-            \new Staff
+        \new Voice
+        {
+            \tuplet 6/4
             {
-                \tempo 4=60
                 c'4
                 d'4
-                \tuplet 3/2
-                {
-                    e'4
-                    f'4
-                    g'4
-                }
+                e'4
             }
-        >>
+        }
         """
     )
-
-    assert abjad.get.timespan(staff, in_seconds=True) == abjad.Timespan(0, 4)
-    assert abjad.get.timespan(staff[0], in_seconds=True) == abjad.Timespan(0, 1)
-    assert abjad.get.timespan(staff[1], in_seconds=True) == abjad.Timespan(1, 2)
-    assert abjad.get.timespan(staff[-1], in_seconds=True) == abjad.Timespan(2, 4)

--- a/tests/test_get_leaf.py
+++ b/tests/test_get_leaf.py
@@ -128,7 +128,7 @@ def test_get_leaf_05():
     Tuplet.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "c'8 cs'8 d'8")
+    tuplet = abjad.Tuplet("3:2", "c'8 cs'8 d'8")
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -195,8 +195,8 @@ def test_get_leaf_07():
     Tuplets inside a voice.
     """
 
-    tuplet_1 = abjad.Tuplet((2, 3), "c'8 cs'8 d'8")
-    tuplet_2 = abjad.Tuplet((2, 3), "ef'8 e'8 f'8")
+    tuplet_1 = abjad.Tuplet("3:2", "c'8 cs'8 d'8")
+    tuplet_2 = abjad.Tuplet("3:2", "ef'8 e'8 f'8")
     voice = abjad.Voice([tuplet_1, tuplet_2])
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
@@ -652,9 +652,9 @@ def test_get_leaf_17():
     """
 
     notes = [abjad.Note(i, abjad.Duration(1, 8)) for i in range(3)]
-    tuplet_1 = abjad.Tuplet((2, 3), notes)
+    tuplet_1 = abjad.Tuplet("3:2", notes)
     notes = [abjad.Note(i, abjad.Duration(1, 8)) for i in range(4, 7)]
-    tuplet_2 = abjad.Tuplet((2, 3), notes)
+    tuplet_2 = abjad.Tuplet("3:2", notes)
     voice = abjad.Voice([tuplet_1, abjad.Note(3, (1, 8)), tuplet_2])
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
@@ -690,9 +690,9 @@ def test_get_leaf_18():
     Does connect through asymmetrically nested tuplets.
     """
 
-    inner_tuplet = abjad.Tuplet((2, 3), "c'8 c'8 c'8")
+    inner_tuplet = abjad.Tuplet("3:2", "c'8 c'8 c'8")
     contents = [abjad.Note("c'4"), inner_tuplet, abjad.Note("c'4")]
-    tuplet = abjad.Tuplet((2, 3), contents)
+    tuplet = abjad.Tuplet("3:2", contents)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -1049,7 +1049,7 @@ def test__inspect_are_logical_voice_03():
     Tuplet and leaves all logical voice.
     """
 
-    tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+    tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
 
     r"""
     \tuplet 3/2

--- a/tests/test_mutate_fuse.py
+++ b/tests/test_mutate_fuse.py
@@ -110,10 +110,10 @@ def test_mutate_fuse_06():
     """
 
     voice = abjad.Voice()
-    tuplet_1 = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+    tuplet_1 = abjad.Tuplet("3:2", "c'8 d'8 e'8")
     voice.append(tuplet_1)
     abjad.beam(tuplet_1[:])
-    tuplet_2 = abjad.Tuplet((2, 3), "c'16 d'16 e'16")
+    tuplet_2 = abjad.Tuplet("3:2", "c'16 d'16 e'16")
     voice.append(tuplet_2)
     abjad.slur(tuplet_2[:])
 
@@ -176,8 +176,8 @@ def test_mutate_fuse_07():
     """
 
     voice = abjad.Voice()
-    tuplet_1 = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
-    tuplet_2 = abjad.Tuplet((2, 3), "c'16 d'16 e'16")
+    tuplet_1 = abjad.Tuplet("3:2", "c'8 d'8 e'8")
+    tuplet_2 = abjad.Tuplet("3:2", "c'16 d'16 e'16")
     voice = abjad.Voice([tuplet_1, tuplet_2])
     abjad.beam(tuplet_1[:])
     abjad.slur(tuplet_2[:])
@@ -238,8 +238,8 @@ def test_mutate_fuse_08():
     Fuses fixed-multiplier tuplets with same multiplier in score.
     """
 
-    tuplet_1 = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
-    tuplet_2 = abjad.Tuplet((2, 3), "c'8 d'8 e'8 f'8 g'8")
+    tuplet_1 = abjad.Tuplet("3:2", "c'8 d'8 e'8")
+    tuplet_2 = abjad.Tuplet("3:2", "c'8 d'8 e'8 f'8 g'8")
     voice = abjad.Voice([tuplet_1, tuplet_2])
     abjad.makers.tweak_tuplet_bracket_edge_height(voice)
     abjad.beam(tuplet_1[:])
@@ -308,8 +308,8 @@ def test_mutate_fuse_09():
     Raises exception when tuplet multipliers differ.
     """
 
-    tuplet_1 = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
-    tuplet_2 = abjad.Tuplet((4, 5), "c'8 d'8 e'8 f'8 g'8")
+    tuplet_1 = abjad.Tuplet("3:2", "c'8 d'8 e'8")
+    tuplet_2 = abjad.Tuplet("5:4", "c'8 d'8 e'8 f'8 g'8")
     tuplets = [tuplet_1, tuplet_2]
 
     with pytest.raises(Exception):
@@ -317,8 +317,8 @@ def test_mutate_fuse_09():
 
 
 def test_mutate_fuse_10():
-    tuplet_1 = abjad.Tuplet((2, 3), "c'8")
-    tuplet_2 = abjad.Tuplet((2, 3), "c'4")
+    tuplet_1 = abjad.Tuplet("3:2", "c'8")
+    tuplet_2 = abjad.Tuplet("3:2", "c'4")
     voice = abjad.Voice([tuplet_1, tuplet_2, abjad.Note("c'4")])
     abjad.makers.tweak_tuplet_bracket_edge_height(voice)
     leaves = abjad.select.leaves(voice)

--- a/tests/test_mutate_helpers.py
+++ b/tests/test_mutate_helpers.py
@@ -613,7 +613,7 @@ def test_mutate__immediately_precedes_03():
 
 
 def test_mutate__immediately_precedes_04():
-    tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+    tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
 
     assert abjad.mutate._immediately_precedes(tuplet[0], tuplet[1])
     assert abjad.mutate._immediately_precedes(tuplet[1], tuplet[2])

--- a/tests/test_mutate_split.py
+++ b/tests/test_mutate_split.py
@@ -1306,8 +1306,8 @@ def test_mutate_split_07():
     """
 
     voice = abjad.Voice()
-    voice.append(abjad.Tuplet((2, 3), "c'8 d'8 e'8"))
-    voice.append(abjad.Tuplet((2, 3), "f'8 g'8 a'8"))
+    voice.append(abjad.Tuplet("3:2", "c'8 d'8 e'8"))
+    voice.append(abjad.Tuplet("3:2", "f'8 g'8 a'8"))
     leaves = abjad.select.leaves(voice)
     abjad.beam(leaves)
 
@@ -1571,7 +1571,7 @@ def test_mutate_split_12():
     Splits tuplet in score.
     """
 
-    tuplet = abjad.Tuplet((4, 5), "c'8 c'8 c'8 c'8 c'8")
+    tuplet = abjad.Tuplet("5:4", "c'8 c'8 c'8 c'8 c'8")
     voice = abjad.Voice([tuplet])
     staff = abjad.Staff([voice])
     abjad.beam(tuplet[:])

--- a/tests/test_mutate_swap.py
+++ b/tests/test_mutate_swap.py
@@ -34,7 +34,7 @@ def test_Mutation_swap_01():
         """
     )
 
-    tuplet = abjad.Tuplet((3, 4), [])
+    tuplet = abjad.Tuplet("4:3", [])
     abjad.makers.tweak_tuplet_number_text(tuplet)
     abjad.mutate.swap(voice[:2], tuplet)
 
@@ -156,7 +156,7 @@ def test_Mutation_swap_03():
         """
     )
 
-    tuplet = abjad.Tuplet((3, 4), [])
+    tuplet = abjad.Tuplet("4:3", [])
     abjad.makers.tweak_tuplet_number_text(tuplet)
     abjad.mutate.swap(voice[1:2], tuplet)
 
@@ -211,7 +211,7 @@ def test_Mutation_swap_05():
     leaves = abjad.select.leaves(voice)
     abjad.beam(leaves)
 
-    tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+    tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
     with pytest.raises(Exception):
         abjad.mutate.swap(voice[1:2], tuplet)
 
@@ -248,7 +248,7 @@ def test_Mutation_swap_06():
         """
     )
 
-    tuplet = abjad.Tuplet((2, 3), [])
+    tuplet = abjad.Tuplet("3:2", [])
     with pytest.raises(Exception):
         abjad.mutate.swap([voice[0], voice[2]], tuplet)
 

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -2,7 +2,7 @@ import abjad
 
 
 def test_Tuplet_grob_override_01():
-    tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8 f'8")
+    tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8 f'8")
     abjad.override(tuplet).Glissando.thickness = 3
     abjad.makers.tweak_tuplet_bracket_edge_height(tuplet)
 

--- a/tests/test_parentage.py
+++ b/tests/test_parentage.py
@@ -489,7 +489,7 @@ def test_Parentage_orphan_01():
 
 
 def test_Parentage_root_01():
-    tuplet = abjad.Tuplet((2, 3), "c'8 d'8 e'8")
+    tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
     staff = abjad.Staff([tuplet])
     leaves = abjad.select.leaves(staff)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -26,7 +26,7 @@ def test_LilyPondParser__containers__Container_01():
 def test_LilyPondParser__containers__Tuplet_01():
     pitches = abjad.makers.make_pitches([0, 2, 4])
     notes = abjad.makers.make_notes(pitches, [abjad.Duration(1, 8)])
-    target = abjad.Tuplet((2, 3), notes)
+    target = abjad.Tuplet("3:2", notes)
 
     assert abjad.lilypond(target) == abjad.string.normalize(
         r"""

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -19,7 +19,7 @@ def test_score_01():
         abjad.Score(),
         abjad.Skip((1, 4)),
         abjad.Staff(),
-        abjad.Tuplet((2, 3), "c'8 d'8 e'8"),
+        abjad.Tuplet("3:2", "c'8 d'8 e'8"),
         abjad.Voice(),
     ):
         with pytest.raises(AttributeError):


### PR DESCRIPTION
Modernize all examples of tuplet initialization in the docs:

    OLD: abjad.Tuplet((2, 3), "c'4 d'4 e'4")
    NEW: abjad.Tuplet("3:2", "c'4 d'4 e'4")