### PR TITLE
Teach abjad.Tuplet.trivial() about ratios like 3:3

### DIFF
--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -5341,66 +5341,15 @@ class Tuplet(Container):
 
     @property
     def denominator(self) -> int | None:
-        r"""
-        Gets and sets preferred denominator of tuplet.
-
-        ..  container:: example
-
-            Gets preferred denominator of tuplet:
-
-            >>> tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
-            >>> tuplet.denominator is None
-            True
-            >>> abjad.show(tuplet) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(tuplet)
-                >>> print(string)
-                \tuplet 3/2
-                {
-                    c'8
-                    d'8
-                    e'8
-                }
-
-        ..  container:: example
-
-            Sets preferred denominator of tuplet:
-
-            >>> tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
-            >>> abjad.show(tuplet) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(tuplet)
-                >>> print(string)
-                \tuplet 3/2
-                {
-                    c'8
-                    d'8
-                    e'8
-                }
-
-            >>> tuplet.denominator = 4
-            >>> abjad.show(tuplet) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(tuplet)
-                >>> print(string)
-                \tuplet 6/4
-                {
-                    c'8
-                    d'8
-                    e'8
-                }
-
+        """
+        DEPRECATED: set tuplet multiplier (or ratio) directly.
         """
         return self._denominator
 
     @denominator.setter
     def denominator(self, argument):
+        # if argument is not None:
+        #     raise Exception("ASDF")
         if isinstance(argument, int):
             if not 0 < argument:
                 raise ValueError(argument)

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -6402,7 +6402,7 @@ class Tuplet(Container):
             False
 
         """
-        if self.multiplier != (1, 1):
+        if _duration.Duration(self.multiplier) != _duration.Duration(1, 1):
             return False
         for component in self:
             if isinstance(component, Tuplet):


### PR DESCRIPTION
Teach `abjad.Tuplet.trivial()` about ratios like 3:3
    
        OLD:
    
            >>> abjad.Tuplet("1:1", "c'4 d'4 e'4").trivial()
            True
    
            >>> abjad.Tuplet("3:3", "c'4 d'4 e'4").trivial()
            False
    
        NEW:
    
            >>> abjad.Tuplet("1:1", "c'4 d'4 e'4").trivial()
            True
    
            >>> abjad.Tuplet("3:3", "c'4 d'4 e'4").trivial()
            True
