### PR TITLE
Clean up abjad.makers.make_tuplet()

### DIFF
--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -887,26 +887,26 @@ def make_pitches(argument: list | str) -> list[_pitch.NamedPitch]:
     return pitches
 
 
-def tuplet_from_duration_and_proportion(
+def make_tuplet(
     duration: _duration.Duration,
     proportion: tuple[int, ...],
     *,
     tag: _tag.Tag | None = None,
 ) -> _score.Tuplet:
     r"""
-    Makes tuplet from ``proportion`` and ``pair``.
+    Makes tuplet from ``duration`` and ``proportion``.
 
     ..  container:: example
 
         Helper function:
 
-        >>> def make_score(duration, proportion):
-        ...     tuplet = abjad.makers.tuplet_from_duration_and_proportion(
-        ...         duration, proportion
-        ...     )
-        ...     abjad.makers.tweak_tuplet_number_text(tuplet)
+        >>> def make_score(tuplet):
+        ...     abjad.tweak(tuplet, r"\tweak bracket-visibility ##t")
+        ...     abjad.tweak(tuplet, r"\tweak padding #1.5")
+        ...     abjad.tweak(tuplet, r"\tweak text #tuplet-number::calc-fraction-text")
         ...     staff = abjad.Staff([tuplet], lilypond_type="RhythmicStaff")
         ...     score = abjad.Score([staff], name="Score")
+        ...     duration = abjad.get.duration(tuplet)
         ...     pair = duration.numerator, duration.denominator
         ...     time_signature = abjad.TimeSignature(pair)
         ...     leaf = abjad.select.leaf(staff, 0)
@@ -917,8 +917,9 @@ def tuplet_from_duration_and_proportion(
 
         Divides duration of 3/16 into increasing number of parts:
 
-        >>> duration = abjad.Duration(3, 16)
-        >>> score = make_score(duration, (1, 2, 2))
+        >>> duration, proportion = abjad.Duration(3, 16), (1, 2, 2)
+        >>> tuplet = abjad.makers.make_tuplet(duration, proportion)
+        >>> score = make_score(tuplet)
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -926,6 +927,8 @@ def tuplet_from_duration_and_proportion(
             >>> tuplet = score[0][0]
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
+            \tweak bracket-visibility ##t
+            \tweak padding #1.5
             \tweak text #tuplet-number::calc-fraction-text
             \tuplet 5/3
             {
@@ -935,7 +938,9 @@ def tuplet_from_duration_and_proportion(
                 c'8
             }
 
-        >>> score = make_score(duration, (1, 2, 2, 3))
+        >>> duration, proportion = abjad.Duration(3, 16), (1, 2, 2, 3)
+        >>> tuplet = abjad.makers.make_tuplet(duration, proportion)
+        >>> score = make_score(tuplet)
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -943,6 +948,8 @@ def tuplet_from_duration_and_proportion(
             >>> tuplet = score[0][0]
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
+            \tweak bracket-visibility ##t
+            \tweak padding #1.5
             \tweak text #tuplet-number::calc-fraction-text
             \tuplet 4/3
             {
@@ -953,7 +960,9 @@ def tuplet_from_duration_and_proportion(
                 c'16.
             }
 
-        >>> score = make_score(duration, (1, 2, 2, 3, 3))
+        >>> duration, proportion = abjad.Duration(3, 16), (1, 2, 2, 3, 3)
+        >>> tuplet = abjad.makers.make_tuplet(duration, proportion)
+        >>> score = make_score(tuplet)
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -961,6 +970,8 @@ def tuplet_from_duration_and_proportion(
             >>> tuplet = score[0][0]
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
+            \tweak bracket-visibility ##t
+            \tweak padding #1.5
             \tweak text #tuplet-number::calc-fraction-text
             \tuplet 11/6
             {
@@ -970,111 +981,15 @@ def tuplet_from_duration_and_proportion(
                 c'16
                 c'16.
                 c'16.
-            }
-
-        >>> score = make_score(duration, (1, 2, 2, 3, 3, 4))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 5/4
-            {
-                \time 3/16
-                c'64
-                c'32
-                c'32
-                c'32.
-                c'32.
-                c'16
-            }
-
-    ..  container:: example
-
-        Divides duration of 2/2 * 3/16 = 6/32 into increasing number of parts:
-
-        >>> duration = abjad.Duration(6, 32)
-        >>> score = make_score(duration, (1, 2, 2))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 5/3
-            {
-                \time 3/16
-                c'16
-                c'8
-                c'8
-            }
-
-        >>> score = make_score(duration, (1, 2, 2, 3))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 4/3
-            {
-                \time 3/16
-                c'32
-                c'16
-                c'16
-                c'16.
-            }
-
-        >>> score = make_score(duration, (1, 2, 2, 3, 3))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 11/6
-            {
-                \time 3/16
-                c'32
-                c'16
-                c'16
-                c'16.
-                c'16.
-            }
-
-        >>> score = make_score(duration, (1, 2, 2, 3, 3, 4))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tuplet 5/4
-            {
-                \time 3/16
-                c'64
-                c'32
-                c'32
-                c'32.
-                c'32.
-                c'16
             }
 
     ..  container:: example
 
         Divides duration of 7/16 into increasing number of parts:
 
-        >>> duration = abjad.Duration(7, 16)
-        >>> score = make_score(duration, (1,))
+        >>> duration, proportion = abjad.Duration(7, 16), (1, 2, 2)
+        >>> tuplet = abjad.makers.make_tuplet(duration, proportion)
+        >>> score = make_score(tuplet)
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1082,47 +997,20 @@ def tuplet_from_duration_and_proportion(
             >>> tuplet = score[0][0]
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
+            \tweak bracket-visibility ##t
+            \tweak padding #1.5
             \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
+            \tuplet 10/7
             {
                 \time 7/16
-                c'4..
-            }
-
-        >>> score = make_score(duration, (1, 2))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 12/7
-            {
-                \time 7/16
-                c'4
-                c'2
-            }
-
-        >>> score = make_score(duration, (1, 2, 4))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 7/16
-                c'16
                 c'8
                 c'4
+                c'4
             }
 
-        >>> score = make_score(duration, (1, 2, 4, 1))
+        >>> duration, proportion = abjad.Duration(7, 16), (1, 2, 2, 3)
+        >>> tuplet = abjad.makers.make_tuplet(duration, proportion)
+        >>> score = make_score(tuplet)
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1130,17 +1018,21 @@ def tuplet_from_duration_and_proportion(
             >>> tuplet = score[0][0]
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
+            \tweak bracket-visibility ##t
+            \tweak padding #1.5
             \tweak text #tuplet-number::calc-fraction-text
             \tuplet 8/7
             {
                 \time 7/16
                 c'16
                 c'8
-                c'4
-                c'16
+                c'8
+                c'8.
             }
 
-        >>> score = make_score(duration, (1, 2, 4, 1, 2))
+        >>> duration, proportion = abjad.Duration(7, 16), (1, 2, 2, 3, 3)
+        >>> tuplet = abjad.makers.make_tuplet(duration, proportion)
+        >>> score = make_score(tuplet)
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1148,153 +1040,26 @@ def tuplet_from_duration_and_proportion(
             >>> tuplet = score[0][0]
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
+            \tweak bracket-visibility ##t
+            \tweak padding #1.5
             \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 10/7
+            \tuplet 11/7
             {
                 \time 7/16
                 c'16
                 c'8
-                c'4
-                c'16
                 c'8
-            }
-
-        >>> score = make_score(duration, (1, 2, 4, 1, 2, 4))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 7/16
-                c'32
-                c'16
-                c'8
-                c'32
-                c'16
-                c'8
-            }
-
-    ..  container:: example
-
-        Divides duration of 2/2 * 7/16 = 14/32 into increasing number of parts:
-
-        >>> duration = abjad.Duration(14, 32)
-        >>> score = make_score(duration, (1,))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 7/16
-                c'4..
-            }
-
-        >>> score = make_score(duration, (1, 2))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 12/7
-            {
-                \time 7/16
-                c'4
-                c'2
-            }
-
-        >>> score = make_score(duration, (1, 2, 4))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 7/16
-                c'16
-                c'8
-                c'4
-            }
-
-        >>> score = make_score(duration, (1, 2, 4, 1))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 8/7
-            {
-                \time 7/16
-                c'16
-                c'8
-                c'4
-                c'16
-            }
-
-        >>> score = make_score(duration, (1, 2, 4, 1, 2))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 10/7
-            {
-                \time 7/16
-                c'16
-                c'8
-                c'4
-                c'16
-                c'8
-            }
-
-        >>> score = make_score(duration, (1, 2, 4, 1, 2, 4))
-        >>> abjad.show(score) # doctest: +SKIP
-
-        ..  docs::
-
-            >>> tuplet = score[0][0]
-            >>> string = abjad.lilypond(tuplet)
-            >>> print(string)
-            \tweak text #tuplet-number::calc-fraction-text
-            \tuplet 1/1
-            {
-                \time 7/16
-                c'32
-                c'16
-                c'8
-                c'32
-                c'16
-                c'8
+                c'8.
+                c'8.
             }
 
     ..  container:: example
 
         Interprets negative integers in ``proportion`` as rests:
 
-        >>> duration = abjad.Duration(1, 4)
-        >>> score = make_score(duration, (1, 1, 1, -1, 1))
+        >>> duration, proportion = abjad.Duration(1, 4), (1, 1, 1, -1, 1)
+        >>> tuplet = abjad.makers.make_tuplet(duration, proportion)
+        >>> score = make_score(tuplet)
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1302,6 +1067,9 @@ def tuplet_from_duration_and_proportion(
             >>> tuplet = score[0][0]
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
+            \tweak bracket-visibility ##t
+            \tweak padding #1.5
+            \tweak text #tuplet-number::calc-fraction-text
             \tuplet 5/4
             {
                 \time 1/4
@@ -1312,7 +1080,9 @@ def tuplet_from_duration_and_proportion(
                 c'16
             }
 
-        >>> score = make_score(duration, (3, -2, 2))
+        >>> duration, proportion = abjad.Duration(1, 4), (3, -2, 2)
+        >>> tuplet = abjad.makers.make_tuplet(duration, proportion)
+        >>> score = make_score(tuplet)
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1320,6 +1090,9 @@ def tuplet_from_duration_and_proportion(
             >>> tuplet = score[0][0]
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
+            \tweak bracket-visibility ##t
+            \tweak padding #1.5
+            \tweak text #tuplet-number::calc-fraction-text
             \tuplet 7/4
             {
                 \time 1/4
@@ -1332,8 +1105,9 @@ def tuplet_from_duration_and_proportion(
 
         Works with nonassignable rests:
 
-        >>> duration = abjad.Duration(7, 16)
-        >>> score = make_score(duration, (11, -5))
+        >>> duration, proportion = abjad.Duration(7, 16), (11, -5)
+        >>> tuplet = abjad.makers.make_tuplet(duration, proportion)
+        >>> score = make_score(tuplet)
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1341,6 +1115,8 @@ def tuplet_from_duration_and_proportion(
             >>> tuplet = score[0][0]
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
+            \tweak bracket-visibility ##t
+            \tweak padding #1.5
             \tweak text #tuplet-number::calc-fraction-text
             \tuplet 8/7
             {
@@ -1356,8 +1132,9 @@ def tuplet_from_duration_and_proportion(
 
         Reduces integers in ``proportion`` relative to each other:
 
-        >>> duration = abjad.Duration(1, 4)
-        >>> score = make_score(duration, (1, 1, 1))
+        >>> duration, proportion = abjad.Duration(1, 4), (1, 1, 1)
+        >>> tuplet = abjad.makers.make_tuplet(duration, proportion)
+        >>> score = make_score(tuplet)
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1365,6 +1142,9 @@ def tuplet_from_duration_and_proportion(
             >>> tuplet = score[0][0]
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
+            \tweak bracket-visibility ##t
+            \tweak padding #1.5
+            \tweak text #tuplet-number::calc-fraction-text
             \tuplet 3/2
             {
                 \time 1/4
@@ -1373,7 +1153,9 @@ def tuplet_from_duration_and_proportion(
                 c'8
             }
 
-        >>> score = make_score(duration, (4, 4, 4))
+        >>> duration, proportion = abjad.Duration(1, 4), (4, 4, 4)
+        >>> tuplet = abjad.makers.make_tuplet(duration, proportion)
+        >>> score = make_score(tuplet)
         >>> abjad.show(score) # doctest: +SKIP
 
         ..  docs::
@@ -1381,6 +1163,9 @@ def tuplet_from_duration_and_proportion(
             >>> tuplet = score[0][0]
             >>> string = abjad.lilypond(tuplet)
             >>> print(string)
+            \tweak bracket-visibility ##t
+            \tweak padding #1.5
+            \tweak text #tuplet-number::calc-fraction-text
             \tuplet 3/2
             {
                 \time 1/4

--- a/tests/test_makers.py
+++ b/tests/test_makers.py
@@ -99,9 +99,13 @@ def test_makers_make_notes_01():
     )
 
 
-def test_makers_tuplet_from_duration_and_proportion_01():
-    duration = abjad.Duration(6, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 4))
+def test_makers_make_tuplet_01():
+    """
+    Tests characteristic examples.
+    """
+
+    duration, proportion = abjad.Duration(3, 8), (1, 2, 4)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -114,10 +118,8 @@ def test_makers_tuplet_from_duration_and_proportion_01():
         """
     )
 
