### PR TITLE
Move `hide` from indicators to `abjad.attach()`

### DIFF
--- a/source/abjad/bind.py
+++ b/source/abjad/bind.py
@@ -14,7 +14,7 @@ from . import tweaks as _tweaks
 from . import wrapper as _wrapper
 
 
-def _before_attach(indicator, context, deactivate, component):
+def _before_attach(indicator, context, deactivate, hide, synthetic_offset, component):
     if getattr(indicator, "temporarily_do_not_check", False) is True:
         return
     if hasattr(indicator, "allowable_sites"):
@@ -42,6 +42,8 @@ def _before_attach(indicator, context, deactivate, component):
         return
     if deactivate is True:
         return
+    if synthetic_offset is not None:
+        return
     for wrapper in component._get_wrappers():
         if not isinstance(wrapper.unbundle_indicator(), type(indicator)):
             continue
@@ -58,6 +60,8 @@ def _before_attach(indicator, context, deactivate, component):
             if hasattr(indicator, "hide"):
                 if indicator.hide != wrapper.unbundle_indicator().hide:
                     continue
+            if hide != wrapper.hide:
+                continue
             if getattr(indicator, "site", None) != getattr(
                 wrapper.unbundle_indicator(), "site", None
             ):
@@ -318,10 +322,10 @@ def attach(
         >>> for leaf in abjad.select.leaves(staff):
         ...     leaf, abjad.get.effective_indicator(leaf, abjad.Clef)
         ...
-        (Note("c'4"), Clef(name='alto', hide=False))
-        (Note("d'4"), Clef(name='alto', hide=False))
-        (Note("e'4"), Clef(name='alto', hide=False))
-        (Note("f'4"), Clef(name='alto', hide=False))
+        (Note("c'4"), Clef(name='alto'))
+        (Note("d'4"), Clef(name='alto'))
+        (Note("e'4"), Clef(name='alto'))
+        (Note("f'4"), Clef(name='alto'))
 
         This example sets ``context="MusicStaff"`` to show that the alto clef
         governs all notes in a custom staff context (rather than the default
@@ -352,10 +356,10 @@ def attach(
         >>> for leaf in abjad.select.leaves(staff):
         ...     leaf, abjad.get.effective_indicator(leaf, abjad.Clef)
         ...
-        (Note("c'4"), Clef(name='alto', hide=False))
-        (Note("d'4"), Clef(name='alto', hide=False))
-        (Note("e'4"), Clef(name='alto', hide=False))
-        (Note("f'4"), Clef(name='alto', hide=False))
+        (Note("c'4"), Clef(name='alto'))
+        (Note("d'4"), Clef(name='alto'))
+        (Note("e'4"), Clef(name='alto'))
+        (Note("f'4"), Clef(name='alto'))
 
     ..  container:: example
 
@@ -404,10 +408,10 @@ def attach(
         ...     clef = abjad.get.effective_indicator(staff[0], abjad.Clef)
         ...     note, clef
         ...
-        (Note("c'4"), Clef(name='treble', hide=False))
-        (Note("d'4"), Clef(name='treble', hide=False))
-        (Note("e'4"), Clef(name='treble', hide=False))
-        (Note("f'4"), Clef(name='treble', hide=False))
+        (Note("c'4"), Clef(name='treble'))
+        (Note("d'4"), Clef(name='treble'))
+        (Note("e'4"), Clef(name='treble'))
+        (Note("f'4"), Clef(name='treble'))
 
         But a lone inactivate indicator is effective when no active indicator
         is present. Note that ``tag`` must be an ``abjad.Tag`` when
@@ -441,10 +445,10 @@ def attach(
         ...     clef = abjad.get.effective_indicator(staff[0], abjad.Clef)
         ...     note, clef
         ...
-        (Note("c'4"), Clef(name='alto', hide=False))
-        (Note("d'4"), Clef(name='alto', hide=False))
-        (Note("e'4"), Clef(name='alto', hide=False))
-        (Note("f'4"), Clef(name='alto', hide=False))
+        (Note("c'4"), Clef(name='alto'))
+        (Note("d'4"), Clef(name='alto'))
+        (Note("e'4"), Clef(name='alto'))
+        (Note("f'4"), Clef(name='alto'))
 
     """
     if isinstance(indicator, _tweaks.Bundle):
@@ -454,7 +458,10 @@ def attach(
     assert not isinstance(nonbundle_indicator, _tweaks.Bundle)
     assert nonbundle_indicator is not None, repr(nonbundle_indicator)
     assert isinstance(component, _score.Component), repr(component)
-    _before_attach(nonbundle_indicator, context, deactivate, component)
+    assert isinstance(hide, bool), repr(hide)
+    _before_attach(
+        nonbundle_indicator, context, deactivate, hide, synthetic_offset, component
+    )
     _unsafe_attach(
         indicator,
         component,
@@ -674,7 +681,7 @@ def detach(indicator, component: _score.Component, *, by_id: bool = False) -> tu
 
         >>> wrapper = abjad.get.wrappers(staff[0])[0]
         >>> abjad.detach(wrapper, wrapper.component)
-        (Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string='')),)
+        (Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string='')),)
 
         >>> abjad.show(staff) # doctest: +SKIP
 

--- a/source/abjad/contextmanagers.py
+++ b/source/abjad/contextmanagers.py
@@ -144,9 +144,9 @@ class ForbidUpdate:
             ...         print(abjad.get.effective_indicator(note, abjad.Clef))
             ...
             Note("c'4")
-            Clef(name='alto', hide=False)
+            Clef(name='alto')
             Note("d'4")
-            Clef(name='alto', hide=False)
+            Clef(name='alto')
 
         """
         for component_ in _iterate.components(self.component):

--- a/source/abjad/get.py
+++ b/source/abjad/get.py
@@ -934,17 +934,17 @@ def effective_indicator(
         BeforeGraceContainer("cs'16")  None
         Note("cs'16")                  None
         Note("d'4")                    None
-        Container("{ <e' g'>16 gs'16 a'16 as'16 } { e'4 }") Clef(name='alto', hide=False)
-        OnBeatGraceContainer("<e' g'>16 gs'16 a'16 as'16") Clef(name='alto', hide=False)
-        Chord("<e' g'>16")             Clef(name='alto', hide=False)
-        Note("gs'16")                  Clef(name='alto', hide=False)
-        Note("a'16")                   Clef(name='alto', hide=False)
-        Note("as'16")                  Clef(name='alto', hide=False)
-        Voice("e'4", name='MusicVoice') Clef(name='alto', hide=False)
-        Note("e'4")                    Clef(name='alto', hide=False)
-        Note("f'4")                    Clef(name='alto', hide=False)
-        AfterGraceContainer("fs'16")   Clef(name='alto', hide=False)
-        Note("fs'16")                  Clef(name='alto', hide=False)
+        Container("{ <e' g'>16 gs'16 a'16 as'16 } { e'4 }") Clef(name='alto')
+        OnBeatGraceContainer("<e' g'>16 gs'16 a'16 as'16") Clef(name='alto')
+        Chord("<e' g'>16")             Clef(name='alto')
+        Note("gs'16")                  Clef(name='alto')
+        Note("a'16")                   Clef(name='alto')
+        Note("as'16")                  Clef(name='alto')
+        Voice("e'4", name='MusicVoice') Clef(name='alto')
+        Note("e'4")                    Clef(name='alto')
+        Note("f'4")                    Clef(name='alto')
+        AfterGraceContainer("fs'16")   Clef(name='alto')
+        Note("fs'16")                  Clef(name='alto')
 
     ..  container:: example
 
@@ -986,9 +986,9 @@ def effective_indicator(
         Note("c'4")                    None
         Note("d'4")                    None
         Note("e'4")                    None
-        IndependentAfterGraceContainer("gf'16") Clef(name='alto', hide=False)
-        Note("gf'16")                  Clef(name='alto', hide=False)
-        Note("f'4")                    Clef(name='alto', hide=False)
+        IndependentAfterGraceContainer("gf'16") Clef(name='alto')
+        Note("gf'16")                  Clef(name='alto')
+        Note("f'4")                    Clef(name='alto')
 
     ..  container:: example
 
@@ -1031,10 +1031,10 @@ def effective_indicator(
         Note("c'16")                   None
         Note("e'16")                   None
         Note("cs'4")                   None
-        TremoloContainer("d'16 f'16")  Clef(name='alto', hide=False)
-        Note("d'16")                   Clef(name='alto', hide=False)
-        Note("f'16")                   Clef(name='alto', hide=False)
-        Note("ds'4")                   Clef(name='alto', hide=False)
+        TremoloContainer("d'16 f'16")  Clef(name='alto')
+        Note("d'16")                   Clef(name='alto')
+        Note("f'16")                   Clef(name='alto')
+        Note("ds'4")                   Clef(name='alto')
 
     ..  container:: example
 
@@ -1138,8 +1138,9 @@ def effective_indicator(
 
         >>> staff = abjad.Staff("c'4 d'4 e'4 f'4")
         >>> abjad.attach(
-        ...     abjad.Clef("treble", hide=True),
+        ...     abjad.Clef("treble"),
         ...     staff[0],
+        ...     hide=True,
         ...     synthetic_offset=abjad.Offset(-1),
         ... )
         >>> abjad.attach(abjad.Clef("alto"), staff[0])
@@ -1162,16 +1163,16 @@ def effective_indicator(
         ...     clef = abjad.get.effective_indicator(leaf, abjad.Clef)
         ...     (leaf, clef)
         ...
-        (Note("c'4"), Clef(name='alto', hide=False))
-        (Note("d'4"), Clef(name='alto', hide=False))
-        (Note("e'4"), Clef(name='alto', hide=False))
-        (Note("f'4"), Clef(name='alto', hide=False))
+        (Note("c'4"), Clef(name='alto'))
+        (Note("d'4"), Clef(name='alto'))
+        (Note("e'4"), Clef(name='alto'))
+        (Note("f'4"), Clef(name='alto'))
 
         >>> abjad.get.effective_indicator(staff[0], abjad.Clef)
-        Clef(name='alto', hide=False)
+        Clef(name='alto')
 
         >>> abjad.get.effective_indicator(staff[0], abjad.Clef, n=-1)
-        Clef(name='treble', hide=True)
+        Clef(name='treble')
 
         >>> abjad.get.effective_indicator(staff[0], abjad.Clef, n=-2) is None
         True
@@ -1183,10 +1184,11 @@ def effective_indicator(
         >>> staff = abjad.Staff("c'4 d'4 e'4 f'4")
         >>> abjad.attach(abjad.Clef("treble"), staff[0])
         >>> abjad.attach(
-        ...     abjad.Clef("alto", hide=True),
+        ...     abjad.Clef("alto"),
         ...     staff[-1],
+        ...     hide=True,
         ...     synthetic_offset=abjad.Offset(1),
-        ...     )
+        ... )
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -1206,16 +1208,16 @@ def effective_indicator(
         ...     clef = abjad.get.effective_indicator(leaf, abjad.Clef)
         ...     (leaf, clef)
         ...
-        (Note("c'4"), Clef(name='treble', hide=False))
-        (Note("d'4"), Clef(name='treble', hide=False))
-        (Note("e'4"), Clef(name='treble', hide=False))
-        (Note("f'4"), Clef(name='treble', hide=False))
+        (Note("c'4"), Clef(name='treble'))
+        (Note("d'4"), Clef(name='treble'))
+        (Note("e'4"), Clef(name='treble'))
+        (Note("f'4"), Clef(name='treble'))
 
         >>> abjad.get.effective_indicator(staff[-1], abjad.Clef)
-        Clef(name='treble', hide=False)
+        Clef(name='treble')
 
         >>> abjad.get.effective_indicator(staff[-1], abjad.Clef, n=1)
-        Clef(name='alto', hide=True)
+        Clef(name='alto')
 
         >>> abjad.get.effective_indicator(staff[-1], abjad.Clef, n=2) is None
         True
@@ -1248,11 +1250,11 @@ def effective_indicator(
         ...     time_signature = abjad.get.effective_indicator(component, prototype)
         ...     print(component, time_signature)
         ...
-        Staff("c'4 d'4 e'4 f'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
-        Note("c'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
-        Note("d'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
-        Note("e'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
-        Note("f'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
+        Staff("c'4 d'4 e'4 f'4") TimeSignature(pair=(3, 8), partial=None)
+        Note("c'4") TimeSignature(pair=(3, 8), partial=None)
+        Note("d'4") TimeSignature(pair=(3, 8), partial=None)
+        Note("e'4") TimeSignature(pair=(3, 8), partial=None)
+        Note("f'4") TimeSignature(pair=(3, 8), partial=None)
 
     ..  container:: example
 
@@ -1617,27 +1619,27 @@ def effective_wrapper(
         Note("d'4")
             None
         Container("{ <e' g'>16 gs'16 a'16 as'16 } { e'4 }")
-            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string=''))
+            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string=''))
         OnBeatGraceContainer("<e' g'>16 gs'16 a'16 as'16")
-            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string=''))
+            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string=''))
         Chord("<e' g'>16")
-            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string=''))
+            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string=''))
         Note("gs'16")
-            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string=''))
+            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string=''))
         Note("a'16")
-            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string=''))
+            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string=''))
         Note("as'16")
