### PR TITLE
Add tuplet_from_proportion_and_ratio(..., canonical=False) keyword

### DIFF
--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -891,6 +891,7 @@ def tuplet_from_proportion_and_pair(
     proportion: tuple[int, ...],
     pair: tuple[int, int],
     *,
+    canonical: bool = False,
     tag: _tag.Tag | None = None,
 ) -> _score.Tuplet:
     r"""
@@ -1412,6 +1413,13 @@ def tuplet_from_proportion_and_pair(
             components.extend(leaves)
         tuplet = _score.Tuplet.from_duration(duration, components, tag=tag)
     tuplet.normalize_ratio()
+    assert tuplet.ratio.normalized()
+    if canonical is True:
+        if tuplet.augmentation():
+            tuplet.toggle_prolation()
+        assert tuplet.diminution() or tuplet.trivial()
+    else:
+        assert canonical is False
     assert tuplet.ratio.normalized()
     return tuplet
 


### PR DESCRIPTION
Set `canonical=True` to force all tuplet output to be diminished.

Later removed when all `abjad.makers.make_tuplet()` output was changed to always be diminished.