### PR TITLE
Rename abjad.wf.is_wellformed()

### DIFF
--- a/source/abjad/contextmanagers.py
+++ b/source/abjad/contextmanagers.py
@@ -144,7 +144,7 @@ class ForbidUpdate(ContextManager):
         ...         abjad.mutate.replace(note, chord)
         ...
 
-        >>> abjad.wf.wellformed(staff)
+        >>> abjad.wf.is_wellformed(staff)
         True
 
         >>> abjad.show(staff) # doctest: +SKIP

--- a/source/abjad/mutate.py
+++ b/source/abjad/mutate.py
@@ -1525,7 +1525,7 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
         (Note("f'4"), None)
         (Note("g'4"), None)
 
-        >>> abjad.wf.wellformed(staff)
+        >>> abjad.wf.is_wellformed(staff)
         True
 
     ..  container:: example
@@ -1580,7 +1580,7 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
         (Note("f'4"), Clef(name='alto', hide=False))
         (Note("g'4"), Clef(name='alto', hide=False))
 
-        >>> abjad.wf.wellformed(staff)
+        >>> abjad.wf.is_wellformed(staff)
         True
 
     ..  container:: example

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -926,7 +926,7 @@ class Container(Component):
                     }
                 }
 
-            >>> abjad.wf.wellformed(voice)
+            >>> abjad.wf.is_wellformed(voice)
             True
 
             First tuplet must have start slur removed:
@@ -947,7 +947,7 @@ class Container(Component):
                     e'4
                 }
 
-            >>> abjad.wf.wellformed(tuplet_1)
+            >>> abjad.wf.is_wellformed(tuplet_1)
             True
 
         """

--- a/source/abjad/wf.py
+++ b/source/abjad/wf.py
@@ -705,7 +705,7 @@ def check_unmatched_stop_text_spans(argument) -> tuple[list, int]:
                 \stopTextSpan
             }
 
-        >>> abjad.wf.wellformed(voice)
+        >>> abjad.wf.is_wellformed(voice)
         True
 
     """
@@ -804,7 +804,7 @@ def check_unterminated_hairpins(argument) -> tuple[list, int]:
                 \f
             }
 
-        >>> abjad.wf.wellformed(voice)
+        >>> abjad.wf.is_wellformed(voice)
         True
 
     ..  container:: example
@@ -832,7 +832,7 @@ def check_unterminated_hairpins(argument) -> tuple[list, int]:
                 \!
             }
 
-        >>> abjad.wf.wellformed(voice)
+        >>> abjad.wf.is_wellformed(voice)
         True
 
     """
@@ -907,7 +907,7 @@ def check_unterminated_text_spanners(argument) -> tuple[list, int]:
                 \stopTextSpan
             }
 
-        >>> abjad.wf.wellformed(voice)
+        >>> abjad.wf.is_wellformed(voice)
         True
 
     """