-            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string=''))
+            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string=''))
         Voice("e'4", name='MusicVoice')
-            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string=''))
+            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string=''))
         Note("e'4")
-            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string=''))
+            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string=''))
         Note("f'4")
-            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string=''))
+            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string=''))
         AfterGraceContainer("fs'16")
-            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string=''))
+            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string=''))
         Note("fs'16")
-            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto', hide=False), synthetic_offset=None, tag=Tag(string=''))
+            Wrapper(annotation=None, context_name='Staff', deactivate=False, direction=None, indicator=Clef(name='alto'), synthetic_offset=None, tag=Tag(string=''))
 
     """
     if attributes is not None:
@@ -2183,7 +2185,7 @@ def indicator(
         Note("d'4")                    None
         Container("{ <e' g'>16 gs'16 a'16 as'16 } { e'4 }") None
         OnBeatGraceContainer("<e' g'>16 gs'16 a'16 as'16") None
-        Chord("<e' g'>16")             Clef(name='alto', hide=False)
+        Chord("<e' g'>16")             Clef(name='alto')
         Note("gs'16")                  None
         Note("a'16")                   None
         Note("as'16")                  None
@@ -2235,7 +2237,7 @@ def indicator(
         Note("e'16")                   None
         Note("cs'4")                   None
         TremoloContainer("d'16 f'16")  None
-        Note("d'16")                   Clef(name='alto', hide=False)
+        Note("d'16")                   Clef(name='alto')
         Note("f'16")                   None
         Note("ds'4")                   None
 
@@ -2363,7 +2365,7 @@ def indicators(
         OnBeatGraceContainer("<e' g'>16 gs'16 a'16 as'16"):
             []
         Chord("<e' g'>16"):
-            [LilyPondLiteral(argument='\\set fontSize = #-3', site='before', directed=False), StartBeam(), LilyPondLiteral(argument='\\slash', site='before', directed=False), StartSlur(), VoiceNumber(n=1, leak=False), Clef(name='alto', hide=False), Articulation(name='>')]
+            [LilyPondLiteral(argument='\\set fontSize = #-3', site='before', directed=False), StartBeam(), LilyPondLiteral(argument='\\slash', site='before', directed=False), StartSlur(), VoiceNumber(n=1, leak=False), Clef(name='alto'), Articulation(name='>')]
         Note("gs'16"):
             [Articulation(name='.')]
         Note("a'16"):
@@ -2432,7 +2434,7 @@ def indicators(
         Note("e'16")                   [Articulation(name='.')]
         Note("cs'4")                   [Articulation(name='.')]
         TremoloContainer("d'16 f'16")  []
-        Note("d'16")                   [Clef(name='alto', hide=False), Articulation(name='.')]
+        Note("d'16")                   [Clef(name='alto'), Articulation(name='.')]
         Note("f'16")                   [Articulation(name='.')]
         Note("ds'4")                   [Articulation(name='.')]
 

--- a/source/abjad/indicators.py
+++ b/source/abjad/indicators.py
@@ -643,20 +643,20 @@ class Clef:
         >>> for leaf in abjad.select.leaves(voice_1):
         ...     leaf, abjad.get.effective_indicator(leaf, abjad.Clef)
         ...
-        (Note("e'8"), Clef(name='treble', hide=False))
-        (Note("g'8"), Clef(name='treble', hide=False))
-        (Note("f'8"), Clef(name='treble', hide=False))
-        (Note("a'8"), Clef(name='treble', hide=False))
-        (Note("g'8"), Clef(name='treble', hide=False))
-        (Note("b'8"), Clef(name='treble', hide=False))
+        (Note("e'8"), Clef(name='treble'))
+        (Note("g'8"), Clef(name='treble'))
+        (Note("f'8"), Clef(name='treble'))
+        (Note("a'8"), Clef(name='treble'))
+        (Note("g'8"), Clef(name='treble'))
+        (Note("b'8"), Clef(name='treble'))
 
         >>> for leaf in abjad.select.leaves(voice_2):
         ...     leaf, abjad.get.effective_indicator(leaf, abjad.Clef)
         ...
-        (Note("c'4."), Clef(name='treble', hide=False))
-        (Note('c,8'), Clef(name='bass', hide=False))
-        (Note('b,,8'), Clef(name='bass', hide=False))
-        (Note('a,,8'), Clef(name='bass', hide=False))
+        (Note("c'4."), Clef(name='treble'))
+        (Note('c,8'), Clef(name='bass'))
+        (Note('b,,8'), Clef(name='bass'))
+        (Note('a,,8'), Clef(name='bass'))
 
     ..  container:: example
 
@@ -675,7 +675,7 @@ class Clef:
 
         >>> staff = abjad.Staff("c'4 d' e' f'")
         >>> abjad.attach(abjad.Clef("treble"), staff[0])
-        >>> abjad.attach(abjad.Clef("alto", hide=True), staff[2])
+        >>> abjad.attach(abjad.Clef("alto"), staff[2], hide=True)
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> string = abjad.lilypond(staff)
@@ -692,15 +692,14 @@ class Clef:
         >>> for leaf in abjad.iterate.leaves(staff):
         ...     leaf, abjad.get.effective_indicator(leaf, abjad.Clef)
         ...
-        (Note("c'4"), Clef(name='treble', hide=False))
-        (Note("d'4"), Clef(name='treble', hide=False))
-        (Note("e'4"), Clef(name='alto', hide=True))
-        (Note("f'4"), Clef(name='alto', hide=True))
+        (Note("c'4"), Clef(name='treble'))
+        (Note("d'4"), Clef(name='treble'))
+        (Note("e'4"), Clef(name='alto'))
+        (Note("f'4"), Clef(name='alto'))
 
     """
 
     name: str = "treble"
