### PR TITLE
Rename boolean predicates

### DIFF
--- a/source/abjad/_getlib.py
+++ b/source/abjad/_getlib.py
@@ -33,7 +33,7 @@ def _are_logical_voice(components, prototype=None):
         parentage = _parentage.Parentage(component)
         if parentage.logical_voice() != first_logical_voice:
             same_logical_voice = False
-        if not parentage.orphan and not same_logical_voice:
+        if not parentage.is_orphan() and not same_logical_voice:
             return False
     return True
 

--- a/source/abjad/parentage.py
+++ b/source/abjad/parentage.py
@@ -368,99 +368,6 @@ class Parentage(collections.abc.Sequence):
         return self._components
 
     @property
-    def orphan(self) -> bool:
-        r"""
-        Is true when component has no parent.
-
-        ..  container:: example
-
-            REGRESSION. Works with grace notes (and containers):
-
-            >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
-            >>> container = abjad.BeforeGraceContainer("cs'16")
-            >>> abjad.attach(container, music_voice[1])
-            >>> obgc = abjad.on_beat_grace_container("g'16 gs' a' as'", music_voice[2:3])
-            >>> abjad.attach(abjad.Articulation(">"), obgc[0])
-            >>> container = abjad.AfterGraceContainer("fs'16")
-            >>> abjad.attach(container, music_voice[3])
-            >>> staff = abjad.Staff([music_voice])
-            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
-            >>> abjad.show(lilypond_file) # doctest: +SKIP
-
-            ..  docs::
-
-                >>> string = abjad.lilypond(staff)
-                >>> print(string)
-                \new Staff
-                {
-                    \context Voice = "MusicVoice"
-                    {
-                        c'4
-                        \grace {
-                            cs'16
-                        }
-                        d'4
-                        <<
-                            \context Voice = "On_Beat_Grace_Container"
-                            {
-                                \set fontSize = #-3
-                                \slash
-                                \voiceOne
-                                <
-                                    \tweak font-size 0
-                                    \tweak transparent ##t
-                                    e'
-                                    g'
-                                >16
-                                - \accent
-                                [
-                                (
-                                gs'16
-                                a'16
-                                as'16
-                                )
-                                ]
-                            }
-                            \context Voice = "MusicVoice"
-                            {
-                                \voiceTwo
-                                e'4
-                            }
-                        >>
-                        \oneVoice
-                        \afterGrace
-                        f'4
-                        {
-                            fs'16
-                        }
-                    }
-                }
-
-            >>> for component in abjad.select.components(staff):
-            ...     parentage = abjad.get.parentage(component)
-            ...     print(f"{repr(component):30} {repr(parentage.orphan)}")
-            Staff("{ c'4 d'4 { { <e' g'>16 gs'16 a'16 as'16 } { e'4 } } f'4 }") True
-            Voice("c'4 d'4 { { <e' g'>16 gs'16 a'16 as'16 } { e'4 } } f'4", name='MusicVoice') False
-            Note("c'4")                    False
-            BeforeGraceContainer("cs'16")  False
-            Note("cs'16")                  False
-            Note("d'4")                    False
-            Container("{ <e' g'>16 gs'16 a'16 as'16 } { e'4 }") False
-            OnBeatGraceContainer("<e' g'>16 gs'16 a'16 as'16") False
-            Chord("<e' g'>16")             False
-            Note("gs'16")                  False
-            Note("a'16")                   False
-            Note("as'16")                  False
-            Voice("e'4", name='MusicVoice') False
-            Note("e'4")                    False
-            Note("f'4")                    False
-            AfterGraceContainer("fs'16")   False
-            Note("fs'16")                  False
-
-        """
-        return self.parent is None
-
-    @property
     def parent(self) -> _score.Component | None:
         r"""
         Gets parent.
@@ -1248,6 +1155,98 @@ class Parentage(collections.abc.Sequence):
                         return component
                     i -= 1
         return None
+
+    def is_orphan(self) -> bool:
+        r"""
+        Is true when component has no parent.
+
+        ..  container:: example
+
+            REGRESSION. Works with grace notes (and containers):
+
+            >>> music_voice = abjad.Voice("c'4 d' e' f'", name="MusicVoice")
+            >>> container = abjad.BeforeGraceContainer("cs'16")
+            >>> abjad.attach(container, music_voice[1])
+            >>> obgc = abjad.on_beat_grace_container("g'16 gs' a' as'", music_voice[2:3])
+            >>> abjad.attach(abjad.Articulation(">"), obgc[0])
+            >>> container = abjad.AfterGraceContainer("fs'16")
+            >>> abjad.attach(container, music_voice[3])
+            >>> staff = abjad.Staff([music_voice])
+            >>> lilypond_file = abjad.LilyPondFile([r'\include "abjad.ily"', staff])
+            >>> abjad.show(lilypond_file) # doctest: +SKIP
+
+            ..  docs::
+
+                >>> string = abjad.lilypond(staff)
+                >>> print(string)
+                \new Staff
+                {
+                    \context Voice = "MusicVoice"
+                    {
+                        c'4
+                        \grace {
+                            cs'16
+                        }
+                        d'4
+                        <<
+                            \context Voice = "On_Beat_Grace_Container"
+                            {
+                                \set fontSize = #-3
+                                \slash
+                                \voiceOne
+                                <
+                                    \tweak font-size 0
+                                    \tweak transparent ##t
+                                    e'
+                                    g'
+                                >16
+                                - \accent
+                                [
+                                (
+                                gs'16
+                                a'16
+                                as'16
+                                )
+                                ]
+                            }
+                            \context Voice = "MusicVoice"
+                            {
+                                \voiceTwo
+                                e'4
+                            }
+                        >>
+                        \oneVoice
+                        \afterGrace
+                        f'4
+                        {
+                            fs'16
+                        }
+                    }
+                }
+
+            >>> for component in abjad.select.components(staff):
+            ...     parentage = abjad.get.parentage(component)
+            ...     print(f"{repr(component):30} {repr(parentage.is_orphan())}")
+            Staff("{ c'4 d'4 { { <e' g'>16 gs'16 a'16 as'16 } { e'4 } } f'4 }") True
+            Voice("c'4 d'4 { { <e' g'>16 gs'16 a'16 as'16 } { e'4 } } f'4", name='MusicVoice') False
+            Note("c'4")                    False
+            BeforeGraceContainer("cs'16")  False
+            Note("cs'16")                  False
+            Note("d'4")                    False
+            Container("{ <e' g'>16 gs'16 a'16 as'16 } { e'4 }") False
+            OnBeatGraceContainer("<e' g'>16 gs'16 a'16 as'16") False
+            Chord("<e' g'>16")             False
+            Note("gs'16")                  False
+            Note("a'16")                   False
+            Note("as'16")                  False
+            Voice("e'4", name='MusicVoice') False
+            Note("e'4")                    False
+            Note("f'4")                    False
+            AfterGraceContainer("fs'16")   False
+            Note("fs'16")                  False
+
+        """
+        return self.parent is None
 
     def logical_voice(self) -> dict:
         r"""