-
-def test_makers_tuplet_from_duration_and_proportion_02():
-    duration = abjad.Duration(6, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 1, 2, 4))
+    duration, proportion = abjad.Duration(3, 8), (1, 1, 2, 4)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -131,10 +133,8 @@ def test_makers_tuplet_from_duration_and_proportion_02():
         """
     )
 
-
-def test_makers_tuplet_from_duration_and_proportion_03():
-    duration = abjad.Duration(7, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (-2, 3, 7))
+    duration, proportion = abjad.Duration(7, 16), (-2, 3, 7)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -147,10 +147,8 @@ def test_makers_tuplet_from_duration_and_proportion_03():
         """
     )
 
-
-def test_makers_tuplet_from_duration_and_proportion_04():
-    duration = abjad.Duration(1, 4)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (7, 7, -4, -1))
+    duration, proportion = abjad.Duration(1, 4), (7, 7, -4, -1)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -165,9 +163,13 @@ def test_makers_tuplet_from_duration_and_proportion_04():
     )
 
 
-def test_makers_tuplet_from_duration_and_proportion_05():
-    duration = abjad.Duration(12, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 2))
+def test_makers_make_tuplet_02():
+    """
+    Varies duration.
+    """
+
+    duration, proportion = abjad.Duration(3, 4), (1, 2, 2)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -180,58 +182,8 @@ def test_makers_tuplet_from_duration_and_proportion_05():
         """
     )
 
-
-def test_makers_tuplet_from_duration_and_proportion_06():
-    duration = abjad.Duration(12, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (2, 4, 4))
-
-    assert abjad.lilypond(tuplet) == abjad.string.normalize(
-        r"""
-        \tuplet 5/3
-        {
-            c'4
-            c'2
-            c'2
-        }
-        """
-    )
-
-
-def test_makers_tuplet_from_duration_and_proportion_07():
-    duration = abjad.Duration(12, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (4, 8, 8))
-
-    assert abjad.lilypond(tuplet) == abjad.string.normalize(
-        r"""
-        \tuplet 5/3
-        {
-            c'4
-            c'2
-            c'2
-        }
-        """
-    )
-
-
-def test_makers_tuplet_from_duration_and_proportion_08():
-    duration = abjad.Duration(12, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (8, 16, 16))
-
-    assert abjad.lilypond(tuplet) == abjad.string.normalize(
-        r"""
-        \tuplet 5/3
-        {
-            c'4
-            c'2
-            c'2
-        }
-        """
-    )
-
-
-def test_makers_tuplet_from_duration_and_proportion_09():
-    duration = abjad.Duration(3, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (2, 4, 4))
+    duration, proportion = abjad.Duration(3, 16), (1, 2, 2)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -244,10 +196,8 @@ def test_makers_tuplet_from_duration_and_proportion_09():
         """
     )
 
