### PR TITLE
Rename abjad.makers.tuplet_from_duration_and_proportion()

### DIFF
--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -887,9 +887,9 @@ def make_pitches(argument: list | str) -> list[_pitch.NamedPitch]:
     return pitches
 
 
-def tuplet_from_proportion_and_pair(
+def tuplet_from_duration_and_proportion(
+    duration: _duration.Duration,
     proportion: tuple[int, ...],
-    pair: tuple[int, int],
     *,
     tag: _tag.Tag | None = None,
 ) -> _score.Tuplet:
@@ -900,13 +900,14 @@ def tuplet_from_proportion_and_pair(
 
         Helper function:
 
-        >>> def make_score(proportion, pair):
-        ...     tuplet = abjad.makers.tuplet_from_proportion_and_pair(proportion, pair)
+        >>> def make_score(duration, proportion):
+        ...     tuplet = abjad.makers.tuplet_from_duration_and_proportion(
+        ...         duration, proportion
+        ...     )
         ...     abjad.makers.tweak_tuplet_number_text(tuplet)
         ...     staff = abjad.Staff([tuplet], lilypond_type="RhythmicStaff")
         ...     score = abjad.Score([staff], name="Score")
-        ...     fraction = abjad.Fraction(*pair)
-        ...     pair = fraction.numerator, fraction.denominator
+        ...     pair = duration.numerator, duration.denominator
         ...     time_signature = abjad.TimeSignature(pair)
         ...     leaf = abjad.select.leaf(staff, 0)
         ...     abjad.attach(time_signature, leaf)
@@ -916,7 +917,8 @@ def tuplet_from_proportion_and_pair(
 
         Divides duration of 3/16 into increasing number of parts:
 
-        >>> score = make_score((1, 2, 2), (3, 16))
+        >>> duration = abjad.Duration(3, 16)
+        >>> score = make_score(duration, (1, 2, 2))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -933,7 +935,7 @@ def tuplet_from_proportion_and_pair(
                 c'8
             }
 
-        >>> score = make_score((1, 2, 2, 3), (3, 16))
+        >>> score = make_score(duration, (1, 2, 2, 3))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -951,7 +953,7 @@ def tuplet_from_proportion_and_pair(
                 c'16.
             }
 
-        >>> score = make_score((1, 2, 2, 3, 3), (3, 16))
+        >>> score = make_score(duration, (1, 2, 2, 3, 3))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -970,7 +972,7 @@ def tuplet_from_proportion_and_pair(
                 c'16.
             }
 
-        >>> score = make_score((1, 2, 2, 3, 3, 4), (3, 16))
+        >>> score = make_score(duration, (1, 2, 2, 3, 3, 4))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -993,7 +995,8 @@ def tuplet_from_proportion_and_pair(
 
         Divides duration of 2/2 * 3/16 = 6/32 into increasing number of parts:
 
-        >>> score = make_score((1, 2, 2), (6, 32))
+        >>> duration = abjad.Duration(6, 32)
+        >>> score = make_score(duration, (1, 2, 2))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1010,7 +1013,7 @@ def tuplet_from_proportion_and_pair(
                 c'8
             }
 
-        >>> score = make_score((1, 2, 2, 3), (6, 32))
+        >>> score = make_score(duration, (1, 2, 2, 3))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1028,7 +1031,7 @@ def tuplet_from_proportion_and_pair(
                 c'16.
             }
 
-        >>> score = make_score((1, 2, 2, 3, 3), (6, 32))
+        >>> score = make_score(duration, (1, 2, 2, 3, 3))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1047,7 +1050,7 @@ def tuplet_from_proportion_and_pair(
                 c'16.
             }
 
-        >>> score = make_score((1, 2, 2, 3, 3, 4), (6, 32))
+        >>> score = make_score(duration, (1, 2, 2, 3, 3, 4))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1070,7 +1073,8 @@ def tuplet_from_proportion_and_pair(
 
         Divides duration of 7/16 into increasing number of parts:
 
-        >>> score = make_score((1,), (7, 16))
+        >>> duration = abjad.Duration(7, 16)
+        >>> score = make_score(duration, (1,))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1085,7 +1089,7 @@ def tuplet_from_proportion_and_pair(
                 c'4..
             }
 
-        >>> score = make_score((1, 2), (7, 16))
+        >>> score = make_score(duration, (1, 2))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1101,7 +1105,7 @@ def tuplet_from_proportion_and_pair(
                 c'2
             }
 
-        >>> score = make_score((1, 2, 4), (7, 16))
+        >>> score = make_score(duration, (1, 2, 4))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1118,7 +1122,7 @@ def tuplet_from_proportion_and_pair(
                 c'4
             }
 
-        >>> score = make_score((1, 2, 4, 1), (7, 16))
+        >>> score = make_score(duration, (1, 2, 4, 1))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1136,7 +1140,7 @@ def tuplet_from_proportion_and_pair(
                 c'16
             }
 
-        >>> score = make_score((1, 2, 4, 1, 2), (7, 16))
+        >>> score = make_score(duration, (1, 2, 4, 1, 2))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1155,7 +1159,7 @@ def tuplet_from_proportion_and_pair(
                 c'8
             }
 
-        >>> score = make_score((1, 2, 4, 1, 2, 4), (7, 16))
+        >>> score = make_score(duration, (1, 2, 4, 1, 2, 4))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1179,7 +1183,8 @@ def tuplet_from_proportion_and_pair(
 
         Divides duration of 2/2 * 7/16 = 14/32 into increasing number of parts:
 
-        >>> score = make_score((1,), (14, 32))
+        >>> duration = abjad.Duration(14, 32)
+        >>> score = make_score(duration, (1,))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1194,7 +1199,7 @@ def tuplet_from_proportion_and_pair(
                 c'4..
             }
 
-        >>> score = make_score((1, 2), (14, 32))
+        >>> score = make_score(duration, (1, 2))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1210,7 +1215,7 @@ def tuplet_from_proportion_and_pair(
                 c'2
             }
 
-        >>> score = make_score((1, 2, 4), (14, 32))
+        >>> score = make_score(duration, (1, 2, 4))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1227,7 +1232,7 @@ def tuplet_from_proportion_and_pair(
                 c'4
             }
 
-        >>> score = make_score((1, 2, 4, 1), (14, 32))
+        >>> score = make_score(duration, (1, 2, 4, 1))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1245,7 +1250,7 @@ def tuplet_from_proportion_and_pair(
                 c'16
             }
 
-        >>> score = make_score((1, 2, 4, 1, 2), (14, 32))
+        >>> score = make_score(duration, (1, 2, 4, 1, 2))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1264,7 +1269,7 @@ def tuplet_from_proportion_and_pair(
                 c'8
             }
 
-        >>> score = make_score((1, 2, 4, 1, 2, 4), (14, 32))
+        >>> score = make_score(duration, (1, 2, 4, 1, 2, 4))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1288,7 +1293,8 @@ def tuplet_from_proportion_and_pair(
 
         Interprets negative integers in ``proportion`` as rests:
 
-        >>> score = make_score((1, 1, 1, -1, 1), (1, 4))
+        >>> duration = abjad.Duration(1, 4)
+        >>> score = make_score(duration, (1, 1, 1, -1, 1))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1306,7 +1312,7 @@ def tuplet_from_proportion_and_pair(
                 c'16
             }
 
-        >>> score = make_score((3, -2, 2), (1, 4))
+        >>> score = make_score(duration, (3, -2, 2))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1326,7 +1332,8 @@ def tuplet_from_proportion_and_pair(
 
         Works with nonassignable rests:
 
-        >>> score = make_score((11, -5), (7, 16))
+        >>> duration = abjad.Duration(7, 16)
+        >>> score = make_score(duration, (11, -5))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1349,7 +1356,8 @@ def tuplet_from_proportion_and_pair(
 
         Reduces integers in ``proportion`` relative to each other:
 
-        >>> score = make_score((1, 1, 1), (1, 4))
+        >>> duration = abjad.Duration(1, 4)
+        >>> score = make_score(duration, (1, 1, 1))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1365,7 +1373,7 @@ def tuplet_from_proportion_and_pair(
                 c'8
             }
 
-        >>> score = make_score((4, 4, 4), (1, 4))
+        >>> score = make_score(duration, (4, 4, 4))
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1382,12 +1390,10 @@ def tuplet_from_proportion_and_pair(
             }
 
     """
+    assert isinstance(duration, _duration.Duration), repr(duration)
     assert isinstance(proportion, tuple), repr(proportion)
     assert all(isinstance(_, int) for _ in proportion), repr(proportion)
     assert not any(_ == 0 for _ in proportion), repr(proportion)
-    assert isinstance(pair, tuple), repr(pair)
-    assert all(isinstance(_, int) for _ in pair), repr(pair)
-    duration = _duration.Duration(pair)
     if len(proportion) == 1:
         if 0 < proportion[0]:
             pitch_list = [_pitch.NamedPitch("c'")]
@@ -1397,7 +1403,7 @@ def tuplet_from_proportion_and_pair(
         leaves = make_leaves([pitch_list], [duration], tag=tag)
         tuplet = _score.Tuplet.from_duration(duration, leaves, tag=tag)
     else:
-        numerator, denominator = pair
+        numerator, denominator = duration.pair
         exponent = int(math.log(_math.weight(proportion), 2) - math.log(numerator, 2))
         denominator = int(denominator * 2**exponent)
         components: list[_score.Leaf | _score.Tuplet] = []

--- a/tests/test_makers.py
+++ b/tests/test_makers.py
@@ -99,8 +99,9 @@ def test_makers_make_notes_01():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_01():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((1, 2, 4), (6, 16))
+def test_makers_tuplet_from_duration_and_proportion_01():
+    duration = abjad.Duration(6, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 4))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -114,8 +115,9 @@ def test_makers_tuplet_from_proportion_and_pair_01():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_02():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((1, 1, 2, 4), (6, 16))
+def test_makers_tuplet_from_duration_and_proportion_02():
+    duration = abjad.Duration(6, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 1, 2, 4))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -130,8 +132,9 @@ def test_makers_tuplet_from_proportion_and_pair_02():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_03():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((-2, 3, 7), (7, 16))
+def test_makers_tuplet_from_duration_and_proportion_03():
+    duration = abjad.Duration(7, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (-2, 3, 7))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -145,8 +148,9 @@ def test_makers_tuplet_from_proportion_and_pair_03():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_04():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((7, 7, -4, -1), (1, 4))
+def test_makers_tuplet_from_duration_and_proportion_04():
+    duration = abjad.Duration(1, 4)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (7, 7, -4, -1))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -161,8 +165,9 @@ def test_makers_tuplet_from_proportion_and_pair_04():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_05():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((1, 2, 2), (12, 16))
+def test_makers_tuplet_from_duration_and_proportion_05():
+    duration = abjad.Duration(12, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 2))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -176,8 +181,9 @@ def test_makers_tuplet_from_proportion_and_pair_05():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_06():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((2, 4, 4), (12, 16))
+def test_makers_tuplet_from_duration_and_proportion_06():
+    duration = abjad.Duration(12, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (2, 4, 4))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -191,8 +197,9 @@ def test_makers_tuplet_from_proportion_and_pair_06():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_07():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((4, 8, 8), (12, 16))
+def test_makers_tuplet_from_duration_and_proportion_07():
+    duration = abjad.Duration(12, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (4, 8, 8))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -206,8 +213,9 @@ def test_makers_tuplet_from_proportion_and_pair_07():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_08():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((8, 16, 16), (12, 16))
+def test_makers_tuplet_from_duration_and_proportion_08():
+    duration = abjad.Duration(12, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (8, 16, 16))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -221,8 +229,9 @@ def test_makers_tuplet_from_proportion_and_pair_08():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_09():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((2, 4, 4), (3, 16))
+def test_makers_tuplet_from_duration_and_proportion_09():
+    duration = abjad.Duration(3, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (2, 4, 4))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -236,8 +245,9 @@ def test_makers_tuplet_from_proportion_and_pair_09():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_10():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((2, 4, 4), (6, 16))
+def test_makers_tuplet_from_duration_and_proportion_10():
+    duration = abjad.Duration(6, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (2, 4, 4))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -251,8 +261,9 @@ def test_makers_tuplet_from_proportion_and_pair_10():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_11():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((2, 4, 4), (12, 16))
+def test_makers_tuplet_from_duration_and_proportion_11():
+    duration = abjad.Duration(12, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (2, 4, 4))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -266,8 +277,9 @@ def test_makers_tuplet_from_proportion_and_pair_11():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_12():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((2, 4, 4), (24, 16))
+def test_makers_tuplet_from_duration_and_proportion_12():
+    duration = abjad.Duration(24, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (2, 4, 4))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -281,8 +293,9 @@ def test_makers_tuplet_from_proportion_and_pair_12():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_13():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((1, 2, 2), (6, 2))
+def test_makers_tuplet_from_duration_and_proportion_13():
+    duration = abjad.Duration(6, 2)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 2))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -296,8 +309,9 @@ def test_makers_tuplet_from_proportion_and_pair_13():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_14():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((1, 2, 2), (6, 4))
+def test_makers_tuplet_from_duration_and_proportion_14():
+    duration = abjad.Duration(6, 4)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 2))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -311,8 +325,9 @@ def test_makers_tuplet_from_proportion_and_pair_14():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_15():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((1, 2, 2), (6, 8))
+def test_makers_tuplet_from_duration_and_proportion_15():
+    duration = abjad.Duration(6, 8)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 2))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -326,8 +341,9 @@ def test_makers_tuplet_from_proportion_and_pair_15():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_16():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((1, 2, 2), (6, 16))
+def test_makers_tuplet_from_duration_and_proportion_16():
+    duration = abjad.Duration(6, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 2))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -341,8 +357,9 @@ def test_makers_tuplet_from_proportion_and_pair_16():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_17():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((1, -1, -1), (3, 16))
+def test_makers_tuplet_from_duration_and_proportion_17():
+    duration = abjad.Duration(3, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, -1, -1))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -356,8 +373,9 @@ def test_makers_tuplet_from_proportion_and_pair_17():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_18():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((1, 1, -1, -1), (4, 16))
+def test_makers_tuplet_from_duration_and_proportion_18():
+    duration = abjad.Duration(4, 16)
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 1, -1, -1))
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -372,8 +390,11 @@ def test_makers_tuplet_from_proportion_and_pair_18():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_19():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((1, 1, 1, -1, -1), (5, 16))
+def test_makers_tuplet_from_duration_and_proportion_19():
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(
+        abjad.Duration(5, 16),
+        (1, 1, 1, -1, -1),
+    )
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -389,8 +410,11 @@ def test_makers_tuplet_from_proportion_and_pair_19():
     )
 
 
-def test_makers_tuplet_from_proportion_and_pair_20():
-    tuplet = abjad.makers.tuplet_from_proportion_and_pair((1, 1, 1, 1, -1, -1), (6, 16))
+def test_makers_tuplet_from_duration_and_proportion_20():
+    tuplet = abjad.makers.tuplet_from_duration_and_proportion(
+        abjad.Duration(6, 16),
+        (1, 1, 1, 1, -1, -1),
+    )
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""


### PR DESCRIPTION
Rename `abjad.makers.tuplet_from_duration_and_proportion()`.

    OLD:

        >>> proportion = (1, 1, 1)
        >>> pair = (1, 4)
        >>> abjad.makers.tuplet_from_proportion_and_pair(proportion, pair)

    NEW:

        >>> duration = abjad.Duration(1, 4)
        >>> proportion = (1, 1, 1)
        >>> abjad.makers.tuplet_from_duration_and_proportion(duration, proportion)