### PR TITLE
Default boolean keywords to false

### DIFF
--- a/source/abjad/_updatelib.py
+++ b/source/abjad/_updatelib.py
@@ -99,7 +99,7 @@ def _get_measure_start_offsets(component):
     prototype = _indicators.TimeSignature
     root = _parentage.Parentage(component).root
     for component_ in _iterate_entire_score(root):
-        wrappers_ = component_._get_indicators(prototype, unwrap=False)
+        wrappers_ = component_._get_indicators(prototype, wrapper=True)
         wrappers.extend(wrappers_)
     pairs = []
     for wrapper in wrappers:
@@ -267,7 +267,7 @@ def _update_all_indicators(root):
     """
     components = _iterate_entire_score(root)
     for component in components:
-        for wrapper in component._get_indicators(unwrap=False):
+        for wrapper in component._get_indicators(wrapper=True):
             if wrapper.context is not None:
                 wrapper._update_effective_context()
         component._indicators_are_current = True

--- a/source/abjad/bind.py
+++ b/source/abjad/bind.py
@@ -42,7 +42,7 @@ def _before_attach(indicator, context, deactivate, component):
         return
     if deactivate is True:
         return
-    for wrapper in component._get_indicators(unwrap=False):
+    for wrapper in component._get_indicators(wrapper=True):
         if not isinstance(wrapper.unbundle_indicator(), type(indicator)):
             continue
         if getattr(indicator, "leak", None) != getattr(
@@ -485,7 +485,7 @@ class Wrapper:
             component,
             prototype,
             attributes={"command": command},
-            unwrap=False,
+            wrapper=True,
         )
         wrapper_site = None
         if wrapper is not None:
@@ -926,22 +926,24 @@ def attach(
     r"""
     Attaches ``attachable`` to (leaf or container) ``target``.
 
-    Acceptable types of ``attachable``:
+    ..  container:: example
 
-    ::
+        Acceptable types of ``attachable``:
 
-        * indicator
-        * abjad.Wrapper
-        * abjad.BeforeGraceContainer
-        * abjad.AfterGraceContainer
+        ::
 
-    The class of ``target`` is almost always ``abjad.Leaf``. A small number
-    of indicators (like ``abjad.LilyPondLiteral``) can attach to both ``abjad.Leaf``
-    and ``abjad.Container`` objects.
+            * indicator
+            * abjad.Wrapper
+            * abjad.BeforeGraceContainer
+            * abjad.AfterGraceContainer
 
-    Attaches clef to first note in staff:
+        The class of ``target`` is almost always ``abjad.Leaf``. A small number
+        of indicators (like ``abjad.LilyPondLiteral``) can attach to both
+        ``abjad.Leaf`` and ``abjad.Container`` objects.
 
     ..  container:: example
+
+        Attaches clef to first note in staff:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> abjad.attach(abjad.Clef("alto"), staff[0])

--- a/source/abjad/format.py
+++ b/source/abjad/format.py
@@ -51,7 +51,7 @@ def _get_grob_revert_contributions(component, contributions):
 def _get_indicator_contributions(component, contributions):
     wrappers = []
     for parent in component._get_parentage():
-        wrappers_ = parent._get_indicators(unwrap=False)
+        wrappers_ = parent._get_indicators(wrapper=True)
         wrappers.extend(wrappers_)
     up_markup_wrappers = []
     down_markup_wrappers = []

--- a/source/abjad/get.py
+++ b/source/abjad/get.py
@@ -116,7 +116,7 @@ def annotation(
     key: str,
     default: typing.Any = None,
     *,
-    unwrap: bool = True,
+    wrapper: bool = False,
 ) -> typing.Any:
     r"""
     Gets annotation attached to ``component`` with ``key``.
@@ -146,14 +146,14 @@ def annotation(
 
         Returns ``default`` when no annotation with ``key`` is found:
 
-        >>> abjad.get.annotation(staff[1], "motive_number", "TBD")
-        'TBD'
+        >>> abjad.get.annotation(staff[1], "motive_number", "unknown")
+        'unknown'
 
     """
     assert isinstance(component, _score.Component), repr(component)
     assert isinstance(key, str), repr(key)
-    assert isinstance(unwrap, bool), repr(unwrap)
-    return _getlib._get_annotation(component, key, default, unwrap=unwrap)
+    assert isinstance(wrapper, bool), repr(wrapper)
+    return _getlib._get_annotation(component, key, default, wrapper=wrapper)
 
 
 def annotation_wrappers(argument):
@@ -889,7 +889,7 @@ def effective(
     attributes: dict | None = None,
     default: typing.Any = None,
     n: int = 0,
-    unwrap: bool = True,
+    wrapper: bool = False,
 ) -> typing.Any:
     r"""
     Gets effective indicator.
@@ -1431,7 +1431,7 @@ def effective(
     if attributes is not None:
         assert isinstance(attributes, dict), repr(attributes)
     result = _getlib._get_effective(
-        argument, prototype, attributes=attributes, n=n, unwrap=unwrap
+        argument, prototype, attributes=attributes, n=n, wrapper=wrapper
     )
     if result is None:
         result = default
@@ -1679,7 +1679,7 @@ def effective_wrapper(
     """
     if attributes is not None:
         assert isinstance(attributes, dict), repr(attributes)