--- a/source/abjad/select.py
+++ b/source/abjad/select.py
@@ -832,8 +832,8 @@ def components(
     for component in generator:
         if (
             grace is None
-            or (grace is True and _get.grace(component))
-            or (grace is False and not _get.grace(component))
+            or (grace is True and _get.is_grace_music(component))
+            or (grace is False and not _get.is_grace_music(component))
         ):
             result.append(component)
     return result
@@ -4299,8 +4299,8 @@ def logical_ties(
     for logical_tie in generator:
         if (
             grace is None
-            or (grace is True and _get.grace(logical_tie.head))
-            or (grace is False and not _get.grace(logical_tie.head))
+            or (grace is True and _get.is_grace_music(logical_tie.head))
+            or (grace is False and not _get.is_grace_music(logical_tie.head))
         ):
             result.append(logical_tie)
     return result

--- a/source/abjad/timespan.py
+++ b/source/abjad/timespan.py
@@ -786,9 +786,9 @@ class Timespan:
         timespan_2 = dataclasses.replace(
             self, start_offset=stop_offsets[0], stop_offset=stop_offsets[1]
         )
-        if timespan_1.wellformed:
+        if timespan_1.is_wellformed():
             result.append(timespan_1)
-        if timespan_2.wellformed:
+        if timespan_2.is_wellformed():
             result.append(timespan_2)
         result.sort()
         return result
@@ -918,19 +918,6 @@ class Timespan:
         """
         return self.start_offset, self.stop_offset
 
-    @property
-    def wellformed(self) -> bool:
-        """
-        Is true when timespan start offset preceeds timespan stop offset.
-
-        ..  container:: example
-
-            >>> abjad.Timespan(0, 10).wellformed
-            True
-
-        """
-        return self.start_offset < self.stop_offset
-
     ### PUBLIC METHODS ###
 
     def divide_by_ratio(self, ratio) -> tuple["Timespan", ...]:
@@ -1006,6 +993,18 @@ class Timespan:
             result = _duration.Duration(sum(x.duration for x in self & timespan))
             return result
         return None
+
+    def is_wellformed(self) -> bool:
+        """
+        Is true when timespan start offset preceeds timespan stop offset.
+
+        ..  container:: example
+
+            >>> abjad.Timespan(0, 10).is_wellformed()
+            True
+
+        """
+        return self.start_offset < self.stop_offset
 
     def reflect(self, axis=None) -> "Timespan":
         """
@@ -2065,7 +2064,7 @@ class TimespanList(list):
 
         Is false when timespans are not all wellformed.
         """
-        return all(self._get_timespan(argument).wellformed for argument in self)
+        return all(self._get_timespan(argument).is_wellformed() for argument in self)
 
     @property
     def axis(self) -> _duration.Offset | None:
@@ -3385,7 +3384,7 @@ class TimespanList(list):
 
         Operates in place and returns timespan list.
         """
-        timespans = [x for x in self if x.wellformed]
+        timespans = [x for x in self if x.is_wellformed()]
         self[:] = timespans
         return self
 

--- a/source/abjad/tweaks.py
+++ b/source/abjad/tweaks.py
@@ -48,7 +48,7 @@ class Tweak:
         post_event, attribute, value = self._parse()
         return attribute
 
-    def post_event(self) -> bool:
+    def is_post_event(self) -> bool:
         post_event, attribute, value = self._parse()
         return post_event
 

--- a/source/abjad/wf.py
+++ b/source/abjad/wf.py
@@ -492,7 +492,7 @@ def check_overlapping_beams(argument) -> tuple[list, int]:
         wrappers.sort(key=lambda _: _get.timespan(_.component).start_offset)
         open_beam_count = 0
         for wrapper in wrappers:
-            if _get.grace(wrapper.component) is True:
+            if _get.is_grace_music(wrapper.component) is True:
                 continue
             total += 1
             if isinstance(wrapper.unbundle_indicator(), _indicators.StartBeam):

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -3,7 +3,7 @@ import pytest
 import abjad
 
 
-def test_get_bar_line_crossing_01():
+def test_get_is_bar_line_crossing_01():
     """
     Works with partial.
     """
@@ -27,22 +27,22 @@ def test_get_bar_line_crossing_01():
         """
     )
 
-    assert not abjad.get.bar_line_crossing(staff[0])
-    assert not abjad.get.bar_line_crossing(staff[1])
-    assert abjad.get.bar_line_crossing(staff[2])
-    assert not abjad.get.bar_line_crossing(staff[3])
+    assert not abjad.get.is_bar_line_crossing(staff[0])
+    assert not abjad.get.is_bar_line_crossing(staff[1])
+    assert abjad.get.is_bar_line_crossing(staff[2])
+    assert not abjad.get.is_bar_line_crossing(staff[3])
 
 
-def test_get_bar_line_crossing_02():
+def test_get_is_bar_line_crossing_02():
     """
     Works when no explicit time signature is abjad.attached.
     """
 
     staff = abjad.Staff("c'2 d'1 e'2")
 
-    assert not abjad.get.bar_line_crossing(staff[0])
-    assert abjad.get.bar_line_crossing(staff[1])
-    assert not abjad.get.bar_line_crossing(staff[2])
+    assert not abjad.get.is_bar_line_crossing(staff[0])
+    assert abjad.get.is_bar_line_crossing(staff[1])
+    assert not abjad.get.is_bar_line_crossing(staff[2])
 
 
 def test_get_duration_01():

--- a/tests/test_parentage.py
+++ b/tests/test_parentage.py
@@ -483,9 +483,9 @@ def test_Parentage_logical_voice_11():
 def test_Parentage_orphan_01():
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
 
-    assert abjad.get.parentage(staff).orphan
+    assert abjad.get.parentage(staff).is_orphan()
     for note in staff:
-        assert not abjad.get.parentage(note).orphan
+        assert not abjad.get.parentage(note).is_orphan()
 
 
 def test_Parentage_root_01():


### PR DESCRIPTION
Rename boolean predicates.

    OLD: abjad.get.bar_line_crossing()
    NEW: abjad.get.is_bar_line_crossing()

    OLD: abjad.get.grace()
    NEW: abjad.get.is_grace_music()

    OLD: abjad.get.sustained()
    NEW: abjad.get.is_sustained()

    OLD: abjad.Dynamic.effort
    NEW: abjad.Dynamic.is_effort()

    OLD: abjad.Dynamic.sforzando
    NEW: abjad.Dynamic.is_sforzando()

    OLD: abjad.Parentage.orphan
    NEW: abjad.Parentage.is_orphan()

    OLD: abjad.Timespan.wellformed
    NEW: abjad.Timespan.is_wellformed()

    OLD: abjad.Tweak.post_event
    NEW: abjad.Tweak.is_post_event()