@@ -1034,7 +1034,7 @@ def tabulate_wellformedness(
     do_not_check_unterminated_text_spanners: bool = False,
 ) -> tuple[int, str]:
     """
-    Tabulates wellformedness.
+    Tabulates wellformedness of ``component``.
     """
     triples = _call_functions(
         component,
@@ -1064,7 +1064,7 @@ def tabulate_wellformedness(
     return total_violators, "\n".join(strings)
 
 
-def wellformed(
+def is_wellformed(
     component,
     do_not_check_beamed_lone_notes: bool = False,
     do_not_check_beamed_long_notes: bool = False,

--- a/tests/test_Chord.py
+++ b/tests/test_Chord.py
@@ -256,8 +256,8 @@ def test_Chord___init___08():
     assert abjad.lilypond(skip) == "s8"
     assert abjad.lilypond(chord) == "<>8"
 
-    assert abjad.wf.wellformed(skip)
-    assert abjad.wf.wellformed(chord)
+    assert abjad.wf.is_wellformed(skip)
+    assert abjad.wf.is_wellformed(chord)
 
 
 def test_Chord___init___09():
@@ -270,7 +270,7 @@ def test_Chord___init___09():
 
     assert abjad.lilypond(chord) == "<>8"
     assert abjad.get.parentage(chord).parent is None
-    assert abjad.wf.wellformed(chord)
+    assert abjad.wf.is_wellformed(chord)
 
 
 def test_Chord___init___10():
@@ -283,7 +283,7 @@ def test_Chord___init___10():
 
     assert abjad.lilypond(chord) == "<>8"
     assert abjad.get.parentage(chord).parent is None
-    assert abjad.wf.wellformed(chord)
+    assert abjad.wf.is_wellformed(chord)
 
 
 def test_Chord___init___11():
@@ -296,7 +296,7 @@ def test_Chord___init___11():
 
     assert abjad.lilypond(chord) == "<>8"
     assert abjad.get.parentage(chord).parent is None
-    assert abjad.wf.wellformed(chord)
+    assert abjad.wf.is_wellformed(chord)
 
 
 def test_Chord___init___12():
@@ -309,8 +309,8 @@ def test_Chord___init___12():
 
     assert abjad.lilypond(rest) == "r8"
     assert abjad.lilypond(chord) == "<>8"
-    assert abjad.wf.wellformed(rest)
-    assert abjad.wf.wellformed(chord)
+    assert abjad.wf.is_wellformed(rest)
+    assert abjad.wf.is_wellformed(chord)
 
 
 def test_Chord___init___13():
@@ -322,7 +322,7 @@ def test_Chord___init___13():
     chord = abjad.Chord(tuplet[1])
 
     assert abjad.lilypond(chord) == "<>8"
-    assert abjad.wf.wellformed(chord)
+    assert abjad.wf.is_wellformed(chord)
     assert abjad.get.parentage(chord).parent is None
 
 
@@ -336,8 +336,8 @@ def test_Chord___init___14():
 
     assert abjad.lilypond(note) == "d'8"
     assert abjad.lilypond(chord) == "<d'>8"
-    assert abjad.wf.wellformed(note)
-    assert abjad.wf.wellformed(chord)
+    assert abjad.wf.is_wellformed(note)
+    assert abjad.wf.is_wellformed(chord)
 
 
 def test_Chord___init___15():
@@ -349,7 +349,7 @@ def test_Chord___init___15():
     chord = abjad.Chord(tuplet[1])
 
     assert abjad.lilypond(chord) == "<c'>8"
-    assert abjad.wf.wellformed(chord)
+    assert abjad.wf.is_wellformed(chord)
     assert abjad.get.parentage(chord).parent is None
 
 
@@ -362,7 +362,7 @@ def test_Chord___init___16():
     chord = abjad.Chord(staff[1])
 
     assert abjad.lilypond(chord) == "<d'>8"
-    assert abjad.wf.wellformed(chord)
+    assert abjad.wf.is_wellformed(chord)
     assert abjad.get.parentage(chord).parent is None
 
 

--- a/tests/test_Container.py
+++ b/tests/test_Container.py
@@ -93,7 +93,7 @@ def test_Container___delitem___01():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
     # container leaves are still slurred
     assert abjad.lilypond(container) == abjad.string.normalize(
@@ -107,7 +107,7 @@ def test_Container___delitem___01():
         """
     ), print(abjad.lilypond(container))
 
-    assert abjad.wf.wellformed(container)
+    assert abjad.wf.is_wellformed(container)
 
 
 def test_Container___delitem___02():
@@ -131,7 +131,7 @@ def test_Container___delitem___02():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___delitem___03():
@@ -154,7 +154,7 @@ def test_Container___delitem___03():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___delitem___04():
@@ -176,7 +176,7 @@ def test_Container___delitem___04():
         """
     )
 
-    assert abjad.wf.wellformed(voice, do_not_check_overlapping_beams=True)
+    assert abjad.wf.is_wellformed(voice, do_not_check_overlapping_beams=True)
 
 
 def test_Container___delitem___05():
@@ -198,7 +198,7 @@ def test_Container___delitem___05():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___delitem___06():
@@ -242,7 +242,7 @@ def test_Container___delitem___07():
         """
     )
 
-    assert abjad.wf.wellformed(tuplet)
+    assert abjad.wf.is_wellformed(tuplet)
 
 
 def test_Container___delitem___08():
@@ -295,8 +295,8 @@ def test_Container___delitem___08():
         """
     ), print(string)
 
-    assert abjad.wf.wellformed(voice)
-    assert abjad.wf.wellformed(leaf)
+    assert abjad.wf.is_wellformed(voice)
+    assert abjad.wf.is_wellformed(leaf)
 
 
 def test_Container___delitem___09():
@@ -334,7 +334,7 @@ def test_Container___delitem___09():
 
     assert len(voice._dependent_wrappers) == 0
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___getitem___01():
@@ -518,7 +518,7 @@ def test_Container___setitem___01():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___02():
@@ -561,7 +561,7 @@ def test_Container___setitem___02():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___03():
@@ -605,7 +605,7 @@ def test_Container___setitem___03():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___04():
@@ -656,7 +656,7 @@ def test_Container___setitem___04():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___05():
@@ -700,7 +700,7 @@ def test_Container___setitem___05():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___06():
@@ -750,7 +750,7 @@ def test_Container___setitem___06():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___07():
@@ -814,7 +814,7 @@ def test_Container___setitem___07():
         """
     ), print(abjad.lilypond(voice_1))
 
-    assert abjad.wf.wellformed(voice_1)
+    assert abjad.wf.is_wellformed(voice_1)
 
     assert abjad.lilypond(voice_2) == abjad.string.normalize(
         r"""
@@ -828,7 +828,7 @@ def test_Container___setitem___07():
         """
     ), print(abjad.lilypond(voice_2))
 
-    assert abjad.wf.wellformed(voice_2)
+    assert abjad.wf.is_wellformed(voice_2)
 
 
 def test_Container___setitem___08():
@@ -903,7 +903,7 @@ def test_Container___setitem___08():
         """
     ), print(abjad.lilypond(voice_1))
 
-    assert abjad.wf.wellformed(voice_1)
+    assert abjad.wf.is_wellformed(voice_1)
 
     assert abjad.lilypond(voice_2) == abjad.string.normalize(
         r"""
@@ -915,7 +915,7 @@ def test_Container___setitem___08():
         """
     ), print(abjad.lilypond(voice_2))
 
-    assert abjad.wf.wellformed(voice_2)
+    assert abjad.wf.is_wellformed(voice_2)
 
 
 def test_Container___setitem___09():
@@ -939,7 +939,7 @@ def test_Container___setitem___09():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Container___setitem___10():
@@ -967,7 +967,7 @@ def test_Container___setitem___10():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___11():
@@ -1023,7 +1023,7 @@ def test_Container___setitem___11():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___12():
@@ -1049,7 +1049,7 @@ def test_Container___setitem___12():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___13():
@@ -1077,7 +1077,7 @@ def test_Container___setitem___13():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___14():
@@ -1124,7 +1124,7 @@ def test_Container___setitem___14():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(container) == 0
 
 
@@ -1174,7 +1174,7 @@ def test_Container___setitem___15():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Container___setitem___16():
@@ -1278,7 +1278,7 @@ def test_Container___setitem___17():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Container___setitem___18():
@@ -1319,7 +1319,7 @@ def test_Container___setitem___18():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___19():
@@ -1345,7 +1345,7 @@ def test_Container___setitem___19():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container___setitem___20():
@@ -1483,7 +1483,7 @@ def test_Container_append_01():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container_append_02():
@@ -1510,7 +1510,7 @@ def test_Container_append_02():
         """
     ), print(abjad.lilypond(tuplet))
 
-    assert abjad.wf.wellformed(tuplet)
+    assert abjad.wf.is_wellformed(tuplet)
 
 
 def test_Container_append_03():
@@ -1638,7 +1638,7 @@ def test_Container_append_05():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container_append_06():
@@ -1676,7 +1676,7 @@ def test_Container_extend_01():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container_extend_02():
@@ -1707,7 +1707,7 @@ def test_Container_extend_02():
         """
     ), print(abjad.lilypond(voice_1))
 
-    assert abjad.wf.wellformed(voice_1)
+    assert abjad.wf.is_wellformed(voice_1)
 
 
 def test_Container_extend_03():
@@ -1731,7 +1731,7 @@ def test_Container_extend_03():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container_extend_04():
@@ -1755,7 +1755,7 @@ def test_Container_extend_04():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Container_extend_05():
@@ -1908,7 +1908,7 @@ def test_Container_extend_09():
         """
     ), print(abjad.lilypond(container))
 
-    assert abjad.wf.wellformed(container)
+    assert abjad.wf.is_wellformed(container)
 
 
 def test_Container_extend_10():
@@ -1942,7 +1942,7 @@ def test_Container_extend_10():
         """
     ), print(abjad.lilypond(container))
 
