### PR TITLE
Rename proportion functions

### DIFF
--- a/source/abjad/math.py
+++ b/source/abjad/math.py
@@ -383,25 +383,28 @@ def difference_series(argument):
     return type(argument)(result)
 
 
-def divide_integer_by_ratio(n, ratio) -> list[fractions.Fraction | float]:
+# TODO: constrain `n` to integer
+def divide_integer_by_proportion(
+    n: int | float, proportion: tuple[int, ...]
+) -> list[fractions.Fraction | float]:
     """
-    Divides integer ``n`` by tuple ``ratio``.
+    Divides integer ``n`` by tuple ``proportion``.
 
     ..  container:: example
 
-        >>> abjad.math.divide_integer_by_ratio(1, (1, 1, 3))
+        >>> abjad.math.divide_integer_by_proportion(1, (1, 1, 3))
         [Fraction(1, 5), Fraction(1, 5), Fraction(3, 5)]
 
     ..  container:: example
 
-        >>> abjad.math.divide_integer_by_ratio(1.0, (1, 1, 3))
+        >>> abjad.math.divide_integer_by_proportion(1.0, (1, 1, 3))
         [0.2, 0.2, 0.6]
 
     """
     assert isinstance(n, int | float), repr(n)
-    assert isinstance(ratio, tuple), repr(ratio)
-    denominator = sum(ratio)
-    factors = [fractions.Fraction(_, denominator) for _ in ratio]
+    assert isinstance(proportion, tuple), repr(proportion)
+    denominator = sum(proportion)
+    factors = [fractions.Fraction(_, denominator) for _ in proportion]
     result = [n * _ for _ in factors]
     return result
 
@@ -990,69 +993,68 @@ def _least_common_multiple_helper(m, n):
     return result
 
 
-def partition_integer_by_ratio(n, ratio) -> list[int]:
+def partition_integer_by_proportion(n: int, proportion: tuple[int, ...]) -> list[int]:
     """
-    Partitions positive integer-equivalent ``n`` by ``ratio``.
+    Partitions positive integer-equivalent ``n`` by ``proportion``.
 
     Returns result with weight equal to absolute value of ``n``.
 
     ..  container:: example
 
-        Partitions positive integer-equivalent ``n`` by ``ratio`` with positive
+        Partitions positive integer-equivalent ``n`` by ``proportion`` with positive
         parts:
 
-        >>> abjad.math.partition_integer_by_ratio(10, (1, 2))
+        >>> abjad.math.partition_integer_by_proportion(10, (1, 2))
         [3, 7]
 
     ..  container:: example
 
-        Partitions positive integer-equivalent ``n`` by ``ratio`` with negative
+        Partitions positive integer-equivalent ``n`` by ``proportion`` with negative
         parts:
 
-        >>> abjad.math.partition_integer_by_ratio(10, (1, -2))
+        >>> abjad.math.partition_integer_by_proportion(10, (1, -2))
         [3, -7]
 
     ..  container:: example
 
-        Partitions negative integer-equivalent ``n`` by ``ratio``:
+        Partitions negative integer-equivalent ``n`` by ``proportion``:
 
-        >>> abjad.math.partition_integer_by_ratio(-10, (1, 2))
+        >>> abjad.math.partition_integer_by_proportion(-10, (1, 2))
         [-3, -7]
 
     ..  container:: example
 
-        Partitions negative integer-equivalent ``n`` by ``ratio`` with negative
+        Partitions negative integer-equivalent ``n`` by ``proportion`` with negative
         parts:
 
-        >>> abjad.math.partition_integer_by_ratio(-10, (1, -2))
+        >>> abjad.math.partition_integer_by_proportion(-10, (1, -2))
         [-3, 7]
 
     ..  container:: example
 
         More examples:
 
-        >>> abjad.math.partition_integer_by_ratio(10, (1,))
+        >>> abjad.math.partition_integer_by_proportion(10, (1,))
         [10]
 
-        >>> abjad.math.partition_integer_by_ratio(10, (1, 1))
+        >>> abjad.math.partition_integer_by_proportion(10, (1, 1))
         [5, 5]
 
-        >>> abjad.math.partition_integer_by_ratio(10, (1, -1, -1))
+        >>> abjad.math.partition_integer_by_proportion(10, (1, -1, -1))
         [3, -4, -3]
 
-        >>> abjad.math.partition_integer_by_ratio(-10, (1, 1, 1, 1))
+        >>> abjad.math.partition_integer_by_proportion(-10, (1, 1, 1, 1))
         [-3, -2, -3, -2]
 
-        >>> abjad.math.partition_integer_by_ratio(-10, (1, 1, 1, 1, 1))
+        >>> abjad.math.partition_integer_by_proportion(-10, (1, 1, 1, 1, 1))
         [-2, -2, -2, -2, -2]
 
     """
