### PR TITLE
Clean up prolation properties

### DIFF
--- a/source/abjad/duration.py
+++ b/source/abjad/duration.py
@@ -788,37 +788,6 @@ class Duration(fractions.Fraction):
         return False
 
     @property
-    def is_dyadic(self) -> bool:
-        r"""
-        Is true when denominator of duration is integer power of two.
-
-        ..  container:: example
-
-            >>> for n in range(1, 16 + 1):
-            ...     duration = abjad.Duration(1, n)
-            ...     print(f"{duration!s}\t{duration.is_dyadic}")
-            ...
-            1       True
-            1/2     True
-            1/3     False
-            1/4     True
-            1/5     False
-            1/6     False
-            1/7     False
-            1/8     True
-            1/9     False
-            1/10    False
-            1/11    False
-            1/12    False
-            1/13    False
-            1/14    False
-            1/15    False
-            1/16    True
-
-        """
-        return _math.is_nonnegative_integer_power_of_two(self.denominator)
-
-    @property
     def lilypond_duration_string(self) -> str:
         """
         Gets LilyPond duration string.
@@ -865,23 +834,36 @@ class Duration(fractions.Fraction):
         """
         return self.numerator, self.denominator
 
-    @property
-    def prolation_string(self) -> str:
-        """
-        Gets prolation string.
+    def is_dyadic(self) -> bool:
+        r"""
+        Is true when denominator of duration is integer power of two.
 
         ..  container:: example
 
-            Gets prolation string:
-
-            >>> abjad.Duration(3, 16).prolation_string
-            '16:3'
+            >>> for n in range(1, 16 + 1):
+            ...     duration = abjad.Duration(1, n)
+            ...     print(f"{duration!s}\t{duration.is_dyadic()}")
+            ...
+            1       True
+            1/2     True
+            1/3     False
+            1/4     True
+            1/5     False
+            1/6     False
+            1/7     False
+            1/8     True
+            1/9     False
+            1/10    False
+            1/11    False
+            1/12    False
+            1/13    False
+            1/14    False
+            1/15    False
+            1/16    True
 
         """
-        return f"{self.denominator}:{self.numerator}"
+        return _math.is_nonnegative_integer_power_of_two(self.denominator)
 
-    # TODO: change to method
-    @property
     def reciprocal(self) -> "Duration":
         """
         Gets reciprocal.
@@ -890,7 +872,7 @@ class Duration(fractions.Fraction):
 
             Gets reciprocal:
 
-            >>> abjad.Duration(3, 7).reciprocal
+            >>> abjad.Duration(3, 7).reciprocal()
             Duration(7, 3)
 
         """

--- a/source/abjad/indicators.py
+++ b/source/abjad/indicators.py
@@ -7340,7 +7340,7 @@ class TimeSignature:
     def _get_contributions(self, *, component=None, wrapper=None):
         contributions = _contributions.ContributionsBySite()
         site = getattr(contributions, self.site)
-        if not self.is_dyadic and not self.hide:
+        if not self.is_dyadic() and not self.hide:
             string = '#(ly:expect-warning "strange time signature found")'
             site.commands.append(string)
         strings = self._get_lilypond_format()
@@ -7388,37 +7388,46 @@ class TimeSignature:
         return _duration.Duration(*self.pair)
 
     @property
-    def implied_prolation(self) -> fractions.Fraction:
+    def numerator(self) -> int:
         """
-        Gets implied prolation of time signature.
+        Gets numerator of time signature.
 
         ..  container:: example
 
-            Implied prolation of dyadic time signature is always 1:
-
-            >>> abjad.TimeSignature((3, 8)).implied_prolation
-            Fraction(1, 1)
-
-            Implied prolation of nondyadic time signature is always less than 1:
-
-            >>> abjad.TimeSignature((7, 12)).implied_prolation
-            Fraction(2, 3)
+            >>> abjad.TimeSignature((3, 8)).numerator
+            3
 
         """
-        numerator = _math.greatest_power_of_two_less_equal(self.denominator)
-        return fractions.Fraction(numerator, self.denominator)
+        return self.pair[0]
 
-    @property
+    @staticmethod
+    def from_string(string) -> "TimeSignature":
+        """
+        Makes new time signature from fraction ``string``.
+
+        ..  container:: example
+
+            >>> abjad.TimeSignature.from_string("6/8")
+            TimeSignature(pair=(6, 8), hide=False, partial=None)
+
+        """
+        assert isinstance(string, str), repr(string)
+        parts = string.split("/")
+        assert len(parts) == 2, repr(parts)
+        numbers = [int(_) for _ in parts]
+        numerator, denominator = numbers
+        return TimeSignature((numerator, denominator))
+
     def is_dyadic(self) -> bool:
         r"""
         Is true when denominator of time signature is integer power of two.
 
         ..  container:: example
 