-    assert abjad.wf.wellformed(container)
+    assert abjad.wf.is_wellformed(container)
 
 
 def test_Container_index_01():
@@ -1967,7 +1967,7 @@ def test_Container_insert_01():
     abjad.beam(voice[:])
     voice.insert(0, abjad.Rest((1, 8)))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
         \new Voice
@@ -1989,7 +1989,7 @@ def test_Container_insert_02():
     abjad.beam(voice[:])
     voice.insert(1, abjad.Note(1, (1, 8)))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
         \new Voice
@@ -2011,7 +2011,7 @@ def test_Container_insert_03():
     abjad.beam(voice[:])
     voice.insert(4, abjad.Rest((1, 4)))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
         \new Voice
@@ -2037,7 +2037,7 @@ def test_Container_insert_04():
     abjad.beam(voice[:])
     voice.insert(1000, abjad.Rest((1, 4)))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
         \new Voice
@@ -2063,7 +2063,7 @@ def test_Container_insert_05():
     abjad.beam(voice[:])
     voice.insert(-1, abjad.Note(4.5, (1, 8)))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
         \new Voice
@@ -2089,7 +2089,7 @@ def test_Container_insert_06():
     abjad.beam(voice[:])
     voice.insert(-1000, abjad.Rest((1, 8)))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
         \new Voice
@@ -2117,8 +2117,8 @@ def test_Container_insert_07():
     note = voice[0]
     staff.insert(1, voice[0])
 
-    assert abjad.wf.wellformed(voice)
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(voice)
+    assert abjad.wf.is_wellformed(staff)
     assert note not in voice
     assert abjad.get.parentage(note).parent is staff
 
@@ -2128,7 +2128,7 @@ def test_Container_insert_08():
     abjad.beam(voice[:])
     voice.insert(1, abjad.Note("cs'8"))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
         \new Voice
@@ -2262,12 +2262,12 @@ def test_Container_pop_01():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
     "Result is now d'8 [ ]"
 
     assert abjad.lilypond(result) == "d'8\n[\n]"
-    assert abjad.wf.wellformed(result, do_not_check_beamed_lone_notes=True)
+    assert abjad.wf.is_wellformed(result, do_not_check_beamed_lone_notes=True)
 
 
 def test_Container_pop_02():
@@ -2312,7 +2312,7 @@ def test_Container_pop_02():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
     assert abjad.lilypond(container) == abjad.string.normalize(
         r"""
@@ -2324,7 +2324,7 @@ def test_Container_pop_02():
         """
     ), print(abjad.lilypond(container))
 
-    assert abjad.wf.wellformed(container)
+    assert abjad.wf.is_wellformed(container)
 
 
 def test_Container_remove_01():
@@ -2374,8 +2374,8 @@ def test_Container_remove_01():
 
     assert abjad.lilypond(note) == "d'8\n[\n]"
 
-    assert abjad.wf.wellformed(voice)
-    assert abjad.wf.wellformed(note, do_not_check_beamed_lone_notes=True)
+    assert abjad.wf.is_wellformed(voice)
+    assert abjad.wf.is_wellformed(note, do_not_check_beamed_lone_notes=True)
 
 
 def test_Container_remove_02():