-    hide: bool = dataclasses.field(compare=False, default=False)
 
     context: typing.ClassVar[str] = "Staff"
     # find_context_on_attach: typing.ClassVar[bool] = True
@@ -736,7 +735,6 @@ class Clef:
 
     def __post_init__(self):
         assert isinstance(self.name, str), repr(self.name)
-        assert isinstance(self.hide, bool), repr(self.hide)
 
     def _calculate_middle_c_position(self, clef_name):
         alteration = 0
@@ -777,16 +775,17 @@ class Clef:
             "tab": None,
         }[clef_name]
 
-    def _get_lilypond_format(self):
-        return rf'\clef "{self.name}"'
-
-    def _get_contributions(self):
+    def _get_contributions(self, *, wrapper=None):
+        assert wrapper is not None
         contributions = _contributions.ContributionsBySite()
-        if not self.hide:
+        if wrapper.hide is False:
             site = getattr(contributions, self.site)
             string = self._get_lilypond_format()
             site.commands.append(string)
         return contributions
+
+    def _get_lilypond_format(self):
+        return rf'\clef "{self.name}"'
 
     @classmethod
     def from_pitches(class_, pitches) -> "Clef":
@@ -802,7 +801,7 @@ class Clef:
             >>> staff = abjad.Staff(notes)
             >>> pitches = abjad.iterate.pitches(staff)
             >>> abjad.Clef.from_pitches(pitches)