-    return effective(argument, prototype, attributes=attributes, n=n, unwrap=False)
+    return effective(argument, prototype, attributes=attributes, n=n, wrapper=True)
 
 
 def has_effective_indicator(
@@ -2127,7 +2127,7 @@ def indicator(
     prototype: type | tuple[type, ...] | None = None,
     *,
     default: typing.Any = None,
-    unwrap: bool = True,
+    wrapper: bool = False,
 ) -> typing.Any:
     r"""
     Gets indicator.
@@ -2270,7 +2270,7 @@ def indicator(
 
     Returns default when no indicator of ``prototype`` attaches to ``argument``.
     """
-    return _getlib._get_indicator(argument, prototype, default=default, unwrap=unwrap)
+    return _getlib._get_indicator(argument, prototype, default=default, wrapper=wrapper)
 
 
 def indicators(
@@ -2278,7 +2278,7 @@ def indicators(
     prototype: type | tuple[type, ...] | None = None,
     *,
     attributes: dict | None = None,
-    unwrap: bool = True,
+    wrapper: bool = False,
 ) -> list:
     r"""
     Get indicators.
@@ -2463,7 +2463,7 @@ def indicators(
     if attributes is not None:
         assert isinstance(attributes, dict), repr(attributes)
     result = argument._get_indicators(
-        prototype=prototype, attributes=attributes, unwrap=unwrap
+        prototype=prototype, attributes=attributes, wrapper=wrapper
     )
     return list(result)
 
@@ -4477,7 +4477,7 @@ def wrapper(
     """
     if attributes is not None:
         assert isinstance(attributes, dict), repr(attributes)
-    return indicator(argument, prototype=prototype, unwrap=False)
+    return indicator(argument, prototype=prototype, wrapper=True)
 
 
 def wrappers(
@@ -4609,7 +4609,7 @@ def wrappers(
     """
     if attributes is not None:
         assert isinstance(attributes, dict), repr(attributes)
-    return indicators(argument, prototype=prototype, unwrap=False)
+    return indicators(argument, prototype=prototype, wrapper=True)
 
 
 class Lineage(collections.abc.Sequence):

--- a/source/abjad/illustrators.py
+++ b/source/abjad/illustrators.py
@@ -511,7 +511,7 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
     )
     score = _score.Score([staff_group], name="Score")
     for leaf in leaves:
-        markup_wrappers = _get.indicators(leaf, _indicators.Markup, unwrap=False)
+        markup_wrappers = _get.indicators(leaf, _indicators.Markup, wrapper=True)
         written_duration = leaf.written_duration
         if isinstance(leaf, _score.Note):
             if leaf.written_pitch < lowest_treble_pitch:

--- a/source/abjad/indicators.py
+++ b/source/abjad/indicators.py
@@ -2596,7 +2596,7 @@ class KeyCluster:
         Includes flat markup:
 
         >>> chord = abjad.Chord("<c' e' g' b' d'' f''>8")
-        >>> key_cluster = abjad.KeyCluster(include_flat_markup=True)
+        >>> key_cluster = abjad.KeyCluster()
         >>> abjad.attach(key_cluster, chord, direction=abjad.UP)
         >>> staff = abjad.Staff([chord])
         >>> abjad.show(staff) # doctest: +SKIP
@@ -2622,7 +2622,7 @@ class KeyCluster:
         Includes natural markup:
 
         >>> chord = abjad.Chord("<c' e' g' b' d'' f''>8")
-        >>> key_cluster = abjad.KeyCluster(include_natural_markup=True)
+        >>> key_cluster = abjad.KeyCluster()
         >>> abjad.attach(key_cluster, chord, direction=abjad.UP)
         >>> staff = abjad.Staff([chord])
         >>> abjad.show(staff) # doctest: +SKIP
@@ -2661,24 +2661,23 @@ class KeyCluster:
         <c' e' g' b' d'' f''>8
         ^ \markup \center-column { \natural \flat }
 
-        The reason for this is that chords contain multiple note-heads: if key cluster
-        formatted tweaks instead of overrides, the five format commands shown above would
-        need to be duplicated immediately before each note-head.
+        The reason for this is that chords contain multiple note-heads: if key
+        cluster formatted tweaks instead of overrides, the five format commands
+        shown above would need to be duplicated immediately before each
+        note-head.
 
     """
 
-    include_flat_markup: bool = True
-    include_natural_markup: bool = True
+    hide_flat_markup: bool = False
+    hide_natural_markup: bool = False
 
     directed: typing.ClassVar[bool] = True
     site: typing.ClassVar[str] = "after"
 
     def __post_init__(self):
-        assert isinstance(self.include_flat_markup, bool), repr(
-            self.include_flat_markup
-        )
-        assert isinstance(self.include_natural_markup, bool), repr(
-            self.include_natural_markup
+        assert isinstance(self.hide_flat_markup, bool), repr(self.hide_flat_markup)
+        assert isinstance(self.hide_natural_markup, bool), repr(
+            self.hide_natural_markup
         )
 
     def _get_contributions(self, wrapper=None):
@@ -2692,11 +2691,12 @@ class KeyCluster:
             "\\once \\override NoteHead.text =\n"
             "\\markup \\filled-box #'(-0.6 . 0.6) #'(-0.7 . 0.7) #0.25"
         )
-        if self.include_flat_markup and self.include_natural_markup:
+        if self.hide_flat_markup is False and self.hide_natural_markup is False:
             string = r"\center-column { \natural \flat }"
-        elif self.include_flat_markup:
+        elif self.hide_flat_markup is False:
             string = r"\center-column \flat"
         else:
+            assert self.hide_natural_markup is False
             string = r"\center-column \natural"
         string = rf"\markup {string}"
         if wrapper.direction is _enums.UP:
@@ -4298,7 +4298,7 @@ class RepeatTie:
         >>> abjad.get.indicators(voice[1], abjad.RepeatTie)
         [RepeatTie()]
 
-        >>> wrapper = abjad.get.indicator(voice[1], abjad.RepeatTie, unwrap=False)
+        >>> wrapper = abjad.get.indicator(voice[1], abjad.RepeatTie, wrapper=True)
         >>> wrapper.get_item()
         Bundle(indicator=RepeatTie(), tweaks=(Tweak(string='- \\tweak color #blue', i=None, tag=None),), comment=None)
 

--- a/source/abjad/instruments.py
+++ b/source/abjad/instruments.py
@@ -337,7 +337,8 @@ class Tuning:
     def voice_pitch_classes(
         self,
         pitch_classes: list[_pitch.NamedPitchClass],
-        allow_open_strings: bool = True,
+        *,
+        forbid_open_strings: bool = False,
     ) -> list[tuple[_pitch.NamedPitch | None, ...]]:
         r"""
         Voices ``pitch_classes``.
@@ -361,7 +362,7 @@ class Tuning:
             (NamedPitch("a'"), None, None, None)
 
             >>> pcs = [abjad.NamedPitchClass(_) for _ in ["a", "d"]]
-            >>> voicings = tuning.voice_pitch_classes(pcs, allow_open_strings=False)
+            >>> voicings = tuning.voice_pitch_classes(pcs, forbid_open_strings=True)
             >>> for voicing in voicings:
             ...     voicing
             ...
@@ -419,6 +420,7 @@ class Tuning:
         assert all(isinstance(_, _pitch.NamedPitchClass) for _ in pitch_classes), repr(
             pitch_classes
         )
+        assert isinstance(forbid_open_strings, bool), repr(forbid_open_strings)
         nones = [None] * (len(self.pitches) - len(pitch_classes))
         pcs_and_nones = pitch_classes + nones
         permutations = _enumerate.yield_permutations(pcs_and_nones)
@@ -433,7 +435,7 @@ class Tuning:
                     sequences.append([None])
                     continue
                 pitches = list(pitch_range.voice_pitch_class(pitch_class))
-                if not allow_open_strings:
+                if forbid_open_strings is True:
                     pitches = [
                         pitch for pitch in pitches if pitch != pitch_range.start_pitch
                     ]

--- a/source/abjad/iterpitches.py
+++ b/source/abjad/iterpitches.py
@@ -240,7 +240,7 @@ def transpose_from_sounding_pitch(argument) -> None:
             pitches = [interval.transpose(pitch) for pitch in leaf.written_pitches]
             for note_head, pitch in zip(leaf.note_heads, pitches, strict=True):
                 note_head.written_pitch = pitch
-        wrapper = _get.indicator(leaf, _indicators.StartTrillSpan, unwrap=False)
+        wrapper = _get.indicator(leaf, _indicators.StartTrillSpan, wrapper=True)
         if wrapper is not None:
             start_trill_span = wrapper.unbundle_indicator()
             new_pitch = interval.transpose(start_trill_span.pitch)
@@ -311,7 +311,7 @@ def transpose_from_written_pitch(argument) -> None:
             pitches = [interval.transpose(pitch) for pitch in leaf.written_pitches]
             for note_head, pitch in zip(leaf.note_heads, pitches, strict=True):
                 note_head.written_pitch = pitch
-        wrapper = _get.indicator(leaf, _indicators.StartTrillSpan, unwrap=False)
+        wrapper = _get.indicator(leaf, _indicators.StartTrillSpan, wrapper=True)
         if wrapper is not None:
             start_trill_span = wrapper.unbundle_indicator()
             new_pitch = interval.transpose(start_trill_span.pitch)

--- a/source/abjad/meter.py
+++ b/source/abjad/meter.py
@@ -915,9 +915,9 @@ class Meter:
         components: typing.Sequence[_score.Component],
         *,
         boundary_depth: int | None = None,
+        do_not_rewrite_tuplets: bool = False,
         initial_offset: _duration.Offset = _duration.Offset(0),
         maximum_dot_count: int | None = None,
-        rewrite_tuplets: bool = True,
     ) -> None:
         r"""
         Rewrites ``components`` according to ``meter``.
@@ -1991,7 +1991,7 @@ class Meter:
             >>> meter.rewrite(
             ...     staff[:],
             ...     boundary_depth=1,
-            ...     rewrite_tuplets=False,
+            ...     do_not_rewrite_tuplets=True,
             ... )
             >>> abjad.show(staff) # doctest: +SKIP
 
@@ -2026,7 +2026,7 @@ class Meter:
         if maximum_dot_count is not None:
             assert isinstance(maximum_dot_count, int)
             assert 0 <= maximum_dot_count
-        assert isinstance(rewrite_tuplets, bool)
+        assert isinstance(do_not_rewrite_tuplets, bool)
 
         def recurse(
             logical_tie: _select.LogicalTie,
@@ -2141,7 +2141,7 @@ class Meter:
                     boundary_offsets=boundary_offsets,
                     depth=0,
                 )
-            elif isinstance(item, _score.Tuplet) and not rewrite_tuplets:
+            elif isinstance(item, _score.Tuplet) and do_not_rewrite_tuplets is True:
                 pass
             else:
                 duration = sum([_._get_preprolated_duration() for _ in item])

--- a/source/abjad/rhythmtrees.py
+++ b/source/abjad/rhythmtrees.py
@@ -300,7 +300,7 @@ class RhythmTreeLeaf(RhythmTreeNode, uqbar.containers.UniqueTreeNode):
 
         Pitched rhythm-tree leaves makes notes:
 
-        >>> rtl = abjad.rhythmtrees.RhythmTreeLeaf((5, 1), is_pitched=True)
+        >>> rtl = abjad.rhythmtrees.RhythmTreeLeaf((5, 1), is_unpitched=False)
         >>> components = rtl(abjad.Duration(1, 4))
         >>> voice = abjad.Voice(components)
         >>> abjad.setting(voice[0]).Score.proportionalNotationDuration = "#1/12"
@@ -322,7 +322,7 @@ class RhythmTreeLeaf(RhythmTreeNode, uqbar.containers.UniqueTreeNode):
 
         Unpitched rhythm-tree leaves make rests:
 
-        >>> rtl = abjad.rhythmtrees.RhythmTreeLeaf((5, 1), is_pitched=False)
+        >>> rtl = abjad.rhythmtrees.RhythmTreeLeaf((5, 1), is_unpitched=True)
         >>> components = rtl(abjad.Duration(1, 4))
         >>> voice = abjad.Voice(components)
         >>> abjad.setting(voice[0]).Score.proportionalNotationDuration = "#1/12"
@@ -346,13 +346,13 @@ class RhythmTreeLeaf(RhythmTreeNode, uqbar.containers.UniqueTreeNode):
         self,
         pair: tuple[int, int],
         *,
-        is_pitched: bool = True,
+        is_unpitched: bool = False,
         name: str | None = None,
     ) -> None:
         assert isinstance(pair, tuple), repr(pair)
         uqbar.containers.UniqueTreeNode.__init__(self, name=name)
         RhythmTreeNode.__init__(self, pair)
-        self.is_pitched = is_pitched
+        self.is_unpitched = is_unpitched
 
     def __call__(
         self, duration: _duration.Duration
@@ -362,9 +362,10 @@ class RhythmTreeLeaf(RhythmTreeNode, uqbar.containers.UniqueTreeNode):
         """
         assert isinstance(duration, _duration.Duration), repr(duration)
         pitches: list[int | None]
-        if self.is_pitched:
+        if self.is_unpitched is False:
             pitches = [0]
         else:
+            assert self.is_unpitched is True
             pitches = [None]
         pitch_lists = _makers.make_pitch_lists(pitches)
         duration *= _duration.Duration(self.pair)
@@ -387,7 +388,7 @@ class RhythmTreeLeaf(RhythmTreeNode, uqbar.containers.UniqueTreeNode):
         """
         properties = [
             f"{self.pair!r}",
-            f"is_pitched={self.is_pitched!r}",
+            f"is_unpitched={self.is_unpitched!r}",
         ]
         if self.name is not None:
             properties.append(f"name={self.name!r}")
@@ -398,15 +399,15 @@ class RhythmTreeLeaf(RhythmTreeNode, uqbar.containers.UniqueTreeNode):
         return [str(self._get_fraction_string())]
 
     @property
-    def is_pitched(self) -> bool:
+    def is_unpitched(self) -> bool:
         """
-        Is true when rhythm-tree leaf is pitched.
+        Is true when rhythm-tree leaf is unpitched.
         """
-        return self._is_pitched
+        return self._is_unpitched
 
-    @is_pitched.setter
-    def is_pitched(self, argument):
-        self._is_pitched = bool(argument)
+    @is_unpitched.setter
+    def is_unpitched(self, argument):
+        self._is_unpitched = bool(argument)
 
     @property
     def rtm_format(self) -> str:
@@ -415,16 +416,17 @@ class RhythmTreeLeaf(RhythmTreeNode, uqbar.containers.UniqueTreeNode):
 
         ..  container:: example
 
-            >>> abjad.rhythmtrees.RhythmTreeLeaf((5, 1), is_pitched=True).rtm_format
+            >>> abjad.rhythmtrees.RhythmTreeLeaf((5, 1), is_unpitched=False).rtm_format
             '5'
 
-            >>> abjad.rhythmtrees.RhythmTreeLeaf((5, 1), is_pitched=False).rtm_format
+            >>> abjad.rhythmtrees.RhythmTreeLeaf((5, 1), is_unpitched=True).rtm_format
             '-5'
 
         """
         string = self._get_fraction_string()
-        if self.is_pitched:
+        if self.is_unpitched is False:
             return f"{string!s}"
+        assert self.is_unpitched is True
         return f"-{string!s}"
 
 
@@ -949,7 +951,7 @@ class RhythmTreeParser(Parser):
         else:
             assert isinstance(p[1], _duration.Duration), repr(p[1])
             pair = abs(p[1]).pair
-        p[0] = RhythmTreeLeaf(pair, is_pitched=0 < p[1])
+        p[0] = RhythmTreeLeaf(pair, is_unpitched=not 0 < p[1])
 
     def p_node__container(self, p):
         """

--- a/source/abjad/sequence.py
+++ b/source/abjad/sequence.py
@@ -1386,13 +1386,29 @@ def has_duplicates(sequence):
     return len(set(sequence)) < len(sequence)
 
 
-def is_decreasing(sequence, *, strict: bool = True) -> bool:
+def is_decreasing(sequence, *, strict: bool = False) -> bool:
     """
     Is true when ``sequence`` is decreasing.
 
-    Is true when sequence is strictly decreasing:
+    ..  container:: example
+
+        Is true when sequence decreases monotonically:
+
+        >>> abjad.sequence.is_decreasing([5, 4, 3, 2, 1, 0])
+        True
+
+        >>> abjad.sequence.is_decreasing([3, 3, 3, 2, 1, 0])
+        True
+
+        >>> abjad.sequence.is_decreasing([3, 3, 3, 3, 3, 3])
+        True
+
+        >>> abjad.sequence.is_decreasing([])
+        True
 
     ..  container:: example
+
+        Is true when sequence is strictly decreasing:
 
         >>> abjad.sequence.is_decreasing([5, 4, 3, 2, 1, 0], strict=True)
         True
@@ -1406,24 +1422,8 @@ def is_decreasing(sequence, *, strict: bool = True) -> bool:
         >>> abjad.sequence.is_decreasing([], strict=True)
         True
 
-    ..  container:: example
-
-        Is true when sequence decreases monotonically:
-
-        >>> abjad.sequence.is_decreasing([5, 4, 3, 2, 1, 0], strict=False)
-        True
-
-        >>> abjad.sequence.is_decreasing([3, 3, 3, 2, 1, 0], strict=False)
-        True
-
-        >>> abjad.sequence.is_decreasing([3, 3, 3, 3, 3, 3], strict=False)
-        True
-
-        >>> abjad.sequence.is_decreasing([], strict=False)
-        True
-
     """
-    if strict:
+    if strict is True:
         try:
             previous = None
             for current in sequence:
@@ -1435,6 +1435,7 @@ def is_decreasing(sequence, *, strict: bool = True) -> bool:
         except TypeError:
             return False
     else:
+        assert strict is False
         try:
             previous = None
             for current in sequence:
@@ -1447,13 +1448,29 @@ def is_decreasing(sequence, *, strict: bool = True) -> bool:
             return False
 
 
-def is_increasing(sequence, *, strict: bool = True) -> bool:
+def is_increasing(sequence, *, strict: bool = False) -> bool:
     """
     Is true when ``sequence`` is increasing.
 
-    Is true when sequence is strictly increasing:
+    ..  container:: example
+
+        Is true when sequence increases monotonically:
+
+        >>> abjad.sequence.is_increasing([0, 1, 2, 3, 4, 5])
+        True
+
+        >>> abjad.sequence.is_increasing([0, 1, 2, 3, 3, 3])
+        True
+
+        >>> abjad.sequence.is_increasing([3, 3, 3, 3, 3, 3])
+        True
+
+        >>> abjad.sequence.is_increasing([])
+        True
 
     ..  container:: example
+
+        Is true when sequence is strictly increasing:
 
         >>> abjad.sequence.is_increasing([0, 1, 2, 3, 4, 5], strict=True)
         True
@@ -1467,24 +1484,8 @@ def is_increasing(sequence, *, strict: bool = True) -> bool:
         >>> abjad.sequence.is_increasing([], strict=True)
         True
 
-    ..  container:: example
-
-        Is true when sequence increases monotonically:
-
-        >>> abjad.sequence.is_increasing([0, 1, 2, 3, 4, 5], strict=False)
-        True
-
-        >>> abjad.sequence.is_increasing([0, 1, 2, 3, 3, 3], strict=False)
-        True
-
-        >>> abjad.sequence.is_increasing([3, 3, 3, 3, 3, 3], strict=False)
-        True
-
-        >>> abjad.sequence.is_increasing([], strict=False)
-        True
-
     """
-    if strict:
+    if strict is True:
         try:
             previous = None
             for current in sequence:
@@ -1496,6 +1497,7 @@ def is_increasing(sequence, *, strict: bool = True) -> bool:
         except TypeError:
             return False
     else:
+        assert strict is False
         try:
             previous = None
             for current in sequence:
@@ -2408,16 +2410,30 @@ def weight(sequence) -> typing.Any:
     return sum(weights)
 
 
-def zip(sequences, *, cyclic: bool = False, truncate: bool = True) -> list[tuple]:
+def zip(
+    sequences, *, cyclic: bool = False, do_not_truncate: bool = False
+) -> list[tuple]:
     """
     Zips ``sequences``.
 
-    Zips cyclically:
+    ..  container:: example
+
+        Zips ``sequences`` strictly:
+
+        >>> sequences = [[1, 2, 3, 4], [11, 12, 13], [21, 22, 23]]
+        >>> for triple in abjad.sequence.zip(sequences):
+        ...     triple
+        ...
+        (1, 11, 21)
+        (2, 12, 22)
+        (3, 13, 23)
 
     ..  container:: example
 
-        >>> sequence = [[1, 2, 3], ['a', 'b']]
-        >>> for item in abjad.sequence.zip(sequence, cyclic=True):
+        Zips ``sequences`` cyclically:
+
+        >>> sequences = [[1, 2, 3], ['a', 'b']]
+        >>> for item in abjad.sequence.zip(sequences, cyclic=True):
         ...     item
         ...
         (1, 'a')
@@ -2433,10 +2449,12 @@ def zip(sequences, *, cyclic: bool = False, truncate: bool = True) -> list[tuple
         (12, 20, 32)
         (10, 21, 33)
 
-        Zips without truncation:
+    ..  container:: example
 
-        >>> sequence = [[1, 2, 3, 4], [11, 12, 13], [21, 22, 23]]
-        >>> for item in abjad.sequence.zip(sequence, truncate=False):
+        Zips ``sequences`` and does not truncate:
+
+        >>> sequences = [[1, 2, 3, 4], [11, 12, 13], [21, 22, 23]]
+        >>> for item in abjad.sequence.zip(sequences, do_not_truncate=True):
         ...     item
         ...
         (1, 11, 21)
@@ -2444,27 +2462,14 @@ def zip(sequences, *, cyclic: bool = False, truncate: bool = True) -> list[tuple
         (3, 13, 23)
         (4,)
 
-    ..  container:: example
-
-        Zips strictly:
-
-        >>> sequences = [[1, 2, 3, 4], [11, 12, 13], [21, 22, 23]]
-        >>> for triple in abjad.sequence.zip(sequences):
-        ...     triple
-        ...
-        (1, 11, 21)
-        (2, 12, 22)
-        (3, 13, 23)
-
-    Returns list of tuples.
     """
-    for item in sequences:
-        if not isinstance(item, collections.abc.Iterable):
-            raise Exception(f"must be iterable: {item!r}.")
-    items: list[typing.Any] = []
-    if cyclic:
+    for sequence in sequences:
+        if not isinstance(sequence, collections.abc.Iterable):
+            raise Exception(f"must be iterable: {sequence!r}.")
+    result: list = []
+    if cyclic is True:
         if not min(len(_) for _ in sequences):
-            return items
+            return result
         maximum_length = max([len(_) for _ in sequences])
         for i in range(maximum_length):
             part = []
@@ -2472,8 +2477,8 @@ def zip(sequences, *, cyclic: bool = False, truncate: bool = True) -> list[tuple
                 index = i % len(item)
                 element = item[index]
                 part.append(element)
-            items.append(part)
-    elif not truncate:
+            result.append(part)
+    elif do_not_truncate is True:
         maximum_length = max([len(_) for _ in sequences])
         for i in range(maximum_length):
             part = []
@@ -2482,9 +2487,11 @@ def zip(sequences, *, cyclic: bool = False, truncate: bool = True) -> list[tuple
                     part.append(item[i])
                 except IndexError:
                     pass
-            items.append(part)
-    elif truncate:
+            result.append(part)
+    else:
+        assert cyclic is False
+        assert do_not_truncate is False
         for item in builtins.zip(*sequences):
-            items.append(item)
-    result = [tuple(_) for _ in items]
-    return result
+            result.append(item)
+    tuples = [tuple(_) for _ in result]
+    return tuples

--- a/source/abjad/wf.py
+++ b/source/abjad/wf.py
@@ -136,10 +136,10 @@ def check_beamed_long_notes(argument) -> tuple[list, int]:
         total += 1
         if leaf.written_duration < _duration.Duration((1, 4)):
             continue
-        start_wrapper = _get.effective(leaf, _indicators.StartBeam, unwrap=False)
+        start_wrapper = _get.effective(leaf, _indicators.StartBeam, wrapper=True)
         if start_wrapper is None:
             continue
-        stop_wrapper = _get.effective(leaf, _indicators.StopBeam, unwrap=False)
+        stop_wrapper = _get.effective(leaf, _indicators.StopBeam, wrapper=True)
         if stop_wrapper is None:
             violators.append(leaf)
             continue
@@ -947,70 +947,70 @@ _globals = globals()
 
 def _call_functions(
     component,
-    check_beamed_lone_notes: bool = True,
-    check_beamed_long_notes: bool = True,
-    check_duplicate_ids: bool = True,
-    check_empty_containers: bool = True,
-    check_missing_parents: bool = True,
-    check_notes_on_wrong_clef: bool = True,
-    check_orphaned_dependent_wrappers: bool = True,
-    check_out_of_range_pitches: bool = True,
-    check_overlapping_beams: bool = True,
-    check_overlapping_text_spanners: bool = True,
-    check_unmatched_stop_text_spans: bool = True,
-    check_unterminated_hairpins: bool = True,
-    check_unterminated_text_spanners: bool = True,
+    do_not_check_beamed_lone_notes: bool = False,
+    do_not_check_beamed_long_notes: bool = False,
+    do_not_check_duplicate_ids: bool = False,
+    do_not_check_empty_containers: bool = False,
+    do_not_check_missing_parents: bool = False,
+    do_not_check_notes_on_wrong_clef: bool = False,
+    do_not_check_orphaned_dependent_wrappers: bool = False,
+    do_not_check_out_of_range_pitches: bool = False,
+    do_not_check_overlapping_beams: bool = False,
+    do_not_check_overlapping_text_spanners: bool = False,
+    do_not_check_unmatched_stop_text_spans: bool = False,
+    do_not_check_unterminated_hairpins: bool = False,
+    do_not_check_unterminated_text_spanners: bool = False,
 ):
     triples = []
-    if check_beamed_lone_notes:
+    if do_not_check_beamed_lone_notes is False:
         name = "check_beamed_lone_notes"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_beamed_long_notes:
+    if do_not_check_beamed_long_notes is False:
         name = "check_beamed_long_notes"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_duplicate_ids:
+    if do_not_check_duplicate_ids is False:
         name = "check_duplicate_ids"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_empty_containers:
+    if do_not_check_empty_containers is False:
         name = "check_empty_containers"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_missing_parents:
+    if do_not_check_missing_parents is False:
         name = "check_missing_parents"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_notes_on_wrong_clef:
+    if do_not_check_notes_on_wrong_clef is False:
         name = "check_notes_on_wrong_clef"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_orphaned_dependent_wrappers:
+    if do_not_check_orphaned_dependent_wrappers is False:
         name = "check_orphaned_dependent_wrappers"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_out_of_range_pitches:
+    if do_not_check_out_of_range_pitches is False:
         name = "check_out_of_range_pitches"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_overlapping_beams:
+    if do_not_check_overlapping_beams is False:
         name = "check_overlapping_beams"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_overlapping_text_spanners:
+    if do_not_check_overlapping_text_spanners is False:
         name = "check_overlapping_text_spanners"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_unmatched_stop_text_spans:
+    if do_not_check_unmatched_stop_text_spans is False:
         name = "check_unmatched_stop_text_spans"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_unterminated_hairpins:
+    if do_not_check_unterminated_hairpins is False:
         name = "check_unterminated_hairpins"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
-    if check_unterminated_text_spanners:
+    if do_not_check_unterminated_text_spanners is False:
         name = "check_unterminated_text_spanners"
         violators, count = _globals[name](component)
         triples.append((violators, count, name))
@@ -1019,38 +1019,38 @@ def _call_functions(
 
 def tabulate_wellformedness(
     component,
-    check_beamed_lone_notes: bool = True,
-    check_beamed_long_notes: bool = True,
-    check_duplicate_ids: bool = True,
-    check_empty_containers: bool = True,
-    check_missing_parents: bool = True,
-    check_notes_on_wrong_clef: bool = True,
-    check_orphaned_dependent_wrappers: bool = True,
-    check_out_of_range_pitches: bool = True,
-    check_overlapping_beams: bool = True,
-    check_overlapping_text_spanners: bool = True,
-    check_unmatched_stop_text_spans: bool = True,
-    check_unterminated_hairpins: bool = True,
-    check_unterminated_text_spanners: bool = True,
+    do_not_check_beamed_lone_notes: bool = False,
+    do_not_check_beamed_long_notes: bool = False,
+    do_not_check_duplicate_ids: bool = False,
+    do_not_check_empty_containers: bool = False,
+    do_not_check_missing_parents: bool = False,
+    do_not_check_notes_on_wrong_clef: bool = False,
+    do_not_check_orphaned_dependent_wrappers: bool = False,
+    do_not_check_out_of_range_pitches: bool = False,
+    do_not_check_overlapping_beams: bool = False,
+    do_not_check_overlapping_text_spanners: bool = False,
+    do_not_check_unmatched_stop_text_spans: bool = False,
+    do_not_check_unterminated_hairpins: bool = False,
+    do_not_check_unterminated_text_spanners: bool = False,
 ) -> tuple[int, str]:
     """
     Tabulates wellformedness.
     """
     triples = _call_functions(
         component,
-        check_beamed_lone_notes=check_beamed_lone_notes,
-        check_beamed_long_notes=check_beamed_long_notes,
-        check_duplicate_ids=check_duplicate_ids,
-        check_empty_containers=check_empty_containers,
-        check_missing_parents=check_missing_parents,
-        check_notes_on_wrong_clef=check_notes_on_wrong_clef,
-        check_orphaned_dependent_wrappers=check_orphaned_dependent_wrappers,
-        check_out_of_range_pitches=check_out_of_range_pitches,
-        check_overlapping_beams=check_overlapping_beams,
-        check_overlapping_text_spanners=check_overlapping_text_spanners,
-        check_unmatched_stop_text_spans=check_unmatched_stop_text_spans,
-        check_unterminated_hairpins=check_unterminated_hairpins,
-        check_unterminated_text_spanners=check_unterminated_text_spanners,
+        do_not_check_beamed_lone_notes=do_not_check_beamed_lone_notes,
+        do_not_check_beamed_long_notes=do_not_check_beamed_long_notes,
+        do_not_check_duplicate_ids=do_not_check_duplicate_ids,
+        do_not_check_empty_containers=do_not_check_empty_containers,
+        do_not_check_missing_parents=do_not_check_missing_parents,
+        do_not_check_notes_on_wrong_clef=do_not_check_notes_on_wrong_clef,
+        do_not_check_orphaned_dependent_wrappers=do_not_check_orphaned_dependent_wrappers,
+        do_not_check_out_of_range_pitches=do_not_check_out_of_range_pitches,
+        do_not_check_overlapping_beams=do_not_check_overlapping_beams,
+        do_not_check_overlapping_text_spanners=do_not_check_overlapping_text_spanners,
+        do_not_check_unmatched_stop_text_spans=do_not_check_unmatched_stop_text_spans,
+        do_not_check_unterminated_hairpins=do_not_check_unterminated_hairpins,
+        do_not_check_unterminated_text_spanners=do_not_check_unterminated_text_spanners,
     )
     strings = []
     total_violators = 0
@@ -1066,38 +1066,38 @@ def tabulate_wellformedness(
 
 def wellformed(
     component,
-    check_beamed_lone_notes: bool = True,
-    check_beamed_long_notes: bool = True,
-    check_duplicate_ids: bool = True,
-    check_empty_containers: bool = True,
-    check_missing_parents: bool = True,
-    check_notes_on_wrong_clef: bool = True,
-    check_orphaned_dependent_wrappers: bool = True,
-    check_out_of_range_pitches: bool = True,
-    check_overlapping_beams: bool = True,
-    check_overlapping_text_spanners: bool = True,
-    check_unmatched_stop_text_spans: bool = True,
-    check_unterminated_hairpins: bool = True,
-    check_unterminated_text_spanners: bool = True,
+    do_not_check_beamed_lone_notes: bool = False,
+    do_not_check_beamed_long_notes: bool = False,
+    do_not_check_duplicate_ids: bool = False,
+    do_not_check_empty_containers: bool = False,
+    do_not_check_missing_parents: bool = False,
+    do_not_check_notes_on_wrong_clef: bool = False,
+    do_not_check_orphaned_dependent_wrappers: bool = False,
+    do_not_check_out_of_range_pitches: bool = False,
+    do_not_check_overlapping_beams: bool = False,
+    do_not_check_overlapping_text_spanners: bool = False,
+    do_not_check_unmatched_stop_text_spans: bool = False,
+    do_not_check_unterminated_hairpins: bool = False,
+    do_not_check_unterminated_text_spanners: bool = False,
 ) -> bool:
     """
     Is true when ``component`` is wellformed.
     """
     triples = _call_functions(
         component,
-        check_beamed_lone_notes=check_beamed_lone_notes,
-        check_beamed_long_notes=check_beamed_long_notes,
-        check_duplicate_ids=check_duplicate_ids,
-        check_empty_containers=check_empty_containers,
-        check_missing_parents=check_missing_parents,
-        check_notes_on_wrong_clef=check_notes_on_wrong_clef,
-        check_orphaned_dependent_wrappers=check_orphaned_dependent_wrappers,
-        check_out_of_range_pitches=check_out_of_range_pitches,
-        check_overlapping_beams=check_overlapping_beams,
-        check_overlapping_text_spanners=check_overlapping_text_spanners,
-        check_unmatched_stop_text_spans=check_unmatched_stop_text_spans,
-        check_unterminated_hairpins=check_unterminated_hairpins,
-        check_unterminated_text_spanners=check_unterminated_text_spanners,
+        do_not_check_beamed_lone_notes=do_not_check_beamed_lone_notes,
+        do_not_check_beamed_long_notes=do_not_check_beamed_long_notes,
+        do_not_check_duplicate_ids=do_not_check_duplicate_ids,
+        do_not_check_empty_containers=do_not_check_empty_containers,
+        do_not_check_missing_parents=do_not_check_missing_parents,
+        do_not_check_notes_on_wrong_clef=do_not_check_notes_on_wrong_clef,
+        do_not_check_orphaned_dependent_wrappers=do_not_check_orphaned_dependent_wrappers,
+        do_not_check_out_of_range_pitches=do_not_check_out_of_range_pitches,
+        do_not_check_overlapping_beams=do_not_check_overlapping_beams,
+        do_not_check_overlapping_text_spanners=do_not_check_overlapping_text_spanners,
+        do_not_check_unmatched_stop_text_spans=do_not_check_unmatched_stop_text_spans,
+        do_not_check_unterminated_hairpins=do_not_check_unterminated_hairpins,
+        do_not_check_unterminated_text_spanners=do_not_check_unterminated_text_spanners,
     )
     for violators, total, name in triples:
         if violators:

--- a/tests/test_Container.py
+++ b/tests/test_Container.py
@@ -176,7 +176,7 @@ def test_Container___delitem___04():
         """
     )
 
-    assert abjad.wf.wellformed(voice, check_overlapping_beams=False)
+    assert abjad.wf.wellformed(voice, do_not_check_overlapping_beams=True)
 
 
 def test_Container___delitem___05():
@@ -2267,7 +2267,7 @@ def test_Container_pop_01():
     "Result is now d'8 [ ]"
 
     assert abjad.lilypond(result) == "d'8\n[\n]"
-    assert abjad.wf.wellformed(result, check_beamed_lone_notes=False)
+    assert abjad.wf.wellformed(result, do_not_check_beamed_lone_notes=True)
 
 
 def test_Container_pop_02():
@@ -2375,7 +2375,7 @@ def test_Container_remove_01():
     assert abjad.lilypond(note) == "d'8\n[\n]"
 
     assert abjad.wf.wellformed(voice)
-    assert abjad.wf.wellformed(note, check_beamed_lone_notes=False)
+    assert abjad.wf.wellformed(note, do_not_check_beamed_lone_notes=True)
 
 
 def test_Container_remove_02():

--- a/tests/test_mutate_extract.py
+++ b/tests/test_mutate_extract.py
@@ -94,7 +94,7 @@ def test_mutate_extract_02():
     for note in notes:
         assert abjad.wf.wellformed(note)
 
-    assert abjad.wf.wellformed(voice, check_overlapping_beams=False)
+    assert abjad.wf.wellformed(voice, do_not_check_overlapping_beams=True)
 
 
 def test_mutate_extract_03():

--- a/tests/test_mutate_swap.py
+++ b/tests/test_mutate_swap.py
@@ -60,7 +60,7 @@ def test_Mutation_swap_01():
         """
     )
 
-    assert abjad.wf.wellformed(voice, check_overlapping_beams=False)
+    assert abjad.wf.wellformed(voice, do_not_check_overlapping_beams=True)
 
 
 def test_Mutation_swap_02():

--- a/tests/test_rhythmtrees.py
+++ b/tests/test_rhythmtrees.py
@@ -361,24 +361,24 @@ def test_RhythmTreeLeaf___copy___01():
 
 
 def test_RhythmTreeLeaf___copy___02():
-    rtl = abjad.rhythmtrees.RhythmTreeLeaf((2, 1), is_pitched=True)
+    rtl = abjad.rhythmtrees.RhythmTreeLeaf((2, 1), is_unpitched=False)
     copied = copy.copy(rtl)
     assert repr(rtl) == repr(copied)
     assert rtl is not copied
 
 
 def test_RhythmTreeLeaf___eq___01():
-    a = abjad.rhythmtrees.RhythmTreeLeaf((1, 1), is_pitched=True)
-    b = abjad.rhythmtrees.RhythmTreeLeaf((1, 1), is_pitched=True)
+    a = abjad.rhythmtrees.RhythmTreeLeaf((1, 1), is_unpitched=False)
+    b = abjad.rhythmtrees.RhythmTreeLeaf((1, 1), is_unpitched=False)
     assert repr(a) == repr(b)
     assert a != b
 
 
 def test_RhythmTreeLeaf___eq___02():
-    a = abjad.rhythmtrees.RhythmTreeLeaf((1, 1), is_pitched=True)
-    b = abjad.rhythmtrees.RhythmTreeLeaf((1, 1), is_pitched=False)
-    c = abjad.rhythmtrees.RhythmTreeLeaf((2, 1), is_pitched=True)
-    d = abjad.rhythmtrees.RhythmTreeLeaf((2, 1), is_pitched=False)
+    a = abjad.rhythmtrees.RhythmTreeLeaf((1, 1), is_unpitched=True)
+    b = abjad.rhythmtrees.RhythmTreeLeaf((1, 1), is_unpitched=True)
+    c = abjad.rhythmtrees.RhythmTreeLeaf((2, 1), is_unpitched=False)
+    d = abjad.rhythmtrees.RhythmTreeLeaf((2, 1), is_unpitched=True)
     assert a != b
     assert a != c
     assert a != d


### PR DESCRIPTION
Default boolean keywords to false

    OLD: abjad.sequence.is_decreasing(..., strict: bool = True)
         abjad.sequence.is_increasing(..., strict: bool = False)

    NEW: abjad.sequence.is_decreasing(..., strict: bool = True)
         abjad.sequence.is_increasing(..., strict: bool = False)

    OLD: abjad.sequence.zip(..., truncate: bool = True)
    NEW: abjad.sequence.zip(..., do_not_truncate: bool = False)

    OLD: abjad.rhythmtrees.RhythmTreeLeaf(..., is_pitched: bool = True)
    NEW: abjad.rhythmtrees.RhythmTreeLeaf(..., is_unpitched: bool = False)

    OLD: abjad.Meter.rewrite(..., rewrite_tuplets: bool = True)
    NEW: abjad.Meter.rewrite(..., do_not_rewrite_tuplets: bool = False)

    OLD: abjad.io.count_function_calls(..., fixed_point: bool = True)
    NEW: abjad.io.count_function_calls(..., only_one_time: bool = False)

    OLD: abjad.io.profile(..., strip_dirs: bool = True)
    NEW: abjad.io.profile(..., do_not_strip_dirs: bool = False)

    OLD: abjad.instruments.Tuning.voice_pitch_classes(..., allow_open_strings=True)
    NEW: abjad.instruments.Tuning.voice_pitch_classes(..., forbid_open_strings=False)

    OLD: abjad.indicators.KeyCluster(..., include_flat_markup: bool = True)
         abjad.indicators.KeyCluster(..., include_natural_markup: bool = True)

    NEW: abjad.indicators.KeyCluster(..., hide_flat_markup: bool = False)
         abjad.indicators.KeyCluster(..., hide_natural_markup: bool = False)

    OLD:

        abjad.wf.wellformed(
            component,
            check_beamed_lone_notes: bool = True,
            check_beamed_long_notes: bool = True,
            check_duplicate_ids: bool = True,
            check_empty_containers: bool = True,
            check_missing_parents: bool = True,
            check_notes_on_wrong_clef: bool = True,
            check_orphaned_dependent_wrappers: bool = True,
            check_out_of_range_pitches: bool = True,
            check_overlapping_beams: bool = True,
            check_overlapping_text_spanners: bool = True,
            check_unmatched_stop_text_spans: bool = True,
            check_unterminated_hairpins: bool = True,
            check_unterminated_text_spanners: bool = True,
        )

    NEW:

        abjad.wf.wellformed(
            component,
            do_not_check_beamed_lone_notes: bool = False,
            do_not_check_beamed_long_notes: bool = False,
            do_not_check_duplicate_ids: bool = False,
            do_not_check_empty_containers: bool = False,
            do_not_check_missing_parents: bool = False,
            do_not_check_notes_on_wrong_clef: bool = False,
            do_not_check_orphaned_dependent_wrappers: bool = False,
            do_not_check_out_of_range_pitches: bool = False,
            do_not_check_overlapping_beams: bool = False,
            do_not_check_overlapping_text_spanners: bool = False,
            do_not_check_unmatched_stop_text_spans: bool = False,
            do_not_check_unterminated_hairpins: bool = False,
            do_not_check_unterminated_text_spanners: bool = False,
        )

    OLD:

        * abjad.get.annotation_wrappers(..., unwrap: bool = True)
        * abjad.get.effective_wrapper(..., unwrap: bool = True)
        * abjad.get.indicator(..., unwrap: bool = True)
        * abjad.get.indicators(..., unwrap: bool = True)

    NEW:

        * abjad.get.annotation_wrappers(..., wrapper: bool = False)
        * abjad.get.effective_wrapper(..., wrapper: bool = False)
        * abjad.get.indicator(..., wrapper: bool = False)
        * abjad.get.indicators(..., wrapper: bool = False)