@@ -2418,7 +2418,7 @@ def test_Container_remove_02():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
     assert abjad.lilypond(container) == abjad.string.normalize(
         r"""
@@ -2429,7 +2429,7 @@ def test_Container_remove_02():
         """
     )
 
-    assert abjad.wf.wellformed(container)
+    assert abjad.wf.is_wellformed(container)
 
 
 def test_Container_remove_03():

--- a/tests/test_MultimeasureRest.py
+++ b/tests/test_MultimeasureRest.py
@@ -26,7 +26,7 @@ def test_MultimeasureRest___init___01():
         """
     )
 
-    assert abjad.wf.wellformed(multimeasure_rest)
+    assert abjad.wf.is_wellformed(multimeasure_rest)
 
 
 def test_MultimeasureRest___init___02():
@@ -50,7 +50,7 @@ def test_MultimeasureRest___init___02():
         """
     )
 
-    assert abjad.wf.wellformed(score)
+    assert abjad.wf.is_wellformed(score)
 
 
 def test_MultimeasureRest___init___03():

--- a/tests/test_Note.py
+++ b/tests/test_Note.py
@@ -266,7 +266,7 @@ def test_Note___init___08():
         """
     )
 
-    assert abjad.wf.wellformed(note)
+    assert abjad.wf.is_wellformed(note)
 
 
 def test_Note___init___09():
@@ -285,7 +285,7 @@ def test_Note___init___09():
         """
     )
 
-    assert abjad.wf.wellformed(note)
+    assert abjad.wf.is_wellformed(note)
 
 
 def test_Note___init___10():
@@ -306,7 +306,7 @@ def test_Note___init___10():
         """
     ), print(abjad.lilypond(note))
 
-    assert abjad.wf.wellformed(note)
+    assert abjad.wf.is_wellformed(note)
 
 
 def test_Note___init___11():
@@ -323,7 +323,7 @@ def test_Note___init___11():
         """
     )
 
-    assert abjad.wf.wellformed(note)
+    assert abjad.wf.is_wellformed(note)
 
 
 def test_Note___init___12():

--- a/tests/test_NoteHeadList.py
+++ b/tests/test_NoteHeadList.py
@@ -96,7 +96,7 @@ def test_NoteHeadList___setitem___03():
         """
     )
 
-    assert abjad.wf.wellformed(chord)
+    assert abjad.wf.is_wellformed(chord)
 
 
 def test_NoteHeadList_append_01():

--- a/tests/test_Rest.py
+++ b/tests/test_Rest.py
@@ -123,7 +123,7 @@ def test_Rest___init___04():
         """
     )
 
-    assert abjad.wf.wellformed(rest)
+    assert abjad.wf.is_wellformed(rest)
 
 
 def test_Rest___init___05():
@@ -144,7 +144,7 @@ def test_Rest___init___05():
         """
     )
 
-    assert abjad.wf.wellformed(rest)
+    assert abjad.wf.is_wellformed(rest)
 
 
 def test_Rest___init___06():
@@ -161,7 +161,7 @@ def test_Rest___init___06():
         """
     )
 
-    assert abjad.wf.wellformed(rest)
+    assert abjad.wf.is_wellformed(rest)
 
 
 def test_Rest___init___07():
@@ -178,7 +178,7 @@ def test_Rest___init___07():
         """
     )
 
-    assert abjad.wf.wellformed(rest)
+    assert abjad.wf.is_wellformed(rest)
 
 
 def test_Rest___init___08():
@@ -195,7 +195,7 @@ def test_Rest___init___08():
         """
     )
 
-    assert abjad.wf.wellformed(rest)
+    assert abjad.wf.is_wellformed(rest)
 
 
 def test_Rest___init___09():
@@ -212,7 +212,7 @@ def test_Rest___init___09():
         """
     )
 
-    assert abjad.wf.wellformed(rest)
+    assert abjad.wf.is_wellformed(rest)
 
 
 def test_Rest___init___10():
@@ -229,7 +229,7 @@ def test_Rest___init___10():
         """
     )
 
-    assert abjad.wf.wellformed(rest)
+    assert abjad.wf.is_wellformed(rest)
 
 
 def test_Rest___init___11():
@@ -247,7 +247,7 @@ def test_Rest___init___11():
         """
     )
 
-    assert abjad.wf.wellformed(rest)
+    assert abjad.wf.is_wellformed(rest)
 
 
 def test_Rest___init___12():
@@ -274,7 +274,7 @@ def test_Rest___init___12():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Rest___init___13():
@@ -290,4 +290,4 @@ def test_Rest___init___13():
         """
     )
 
-    assert abjad.wf.wellformed(rest)
+    assert abjad.wf.is_wellformed(rest)

--- a/tests/test_Staff.py
+++ b/tests/test_Staff.py
@@ -160,7 +160,7 @@ def test_Staff___getitem___01():
     )
 
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert isinstance(staff[0], abjad.Note)
     assert isinstance(staff[1], abjad.Rest)
     assert isinstance(staff[2], abjad.Chord)