-            >>> abjad.TimeSignature((3, 8)).is_dyadic
+            >>> abjad.TimeSignature((3, 8)).is_dyadic()
             True
 
-            >>> abjad.TimeSignature((7, 12)).is_dyadic
+            >>> abjad.TimeSignature((7, 12)).is_dyadic()
             False
 
             Nondyadic time signatures suppress LilyPond "strange time
@@ -7451,36 +7460,25 @@ class TimeSignature:
         """
         return _math.is_nonnegative_integer_power_of_two(self.denominator)
 
-    @property
-    def numerator(self) -> int:
+    def prolation(self) -> fractions.Fraction:
         """
-        Gets numerator of time signature.
+        Gets prolation of time signature.
 
         ..  container:: example
 
-            >>> abjad.TimeSignature((3, 8)).numerator
-            3
+            Prolation of dyadic time signature is always 1:
+
+            >>> abjad.TimeSignature((3, 8)).prolation()
+            Fraction(1, 1)
+
+            Prolation of nondyadic time signature is always less than 1:
+
+            >>> abjad.TimeSignature((7, 12)).prolation()
+            Fraction(2, 3)
 
         """
-        return self.pair[0]
-
-    @staticmethod
-    def from_string(string) -> "TimeSignature":
-        """
-        Makes new time signature from fraction ``string``.
-
-        ..  container:: example
-
-            >>> abjad.TimeSignature.from_string("6/8")
-            TimeSignature(pair=(6, 8), hide=False, partial=None)
-
-        """
-        assert isinstance(string, str), repr(string)
-        parts = string.split("/")
-        assert len(parts) == 2, repr(parts)
-        numbers = [int(_) for _ in parts]
-        numerator, denominator = numbers
-        return TimeSignature((numerator, denominator))
+        numerator = _math.greatest_power_of_two_less_equal(self.denominator)
+        return fractions.Fraction(numerator, self.denominator)
 
 
 @dataclasses.dataclass(frozen=True, order=True, slots=True, unsafe_hash=True)

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -12,7 +12,7 @@ from . import tag as _tag
 from . import tweaks as _tweaks
 
 
-def _group_by_implied_prolation(durations):
+def _group_by_prolation(durations):
     assert all(isinstance(_, _duration.Duration) for _ in durations), repr(durations)
     assert 0 < len(durations)
     duration_list = [durations[0]]
@@ -603,7 +603,7 @@ def make_leaves(
     maximum_length = max(len(durations), len(pitch_lists))
     durations = _sequence.repeat_to_length(durations, maximum_length)
     pitch_lists = _sequence.repeat_to_length(pitch_lists, maximum_length)
-    duration_lists = _group_by_implied_prolation(durations)
+    duration_lists = _group_by_prolation(durations)
     result: list[_score.Tuplet | _score.Leaf] = []
     for duration_list in duration_lists:
         factors_ = _math.factors(duration_list[0].denominator)
@@ -794,7 +794,7 @@ def make_notes(
     maximum_length = max(len(pitches), len(durations))
     pitches = _sequence.repeat_to_length(pitches, maximum_length)
     durations = _sequence.repeat_to_length(durations, maximum_length)
-    duration_lists = _group_by_implied_prolation(durations)
+    duration_lists = _group_by_prolation(durations)
     result: list[_score.Note | _score.Tuplet] = []
     for duration_list in duration_lists:
         factors = set(_math.factors(duration_list[0].denominator))
@@ -814,7 +814,7 @@ def make_notes(
             denominator = duration_list[0].denominator
             numerator = _math.greatest_power_of_two_less_equal(denominator)
             duration = _duration.Duration(numerator, denominator)
-            duration_list = [duration.reciprocal * _ for _ in duration_list]
+            duration_list = [duration.reciprocal() * _ for _ in duration_list]
             notes = _make_unprolated_notes(
                 pitches_,
                 duration_list,

--- a/source/abjad/parentage.py
+++ b/source/abjad/parentage.py
@@ -114,14 +114,6 @@ class Parentage(collections.abc.Sequence):
         rhs = getattr(component, "name", None) or id(component)
         return f"{lhs}-{rhs!r}"
 
-    def _prolations(self):
-        prolations = []
-        default = fractions.Fraction(1)
-        for parent in self:
-            prolation = getattr(parent, "implied_prolation", default)
-            prolations.append(prolation)
-        return prolations
-
     ### PUBLIC PROPERTIES ###
 
     @property
@@ -661,7 +653,14 @@ class Parentage(collections.abc.Sequence):
             Note("fs'16")                  Fraction(2, 3)
 
         """