-            Clef(name='bass', hide=False)
+            Clef(name='bass')
 
             Chooses between treble and bass based on minimal number of ledger lines.
 
@@ -1256,15 +1255,15 @@ class Dynamic:
         ...     print(f"{leaf!r}:")
         ...     print(f"    {dynamic!r}")
         Note("e'8"):
-            Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+            Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
         Note("g'8"):
-            Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+            Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
         Note("f'8"):
-            Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+            Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
         Note("a'8"):
-            Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+            Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
         Note("c'2"):
-            Dynamic(name='mf', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+            Dynamic(name='mf', command=None, leak=False, name_is_textual=False, ordinal=None)
 
     ..  container:: example exception
 
@@ -1457,7 +1456,7 @@ class Dynamic:
 
         >>> voice = abjad.Voice("c'4 d' e' f'")
         >>> abjad.attach(abjad.Dynamic("f"), voice[0])
-        >>> abjad.attach(abjad.Dynamic("mf", hide=True), voice[2])
+        >>> abjad.attach(abjad.Dynamic("mf"), voice[2], hide=True)
         >>> abjad.show(voice) # doctest: +SKIP
 
         >>> string = abjad.lilypond(voice)
@@ -1476,13 +1475,13 @@ class Dynamic:
         ...     print(f"{leaf!r}:")
         ...     print(f"    {dynamic!r}")
         Note("c'4"):
-            Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+            Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
         Note("d'4"):
-            Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+            Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
         Note("e'4"):
-            Dynamic(name='mf', command=None, hide=True, leak=False, name_is_textual=False, ordinal=None)
+            Dynamic(name='mf', command=None, leak=False, name_is_textual=False, ordinal=None)
         Note("f'4"):
-            Dynamic(name='mf', command=None, hide=True, leak=False, name_is_textual=False, ordinal=None)
+            Dynamic(name='mf', command=None, leak=False, name_is_textual=False, ordinal=None)
 
     ..  container:: example
 
@@ -1642,7 +1641,7 @@ class Dynamic:
         >>> import copy
         >>> dynamic = abjad.Dynamic("pp", leak=True)
         >>> copy.copy(dynamic)
-        Dynamic(name='pp', command=None, hide=False, leak=True, name_is_textual=False, ordinal=None)
+        Dynamic(name='pp', command=None, leak=True, name_is_textual=False, ordinal=None)
 
     ..  container:: example
 
@@ -1714,13 +1713,12 @@ class Dynamic:
         >>> import dataclasses
         >>> dynamic = abjad.Dynamic("appena udibile", name_is_textual=True)
         >>> dataclasses.replace(dynamic)
-        Dynamic(name='appena udibile', command=None, hide=False, leak=False, name_is_textual=True, ordinal=None)
+        Dynamic(name='appena udibile', command=None, leak=False, name_is_textual=True, ordinal=None)
 
     """
 
     name: "str" = "f"
     command: str | None = None
-    hide: bool = dataclasses.field(compare=False, default=False)
     leak: bool = dataclasses.field(compare=False, default=False)
     name_is_textual: bool = False
     ordinal: int | _math.Infinity | _math.NegativeInfinity | None = None
@@ -1743,7 +1741,6 @@ class Dynamic:
         if self.command is not None:
             assert isinstance(self.command, str), repr(self.command)
             assert self.command.startswith("\\"), repr(self.command)
-        assert isinstance(self.hide, bool), repr(self.hide)
         assert isinstance(self.leak, bool), repr(self.leak)
         assert isinstance(self.name_is_textual, bool), repr(self.name_is_textual)
         if self.ordinal is not None:
@@ -1916,8 +1913,20 @@ class Dynamic:
         string = f"{direction} #(make-dynamic-script {string})"
         return string
 
+    def _get_contributions(self, *, wrapper=None):
+        assert wrapper is not None
+        contributions = _contributions.ContributionsBySite()
+        command = self._get_lilypond_format(wrapper=wrapper)
+        if self.leak:
+            contributions.after.leak.append(_EMPTY_CHORD)
+            if wrapper.hide is False:
+                contributions.after.leaks.append(command)
+        else:
+            if wrapper.hide is False:
+                contributions.after.articulations.append(command)
+        return contributions
+
     def _get_lilypond_format(self, *, wrapper=None):
-        # breakpoint()
         if self.command:
             string = self.command
         elif self.is_effort():
@@ -1931,19 +1940,6 @@ class Dynamic:
                 direction = _string.to_tridirectional_lilypond_symbol(direction_)
                 string = f"{direction} {string}"
         return string
-
-    def _get_contributions(self, *, wrapper=None):
-        assert wrapper is not None
-        contributions = _contributions.ContributionsBySite()
-        command = self._get_lilypond_format(wrapper=wrapper)
-        if self.leak:
-            contributions.after.leak.append(_EMPTY_CHORD)
-            if not self.hide:
-                contributions.after.leaks.append(command)
-        else:
-            if not self.hide:
-                contributions.after.articulations.append(command)
-        return contributions
 
     def get_ordinal(self) -> int | _math.Infinity | _math.NegativeInfinity | None:
         """
@@ -3587,11 +3583,8 @@ class MetronomeMark:
         >>> score = abjad.Score([staff])
         >>> metronome_mark_1 = abjad.MetronomeMark(abjad.Duration(1, 4), 72)
         >>> abjad.attach(metronome_mark_1, staff[0])
-        >>> metronome_mark_2 = abjad.MetronomeMark(
-        ...     textual_indication="Allegro",
-        ...     hide=True,
-        ... )
-        >>> abjad.attach(metronome_mark_2, staff[2])
+        >>> metronome_mark_2 = abjad.MetronomeMark(textual_indication="Allegro")
+        >>> abjad.attach(metronome_mark_2, staff[2], hide=True)
         >>> abjad.show(score) # doctest: +SKIP
 
         >>> string = abjad.lilypond(score)
@@ -3612,10 +3605,10 @@ class MetronomeMark:
         ...     prototype = abjad.MetronomeMark
         ...     leaf, abjad.get.effective_indicator(leaf, prototype)
         ...
-        (Note("c'4"), MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=72, textual_indication=None, custom_markup=None, decimal=False, hide=False))
-        (Note("d'4"), MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=72, textual_indication=None, custom_markup=None, decimal=False, hide=False))
-        (Note("e'4"), MetronomeMark(reference_duration=None, units_per_minute=None, textual_indication='Allegro', custom_markup=None, decimal=False, hide=True))
-        (Note("f'4"), MetronomeMark(reference_duration=None, units_per_minute=None, textual_indication='Allegro', custom_markup=None, decimal=False, hide=True))
+        (Note("c'4"), MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=72, textual_indication=None, custom_markup=None, decimal=False))
+        (Note("d'4"), MetronomeMark(reference_duration=Duration(1, 4), units_per_minute=72, textual_indication=None, custom_markup=None, decimal=False))
+        (Note("e'4"), MetronomeMark(reference_duration=None, units_per_minute=None, textual_indication='Allegro', custom_markup=None, decimal=False))
+        (Note("f'4"), MetronomeMark(reference_duration=None, units_per_minute=None, textual_indication='Allegro', custom_markup=None, decimal=False))
 
     ..  container:: example
 