@@ -185,10 +185,10 @@ def test_Staff___getitem___02():
     )
 
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     components = staff[0:0]
     assert len(components) == 0
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Staff___getitem___03():
@@ -203,13 +203,13 @@ def test_Staff___getitem___03():
     )
 
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     components = staff[0:1]
     assert len(components) == 1
     assert isinstance(components[0], abjad.Note)
     for x in staff:
         assert abjad.get.parentage(x).parent == staff
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Staff___getitem___04():
@@ -224,13 +224,13 @@ def test_Staff___getitem___04():
     )
 
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     components = staff[-1:]
     assert len(components) == 1
     assert isinstance(components[0], abjad.Tuplet)
     for x in components:
         assert abjad.get.parentage(x).parent == staff
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Staff___getitem___05():
@@ -245,7 +245,7 @@ def test_Staff___getitem___05():
     )
 
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     components = staff[1:-1]
     assert len(components) == 3
     assert isinstance(components[0], abjad.Rest)
@@ -253,7 +253,7 @@ def test_Staff___getitem___05():
     assert isinstance(components[2], abjad.Skip)
     for x in components:
         assert abjad.get.parentage(x).parent == staff
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Staff___getitem___06():
@@ -268,7 +268,7 @@ def test_Staff___getitem___06():
     )
 
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     components = staff[2:]
     assert len(components) == 3
     assert isinstance(components[0], abjad.Chord)
@@ -276,7 +276,7 @@ def test_Staff___getitem___06():
     assert isinstance(components[2], abjad.Tuplet)
     for x in components:
         assert abjad.get.parentage(x).parent == staff
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Staff___getitem___07():
@@ -291,7 +291,7 @@ def test_Staff___getitem___07():
     )
 
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     components = staff[:-2]
     assert len(components) == 3
     assert isinstance(components[0], abjad.Note)
@@ -299,7 +299,7 @@ def test_Staff___getitem___07():
     assert isinstance(components[2], abjad.Chord)
     for x in components:
         assert abjad.get.parentage(x).parent == staff
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Staff___getitem___08():
@@ -314,7 +314,7 @@ def test_Staff___getitem___08():
     )
 
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     components = staff[:]
     assert len(components) == 5
     assert isinstance(components[0], abjad.Note)
@@ -365,7 +365,7 @@ def test_Staff___setitem___01():
     )
 
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert isinstance(staff[0], abjad.Note)
     assert isinstance(staff[1], abjad.Rest)
     assert isinstance(staff[2], abjad.Chord)
@@ -373,7 +373,7 @@ def test_Staff___setitem___01():
     assert isinstance(staff[4], abjad.Tuplet)
     staff[1] = abjad.Chord([12, 13, 15], (1, 4))
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert isinstance(staff[0], abjad.Note)
     assert isinstance(staff[1], abjad.Chord)
     assert isinstance(staff[2], abjad.Chord)
@@ -381,7 +381,7 @@ def test_Staff___setitem___01():
     assert isinstance(staff[4], abjad.Tuplet)
     staff[0] = abjad.Rest((1, 4))
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert isinstance(staff[0], abjad.Rest)
     assert isinstance(staff[1], abjad.Chord)
     assert isinstance(staff[2], abjad.Chord)
@@ -389,7 +389,7 @@ def test_Staff___setitem___01():
     assert isinstance(staff[4], abjad.Tuplet)
     staff[-2] = abjad.Tuplet("3:2", "c'8 c'8 c'8")
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert isinstance(staff[0], abjad.Rest)
     assert isinstance(staff[1], abjad.Chord)
     assert isinstance(staff[2], abjad.Chord)
@@ -397,7 +397,7 @@ def test_Staff___setitem___01():
     assert isinstance(staff[4], abjad.Tuplet)
     staff[-1] = abjad.Note(13, (1, 4))
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert isinstance(staff[0], abjad.Rest)
     assert isinstance(staff[1], abjad.Chord)
     assert isinstance(staff[2], abjad.Chord)
@@ -405,7 +405,7 @@ def test_Staff___setitem___01():
     assert isinstance(staff[4], abjad.Note)
     staff[-3] = abjad.Skip((1, 4))
     assert len(staff) == 5
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert isinstance(staff[0], abjad.Rest)
     assert isinstance(staff[1], abjad.Chord)
     assert isinstance(staff[2], abjad.Skip)
@@ -476,7 +476,7 @@ def test_Staff___setitem___07():
         assert x.written_pitch == "d'"
     for x in staff[4:8]:
         assert x.written_pitch == "c'"
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Staff___setitem___08():
@@ -493,7 +493,7 @@ def test_Staff___setitem___08():
         assert x.written_duration == abjad.Duration(1, 4)
     for x in staff[4:8]:
         assert x.written_duration == abjad.Duration(1, 8)
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Staff___setitem___09():
@@ -511,7 +511,7 @@ def test_Staff___setitem___09():
             assert isinstance(x, abjad.Tuplet)
         else:
             assert isinstance(x, abjad.Note)
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_Staff_append_01():
@@ -521,7 +521,7 @@ def test_Staff_append_01():
 
     staff = abjad.Staff("c'4 c'4 c'4 c'4")
     staff.append(abjad.Note("c'4"))
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(staff) == 5
     assert staff._get_contents_duration() == abjad.Duration(5, 4)
 
@@ -533,7 +533,7 @@ def test_Staff_append_02():
 
     staff = abjad.Staff("c'4 c'4 c'4 c'4")
     staff.append(abjad.Chord([2, 3, 4], (1, 4)))
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(staff) == 5
     assert staff._get_contents_duration() == abjad.Duration(5, 4)
 