-
-def test_makers_tuplet_from_duration_and_proportion_10():
-    duration = abjad.Duration(6, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (2, 4, 4))
+    duration, proportion = abjad.Duration(3, 8), (1, 2, 2)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -260,10 +210,8 @@ def test_makers_tuplet_from_duration_and_proportion_10():
         """
     )
 
-
-def test_makers_tuplet_from_duration_and_proportion_11():
-    duration = abjad.Duration(12, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (2, 4, 4))
+    duration, proportion = abjad.Duration(3, 4), (1, 2, 2)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -276,10 +224,8 @@ def test_makers_tuplet_from_duration_and_proportion_11():
         """
     )
 
-
-def test_makers_tuplet_from_duration_and_proportion_12():
-    duration = abjad.Duration(24, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (2, 4, 4))
+    duration, proportion = abjad.Duration(3, 2), (1, 2, 2)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -292,10 +238,8 @@ def test_makers_tuplet_from_duration_and_proportion_12():
         """
     )
 
-
-def test_makers_tuplet_from_duration_and_proportion_13():
-    duration = abjad.Duration(6, 2)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 2))
+    duration, proportion = abjad.Duration(3, 1), (1, 2, 2)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -309,57 +253,13 @@ def test_makers_tuplet_from_duration_and_proportion_13():
     )
 
 
-def test_makers_tuplet_from_duration_and_proportion_14():
-    duration = abjad.Duration(6, 4)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 2))
+def test_makers_make_tuplet_03():
+    """
+    Interprets negative numbers in proportion as rests.
+    """
 
-    assert abjad.lilypond(tuplet) == abjad.string.normalize(
-        r"""
-        \tuplet 5/3
-        {
-            c'2
-            c'1
-            c'1
-        }
-        """
-    )
-
-
-def test_makers_tuplet_from_duration_and_proportion_15():
-    duration = abjad.Duration(6, 8)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 2))
-
-    assert abjad.lilypond(tuplet) == abjad.string.normalize(
-        r"""
-        \tuplet 5/3
-        {
-            c'4
-            c'2
-            c'2
-        }
-        """
-    )
-
-
-def test_makers_tuplet_from_duration_and_proportion_16():
-    duration = abjad.Duration(6, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 2, 2))
-
-    assert abjad.lilypond(tuplet) == abjad.string.normalize(
-        r"""
-        \tuplet 5/3
-        {
-            c'8
-            c'4
-            c'4
-        }
-        """
-    )
-
-
-def test_makers_tuplet_from_duration_and_proportion_17():
-    duration = abjad.Duration(3, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, -1, -1))
+    duration, proportion = abjad.Duration(3, 16), (1, -1, -1)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -372,10 +272,8 @@ def test_makers_tuplet_from_duration_and_proportion_17():
         """
     )
 