@@ -3660,7 +3653,6 @@ class MetronomeMark:
     textual_indication: str | None = None
     custom_markup: Markup | None = None
     decimal: bool | str = False
-    hide: bool = dataclasses.field(compare=False, default=False)
 
     context: typing.ClassVar[str] = "Score"
     # TODO: make this work:
@@ -3691,7 +3683,6 @@ class MetronomeMark:
             assert isinstance(self.custom_markup, Markup)
         if self.decimal is not None:
             assert isinstance(self.decimal, bool | str), repr(self.decimal)
-        assert isinstance(self.hide, bool), repr(self.hide)
 
     def __lt__(self, argument) -> bool:
         """
@@ -3730,6 +3721,15 @@ class MetronomeMark:
         string = f"{self._dotted}={self.units_per_minute}"
         return string
 
+    def _get_contributions(self, *, wrapper=None):
+        assert wrapper is not None
+        contributions = _contributions.ContributionsBySite()
+        site = getattr(contributions, self.site)
+        if wrapper.hide is False:
+            string = self._get_lilypond_format()
+            site.commands.append(string)
+        return contributions
+
     def _get_lilypond_format(self):
         equation = None
         if self.reference_duration is not None and self.units_per_minute is not None:
@@ -3744,14 +3744,6 @@ class MetronomeMark:
             return rf"\tempo {self.textual_indication}"
         else:
             return r"\tempo \default"
-
-    def _get_contributions(self):
-        contributions = _contributions.ContributionsBySite()
-        site = getattr(contributions, self.site)
-        if not self.hide:
-            string = self._get_lilypond_format()
-            site.commands.append(string)
-        return contributions
 
     def _get_markup(self):
         if self.custom_markup is not None:
@@ -7291,8 +7283,8 @@ class TimeSignature:
         >>> score = abjad.Score([staff], name="Score")
         >>> time_signature = abjad.TimeSignature((4, 4))
         >>> abjad.attach(time_signature, staff[0])
-        >>> time_signature = abjad.TimeSignature((2, 4), hide=True)
-        >>> abjad.attach(time_signature, staff[2])
+        >>> time_signature = abjad.TimeSignature((2, 4))
+        >>> abjad.attach(time_signature, staff[2], hide=True)
         >>> abjad.show(staff) # doctest: +SKIP
 
         >>> string = abjad.lilypond(staff)
@@ -7310,15 +7302,14 @@ class TimeSignature:
         ...     prototype = abjad.TimeSignature
         ...     leaf, abjad.get.effective_indicator(leaf, prototype)
         ...
-        (Note("c'4"), TimeSignature(pair=(4, 4), hide=False, partial=None))
-        (Note("d'4"), TimeSignature(pair=(4, 4), hide=False, partial=None))
-        (Note("e'4"), TimeSignature(pair=(2, 4), hide=True, partial=None))
-        (Note("f'4"), TimeSignature(pair=(2, 4), hide=True, partial=None))
+        (Note("c'4"), TimeSignature(pair=(4, 4), partial=None))
+        (Note("d'4"), TimeSignature(pair=(4, 4), partial=None))
+        (Note("e'4"), TimeSignature(pair=(2, 4), partial=None))
+        (Note("f'4"), TimeSignature(pair=(2, 4), partial=None))
 
     """
 
     pair: tuple[int, int]
-    hide: bool = dataclasses.field(compare=False, default=False)
     partial: _duration.Duration | None = None
 
     check_effective_context: typing.ClassVar[bool] = True
@@ -7338,16 +7329,16 @@ class TimeSignature:
         assert wrapper is not None
         contributions = _contributions.ContributionsBySite()
         site = getattr(contributions, self.site)
-        if not self.is_dyadic() and not self.hide:
+        if not self.is_dyadic() and wrapper.hide is False:
             string = '#(ly:expect-warning "strange time signature found")'
             site.commands.append(string)
-        strings = self._get_lilypond_format()
+        strings = self._get_lilypond_format(wrapper)
         site.commands.extend(strings)
         return contributions
 
-    def _get_lilypond_format(self):
+    def _get_lilypond_format(self, wrapper):
         result = []
-        if self.hide:
+        if wrapper.hide:
             return result
         if self.partial is None:
             result.append(rf"\time {self.numerator}/{self.denominator}")
@@ -7406,7 +7397,7 @@ class TimeSignature:
         ..  container:: example
 
             >>> abjad.TimeSignature.from_string("6/8")
-            TimeSignature(pair=(6, 8), hide=False, partial=None)
+            TimeSignature(pair=(6, 8), partial=None)
 
         """
         assert isinstance(string, str), repr(string)

--- a/source/abjad/meter.py
+++ b/source/abjad/meter.py
@@ -574,7 +574,7 @@ class Meter:
             >>> rtc = abjad.meter.make_best_guess_rtc((4, 4))
             >>> meter = abjad.Meter(rtc)
             >>> meter.implied_time_signature
-            TimeSignature(pair=(4, 4), hide=False, partial=None)
+            TimeSignature(pair=(4, 4), partial=None)
 
         """
         pair = self.root_node.pair
@@ -816,10 +816,10 @@ class Meter:
             >>> for meter in abjad.Meter.fit_meters(offset_counter, meters):
             ...     print(meter.implied_time_signature)
             ...