@@ -545,7 +545,7 @@ def test_Staff_append_03():
 
     staff = abjad.Staff("c'4 c'4 c'4 c'4")
     staff.append(abjad.Tuplet("3:2", "c'8 c'8 c'8"))
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(staff) == 5
     assert staff._get_contents_duration() == abjad.Duration(5, 4)
 
@@ -555,7 +555,7 @@ def test_Staff_engraver_consists_01():
     staff.consists_commands.append("Horizontal_bracket_engraver")
     staff.consists_commands.append("Instrument_name_engraver")
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert abjad.lilypond(staff) == abjad.string.normalize(
         r"""
         \new Staff
@@ -596,4 +596,4 @@ def test_Staff_engraver_removals_01():
         """
     )
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)

--- a/tests/test_Voice.py
+++ b/tests/test_Voice.py
@@ -88,8 +88,8 @@ def test_Voice___delitem___01():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
-    assert abjad.wf.wellformed(container)
+    assert abjad.wf.is_wellformed(voice)
+    assert abjad.wf.is_wellformed(container)
 
 
 def test_Voice___init__01():

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -342,7 +342,7 @@ def test_get_staff_01():
         """
     )
 
-    assert abjad.wf.wellformed(staff_group)
+    assert abjad.wf.is_wellformed(staff_group)
     assert abjad.get.effective_staff(staff_group[0][0]) is staff_group[1]
     assert abjad.get.effective_staff(staff_group[0][1]) is staff_group[1]
     assert abjad.get.effective_staff(staff_group[0][2]) is staff_group[1]
@@ -394,7 +394,7 @@ def test_get_staff_02():
         """
     )
 
-    assert abjad.wf.wellformed(staff_group)
+    assert abjad.wf.is_wellformed(staff_group)
     assert abjad.get.effective_staff(staff_group[0][0]) is staff_group[1]
     assert abjad.get.effective_staff(staff_group[0][1]) is staff_group[1]
     assert abjad.get.effective_staff(staff_group[0][2]) is staff_group[0]
@@ -443,7 +443,7 @@ def test_get_staff_03():
         """
     )
 
-    assert abjad.wf.wellformed(staff_group)
+    assert abjad.wf.is_wellformed(staff_group)
 
 
 def test_get_staff_04():
@@ -487,7 +487,7 @@ def test_get_staff_04():
         """
     )
 
-    assert abjad.wf.wellformed(staff_group)
+    assert abjad.wf.is_wellformed(staff_group)
     assert abjad.get.effective_staff(staff_group[0][0]) is staff_group[1]
     assert abjad.get.effective_staff(staff_group[0][1]) is staff_group[1]
     assert abjad.get.effective_staff(staff_group[0][2]) is staff_group[1]

--- a/tests/test_mutate_copy.py
+++ b/tests/test_mutate_copy.py
@@ -69,8 +69,8 @@ def test_mutate_copy_01():
         """,
         print(abjad.lilypond(new)),
     )
-    assert abjad.wf.wellformed(score)
-    assert abjad.wf.wellformed(new)
+    assert abjad.wf.is_wellformed(score)
+    assert abjad.wf.is_wellformed(new)
 
 
 def test_mutate_copy_02():
@@ -142,8 +142,8 @@ def test_mutate_copy_02():
         """
     ), print(abjad.lilypond(new))
 
-    assert abjad.wf.wellformed(voice)
-    assert abjad.wf.wellformed(new)
+    assert abjad.wf.is_wellformed(voice)
+    assert abjad.wf.is_wellformed(new)
 
 
 def test_mutate_copy_03():
@@ -305,7 +305,7 @@ def test_mutate_copy_04():
         """
     ), print(abjad.lilypond(new_voice))
 
-    assert abjad.wf.wellformed(new_voice)
+    assert abjad.wf.is_wellformed(new_voice)
 
 
 def test_mutate_copy_05():
@@ -389,7 +389,7 @@ def test_mutate_copy_05():
         """
     ), print(abjad.lilypond(new_voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_copy_06():
@@ -598,7 +598,7 @@ def test_mutate_copy_08():
         }
         """
     )
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_copy_09():
@@ -624,4 +624,4 @@ def test_mutate_copy_09():
         }
         """
     ), print(string)
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)

--- a/tests/test_mutate_extract.py
+++ b/tests/test_mutate_extract.py
@@ -45,8 +45,8 @@ def test_mutate_extract_01():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(note)
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(note)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_extract_02():
@@ -92,9 +92,9 @@ def test_mutate_extract_02():
     ), print(abjad.lilypond(voice))
 
     for note in notes:
-        assert abjad.wf.wellformed(note)
+        assert abjad.wf.is_wellformed(note)
 
-    assert abjad.wf.wellformed(voice, do_not_check_overlapping_beams=True)
+    assert abjad.wf.is_wellformed(voice, do_not_check_overlapping_beams=True)
 
 
 def test_mutate_extract_03():
@@ -146,7 +146,7 @@ def test_mutate_extract_03():
     ), print(abjad.lilypond(voice))
 
     assert not container
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_extract_04():
@@ -219,4 +219,4 @@ def test_mutate_extract_04():
     for container in containers:
         assert not container
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)

--- a/tests/test_mutate_fuse.py
+++ b/tests/test_mutate_fuse.py
@@ -65,7 +65,7 @@ def test_mutate_fuse_04():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_fuse_05():
@@ -101,7 +101,7 @@ def test_mutate_fuse_05():
     )
 
     assert abjad.get.duration(staff) == abjad.Duration(3, 8)
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_mutate_fuse_06():
@@ -167,7 +167,7 @@ def test_mutate_fuse_06():
     assert len(tuplet_1) == 0
     assert len(tuplet_2) == 0
     assert new is not tuplet_1 and new is not tuplet_2
