### PR TITLE
Clean up abjad.annotate()

### DIFF
--- a/source/abjad/_getlib.py
+++ b/source/abjad/_getlib.py
@@ -38,7 +38,7 @@ def _are_logical_voice(components, prototype=None):
     return True
 
 
-def _get_annotation(component, annotation, default=None, unwrap: bool = True):
+def _get_annotation(component, annotation, default=None, *, unwrap: bool = True):
     assert isinstance(annotation, str | enum.Enum), repr(annotation)
     for wrapper in _get_annotation_wrappers(component):
         if wrapper.annotation == annotation:
@@ -194,7 +194,7 @@ def _get_indicator(
     component: _score.Component,
     prototype: type | tuple[type, ...] | None = None,
     *,
-    default: typing.Any | None = None,
+    default: typing.Any = None,
     unwrap: bool = True,
 ) -> typing.Any:
     if not isinstance(component, _score.Component):

--- a/source/abjad/bind.py
+++ b/source/abjad/bind.py
@@ -151,7 +151,7 @@ class Wrapper:
         context: str | None = None,
         deactivate: bool = False,
         direction: _enums.Vertical | None = None,
-        indicator: typing.Any | None = None,
+        indicator: typing.Any = None,
         synthetic_offset: _duration.Offset | None = None,
         tag: _tag.Tag = _tag.Tag(),
     ) -> None:
