### PR TITLE
Remove abjad.Tuplet.from_duration()

### DIFF
--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -1,6 +1,7 @@
 import math
 
 from . import duration as _duration
+from . import get as _get
 from . import iterate as _iterate
 from . import math as _math
 from . import overrides as _overrides
@@ -1186,7 +1187,7 @@ def make_tuplet(
             assert proportion[0] < 0, repr(proportion)
             pitch_list = []
         leaves = make_leaves([pitch_list], [duration], tag=tag)
-        tuplet = _score.Tuplet.from_duration(duration, leaves, tag=tag)
+        tuplet = _score.Tuplet("1:1", leaves, tag=tag)
     else:
         numerator, denominator = duration.pair
         exponent = int(math.log(_math.weight(proportion), 2) - math.log(numerator, 2))
@@ -1201,7 +1202,9 @@ def make_tuplet(
             duration_ = _duration.Duration(abs(item), denominator)
             leaves = make_leaves([pitch_list], [duration_], tag=tag)
             components.extend(leaves)
-        tuplet = _score.Tuplet.from_duration(duration, components, tag=tag)
+        multiplier = duration / _get.duration(components)
+        ratio = _duration.Ratio(multiplier.denominator, multiplier.numerator)
+        tuplet = _score.Tuplet(ratio, components, tag=tag)
     tuplet.normalize_ratio()
     if tuplet.ratio.is_augmented():
         tuplet.toggle_prolation()

--- a/source/abjad/mutate.py
+++ b/source/abjad/mutate.py
@@ -1385,7 +1385,9 @@ def logical_tie_to_tuplet(
         denominator = target_duration._denominator
         note_durations = [_duration.Duration(_, denominator) for _ in proportions]
         notes = _makers.make_notes(pitches, note_durations, tag=tag)
-    tuplet = _score.Tuplet.from_duration(target_duration, notes, tag=tag)
+    multiplier = target_duration / _get.duration(notes)
+    ratio = _duration.Ratio(multiplier.denominator, multiplier.numerator)
+    tuplet = _score.Tuplet(ratio, notes, tag=tag)
     for leaf in argument:
         _bind.detach(_indicators.Tie, leaf)
         _bind.detach(_indicators.RepeatTie, leaf)

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -5552,38 +5552,6 @@ class Tuplet(Container):
             self.ratio = _duration.Ratio(multiplier.denominator, multiplier.numerator)
             assert self._get_duration() == old_duration
 
-    @staticmethod
-    def from_duration(
-        duration: _duration.Duration, components, *, tag: _tag.Tag | None = None
-    ) -> "Tuplet":
-        r"""
-        Makes tuplet from ``duration`` and ``components``.
-
-        ..  container:: example
-
-            >>> duration = abjad.Duration(2, 8)
-            >>> tuplet = abjad.Tuplet.from_duration(duration, "c'8 d' e'")
-            >>> abjad.show(tuplet) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(tuplet)
-                >>> print(string)
-                \tuplet 3/2
-                {
-                    c'8
-                    d'8
-                    e'8
-                }
-
-        """
-        assert isinstance(duration, _duration.Duration), repr(duration)
-        assert len(components), repr(components)
-        tuplet = Tuplet("1:1", components, tag=tag)
-        multiplier = tuplet._get_duration() / duration
-        tuplet.ratio = _duration.Ratio(multiplier.numerator, multiplier.denominator)
-        return tuplet
-
     def is_rest_filled(self) -> bool:
         r"""
         Is true when tuplet is rest-filled.


### PR DESCRIPTION
Remove `abjad.Tuplet.from_duration()`.

    OLD:

        >>> abjad.Tuplet.from_duration(duration, components)

    NEW:

        >>> multiplier = duration / abjad.get.duration(compoennts)
        >>> ratio = abjad.Ratio(multiplier.denominator, multiplier.numerator)
        >>> abjad.Tuplet(ratio, components)