-    assert abjad.wf.wellformed(new)
+    assert abjad.wf.is_wellformed(new)
 
 
 def test_mutate_fuse_07():
@@ -230,7 +230,7 @@ def test_mutate_fuse_07():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_fuse_08():
@@ -298,7 +298,7 @@ def test_mutate_fuse_09():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_fuse_10():

--- a/tests/test_mutate_helpers.py
+++ b/tests/test_mutate_helpers.py
@@ -254,7 +254,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_01():
     ), print(abjad.lilypond(staff))
 
     assert len(result) == 2
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_mutate__fuse_leaves_by_immediate_parent_02():
@@ -292,7 +292,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_02():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(result) == 1
 
 
@@ -305,7 +305,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_03():
     logical_tie = abjad.get.logical_tie(note)
     result = abjad.mutate._fuse_leaves_by_immediate_parent(logical_tie)
     assert len(result) == 1
-    assert abjad.wf.wellformed(note)
+    assert abjad.wf.is_wellformed(note)
 
 
 def test_mutate__fuse_leaves_by_immediate_parent_04():
@@ -333,7 +333,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_04():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
     assert len(result) == 1
 
 
@@ -366,7 +366,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_05():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
     assert len(result) == 1
 
 
@@ -395,7 +395,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_06():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
     assert len(result) == 1
 
 
@@ -431,7 +431,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_07():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(result) == 1
 
 
@@ -477,7 +477,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_08():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(result) == 1
 
 
@@ -534,7 +534,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_09():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(result) == 1
 
 
@@ -584,7 +584,7 @@ def test_mutate__fuse_leaves_by_immediate_parent_10():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(result) == 1
 
 

--- a/tests/test_mutate_replace.py
+++ b/tests/test_mutate_replace.py
@@ -61,7 +61,7 @@ def test_mutate_replace_01():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_replace_02():
@@ -122,7 +122,7 @@ def test_mutate_replace_02():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_replace_03():
@@ -179,7 +179,7 @@ def test_mutate_replace_03():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_replace_04():
@@ -236,7 +236,7 @@ def test_mutate_replace_04():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_replace_05():
@@ -289,7 +289,7 @@ def test_mutate_replace_05():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_replace_06():
@@ -342,4 +342,4 @@ def test_mutate_replace_06():
     ), print(abjad.lilypond(staff))
 
     assert not voice
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)

--- a/tests/test_mutate_split.py
+++ b/tests/test_mutate_split.py
@@ -41,7 +41,7 @@ def test_mutate__set_leaf_duration_01():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate__set_leaf_duration_02():
@@ -88,7 +88,7 @@ def test_mutate__set_leaf_duration_02():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate__set_leaf_duration_03():
@@ -130,7 +130,7 @@ def test_mutate__set_leaf_duration_03():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate__set_leaf_duration_04():
@@ -179,7 +179,7 @@ def test_mutate__set_leaf_duration_04():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate__set_leaf_duration_05():
@@ -226,7 +226,7 @@ def test_mutate__set_leaf_duration_05():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate__set_leaf_duration_06():
@@ -242,7 +242,7 @@ def test_mutate__set_leaf_duration_06():
 
     abjad.mutate._set_leaf_duration(note, abjad.Duration(1, 32))
 
-    assert abjad.wf.wellformed(note)
+    assert abjad.wf.is_wellformed(note)
     assert abjad.lilypond(note) == "c'8 * 1/4"
 
 
@@ -259,7 +259,7 @@ def test_mutate__set_leaf_duration_07():
 
     abjad.mutate._set_leaf_duration(note, abjad.Duration(3, 32))
 
-    assert abjad.wf.wellformed(note)
+    assert abjad.wf.is_wellformed(note)
     assert abjad.lilypond(note) == "c'8 * 3/4"
 
 
@@ -276,7 +276,7 @@ def test_mutate__set_leaf_duration_08():
 
     abjad.mutate._set_leaf_duration(note, abjad.Duration(5, 32))
 
-    assert abjad.wf.wellformed(note)
+    assert abjad.wf.is_wellformed(note)
     assert abjad.lilypond(note) == "c'8 * 5/4"
 
 
@@ -293,7 +293,7 @@ def test_mutate__set_leaf_duration_09():
 
     abjad.mutate._set_leaf_duration(note, abjad.Duration(1, 24))
 
-    assert abjad.wf.wellformed(note)
+    assert abjad.wf.is_wellformed(note)
     assert abjad.lilypond(note) == "c'8 * 1/3"
 
 
@@ -310,7 +310,7 @@ def test_mutate__set_leaf_duration_10():
 
     abjad.mutate._set_leaf_duration(note, abjad.Duration(5, 24))
 
-    assert abjad.wf.wellformed(note)
+    assert abjad.wf.is_wellformed(note)
     assert abjad.lilypond(note) == "c'8 * 5/3"
 
 