-    if not is_integer_equivalent_number(n):
-        raise TypeError(f"is not integer-equivalent number: {n!r}.")
-    if not all(is_integer_equivalent_number(_) for _ in ratio):
-        raise ValueError(f"must be integer tuple ratio, not {ratio!r}.")
+    # assert isinstance(n, int), repr(n)
+    assert isinstance(proportion, tuple), repr(proportion)
+    assert all(isinstance(_, int) for _ in proportion), repr(proportion)
     result = [0]
-    parts = [float(abs(n)) * abs(_) / weight(ratio) for _ in ratio]
+    parts = [float(abs(n)) * abs(_) / weight(proportion) for _ in proportion]
     cumulative_parts = cumulative_sums(parts, start=None)
     for part in cumulative_parts:
         rounded_part = int(round(part)) - sum(result)
@@ -1062,7 +1064,7 @@ def partition_integer_by_ratio(n, ratio) -> list[int]:
     result = result[1:]
     if sign(n) == -1:
         result = [-_ for _ in result]
-    ratio_signs = [sign(_) for _ in ratio]
+    ratio_signs = [sign(_) for _ in proportion]
     result = [pair[0] * pair[1] for pair in zip(ratio_signs, result)]
     return result
 

--- a/source/abjad/select.py
+++ b/source/abjad/select.py
@@ -5901,20 +5901,20 @@ def partition_by_durations(
     return selections
 
 
-def partition_by_ratio(argument, ratio: tuple[int, ...]) -> list[list]:
+def partition_by_proportion(argument, proportion: tuple[int, ...]) -> list[list]:
     r"""
-    Partitions items in ``argument`` by ``ratio``.
+    Partitions items in ``argument`` by ``proportion``.
 
     ..  container:: example
 
-        Partitions leaves by a ratio of 1:1:
+        Partitions leaves by a proportion of 1:1:
 
         >>> string = r"c'8 d' r \tuplet 3/2 { e' r f' } g' a' r"
         >>> staff = abjad.Staff(string)
         >>> abjad.setting(staff).autoBeaming = False
 
         >>> result = abjad.select.leaves(staff)
-        >>> result = abjad.select.partition_by_ratio(result, (1, 1))
+        >>> result = abjad.select.partition_by_proportion(result, (1, 1))
         >>> for item in result:
         ...     item
         ...
@@ -5960,14 +5960,14 @@ def partition_by_ratio(argument, ratio: tuple[int, ...]) -> list[list]:
 
     ..  container:: example
 
-        Partitions leaves by a ratio of 1:1:1:
+        Partitions leaves by a proportion of 1:1:1:
 
         >>> string = r"c'8 d' r \tuplet 3/2 { e' r f' } g' a' r"
         >>> staff = abjad.Staff(string)
         >>> abjad.setting(staff).autoBeaming = False
 
         >>> result = abjad.select.leaves(staff)
-        >>> result = abjad.select.partition_by_ratio(result, (1, 1, 1))
+        >>> result = abjad.select.partition_by_proportion(result, (1, 1, 1))
         >>> for item in result:
         ...     item
         ...
@@ -6013,8 +6013,9 @@ def partition_by_ratio(argument, ratio: tuple[int, ...]) -> list[list]:
             }
 
     """
-    ratio = ratio or (1,)
-    counts = _math.partition_integer_by_ratio(len(argument), ratio)
+    assert isinstance(proportion, tuple), repr(proportion)
+    assert all(isinstance(_, int) for _ in proportion), repr(proportion)
+    counts = _math.partition_integer_by_proportion(len(argument), proportion)
     parts = _sequence.partition_by_counts(argument, counts=counts)
     selections = [list(_) for _ in parts]
     return selections

--- a/source/abjad/sequence.py
+++ b/source/abjad/sequence.py
@@ -644,20 +644,20 @@ def partition_by_counts(
     return result
 
 
-def partition_by_ratio_of_lengths(sequence, ratio: tuple[int, ...]) -> list:
+def partition_by_proportion_of_lengths(sequence, proportion: tuple[int, ...]) -> list:
     r"""
-    Partitions ``sequence`` by ``ratio`` of lengths.
+    Partitions ``sequence`` by ``proportion`` of lengths.
 
     Returns list of ``sequence`` types.
 
     ..  container:: example
 
-        Partitions sequence by ``1:1:1`` ratio:
+        Partitions sequence by ``1:1:1`` proportion:
 
         >>> numbers = list(range(10))
-        >>> ratio = (1, 1, 1)
+        >>> proportion = (1, 1, 1)
 
-        >>> for part in abjad.sequence.partition_by_ratio_of_lengths(numbers, ratio):
+        >>> for part in abjad.sequence.partition_by_proportion_of_lengths(numbers, proportion):
         ...     part
         [0, 1, 2]
         [3, 4, 5, 6]
@@ -665,28 +665,29 @@ def partition_by_ratio_of_lengths(sequence, ratio: tuple[int, ...]) -> list:
 
     ..  container:: example
 
-        Partitions sequence by ``1:1:2`` ratio:
+        Partitions sequence by ``1:1:2`` proportion:
 
         >>> numbers = list(range(10))
-        >>> ratio = (1, 1, 2)
+        >>> proportion = (1, 1, 2)
 
-        >>> for part in abjad.sequence.partition_by_ratio_of_lengths(numbers, ratio):
+        >>> for part in abjad.sequence.partition_by_proportion_of_lengths(numbers, proportion):
         ...     part
         [0, 1, 2]
         [3, 4]
         [5, 6, 7, 8, 9]
 
     """
-    assert isinstance(ratio, tuple), repr(ratio)
+    assert isinstance(proportion, tuple), repr(proportion)
+    assert all(isinstance(_, int) for _ in proportion), repr(proportion)
     length = len(sequence)
-    counts = _math.partition_integer_by_ratio(length, ratio)
+    counts = _math.partition_integer_by_proportion(length, proportion)
     parts = partition_by_counts(sequence, counts, cyclic=False, overhang=_enums.EXACT)
     return parts
 
 
-def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> list:
+def partition_by_proportion_of_weights(sequence, weights: tuple[int, ...]) -> list:
     """
-    Partitions ``sequence`` by ratio of ``weights``.
+    Partitions ``sequence`` by proportion of ``weights``.
 
     Rounded weight-proportions of sequences returned equal to rounded ``weights``.
 
@@ -694,9 +695,9 @@ def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> li
 
     ..  container:: example
 
-        >>> ratio = (1, 1, 1)
+        >>> weights = (1, 1, 1)
         >>> sequence = list(10 * [1])
-        >>> sequence = abjad.sequence.partition_by_ratio_of_weights(sequence, ratio)
+        >>> sequence = abjad.sequence.partition_by_proportion_of_weights(sequence, weights)
         >>> for item in sequence:
         ...     item
         ...
@@ -706,9 +707,9 @@ def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> li
 
     ..  container:: example
 
-        >>> ratio = (1, 1, 1, 1)
+        >>> weights = (1, 1, 1, 1)
         >>> sequence = list(10 * [1])
-        >>> sequence = abjad.sequence.partition_by_ratio_of_weights(sequence, ratio)
+        >>> sequence = abjad.sequence.partition_by_proportion_of_weights(sequence, weights)
         >>> for item in sequence:
         ...     item
         ...
@@ -719,9 +720,9 @@ def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> li
 
     ..  container:: example
 
-        >>> ratio = (2, 2, 3)
+        >>> weights = (2, 2, 3)
         >>> sequence = list(10 * [1])
-        >>> sequence = abjad.sequence.partition_by_ratio_of_weights(sequence, ratio)
+        >>> sequence = abjad.sequence.partition_by_proportion_of_weights(sequence, weights)
         >>> for item in sequence:
         ...     item
         ...
@@ -731,9 +732,9 @@ def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> li
 
     ..  container:: example
 
-        >>> ratio = (3, 2, 2)
+        >>> weights = (3, 2, 2)
         >>> sequence = list(10 * [1])
-        >>> sequence = abjad.sequence.partition_by_ratio_of_weights(sequence, ratio)
+        >>> sequence = abjad.sequence.partition_by_proportion_of_weights(sequence, weights)
         >>> for item in sequence:
         ...     item
         ...
@@ -743,10 +744,10 @@ def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> li
 
     ..  container:: example
 
-        >>> ratio = (1, 1)
+        >>> weights = (1, 1)
         >>> items = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2]
         >>> sequence = list(items)
-        >>> sequence = abjad.sequence.partition_by_ratio_of_weights(sequence, ratio)
+        >>> sequence = abjad.sequence.partition_by_proportion_of_weights(sequence, weights)
         >>> for item in sequence:
         ...     item
         ...
@@ -755,10 +756,10 @@ def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> li
 
     ..  container:: example
 
-        >>> ratio = (1, 1, 1)
+        >>> weights = (1, 1, 1)
         >>> items = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2]
         >>> sequence = list(items)
-        >>> sequence = abjad.sequence.partition_by_ratio_of_weights(sequence, ratio)
+        >>> sequence = abjad.sequence.partition_by_proportion_of_weights(sequence, weights)
         >>> for item in sequence:
         ...     item
         ...
@@ -768,9 +769,9 @@ def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> li
 
     ..  container:: example
 
-        >>> ratio = (1, 1, 1)
+        >>> weights = (1, 1, 1)
         >>> sequence = list([5, 5])
-        >>> sequence = abjad.sequence.partition_by_ratio_of_weights(sequence, ratio)
+        >>> sequence = abjad.sequence.partition_by_proportion_of_weights(sequence, weights)
         >>> for item in sequence:
         ...     item
         ...
@@ -780,9 +781,9 @@ def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> li
 
     ..  container:: example
 
-        >>> ratio = (1, 1, 1, 1)
+        >>> weights = (1, 1, 1, 1)
         >>> sequence = list([5, 5])
-        >>> sequence = abjad.sequence.partition_by_ratio_of_weights(sequence, ratio)
+        >>> sequence = abjad.sequence.partition_by_proportion_of_weights(sequence, weights)
         >>> for item in sequence:
         ...     item
         ...
@@ -793,9 +794,9 @@ def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> li
 
     ..  container:: example
 
-        >>> ratio = (2, 2, 3)
+        >>> weights = (2, 2, 3)
         >>> sequence = list([5, 5])
-        >>> sequence = abjad.sequence.partition_by_ratio_of_weights(sequence, ratio)
+        >>> sequence = abjad.sequence.partition_by_proportion_of_weights(sequence, weights)
         >>> for item in sequence:
         ...     item
         ...
@@ -805,9 +806,9 @@ def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> li
 
     ..  container:: example
 
-        >>> ratio = (3, 2, 2)
+        >>> weights = (3, 2, 2)
         >>> sequence = list([5, 5])
-        >>> sequence = abjad.sequence.partition_by_ratio_of_weights(sequence, ratio)
+        >>> sequence = abjad.sequence.partition_by_proportion_of_weights(sequence, weights)
         >>> for item in sequence:
         ...     item
         ...
@@ -817,8 +818,12 @@ def partition_by_ratio_of_weights(sequence, weights: typing.Sequence[int]) -> li
 
     """
     assert all(isinstance(_, int | float | fractions.Fraction) for _ in sequence)
+    assert isinstance(weights, tuple), repr(weights)
+    assert all(isinstance(_, int) for _ in weights), repr(weights)
     sequence_weight = _math.weight(sequence)
-    partitioned_weights = _math.partition_integer_by_ratio(sequence_weight, weights)
+    partitioned_weights = _math.partition_integer_by_proportion(
+        sequence_weight, tuple(weights)
+    )
     cumulative_weights = _math.cumulative_sums(partitioned_weights, start=None)
     items = []
     sublist: list[typing.Any] = []

--- a/source/abjad/timespan.py
+++ b/source/abjad/timespan.py
@@ -918,15 +918,17 @@ class Timespan:
 
     ### PUBLIC METHODS ###
 
-    def divide_by_ratio(self, ratio) -> tuple["Timespan", ...]:
+    def divide_by_proportion(
+        self, proportion: tuple[int, ...]
+    ) -> tuple["Timespan", ...]:
         """
-        Divides timespan by ``ratio``.
+        Divides timespan by ``proportion``.
 
         ..  container:: example
 
             >>> timespan = abjad.Timespan((1, 2), (3, 2))
 
-            >>> for x in timespan.divide_by_ratio((1, 2, 1)):
+            >>> for x in timespan.divide_by_proportion((1, 2, 1)):
             ...     x
             ...
             Timespan(Offset((1, 2)), Offset((3, 4)))
@@ -934,10 +936,10 @@ class Timespan:
             Timespan(Offset((5, 4)), Offset((3, 2)))
 
         """
-        if isinstance(ratio, int):
-            ratio = ratio * (1,)
-        unit_duration = self.duration / sum(ratio)
-        part_durations = [numerator * unit_duration for numerator in ratio]
+        assert isinstance(proportion, tuple), repr(proportion)
+        assert all(isinstance(_, int) for _ in proportion), repr(proportion)
+        unit_duration = self.duration / sum(proportion)
+        part_durations = [numerator * unit_duration for numerator in proportion]
         start_offsets = _math.cumulative_sums(
             [self.start_offset] + part_durations, start=None
         )


### PR DESCRIPTION
Rename proportion functions

    OLD: abjad.math.divide_integer_by_ratio()
    NEW: abjad.math.divide_integer_by_proportion()

    OLD: abjad.math.partition_integer_by_ratio()
    NEW: abjad.math.partition_integer_by_proportion()

    OLD: abjad.select.partition_by_ratio()
    NEW: abjad.select.partition_by_proportion()

    OLD: abjad.sequence.partition_by_ratio_of_lengths()
    NEW: abjad.sequence.partition_by_proportion_of_lengths()

    OLD: abjad.sequence.partition_by_ratio_of_weights()
    NEW: abjad.sequence.partition_by_proportion_of_weights()

    OLD: abjad.Timespan.divide_by_ratio()
    NEW: abjad.Timespan.divide_by_proportion()

These correspond with the API-wide convention that 'ratio' refers only to the `abjad.Ratio` objects used for the `abjad.Tuplet.ratio` property. The term 'proportion' now refers to proportions everywhere else in the API, usually passed as tuples of integers.