-            TimeSignature(pair=(4, 4), hide=False, partial=None)
-            TimeSignature(pair=(4, 4), hide=False, partial=None)
-            TimeSignature(pair=(4, 4), hide=False, partial=None)
-            TimeSignature(pair=(4, 4), hide=False, partial=None)
+            TimeSignature(pair=(4, 4), partial=None)
+            TimeSignature(pair=(4, 4), partial=None)
+            TimeSignature(pair=(4, 4), partial=None)
+            TimeSignature(pair=(4, 4), partial=None)
 
         ..  container:: example
 
@@ -831,11 +831,11 @@ class Meter:
             >>> for meter in abjad.Meter.fit_meters(offset_counter, meters):
             ...     print(meter.implied_time_signature)
             ...
-            TimeSignature(pair=(3, 4), hide=False, partial=None)
-            TimeSignature(pair=(4, 4), hide=False, partial=None)
-            TimeSignature(pair=(3, 4), hide=False, partial=None)
-            TimeSignature(pair=(5, 4), hide=False, partial=None)
-            TimeSignature(pair=(5, 4), hide=False, partial=None)
+            TimeSignature(pair=(3, 4), partial=None)
+            TimeSignature(pair=(4, 4), partial=None)
+            TimeSignature(pair=(3, 4), partial=None)
+            TimeSignature(pair=(5, 4), partial=None)
+            TimeSignature(pair=(5, 4), partial=None)
 
         """
         assert all(isinstance(_, Meter) for _ in meters), repr(meters)

--- a/source/abjad/metricmodulation.py
+++ b/source/abjad/metricmodulation.py
@@ -339,7 +339,6 @@ class MetricModulation:
 
     left_rhythm: typing.Any
     right_rhythm: typing.Any
-    hide: bool = False
     left_markup: _indicators.Markup | None = None
     right_markup: _indicators.Markup | None = None
     scale: tuple[int | float, int | float] = (1, 1)
@@ -347,7 +346,6 @@ class MetricModulation:
     directed: typing.ClassVar[bool] = True
 
     def __post_init__(self):
-        assert isinstance(self.hide, bool), repr(self.hide)
         if self.left_markup is not None:
             assert isinstance(self.left_markup, _indicators.Markup), repr(
                 self.left_markup
@@ -452,7 +450,7 @@ class MetricModulation:
 
     def _get_contributions(self, *, wrapper=None):
         contributions = _contributions.ContributionsBySite()
-        if not self.hide:
+        if wrapper.hide is False:
             markup = self._get_markup()
             contributions = markup._get_contributions(wrapper=wrapper)
         return contributions

--- a/source/abjad/mutate.py
+++ b/source/abjad/mutate.py
@@ -1499,9 +1499,9 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
         >>> for leaf in staff:
         ...     leaf, abjad.get.effective_indicator(leaf, abjad.Clef)
         ...
-        (Note("c'2"), Clef(name='alto', hide=False))
-        (Note("f'4"), Clef(name='alto', hide=False))
-        (Note("g'4"), Clef(name='alto', hide=False))
+        (Note("c'2"), Clef(name='alto'))
+        (Note("f'4"), Clef(name='alto'))
+        (Note("g'4"), Clef(name='alto'))
 
         >>> chord = abjad.Chord("<d' e'>2")
         >>> abjad.mutate.replace(staff[0], chord)
@@ -1553,9 +1553,9 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
         >>> for leaf in staff:
         ...     leaf, abjad.get.effective_indicator(leaf, abjad.Clef)
         ...
-        (Note("c'2"), Clef(name='alto', hide=False))
-        (Note("f'4"), Clef(name='alto', hide=False))
-        (Note("g'4"), Clef(name='alto', hide=False))
+        (Note("c'2"), Clef(name='alto'))
+        (Note("f'4"), Clef(name='alto'))
+        (Note("g'4"), Clef(name='alto'))
 
         >>> chord = abjad.Chord("<d' e'>2")
         >>> abjad.mutate.replace(staff[0], chord, wrappers=True)
@@ -1576,9 +1576,9 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
         >>> for leaf in staff:
         ...     leaf, abjad.get.effective_indicator(leaf, abjad.Clef)
         ...
-        (Chord("<d' e'>2"), Clef(name='alto', hide=False))
-        (Note("f'4"), Clef(name='alto', hide=False))
-        (Note("g'4"), Clef(name='alto', hide=False))
+        (Chord("<d' e'>2"), Clef(name='alto'))
+        (Note("f'4"), Clef(name='alto'))
+        (Note("g'4"), Clef(name='alto'))
 
         >>> abjad.wf.is_wellformed(staff)
         True
@@ -2483,14 +2483,14 @@ def swap(argument, container):
         ...     time_signature = abjad.get.effective_indicator(component, prototype)
         ...     print(component, time_signature)
         ...
-        Voice("{ 6:4 c'4 d'4 e'4 d'4 e'4 f'4 }") TimeSignature(pair=(3, 4), hide=False, partial=None)
-        Tuplet('6:4', "c'4 d'4 e'4 d'4 e'4 f'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
-        Note("c'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
-        Note("d'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
-        Note("e'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
-        Note("d'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
-        Note("e'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
-        Note("f'4") TimeSignature(pair=(3, 4), hide=False, partial=None)
+        Voice("{ 6:4 c'4 d'4 e'4 d'4 e'4 f'4 }") TimeSignature(pair=(3, 4), partial=None)
+        Tuplet('6:4', "c'4 d'4 e'4 d'4 e'4 f'4") TimeSignature(pair=(3, 4), partial=None)
+        Note("c'4") TimeSignature(pair=(3, 4), partial=None)
+        Note("d'4") TimeSignature(pair=(3, 4), partial=None)
+        Note("e'4") TimeSignature(pair=(3, 4), partial=None)
+        Note("d'4") TimeSignature(pair=(3, 4), partial=None)
+        Note("e'4") TimeSignature(pair=(3, 4), partial=None)
+        Note("f'4") TimeSignature(pair=(3, 4), partial=None)
 
     """
     if isinstance(argument, list):
@@ -2778,12 +2778,12 @@ def wrap(argument, container):
         ...     time_signature = abjad.get.effective_indicator(component, prototype)
         ...     print(component, time_signature)
         ...