@@ -353,7 +353,7 @@ def test_mutate__set_leaf_duration_11():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate__split_container_by_duration_01():
@@ -420,7 +420,7 @@ def test_mutate__split_container_by_duration_01():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate__split_container_by_duration_02():
@@ -495,7 +495,7 @@ def test_mutate__split_container_by_duration_02():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate__split_leaf_by_durations_01():
@@ -537,7 +537,7 @@ def test_mutate__split_leaf_by_durations_01():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_mutate__split_leaf_by_durations_02():
@@ -576,7 +576,7 @@ def test_mutate__split_leaf_by_durations_02():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate__split_leaf_by_durations_03():
@@ -611,7 +611,7 @@ def test_mutate__split_leaf_by_durations_05():
     abjad.mutate._split_leaf_by_durations(staff[0], [abjad.Duration(1, 8)])
 
     assert len(staff) == 2
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_mutate__split_leaf_by_durations_06():
@@ -638,7 +638,7 @@ def test_mutate__split_leaf_by_durations_06():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_mutate__split_leaf_by_durations_07():
@@ -670,7 +670,7 @@ def test_mutate__split_leaf_by_durations_07():
 
     assert abjad.get.after_grace_container(new_leaves[0]) is None
     assert len(abjad.get.after_grace_container(new_leaves[1])) == 1
-    abjad.wf.wellformed(staff)
+    abjad.wf.is_wellformed(staff)
 
 
 def test_mutate__split_leaf_by_durations_08():
@@ -702,7 +702,7 @@ def test_mutate__split_leaf_by_durations_08():
         """
     ), print(abjad.lilypond(staff))
 
-    abjad.wf.wellformed(staff)
+    abjad.wf.is_wellformed(staff)
 
 
 def test_mutate__split_leaf_by_durations_09():
@@ -731,7 +731,7 @@ def test_mutate__split_leaf_by_durations_09():
         """
     ), print(abjad.lilypond(staff))
 
-    abjad.wf.wellformed(staff)
+    abjad.wf.is_wellformed(staff)
 
 
 def test_mutate__split_leaf_by_durations_10():
@@ -796,7 +796,7 @@ def test_mutate__split_leaf_by_durations_10():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_split_01():
@@ -863,7 +863,7 @@ def test_mutate_split_01():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
     assert len(result) == 3
 
 
@@ -947,7 +947,7 @@ def test_mutate_split_02():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(result) == 6
 
 
@@ -1030,7 +1030,7 @@ def test_mutate_split_03():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(result) == 4
 
 
@@ -1114,7 +1114,7 @@ def test_mutate_split_04():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(result) == 8
 
 
@@ -1201,7 +1201,7 @@ def test_mutate_split_05():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(result) == 4
 
 
@@ -1296,7 +1296,7 @@ def test_mutate_split_06():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
     assert len(result) == 6
 
 
@@ -1342,7 +1342,7 @@ def test_mutate_split_07():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_split_08():
@@ -1381,7 +1381,7 @@ def test_mutate_split_08():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_split_09():
@@ -1408,7 +1408,7 @@ def test_mutate_split_09():
         """
     ), print(abjad.lilypond(voice_1))
 
-    assert abjad.wf.wellformed(voice_1)
+    assert abjad.wf.is_wellformed(voice_1)
 
     assert abjad.lilypond(voice_2) == abjad.string.normalize(
         r"""
@@ -1420,7 +1420,7 @@ def test_mutate_split_09():
         """
     ), print(abjad.lilypond(voice_2))
 
-    assert abjad.wf.wellformed(voice_2)
+    assert abjad.wf.is_wellformed(voice_2)
 
 
 def test_mutate_split_10():
@@ -1482,7 +1482,7 @@ def test_mutate_split_10():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_mutate_split_11():
@@ -1563,7 +1563,7 @@ def test_mutate_split_11():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_split_12():
@@ -1664,7 +1664,7 @@ def test_mutate_split_12():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)
 
 
 def test_mutate_split_13():
@@ -1730,7 +1730,7 @@ def test_mutate_split_13():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_split_14():
@@ -1788,7 +1788,7 @@ def test_mutate_split_14():
         """
     ), print(abjad.lilypond(voice))
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_mutate_split_15():
@@ -1817,4 +1817,4 @@ def test_mutate_split_15():
         """
     ), print(abjad.lilypond(staff))
 
-    assert abjad.wf.wellformed(staff)
+    assert abjad.wf.is_wellformed(staff)

--- a/tests/test_mutate_swap.py
+++ b/tests/test_mutate_swap.py
@@ -60,7 +60,7 @@ def test_Mutation_swap_01():
         """
     )
 
-    assert abjad.wf.wellformed(voice, do_not_check_overlapping_beams=True)
+    assert abjad.wf.is_wellformed(voice, do_not_check_overlapping_beams=True)
 
 
 def test_Mutation_swap_02():
@@ -122,7 +122,7 @@ def test_Mutation_swap_02():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Mutation_swap_03():
@@ -184,7 +184,7 @@ def test_Mutation_swap_03():
         """
     )
 
-    assert abjad.wf.wellformed(voice)
+    assert abjad.wf.is_wellformed(voice)
 
 
 def test_Mutation_swap_04():
@@ -285,4 +285,4 @@ def test_Mutation_swap_07():
         """
     )
 
-    assert abjad.wf.wellformed(new_measure)
+    assert abjad.wf.is_wellformed(new_measure)


### PR DESCRIPTION
Rename `abjad.wf.is_wellformed().

    OLD: abjad.wf.wellformed()
    NEW: abjad.wf.is_wellformed()