-
-def test_makers_tuplet_from_duration_and_proportion_18():
-    duration = abjad.Duration(4, 16)
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(duration, (1, 1, -1, -1))
+    duration, proportion = abjad.Duration(1, 4), (1, 1, -1, -1)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -389,12 +287,8 @@ def test_makers_tuplet_from_duration_and_proportion_18():
         """
     )
 
-
-def test_makers_tuplet_from_duration_and_proportion_19():
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(
-        abjad.Duration(5, 16),
-        (1, 1, 1, -1, -1),
-    )
+    duration, proportion = abjad.Duration(5, 16), (1, 1, 1, -1, -1)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -409,12 +303,8 @@ def test_makers_tuplet_from_duration_and_proportion_19():
         """
     )
 
-
-def test_makers_tuplet_from_duration_and_proportion_20():
-    tuplet = abjad.makers.tuplet_from_duration_and_proportion(
-        abjad.Duration(6, 16),
-        (1, 1, 1, 1, -1, -1),
-    )
+    duration, proportion = abjad.Duration(3, 8), (1, 1, 1, 1, -1, -1)
+    tuplet = abjad.makers.make_tuplet(duration, proportion)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""


### PR DESCRIPTION
Clean up `abjad.makers.make_tuplet()`.

    OLD:

        >>> abjad.makers.tuplet_from_duration_and_proportion(duration, proportion)

    NEW:

        >>> abjad.makers.make_tuplet(duration, proportion)