@@ -843,16 +843,16 @@ def _unsafe_attach(
         return None
 
 
-def annotate(component, annotation, indicator) -> None:
+def annotate(component: _score.Component, key: str, value: object) -> None:
     r"""
-    Annotates ``component`` with ``indicator``.
-
-    Annotates first note in staff:
+    Annotates ``component`` with ``key`` equal to ``value``.
 
     ..  container:: example
 
+        Annotations do not affect LilyPond output.
+
         >>> staff = abjad.Staff("c'4 d' e' f'")
-        >>> abjad.annotate(staff[0], "bow_direction", abjad.DOWN)
+        >>> abjad.annotate(staff[0], "motive_number", 6)
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -867,22 +867,13 @@ def annotate(component, annotation, indicator) -> None:
                 f'4
             }
 
-        >>> abjad.get.annotation(staff[0], "bow_direction")
-        <Vertical.DOWN: -1>
-
-        >>> abjad.get.annotation(staff[0], "bow_fraction") is None
-        True
-
-        >>> abjad.get.annotation(staff[0], "bow_fraction", 99)
-        99
+        >>> abjad.get.annotation(staff[0], "motive_number")
+        6
 
     """
-    if isinstance(annotation, _tag.Tag):
-        message = "use the tag=None keyword instead of annotate():\n"
-        message += f"   {repr(annotation)}"
-        raise Exception(message)
-    assert isinstance(annotation, str | enum.Enum), repr(annotation)
-    Wrapper(annotation=annotation, component=component, indicator=indicator)
+    assert isinstance(component, _score.Component), repr(component)
+    assert isinstance(key, str), repr(key)
+    Wrapper(annotation=key, component=component, indicator=value)
 
 
 @typing.overload

--- a/source/abjad/get.py
+++ b/source/abjad/get.py
@@ -112,18 +112,19 @@ def after_grace_container(argument):
 
 
 def annotation(
-    argument,
-    annotation: typing.Any,
-    default: typing.Any | None = None,
+    component: _score.Component,
+    key: str,
+    default: typing.Any = None,
+    *,
     unwrap: bool = True,
 ) -> typing.Any:
     r"""
-    Gets annotation.
+    Gets annotation attached to ``component`` with ``key``.
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 e' e' f'")
-        >>> abjad.annotate(staff[0], 'default_instrument', abjad.Cello())
+        >>> staff = abjad.Staff("c'4 d' e' f'")
+        >>> abjad.annotate(staff[0], "motive_number", 6)
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -133,48 +134,26 @@ def annotation(
             \new Staff
             {
                 c'4
-                e'4
+                d'4
                 e'4
                 f'4
             }
 
-        >>> string = 'default_instrument'
-        >>> abjad.get.annotation(staff[0], string)
-        Cello(clefs=('bass', 'tenor', 'treble'), context='Staff', middle_c_sounding_pitch=NamedPitch("c'"), pitch_range=PitchRange(range_string='[C2, G5]'), tuning=Tuning(pitches=(NamedPitch('c,'), NamedPitch('g,'), NamedPitch('d'), NamedPitch('a'))))
-
-        >>> abjad.get.annotation(staff[1], string) is None
-        True
-
-        >>> abjad.get.annotation(staff[2], string) is None
-        True
-
-        >>> abjad.get.annotation(staff[3], string) is None
-        True
-
-        Returns default when no annotation is found:
-
-        >>> abjad.get.annotation(staff[3], string, abjad.Violin())
-        Violin(clefs=('treble',), context='Staff', middle_c_sounding_pitch=NamedPitch("c'"), pitch_range=PitchRange(range_string='[G3, G7]'), tuning=Tuning(pitches=(NamedPitch('g'), NamedPitch("d'"), NamedPitch("a'"), NamedPitch("e''"))))
+        >>> abjad.get.annotation(staff[0], "motive_number")
+        6
 
     ..  container:: example
 
-        REGRESSION: annotation is not picked up as effective indicator:
+        Returns ``default`` when no annotation with ``key`` is found:
 
-        >>> prototype = abjad.Instrument
-        >>> abjad.get.effective(staff[0], prototype) is None
-        True
-
-        >>> abjad.get.effective(staff[1], prototype) is None
-        True
-
-        >>> abjad.get.effective(staff[2], prototype) is None
-        True
-
-        >>> abjad.get.effective(staff[3], prototype) is None
-        True
+        >>> abjad.get.annotation(staff[1], "motive_number", "TBD")
+        'TBD'
 
     """
-    return _getlib._get_annotation(argument, annotation, default=default, unwrap=unwrap)
+    assert isinstance(component, _score.Component), repr(component)
+    assert isinstance(key, str), repr(key)
+    assert isinstance(unwrap, bool), repr(unwrap)
+    return _getlib._get_annotation(component, key, default, unwrap=unwrap)
 
 
 def annotation_wrappers(argument):
@@ -183,7 +162,7 @@ def annotation_wrappers(argument):
 
     ..  container:: example
 
-        >>> staff = abjad.Staff("c'4 e' e' f'")
+        >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> abjad.annotate(staff[0], 'default_instrument', abjad.Cello())
         >>> abjad.annotate(staff[0], 'default_clef', abjad.Clef('tenor'))
         >>> abjad.show(staff) # doctest: +SKIP
@@ -195,7 +174,7 @@ def annotation_wrappers(argument):
             \new Staff
             {
                 c'4
-                e'4
+                d'4
                 e'4
                 f'4
             }
@@ -908,7 +887,7 @@ def effective(
     prototype: type | tuple[type, ...],
     *,
     attributes: dict | None = None,
-    default: typing.Any | None = None,
+    default: typing.Any = None,
     n: int = 0,
     unwrap: bool = True,
 ) -> typing.Any:
@@ -2147,7 +2126,7 @@ def indicator(
     argument,
     prototype: type | tuple[type, ...] | None = None,
     *,
-    default: typing.Any | None = None,
+    default: typing.Any = None,
     unwrap: bool = True,
 ) -> typing.Any:
     r"""

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -129,6 +129,29 @@ def test_get_duration_04():
         abjad.get.duration(note, in_seconds=True)
 
 
+def test_get_effective_01():
+    """
+    REGRESSION: annotation is not picked up as effective indicator.
+    """
+
+    staff = abjad.Staff("c'4 d'4 e'4 f'4")
+    abjad.annotate(staff[0], "instrument_annotation", abjad.Flute())
+
+    assert abjad.get.effective(staff[0], abjad.Instrument) is None
+    assert abjad.get.effective(staff[1], abjad.Instrument) is None
+    assert abjad.get.effective(staff[2], abjad.Instrument) is None
+    assert abjad.get.effective(staff[3], abjad.Instrument) is None
+
+    staff = abjad.Staff("c'4 d'4 e'4 f'4")
+    abjad.attach(abjad.Piccolo(), staff[0])
+    abjad.annotate(staff[0], "instrument_annotation", abjad.Flute())
+
+    assert abjad.get.effective(staff[0], abjad.Instrument) == abjad.Piccolo()
+    assert abjad.get.effective(staff[1], abjad.Instrument) == abjad.Piccolo()
+    assert abjad.get.effective(staff[2], abjad.Instrument) == abjad.Piccolo()
+    assert abjad.get.effective(staff[3], abjad.Instrument) == abjad.Piccolo()
+
+
 def test_get_has_effective_indicator_01():
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
     abjad.attach("foo", staff[2], context="Staff")


### PR DESCRIPTION
Tightens abjad.annotate() to accept only string keys:

    OLD: abjad.annotate(component, key: str | enums.ENUM, value)
    NEW: abjad.annotate(component, key: str, value)

Also, asserts that component is a component.