-        Staff("{ c'4 d'4 e'4 f'4 }") TimeSignature(pair=(3, 8), hide=False, partial=None)
-        Container("c'4 d'4 e'4 f'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
-        Note("c'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
-        Note("d'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
-        Note("e'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
-        Note("f'4") TimeSignature(pair=(3, 8), hide=False, partial=None)
+        Staff("{ c'4 d'4 e'4 f'4 }") TimeSignature(pair=(3, 8), partial=None)
+        Container("c'4 d'4 e'4 f'4") TimeSignature(pair=(3, 8), partial=None)
+        Note("c'4") TimeSignature(pair=(3, 8), partial=None)
+        Note("d'4") TimeSignature(pair=(3, 8), partial=None)
+        Note("e'4") TimeSignature(pair=(3, 8), partial=None)
+        Note("f'4") TimeSignature(pair=(3, 8), partial=None)
 
     """
     if not isinstance(container, _score.Container) or 0 < len(container):

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -5961,15 +5961,15 @@ class Voice(Context):
         ...     dynamic = abjad.get.effective_indicator(leaf, abjad.Dynamic)
         ...     print(leaf, dynamic)
         ...
-        Note("e''8") Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("d''8") Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("c''4") Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("b'4") Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("c''8") Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+        Note("e''8") Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("d''8") Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("c''4") Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("b'4") Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("c''8") Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
         Note("e'4") None
         Note("f'4") None
         Note("e'8") None
-        Note("d''8") Dynamic(name='f', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+        Note("d''8") Dynamic(name='f', command=None, leak=False, name_is_textual=False, ordinal=None)
 
     ..  container:: example
 
@@ -6039,9 +6039,9 @@ class Voice(Context):
         Note("c''4") None
         Note("b'4") None
         Note("c''8") None
-        Note("e'4") Dynamic(name='p', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("f'4") Dynamic(name='p', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("e'8") Dynamic(name='p', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+        Note("e'4") Dynamic(name='p', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("f'4") Dynamic(name='p', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("e'8") Dynamic(name='p', command=None, leak=False, name_is_textual=False, ordinal=None)
         Note("d''8") None
 
     ..  container:: example
@@ -6109,13 +6109,13 @@ class Voice(Context):
         ...
         Note("e''8") None
         Note("d''8") None
-        Note("c''4") Dynamic(name='mf', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("b'4") Dynamic(name='mf', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("c''8") Dynamic(name='mf', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+        Note("c''4") Dynamic(name='mf', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("b'4") Dynamic(name='mf', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("c''8") Dynamic(name='mf', command=None, leak=False, name_is_textual=False, ordinal=None)
         Note("e'4") None
         Note("f'4") None
         Note("e'8") None
-        Note("d''8") Dynamic(name='mf', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+        Note("d''8") Dynamic(name='mf', command=None, leak=False, name_is_textual=False, ordinal=None)
 
     ..  container:: example
 
@@ -6185,13 +6185,13 @@ class Voice(Context):
         ...
         Note("e''8") None
         Note("d''8") None
-        Note("c''4") Dynamic(name='mf', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("b'4") Dynamic(name='mf', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("c''8") Dynamic(name='mf', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("e'4") Dynamic(name='p', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("f'4") Dynamic(name='p', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("e'8") Dynamic(name='p', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
-        Note("d''8") Dynamic(name='mf', command=None, hide=False, leak=False, name_is_textual=False, ordinal=None)
+        Note("c''4") Dynamic(name='mf', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("b'4") Dynamic(name='mf', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("c''8") Dynamic(name='mf', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("e'4") Dynamic(name='p', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("f'4") Dynamic(name='p', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("e'8") Dynamic(name='p', command=None, leak=False, name_is_textual=False, ordinal=None)
+        Note("d''8") Dynamic(name='mf', command=None, leak=False, name_is_textual=False, ordinal=None)
 
     """
 

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -2,87 +2,10 @@ import pytest
 
 import abjad
 
-
-def test_indicators_01():
-    """
-    Classes ignore "hide" in definitions of __eq__.
-
-    Test will be removed when "hide" migrates from indicators to wrapper.
-    """
-
-    assert abjad.Clef("treble", hide=False) == abjad.Clef("treble", hide=False)
-    assert abjad.Clef("treble", hide=False) == abjad.Clef("treble", hide=True)
-    assert abjad.Clef("treble", hide=True) == abjad.Clef("treble", hide=False)
-    assert abjad.Clef("treble", hide=True) == abjad.Clef("treble", hide=True)
-    assert abjad.Clef("treble", hide=False) != abjad.Clef("alto", hide=False)
-    assert abjad.Clef("treble", hide=False) != abjad.Clef("alto", hide=True)
-    assert abjad.Clef("treble", hide=True) != abjad.Clef("alto", hide=False)
-    assert abjad.Clef("treble", hide=True) != abjad.Clef("alto", hide=True)
-
-    assert abjad.Dynamic("p", hide=False) == abjad.Dynamic("p", hide=False)
-    assert abjad.Dynamic("p", hide=False) == abjad.Dynamic("p", hide=True)
-    assert abjad.Dynamic("p", hide=True) == abjad.Dynamic("p", hide=False)
-    assert abjad.Dynamic("p", hide=True) == abjad.Dynamic("p", hide=True)
-    assert abjad.Dynamic("p", hide=False) != abjad.Dynamic("f", hide=False)
-    assert abjad.Dynamic("p", hide=False) != abjad.Dynamic("f", hide=True)
-    assert abjad.Dynamic("p", hide=True) != abjad.Dynamic("f", hide=False)
-    assert abjad.Dynamic("p", hide=True) != abjad.Dynamic("f", hide=True)
-
-    assert abjad.MetronomeMark(
-        abjad.Duration(1, 4), 60, hide=False
-    ) == abjad.MetronomeMark(abjad.Duration(1, 4), 60, hide=False)
-    assert abjad.MetronomeMark(
-        abjad.Duration(1, 4), 60, hide=False
-    ) == abjad.MetronomeMark(abjad.Duration(1, 4), 60, hide=True)
-    assert abjad.MetronomeMark(
-        abjad.Duration(1, 4), 60, hide=True
-    ) == abjad.MetronomeMark(abjad.Duration(1, 4), 60, hide=False)
-    assert abjad.MetronomeMark(
-        abjad.Duration(1, 4), 60, hide=True
-    ) == abjad.MetronomeMark(abjad.Duration(1, 4), 60, hide=True)
-    assert abjad.MetronomeMark(
-        abjad.Duration(1, 4), 60, hide=False
-    ) != abjad.MetronomeMark(abjad.Duration(1, 4), 72, hide=False)
-    assert abjad.MetronomeMark(
-        abjad.Duration(1, 4), 60, hide=False
-    ) != abjad.MetronomeMark(abjad.Duration(1, 4), 72, hide=True)
-    assert abjad.MetronomeMark(
-        abjad.Duration(1, 4), 60, hide=True
-    ) != abjad.MetronomeMark(abjad.Duration(1, 4), 72, hide=False)
-    assert abjad.MetronomeMark(
-        abjad.Duration(1, 4), 60, hide=True
-    ) != abjad.MetronomeMark(abjad.Duration(1, 4), 72, hide=True)
-
-    assert abjad.TimeSignature(((3, 4)), hide=False) == abjad.TimeSignature(
-        ((3, 4)), hide=False
-    )
-    assert abjad.TimeSignature(((3, 4)), hide=False) == abjad.TimeSignature(
-        ((3, 4)), hide=True
-    )
-    assert abjad.TimeSignature(((3, 4)), hide=True) == abjad.TimeSignature(
-        ((3, 4)), hide=False
-    )
-    assert abjad.TimeSignature(((3, 4)), hide=True) == abjad.TimeSignature(
-        ((3, 4)), hide=True
-    )
-    assert abjad.TimeSignature(((3, 4)), hide=False) != abjad.TimeSignature(
-        ((4, 4)), hide=False
-    )
-    assert abjad.TimeSignature(((3, 4)), hide=False) != abjad.TimeSignature(
-        ((4, 4)), hide=True
-    )
-    assert abjad.TimeSignature(((3, 4)), hide=True) != abjad.TimeSignature(
-        ((4, 4)), hide=False
-    )
-    assert abjad.TimeSignature(((3, 4)), hide=True) != abjad.TimeSignature(
-        ((4, 4)), hide=True
-    )
-
-
 # TODO: parameterize each test below:
 
 
-def test_indicators_02():
+def test_indicators_01():
     """
     Conditions:
         * indicator_1, indicator_2 attach to same leaf
@@ -105,7 +28,7 @@ def test_indicators_02():
     """
 
 
-def test_indicators_03():
+def test_indicators_02():
     """
     Conditions:
         * indicator_1, indicator_2 attach to same leaf
@@ -121,7 +44,7 @@ def test_indicators_03():
         abjad.attach(abjad.Clef("alto"), staff[0])
 
 
-def test_indicators_04():
+def test_indicators_03():
     """
     Conditions:
         * indicator_1, indicator_2 attach to same leaf
@@ -132,12 +55,14 @@ def test_indicators_04():
         * raises exception
     """
     staff = abjad.Staff("c'4 d' e' f'")
-    abjad.attach(abjad.Clef("treble", hide=True), staff[0])
+    # abjad.attach(abjad.Clef("treble", hide=True), staff[0])
+    abjad.attach(abjad.Clef("treble"), staff[0], hide=True)
     with pytest.raises(Exception):
-        abjad.attach(abjad.Clef("treble", hide=True), staff[0])
+        # abjad.attach(abjad.Clef("treble", hide=True), staff[0])
+        abjad.attach(abjad.Clef("treble"), staff[0], hide=True)
 
 
-def test_indicators_05():
+def test_indicators_04():
     """
     Conditions:
         * indicator_1, indicator_2 attach to same leaf
@@ -153,7 +78,7 @@ def test_indicators_05():
         abjad.attach(abjad.Clef("treble", hide=True), staff[0])
 
 
-def test_indicators_06():
+def test_indicators_05():
     """
     Conditions:
         * indicator_1, indicator_2 attach to same leaf
@@ -164,12 +89,13 @@ def test_indicators_06():
         * raises exception
     """
     staff = abjad.Staff("c'4 d' e' f'")
-    abjad.attach(abjad.Clef("treble", hide=True), staff[0])
+    # abjad.attach(abjad.Clef("treble", hide=True), staff[0])
+    abjad.attach(abjad.Clef("treble"), staff[0], hide=True)
     with pytest.raises(Exception):
         abjad.attach(abjad.Clef("treble"), staff[0])
 
 
-def test_indicators_07():
+def test_indicators_06():
     """
     Conditions:
         * indicator_1, indicator_2 attach to same leaf
@@ -181,10 +107,11 @@ def test_indicators_07():
     """
     staff = abjad.Staff("c'4 d' e' f'")
     abjad.attach(abjad.Clef("treble"), staff[0])
-    abjad.attach(abjad.Clef("alto", hide=True), staff[0])
+    # abjad.attach(abjad.Clef("alto", hide=True), staff[0])
+    abjad.attach(abjad.Clef("alto"), staff[0], hide=True)
 
 
-def test_indicators_08():
+def test_indicators_07():
     """
     Conditions:
         * indicator_1, indicator_2 attach to same leaf
@@ -195,11 +122,12 @@ def test_indicators_08():
         * ok
     """
     staff = abjad.Staff("c'4 d' e' f'")
-    abjad.attach(abjad.Clef("treble", hide=True), staff[0])
+    # abjad.attach(abjad.Clef("treble", hide=True), staff[0])
+    abjad.attach(abjad.Clef("treble"), staff[0], hide=True)
     abjad.attach(abjad.Clef("alto"), staff[0])
 
 
-def test_indicators_09():
+def test_indicators_08():
     """
     Conditions:
         * indicator_1, indicator_2 attach to same leaf
@@ -226,7 +154,7 @@ def test_indicators_09():
     abjad.attach(abjad.Ottava(1, site="after"), voice[0])
 
 
-def test_indicators_10():
+def test_indicators_09():
     """
     Conditions:
         * indicator_1, indicator_2 attach to same leaf
@@ -249,7 +177,7 @@ def test_indicators_10():
     abjad.attach(abjad.Ottava(0, site="after"), voice[0])
 
 
-def test_indicators_11():
+def test_indicators_10():
     """
     Conditions:
         * indicator_1, indicator_2 attach to same leaf
@@ -276,7 +204,7 @@ def test_indicators_11():
     assert "attempting to attach conflicting indicator" in str(e)
 
 
-def test_indicators_12():
+def test_indicators_11():
     """
     Conditions:
         * indicator_1, indicator_2 attach to same leaf


### PR DESCRIPTION
Move `hide` from indicators to `abjad.attach()`

    OLD:

        >>> clef = abjad.Clef("alto", hide=True)
        >>> abjad.attach(clef, note)

        >>> dynamic = abjad.Dynamic("f", hide=True)
        >>> abjad.attach(dynamic, note)

        >>> duration = abjad.Duration(1, 4)
        >>> metronome_mark = abjad.MetronomeMark(duration, 66, hide=True)
        >>> abjad.attach(metronome_mark, note)

        >>> time_signature = abjad.TimeSignature((2, 4), hide=True)
        >>> abjad.attach(time_signature, note)

    NEW:

        >>> clef = abjad.Clef("alto")
        >>> abjad.attach(clef, note, hide=True)

        >>> dynamic = abjad.Dynamic("f")
        >>> abjad.attach(dynamic, note, hide=True)

        >>> duration = abjad.Duration(1, 4)
        >>> metronome_mark = abjad.MetronomeMark(duration, 66)
        >>> abjad.attach(metronome_mark, note, hide=True)

        >>> time_signature = abjad.TimeSignature((2, 4))
        >>> abjad.attach(time_signature, note, hide=True)