-        prolations = [fractions.Fraction(1)] + self._prolations()
+        default = fractions.Fraction(1)
+        prolations = [default]
+        for parent in self:
+            if hasattr(parent, "_get_prolation"):
+                prolation = parent._get_prolation()
+            else:
+                prolation = default
+            prolations.append(prolation)
         products = _math.cumulative_products(prolations)
         return products[-1]
 

--- a/tests/test_makers.py
+++ b/tests/test_makers.py
@@ -3,22 +3,22 @@ import pytest
 import abjad
 
 
-def test_makers__group_by_implied_prolation_01():
+def test_makers__group_by_prolation_01():
     with pytest.raises(Exception):
-        abjad.makers._group_by_implied_prolation([])
+        abjad.makers._group_by_prolation([])
 
 
-def test_makers__group_by_implied_prolation_02():
+def test_makers__group_by_prolation_02():
     pairs = [(1, 4)]
     durations = [abjad.Duration(_) for _ in pairs]
-    duration_lists = abjad.makers._group_by_implied_prolation(durations)
+    duration_lists = abjad.makers._group_by_prolation(durations)
     assert duration_lists == [[abjad.Duration(1, 4)]]
 
 
-def test_makers__group_by_implied_prolation_03():
+def test_makers__group_by_prolation_03():
     pairs = [(1, 4), (1, 4), (1, 8)]
     durations = [abjad.Duration(_) for _ in pairs]
-    duration_lists = abjad.makers._group_by_implied_prolation(durations)
+    duration_lists = abjad.makers._group_by_prolation(durations)
     assert duration_lists == [
         [
             abjad.Duration(1, 4),
@@ -28,10 +28,10 @@ def test_makers__group_by_implied_prolation_03():
     ]
 
 
-def test_makers__group_by_implied_prolation_04():
+def test_makers__group_by_prolation_04():
     pairs = [(1, 4), (1, 3), (1, 8)]
     durations = [abjad.Duration(_) for _ in pairs]
-    duration_lists = abjad.makers._group_by_implied_prolation(durations)
+    duration_lists = abjad.makers._group_by_prolation(durations)
     assert duration_lists == [
         [abjad.Duration(1, 4)],
         [abjad.Duration(1, 3)],
@@ -39,20 +39,20 @@ def test_makers__group_by_implied_prolation_04():
     ]
 
 
-def test_makers__group_by_implied_prolation_05():
+def test_makers__group_by_prolation_05():
     pairs = [(1, 4), (1, 2), (1, 3)]
     durations = [abjad.Duration(_) for _ in pairs]
-    duration_lists = abjad.makers._group_by_implied_prolation(durations)
+    duration_lists = abjad.makers._group_by_prolation(durations)
     assert duration_lists == [
         [abjad.Duration(1, 4), abjad.Duration(1, 2)],
         [abjad.Duration(1, 3)],
     ]
 
 
-def test_makers__group_by_implied_prolation_06():
+def test_makers__group_by_prolation_06():
     pairs = [(1, 4), (1, 2), (1, 3), (1, 6), (1, 5)]
     durations = [abjad.Duration(_) for _ in pairs]
-    duration_lists = abjad.makers._group_by_implied_prolation(durations)
+    duration_lists = abjad.makers._group_by_prolation(durations)
     assert duration_lists == [
         [abjad.Duration(1, 4), abjad.Duration(1, 2)],
         [abjad.Duration(1, 3), abjad.Duration(1, 6)],
@@ -60,10 +60,10 @@ def test_makers__group_by_implied_prolation_06():
     ]
 
 
-def test_makers__group_by_implied_prolation_07():
+def test_makers__group_by_prolation_07():
     pairs = [(1, 24), (2, 24), (3, 24), (4, 24), (5, 24), (6, 24)]
     durations = [abjad.Duration(_) for _ in pairs]
-    duration_lists = abjad.makers._group_by_implied_prolation(durations)
+    duration_lists = abjad.makers._group_by_prolation(durations)
     assert duration_lists == [
         [abjad.Duration(1, 24), abjad.Duration(2, 24)],
         [abjad.Duration(3, 24)],


### PR DESCRIPTION
Clean up prolation properties
    
    OLD: abjad.TimeSignature.implied_prolation property
    NEW: abjad.TimeSignature.prolation() method

    OLD: abjad.Duration.is_dyadic property
    NEW: abjad.Duration.is_dyadic() method

    OLD: abjad.Duration.reciprocal property
    NEW: abjad.Duration.reciprocal() method

    OLD: abjad.TimeSignature.is_dyadic property
    NEW: abjad.TimeSignature.is_dyadic() method

    REMOVE: abjad.Duration.implied_prolation property
    REMOVE: abjad.Duration.prolation_string property
    REMOVE: abjad.TremoloContainer.implied_prolation property
    REMOVE: abjad.Tuplet.implied_prolation property