### PR TITLE
Change Tuplet.multiplier from property to method

### DIFF
--- a/docs/source/examples/enumeration.rst
+++ b/docs/source/examples/enumeration.rst
@@ -31,8 +31,7 @@ The following functions recreate Malt's results in Abjad:
     ...     ratio = inner * (1,)
     ...     pair = (outer, lone_note_denominator)
     ...     inner_tuplet = abjad.makers.tuplet_from_ratio_and_pair(ratio, pair)
-    ...     multiplier = inner_tuplet.fraction_multiplier
-    ...     pair = abjad.duration.with_denominator(multiplier, inner)
+    ...     pair = abjad.duration.with_denominator(inner_tuplet.multiplier(), inner)
     ...     inner_tuplet.ratio = abjad.Ratio(pair[1], pair[0])
     ...     inner_tuplet.hide = inner_tuplet.trivial()
     ...     if retrograde:

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -1305,16 +1305,12 @@ def tweak_tuplet_number_text(argument) -> None:
 
       * tuplet is an augmentation (like 3:4), or
       * tuplet is nondyadic (like 4:3), or
-      * tuplet ratio reduces to 1:1
+      * tuplet multiplier equals 1
 
     Does not tweak tuplets for which none of these conditions holds.
     """
     for tuplet in _iterate.components(argument, _score.Tuplet):
         if "text" in vars(_overrides.override(tuplet).TupletNumber):
             continue
-        if (
-            tuplet.augmentation()
-            or not tuplet.dyadic()
-            or tuplet.fraction_multiplier == 1
-        ):
+        if tuplet.augmentation() or not tuplet.dyadic() or tuplet.multiplier() == 1:
             _tweaks.tweak(tuplet, tuplet.tuplet_number_calc_fraction_text_tweak_string)

--- a/source/abjad/rhythmtrees.py
+++ b/source/abjad/rhythmtrees.py
@@ -653,7 +653,7 @@ class RhythmTreeContainer(RhythmTreeNode, uqbar.containers.UniqueTreeList):
                     tuplet.extend(leaves)
                     if 1 < len(leaves):
                         _spanners.tie(leaves)
-            assert tuplet.fraction_multiplier == 1, repr(tuplet.fraction_multiplier)
+            assert tuplet.multiplier() == 1, repr(tuplet.multiplier())
             contents_duration = tuplet._get_duration()
             target_duration = tuplet_duration
             multiplier = target_duration / contents_duration


### PR DESCRIPTION
Change `Tuplet.multiplier` from (unreduced) integer pair to (reduced) fraction

    OLD: Tuplet.multiplier was a read / write property that returned an
    integer pair:

        >>> tuplet = abjad.Tuplet("6:4", "c'4 d'4 e'4")
        >>> tuplet.multiplier
        (4, 6)

        >>> tuplet.multiplier = (8, 12)
        >>> tuplet.multiplier
        (8, 12)

        >>> tuplet.ratio
        Ratio(numerator=12, denominator=8)

    NEW: Tuplet.multiplier() is a method that returns a fraction.
    Use abjad.Tuplet.ratio as the read / write property to work
    with tuplets:

        >>> tuplet = abjad.Tuplet("6:4", "c'4 d'4 e'4")
        >>> tuplet.multiplier()
        Fraction(4, 6)

        >>> tuplet.ratio = abjad.Ratio(12, 8)
        >>> tuplet
        Tuplet("12:8", "c'4 d'4 e'4")

        >>> tuplet.ratio
        Ratio(numerator=12, denominator=8)

        >>> tuplet.multiplier()
        Fraction(8, 12)