### PR TITLE
CHANGE abjad.Tuplet.__init__() accepts ratio only

### DIFF
--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -644,7 +644,8 @@ def make_leaves(
                     use_multimeasure_rests=use_multimeasure_rests,
                 )
                 tuplet_leaves.extend(leaves)
-            tuplet = _score.Tuplet(multiplier, tuplet_leaves)
+            ratio_ = _duration.Ratio(denominator, numerator)
+            tuplet = _score.Tuplet(ratio_, tuplet_leaves)
             result.append(tuplet)
     return result
 

--- a/source/abjad/mutate.py
+++ b/source/abjad/mutate.py
@@ -506,10 +506,9 @@ def _split_container_at_index(CONTAINER, i):
     right_components = CONTAINER[i:]
     # instantiate new left and right containers
     if isinstance(CONTAINER, _score.Tuplet):
-        multiplier = CONTAINER.ratio.denominator, CONTAINER.ratio.numerator
-        left = type(CONTAINER)(multiplier, [])
+        left = type(CONTAINER)(CONTAINER.ratio, [])
         wrap(left_components, left)
-        right = type(CONTAINER)(multiplier, [])
+        right = type(CONTAINER)(CONTAINER.ratio, [])
         wrap(right_components, right)
     else:
         left = CONTAINER.__copy__()

--- a/source/abjad/parsers/parser.py
+++ b/source/abjad/parsers/parser.py
@@ -420,12 +420,13 @@ class GuileProxy:
         Handles LilyPond ``\times`` command.
         """
         n, d = fraction.numerator, fraction.denominator
+        ratio = _duration.Ratio(d, n)
         if not isinstance(music, _score.Context) and not isinstance(music, _score.Leaf):
             assert isinstance(music, _score.Container), repr(music)
             leaves = music[:]
             music[:] = []
-            return _score.Tuplet((n, d), leaves, tag=self.tag)
-        return _score.Tuplet((n, d), [music], tag=self.tag)
+            return _score.Tuplet(ratio, leaves, tag=self.tag)
+        return _score.Tuplet(ratio, [music], tag=self.tag)
 
     def transpose(self, from_pitch, to_pitch, music):
         r"""

--- a/source/abjad/parsers/reduced.py
+++ b/source/abjad/parsers/reduced.py
@@ -601,7 +601,9 @@ class ReducedLyParser(Parser):
         assert isinstance(p[2], _score.Container)
         leaves = p[2][:]
         p[2][:] = []
-        p[0] = _score.Tuplet(p[1], leaves)
+        numerator, denominator = p[1]
+        ratio = _duration.Ratio(denominator, numerator)
+        p[0] = _score.Tuplet(ratio, leaves)
 
     ### PRIVATE METHODS ###
 

--- a/source/abjad/rhythmtrees.py
+++ b/source/abjad/rhythmtrees.py
@@ -641,7 +641,7 @@ class RhythmTreeContainer(RhythmTreeNode, uqbar.containers.UniqueTreeList):
                 basic_written_duration.equal_or_greater_power_of_two
             )
             assert isinstance(basic_written_duration, _duration.Duration)
-            tuplet = _score.Tuplet((1, 1), [])
+            tuplet = _score.Tuplet("1:1", [])
             for node in rtc.children:
                 if isinstance(node, type(self)):
                     tuplet_duration_ = _duration.Duration(node.pair)

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -5042,12 +5042,8 @@ class Tuplet(Container):
             assert len(strings) == 2, repr(ratio)
             numbers = [int(_) for _ in strings]
             ratio_ = _duration.Ratio(*numbers)
-        # TODO: remove this branch and force ratio or string input only
-        elif isinstance(ratio, tuple):
-            ratio_ = _duration.Ratio(*ratio)
-            ratio_ = ratio_.reciprocal()
         else:
-            message = f"tuplet ratio must be ratio, string or pair (not {ratio!r})."
+            message = f"tuplet ratio must be ratio or string (not {ratio!r})."
             raise ValueError(message)
         self.ratio = ratio_
 

--- a/source/abjad/select.py
+++ b/source/abjad/select.py
@@ -267,7 +267,7 @@ def chord(
         ...     "r16 bf'16 <a'' b''>16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 bf'16 <a'' b''>16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)
@@ -358,7 +358,7 @@ def chords(
         ...     "r16 bf'16 <a'' b''>16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 bf'16 <a'' b''>16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)
@@ -1063,7 +1063,7 @@ def flatten(argument, depth: int = 1) -> list:
         ...     "r16 bf'16 <a'' b''>16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 bf'16 <a'' b''>16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)
@@ -1153,7 +1153,7 @@ def flatten(argument, depth: int = 1) -> list:
         ...     "r16 bf'16 <a'' b''>16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 bf'16 <a'' b''>16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)
@@ -2464,7 +2464,7 @@ def leaf(
         ...     "r16 bf'16 <a'' b''>16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 bf'16 <a'' b''>16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)
@@ -4378,7 +4378,7 @@ def note(
         ...     "r16 bf'16 <a'' b''>16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 bf'16 <a'' b''>16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)
@@ -4469,7 +4469,7 @@ def notes(
         ...     "r16 bf'16 <a'' b''>16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 bf'16 <a'' b''>16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)
@@ -6055,7 +6055,7 @@ def rest(
         ...     "r16 bf'16 <a'' b''>16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 bf'16 <a'' b''>16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)
@@ -6146,7 +6146,7 @@ def rests(
         ...     "r16 bf'16 <a'' b''>16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 bf'16 <a'' b''>16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)
@@ -6246,7 +6246,7 @@ def run(argument, n: int, *, exclude: Exclude | None = None) -> list[_score.Leaf
         ...     "r16 d'16 d'16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 e'16 e'16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)
@@ -6341,7 +6341,7 @@ def runs(
         ...     "r16 d'16 d'16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 e'16 e'16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)
@@ -6622,7 +6622,7 @@ def tuplet(
         ...     "r16 bf'16 <a'' b''>16 d'16 <e' fs'>4 ~ <e' fs'>16",
         ...     "r16 bf'16 <a'' b''>16 e'16 <fs' gs'>4 ~ <fs' gs'>16",
         ... ]
-        >>> tuplets = zip([(10, 9), (8, 9), (10, 9)], tuplets)
+        >>> tuplets = zip(["9:10", "9:8", "9:10"], tuplets)
         >>> tuplets = [abjad.Tuplet(*_) for _ in tuplets]
         >>> abjad.makers.tweak_tuplet_number_text(tuplets)
         >>> lilypond_file = abjad.illustrators.components(tuplets)


### PR DESCRIPTION
CHANGE: `abjad.Tuplet.__init__()` accepts ratio only.

    OLD: Tuplet initializer treated these three the same:

        >>> abjad.Tuplet((2, 3), "c'4 d'4 e'4")
        >>> abjad.Tuplet(abjad.Ratio(3, 2), "c'4 d'4 e'4")
        >>> abjad.Tuplet("3:2", "c'4 d'4 e'4")

    NEW: Tuplet initialize allows only ratio and string;
    pair form no longer allowed:

        >>> abjad.Tuplet(abjad.Ratio(3, 2), "c'4 d'4 e'4")
        >>> abjad.Tuplet("3:2", "c'4 d'4 e'4")