### PR TITLE
Change abjad.Wrapper properties to methods

### DIFF
--- a/source/abjad/_getlib.py
+++ b/source/abjad/_getlib.py
@@ -39,15 +39,15 @@ def _are_logical_voice(components, prototype=None):
 def _get_annotation(component, annotation, default=None):
     assert isinstance(annotation, str), repr(annotation)
     for wrapper_ in _get_annotation_wrappers(component):
-        if wrapper_.annotation == annotation:
-            return wrapper_.indicator
+        if wrapper_.annotation() == annotation:
+            return wrapper_.indicator()
     return default
 
 
 def _get_annotation_wrappers(argument):
     wrappers = []
     for wrapper in getattr(argument, "_wrappers", []):
-        if wrapper.annotation:
+        if wrapper.annotation():
             wrappers.append(wrapper)
     return wrappers
 
@@ -109,7 +109,7 @@ def _get_effective_wrapper(component, prototype, *, attributes=None, command=Non
                 enclosing_voice_name = component_.name or id(component_)
         local_wrappers = []
         for wrapper_ in component_._wrappers:
-            if wrapper_.annotation:
+            if wrapper_.annotation():
                 continue
             if isinstance(wrapper_.unbundle_indicator(), prototype):
                 append_wrapper = True
@@ -136,7 +136,7 @@ def _get_effective_wrapper(component, prototype, *, attributes=None, command=Non
         if not isinstance(component_, _score.Context):
             continue
         for wrapper_ in component_._dependent_wrappers:
-            if wrapper_.annotation:
+            if wrapper_.annotation():
                 continue
             if isinstance(wrapper_.unbundle_indicator(), prototype):
                 append_wrapper = True
@@ -223,14 +223,14 @@ def _get_leaf_from_leaf(leaf, n):
 def _get_persistent_wrappers(*, dependent_wrappers=None, omit_with_indicator=None):
     wrappers = {}
     for wrapper in dependent_wrappers:
-        if wrapper.annotation:
+        if wrapper.annotation():
             continue
         if not getattr(wrapper.unbundle_indicator(), "persistent", False):
             continue
         assert isinstance(wrapper.unbundle_indicator().persistent, bool)
         should_omit = False
         if omit_with_indicator is not None:
-            for component in wrapper.component._get_parentage():
+            for component in wrapper.component()._get_parentage():
                 if component._has_indicator(omit_with_indicator):
                     should_omit = True
                     continue

--- a/source/abjad/_updatelib.py
+++ b/source/abjad/_updatelib.py
@@ -103,7 +103,7 @@ def _get_measure_start_offsets(component):
         wrappers.extend(wrappers_)
     pairs = []
     for wrapper in wrappers:
-        component = wrapper.component
+        component = wrapper.component()
         start_offset = component._get_timespan().start_offset
         time_signature = wrapper.unbundle_indicator()
         pair = start_offset, time_signature
@@ -268,7 +268,7 @@ def _update_all_indicators(root):
     components = _iterate_entire_score(root)
     for component in components:
         for wrapper in component._get_wrappers():
-            if wrapper.context_name is not None:
+            if wrapper.context_name() is not None:
                 wrapper._update_effective_context()
         component._indicators_are_current = True
 

--- a/source/abjad/bind.py
+++ b/source/abjad/bind.py
@@ -64,7 +64,7 @@ def _before_attach(
                 is True
             ):
                 continue
-            if hide != wrapper.hide:
+            if hide != wrapper.hide():
                 continue
             if getattr(indicator, "site", None) != getattr(
                 wrapper.unbundle_indicator(), "site", None
@@ -102,7 +102,6 @@ def _unsafe_attach(
         message += f"   {repr(indicator)}"
         raise Exception(message)
     assert isinstance(component, _score.Component), repr(component)
-
     if tag is not None and not isinstance(tag, _tag.Tag):
         raise Exception(f"must be be tag: {repr(tag)}")
     assert nonbundle_indicator is not None, repr(nonbundle_indicator)
@@ -142,14 +141,14 @@ def _unsafe_attach(
         raise Exception(message)
     annotation = None
     if isinstance(indicator, _wrapper.Wrapper):
-        annotation = indicator.annotation
-        context = context or indicator.context_name
-        deactivate = deactivate or indicator.deactivate
-        hide = hide or indicator.hide
-        synthetic_offset = synthetic_offset or indicator.synthetic_offset
-        tag = tag or indicator.tag
+        annotation = indicator.annotation()
+        context = context or indicator.context_name()
+        deactivate = deactivate or indicator.deactivate()
+        hide = hide or indicator.hide()
+        synthetic_offset = synthetic_offset or indicator.synthetic_offset()
+        tag = tag or indicator.tag()
         indicator._detach()
-        indicator = indicator.indicator
+        indicator = indicator.indicator()
     if hasattr(nonbundle_indicator, "context"):
         context = context or nonbundle_indicator.context
     if tag is None:
@@ -697,7 +696,7 @@ def detach(indicator, component: _score.Component, *, by_id: bool = False) -> tu
             }
 
         >>> wrapper = abjad.get.wrappers(staff[0])[0]
-        >>> wrappers = abjad.detach(wrapper, wrapper.component)
+        >>> wrappers = abjad.detach(wrapper, wrapper.component())
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -749,7 +748,7 @@ def detach(indicator, component: _score.Component, *, by_id: bool = False) -> tu
                     result.append(wrapper)
                 elif isinstance(wrapper.unbundle_indicator(), indicator):
                     wrapper._detach()
-                    result.append(wrapper.indicator)
+                    result.append(wrapper.indicator())
             return tuple(result)
     else:
         if "AfterGraceContainer" in indicator.__class__.__name__:
@@ -772,7 +771,7 @@ def detach(indicator, component: _score.Component, *, by_id: bool = False) -> tu
                         pass
                     else:
                         wrapper._detach()
-                        result.append(wrapper.indicator)
+                        result.append(wrapper.indicator())
             return tuple(result)
     items = []
     if after_grace_container is not None:

--- a/source/abjad/format.py
+++ b/source/abjad/format.py
@@ -60,25 +60,25 @@ def _get_indicator_contributions(component, contributions):
     context_wrappers = []
     noncontext_wrappers = []
     for wrapper in wrappers:
-        if wrapper.annotation:
+        if wrapper.annotation():
             continue
-        if not hasattr(wrapper.indicator, "_get_contributions"):
+        if not hasattr(wrapper.indicator(), "_get_contributions"):
             continue
         if (
-            wrapper.context_name is None
-            and getattr(wrapper.indicator, "format_leaf_children", False) is not True
-            and wrapper.component is not component
+            wrapper.context_name() is None
+            and getattr(wrapper.indicator(), "format_leaf_children", False) is not True
+            and wrapper.component() is not component
         ):
             continue
         if isinstance(wrapper.unbundle_indicator(), _indicators.Markup):
-            if wrapper.direction is _enums.UP:
+            if wrapper.direction() is _enums.UP:
                 up_markup_wrappers.append(wrapper)
-            elif wrapper.direction is _enums.DOWN:
+            elif wrapper.direction() is _enums.DOWN:
                 down_markup_wrappers.append(wrapper)
-            elif wrapper.direction in (_enums.CENTER, None):
+            elif wrapper.direction() in (_enums.CENTER, None):
                 neutral_markup_wrappers.append(wrapper)
-        elif wrapper.context_name is not None:
-            if wrapper.component is component:
+        elif wrapper.context_name() is not None:
+            if wrapper.component() is component:
                 context_wrappers.append(wrapper)
         else:
             noncontext_wrappers.append(wrapper)
@@ -92,13 +92,15 @@ def _get_indicator_contributions(component, contributions):
         noncontext_wrappers,
     ):
         for wrapper in wrappers:
-            item = wrapper.indicator
+            item = wrapper.indicator()
             contributions_ = None
             try:
                 contributions_ = item._get_contributions(wrapper=wrapper)
             except TypeError:
                 contributions_ = item._get_contributions()
-            contributions_.tag_contributions(wrapper.tag, deactivate=wrapper.deactivate)
+            contributions_.tag_contributions(
+                wrapper.tag(), deactivate=wrapper.deactivate()
+            )
             if getattr(item, "check_effective_context", False) is True:
                 if wrapper._get_effective_context() is None:
                     for list_ in contributions_.get_contribution_lists():

--- a/source/abjad/illustrators.py
+++ b/source/abjad/illustrators.py
@@ -546,10 +546,10 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
         for wrapper in markup_wrappers:
             markup = wrapper.unbundle_indicator()
             markup_copy = copy.copy(markup)
-            if wrapper.direction in (_enums.UP, None):
-                _bind.attach(markup_copy, treble_leaf, direction=wrapper.direction)
+            if wrapper.direction() in (_enums.UP, None):
+                _bind.attach(markup_copy, treble_leaf, direction=wrapper.direction())
             else:
-                _bind.attach(markup_copy, bass_leaf, direction=wrapper.direction)
+                _bind.attach(markup_copy, bass_leaf, direction=wrapper.direction())
         treble_voice.append(treble_leaf)
         bass_voice.append(bass_leaf)
     if 0 < len(treble_voice):

--- a/source/abjad/indicators.py
+++ b/source/abjad/indicators.py
@@ -189,9 +189,9 @@ class Articulation:
             string = self.shortcut_to_word.get(self.name)
             if not string:
                 string = self.name
-            if wrapper.direction is not None:
+            if wrapper.direction() is not None:
                 direction_ = _string.to_tridirectional_lilypond_symbol(
-                    wrapper.direction
+                    wrapper.direction()
                 )
                 direction = direction_
             else:
@@ -778,7 +778,7 @@ class Clef:
     def _get_contributions(self, *, wrapper=None):
         assert wrapper is not None
         contributions = _contributions.ContributionsBySite()
-        if wrapper.hide is False:
+        if wrapper.hide() is False:
             site = getattr(contributions, self.site)
             string = self._get_lilypond_format()
             site.commands.append(string)
@@ -1885,7 +1885,7 @@ class Dynamic:
         ]
         after = {"f": -0.2, "m": -0.1, "p": -0.25, "r": 0, "s": 0, "z": -0.2}[name[-1]]
         # direction = self.direction
-        direction = wrapper.direction or _enums.DOWN
+        direction = wrapper.direction() or _enums.DOWN
         direction = _string.to_tridirectional_lilypond_symbol(direction)
         strings = []
         strings.append(f"{direction} #(make-dynamic-script")
@@ -1905,7 +1905,7 @@ class Dynamic:
 
     @staticmethod
     def _format_textual(string, *, wrapper=None):
-        if wrapper.direction is None:
+        if wrapper.direction() is None:
             direction = _enums.DOWN
         direction = _string.to_tridirectional_lilypond_symbol(direction)
         assert isinstance(string, str), repr(string)
@@ -1919,10 +1919,10 @@ class Dynamic:
         command = self._get_lilypond_format(wrapper=wrapper)
         if self.leak:
             contributions.after.leak.append(_EMPTY_CHORD)
-            if wrapper.hide is False:
+            if wrapper.hide() is False:
                 contributions.after.leaks.append(command)
         else:
-            if wrapper.hide is False:
+            if wrapper.hide() is False:
                 contributions.after.articulations.append(command)
         return contributions
 
@@ -1935,8 +1935,8 @@ class Dynamic:
             string = self._format_textual(self.name, wrapper=wrapper)
         else:
             string = rf"\{self.name}"
-            if wrapper.direction is not None:
-                direction_ = wrapper.direction
+            if wrapper.direction() is not None:
+                direction_ = wrapper.direction()
                 direction = _string.to_tridirectional_lilypond_symbol(direction_)
                 string = f"{direction} {string}"
         return string
@@ -2687,9 +2687,9 @@ class KeyCluster:
             assert self.hide_natural_markup is False
             string = r"\center-column \natural"
         string = rf"\markup {string}"
-        if wrapper.direction is _enums.UP:
+        if wrapper.direction() is _enums.UP:
             string = rf"^ {string}"
-        elif wrapper.direction is _enums.DOWN:
+        elif wrapper.direction() is _enums.DOWN:
             string = rf"_ {string}"
         site.markup.append(string)
         return contributions
@@ -3362,7 +3362,7 @@ class Markup:
     def _get_lilypond_format(self, *, wrapper=None):
         string = self.string
         if wrapper is not None:
-            direction = wrapper.direction or "-"
+            direction = wrapper.direction() or "-"
             direction = _string.to_tridirectional_lilypond_symbol(direction)
             string = rf"{direction} {self.string}"
         return string
@@ -3725,7 +3725,7 @@ class MetronomeMark:
         assert wrapper is not None
         contributions = _contributions.ContributionsBySite()
         site = getattr(contributions, self.site)
-        if wrapper.hide is False:
+        if wrapper.hide() is False:
             string = self._get_lilypond_format()
             site.commands.append(string)
         return contributions
@@ -4284,7 +4284,7 @@ class RepeatTie:
         [RepeatTie()]
 
         >>> wrapper = abjad.get.wrapper(voice[1], abjad.RepeatTie)
-        >>> wrapper.indicator
+        >>> wrapper.indicator()
         Bundle(indicator=RepeatTie(), tweaks=(Tweak(string='- \\tweak color #blue', i=None, tag=None),), comment=None)
 
         >>> for leaf in voice:
@@ -4401,8 +4401,8 @@ class RepeatTie:
         contributions = _contributions.ContributionsBySite()
         site = getattr(contributions, self.site)
         strings = []
-        if wrapper.direction is not None:
-            string = _string.to_tridirectional_lilypond_symbol(wrapper.direction)
+        if wrapper.direction() is not None:
+            string = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
             strings.append(string)
         strings.append(r"\repeatTie")
         site.spanner_starts.extend(strings)
@@ -4636,8 +4636,8 @@ class StartBeam:
     spanner_start: typing.ClassVar[bool] = True
 
     def _add_direction(self, string, wrapper):
-        if wrapper.direction is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction)
+        if wrapper.direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
             string = f"{symbol} {string}"
         return string
 
@@ -5049,8 +5049,8 @@ class StartHairpin:
         assert self.shape in self.known_shapes, repr(self.shape)
 
     def _add_direction(self, string, *, wrapper=None):
-        if wrapper.direction is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction)
+        if wrapper.direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
             string = f"{symbol} {string}"
         return string
 
@@ -5157,8 +5157,8 @@ class StartPhrasingSlur:
     spanner_start: typing.ClassVar[bool] = True
 
     def _add_direction(self, string, *, wrapper=None):
-        if wrapper.direction is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction)
+        if wrapper.direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
             string = f"{symbol} {string}"
         return string
 
@@ -5391,8 +5391,8 @@ class StartSlur:
     spanner_start: typing.ClassVar[bool] = True
 
     def _add_direction(self, string, *, wrapper=None):
-        if wrapper.direction is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction)
+        if wrapper.direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
             string = f"{symbol} {string}"
         return string
 
@@ -5811,8 +5811,8 @@ class StartTextSpan:
         return contributions
 
     def _add_direction(self, string, *, wrapper=None):
-        if wrapper.direction is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction)
+        if wrapper.direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
             string = f"{symbol} {string}"
         return string
 
@@ -5996,7 +5996,7 @@ class StartTrillSpan:
             if self.pitch:
                 pitch = self.pitch
             else:
-                pitch = wrapper.component.written_pitch + self.interval
+                pitch = wrapper.component().written_pitch + self.interval
             string = string + f" {pitch.name}"
             if self.force_trill_pitch_head_accidental is True:
                 # LilyPond's TrillPitchHead does not obey LilyPond's \accidentalStyle;
@@ -7144,8 +7144,8 @@ class Tie:
     site: typing.ClassVar[str] = "after"
 
     def _add_direction(self, string, *, wrapper=None):
-        if wrapper.direction is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction)
+        if wrapper.direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
             string = f"{symbol} {string}"
         return string
 
@@ -7329,7 +7329,7 @@ class TimeSignature:
         assert wrapper is not None
         contributions = _contributions.ContributionsBySite()
         site = getattr(contributions, self.site)
-        if not self.is_dyadic() and wrapper.hide is False:
+        if not self.is_dyadic() and wrapper.hide() is False:
             string = '#(ly:expect-warning "strange time signature found")'
             site.commands.append(string)
         strings = self._get_lilypond_format(wrapper)
@@ -7338,7 +7338,7 @@ class TimeSignature:
 
     def _get_lilypond_format(self, wrapper):
         result = []
-        if wrapper.hide is True:
+        if wrapper.hide() is True:
             return result
         if self.partial is None:
             result.append(rf"\time {self.numerator}/{self.denominator}")

--- a/source/abjad/iterpitches.py
+++ b/source/abjad/iterpitches.py
@@ -247,11 +247,12 @@ def transpose_from_sounding_pitch(argument) -> None:
             new_start_trill_span = dataclasses.replace(
                 start_trill_span, pitch=new_pitch
             )
-            wrapper_tag = wrapper.tag
+            wrapper_tag = wrapper.tag()
             _bind.detach(wrapper, leaf)
             if wrapper.is_bundled():
                 new_bundle = dataclasses.replace(
-                    wrapper.indicator, indicator=new_start_trill_span
+                    wrapper.indicator(),
+                    indicator=new_start_trill_span,
                 )
                 _bind.attach(new_bundle, leaf, tag=wrapper_tag)
             else:
@@ -321,7 +322,8 @@ def transpose_from_written_pitch(argument) -> None:
             _bind.detach(wrapper, leaf)
             if wrapper.is_bundled():
                 new_bundle = dataclasses.replace(
-                    wrapper.indicator, indicator=new_start_trill_span
+                    wrapper.indicator(),
+                    indicator=new_start_trill_span,
                 )
                 _bind.attach(new_bundle, leaf)
             else:

--- a/source/abjad/metricmodulation.py
+++ b/source/abjad/metricmodulation.py
@@ -449,8 +449,9 @@ class MetricModulation:
         return markup.string
 
     def _get_contributions(self, *, wrapper=None):
+        assert wrapper is not None, repr(wrapper)
         contributions = _contributions.ContributionsBySite()
-        if wrapper.hide is False:
+        if wrapper.hide() is False:
             markup = self._get_markup()
             contributions = markup._get_contributions(wrapper=wrapper)
         return contributions

--- a/source/abjad/mutate.py
+++ b/source/abjad/mutate.py
@@ -1636,9 +1636,11 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
         donor._wrappers.remove(wrapper)
         wrapper._component = recipient
         recipient._wrappers.append(wrapper)
-        if wrapper.context_name is not None:
+        context_name = wrapper.context_name()
+        if context_name is not None:
             context = wrapper._find_correct_effective_context(
-                wrapper.component, wrapper.context_name
+                wrapper.component(),
+                context_name,
             )
             assert context is not None
             context._dependent_wrappers.append(wrapper)

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -122,7 +122,7 @@ class Component:
                 _overrides.setting(self)
             )
         for wrapper in self._wrappers:
-            if not wrapper.annotation:
+            if not wrapper.annotation():
                 continue
             wrapper_ = copy.copy(wrapper)
             wrapper_._component = component
@@ -226,10 +226,12 @@ class Component:
     def _get_markup(self, direction=None):
         wrappers = self._get_wrappers(_indicators.Markup)
         if direction is _enums.UP:
-            return tuple(_.indicator for _ in wrappers if _.direction is _enums.UP)
+            return tuple(_.indicator() for _ in wrappers if _.direction() is _enums.UP)
         elif direction is _enums.DOWN:
-            return tuple(_.indicator for _ in wrappers if _.direction is _enums.DOWN)
-        indicators = [_.indicator for _ in wrappers]
+            return tuple(
+                _.indicator() for _ in wrappers if _.direction() is _enums.DOWN
+            )
+        indicators = [_.indicator() for _ in wrappers]
         return indicators
 
     def _get_parentage(self):
@@ -286,7 +288,7 @@ class Component:
         prototype_classes = tuple(prototype_classes)
         wrappers = []
         for wrapper in self._wrappers:
-            if wrapper.annotation:
+            if wrapper.annotation():
                 continue
             if isinstance(wrapper, prototype_classes):
                 wrappers.append(wrapper)
@@ -294,7 +296,7 @@ class Component:
                 wrappers.append(wrapper)
             elif isinstance(wrapper.unbundle_indicator(), prototype_classes):
                 wrappers.append(wrapper)
-            elif any(wrapper.indicator == _ for _ in prototype_objects):
+            elif any(wrapper.indicator() == _ for _ in prototype_objects):
                 wrappers.append(wrapper)
             elif any(wrapper.unbundle_indicator() == _ for _ in prototype_objects):
                 wrappers.append(wrapper)
@@ -319,7 +321,7 @@ class Component:
             if not hasattr(component, "_lilypond_type"):
                 continue
             for wrapper in component._dependent_wrappers[:]:
-                if wrapper.component is self:
+                if wrapper.component() is self:
                     component._dependent_wrappers.remove(wrapper)
         if self._parent is not None:
             self._parent._components.remove(self)

--- a/source/abjad/wf.py
+++ b/source/abjad/wf.py
@@ -313,10 +313,7 @@ def check_orphaned_dependent_wrappers(argument) -> tuple[list, int]:
         >>> voice = abjad.Voice("c'8 [ d' e' f'")
         >>> assert len(voice._dependent_wrappers) == 1
         >>> wrapper = voice._dependent_wrappers[0]
-        >>> wrapper
-        Wrapper(annotation=None, context_name='Voice', deactivate=False, direction=None, hide=False, indicator=StartBeam(), synthetic_offset=None, tag=Tag(string=''))
-
-        >>> wrapper.component
+        >>> wrapper.component()
         Note("c'8")
 
         >>> abjad.wf.check_orphaned_dependent_wrappers(voice)
@@ -331,7 +328,7 @@ def check_orphaned_dependent_wrappers(argument) -> tuple[list, int]:
 
         >>> voice._dependent_wrappers.append(wrapper)
         >>> assert len(voice._dependent_wrappers) == 1
-        >>> assert wrapper.component not in voice
+        >>> assert wrapper.component() not in voice
 
         >>> abjad.wf.check_orphaned_dependent_wrappers(voice)
         ([Wrapper(annotation=None, context_name='Voice', deactivate=False, direction=None, hide=False, indicator=StartBeam(), synthetic_offset=None, tag=Tag(string=''))], 1)
@@ -342,7 +339,7 @@ def check_orphaned_dependent_wrappers(argument) -> tuple[list, int]:
         assert isinstance(context, _score.Context)
         for wrapper in context._dependent_wrappers:
             total += 1
-            parentage = _get.parentage(wrapper.component)
+            parentage = _get.parentage(wrapper.component())
             if context not in parentage:
                 violators.append(wrapper)
     return violators, total
@@ -495,10 +492,10 @@ def check_overlapping_beams(argument) -> tuple[list, int]:
     violators, total = [], 0
     context_name_to_wrappers = _aggregate_context_wrappers(argument)
     for _, wrappers in context_name_to_wrappers.items():
-        wrappers.sort(key=lambda _: _get.timespan(_.component).start_offset)
+        wrappers.sort(key=lambda _: _get.timespan(_.component()).start_offset)
         open_beam_count = 0
         for wrapper in wrappers:
-            if _get.is_grace_music(wrapper.component) is True:
+            if _get.is_grace_music(wrapper.component()) is True:
                 continue
             total += 1
             if isinstance(wrapper.unbundle_indicator(), _indicators.StartBeam):
@@ -506,7 +503,7 @@ def check_overlapping_beams(argument) -> tuple[list, int]:
             elif isinstance(wrapper.unbundle_indicator(), _indicators.StopBeam):
                 open_beam_count -= 1
             if open_beam_count < 0 or 1 < open_beam_count:
-                violators.append(wrapper.component)
+                violators.append(wrapper.component())
     return violators, total
 
 
@@ -638,7 +635,7 @@ def check_overlapping_text_spanners(argument) -> tuple[list, int]:
         wrappers.sort(key=key)
         open_spanners: dict = {}
         for wrapper in wrappers:
-            if wrapper.deactivate is True:
+            if wrapper.deactivate() is True:
                 continue
             if isinstance(wrapper.unbundle_indicator(), _indicators.StartTextSpan):
                 total += 1
@@ -648,8 +645,8 @@ def check_overlapping_text_spanners(argument) -> tuple[list, int]:
                 if command not in open_spanners:
                     open_spanners[command] = []
                 if open_spanners[command]:
-                    violators.append(wrapper.component)
-                open_spanners[command].append(wrapper.component)
+                    violators.append(wrapper.component())
+                open_spanners[command].append(wrapper.component())
             elif isinstance(wrapper.unbundle_indicator(), _indicators.StopTextSpan):
                 command = wrapper.unbundle_indicator().command
                 command = command.replace("stop", "")
@@ -724,13 +721,13 @@ def check_unmatched_stop_text_spans(argument) -> tuple[list, int]:
                 command = command.replace("Start", "")
                 if command not in open_spanners:
                     open_spanners[command] = []
-                open_spanners[command].append(wrapper.component)
+                open_spanners[command].append(wrapper.component())
             elif isinstance(wrapper.unbundle_indicator(), _indicators.StopTextSpan):
                 command = wrapper.unbundle_indicator().command
                 command = command.replace("stop", "")
                 command = command.replace("Stop", "")
                 if command not in open_spanners or not open_spanners[command]:
-                    violators.append(wrapper.component)
+                    violators.append(wrapper.component())
                 else:
                     open_spanners[command].pop()
     return violators, total
@@ -850,14 +847,14 @@ def check_unterminated_hairpins(argument) -> tuple[list, int]:
                 wrapper.unbundle_indicator(), _indicators.StopHairpin
             ):
                 last_dynamic = wrapper.unbundle_indicator()
-                last_tag = wrapper.tag
+                last_tag = wrapper.tag()
                 if isinstance(wrapper.unbundle_indicator(), _indicators.StartHairpin):
                     total += 1
         if (
             isinstance(last_dynamic, _indicators.StartHairpin)
             and _tag.Tag("RIGHT_BROKEN").string not in last_tag.string
         ):
-            violators.append(wrapper.component)
+            violators.append(wrapper.component())
     return violators, total
 
 
@@ -919,7 +916,7 @@ def check_unterminated_text_spanners(argument) -> tuple[list, int]:
         wrappers.sort(key=lambda _: _.leaked_start_offset())
         open_spanners: dict = {}
         for wrapper in wrappers:
-            if wrapper.deactivate is True:
+            if wrapper.deactivate() is True:
                 continue
             if isinstance(wrapper.unbundle_indicator(), _indicators.StartTextSpan):
                 total += 1
@@ -928,7 +925,7 @@ def check_unterminated_text_spanners(argument) -> tuple[list, int]:
                 command = command.replace("Start", "")
                 if command not in open_spanners:
                     open_spanners[command] = []
-                open_spanners[command].append(wrapper.component)
+                open_spanners[command].append(wrapper.component())
             elif isinstance(wrapper.unbundle_indicator(), _indicators.StopTextSpan):
                 command = wrapper.unbundle_indicator().command
                 command = command.replace("stop", "")

--- a/tests/test_wrapper_Wrapper.py
+++ b/tests/test_wrapper_Wrapper.py
@@ -27,12 +27,12 @@ def test_wrapper_Wrapper___copy___02():
     abjad.attach(clef, staff_1[0], tag=tag)
     wrapper = abjad.get.wrapper(staff_1[0], abjad.Clef)
 
-    assert wrapper.tag == tag
+    assert wrapper.tag() == tag
 
     staff_2 = abjad.mutate.copy(staff_1)
     wrapper = abjad.get.wrapper(staff_2[0], abjad.Clef)
 
-    assert wrapper.tag == tag
+    assert wrapper.tag() == tag
 
 
 def test_wrapper_Wrapper___copy___03():
@@ -45,9 +45,9 @@ def test_wrapper_Wrapper___copy___03():
     abjad.attach(clef, staff_1[0], deactivate=True, tag=abjad.Tag("RED"))
     wrapper_1 = abjad.get.wrapper(staff_1[0], abjad.Clef)
 
-    assert wrapper_1.deactivate is True
+    assert wrapper_1.deactivate() is True
 
     staff_2 = abjad.mutate.copy(staff_1)
     wrapper_2 = abjad.get.wrapper(staff_2[0], abjad.Clef)
 
-    assert wrapper_2.deactivate is True
+    assert wrapper_2.deactivate() is True


### PR DESCRIPTION
Change abjad.Wrapper properties to methods

    OLD properties:
        abjad.wrapper.Wrapper.annotation
        abjad.wrapper.Wrapper.component
        abjad.wrapper.Wrapper.context_name
        abjad.wrapper.Wrapper.direction
        abjad.wrapper.Wrapper.hide
        abjad.wrapper.Wrapper.indicator
        abjad.wrapper.Wrapper.synthetic_offset
    NEW methods:
        abjad.wrapper.Wrapper.annotation()
        abjad.wrapper.Wrapper.component()
        abjad.wrapper.Wrapper.context_name()
        abjad.wrapper.Wrapper.deactivate()
        abjad.wrapper.Wrapper.direction()
        abjad.wrapper.Wrapper.hide()
        abjad.wrapper.Wrapper.indicator()
        abjad.wrapper.Wrapper.synthetic_offset()

    OLD:
        abjad.wrapper.Wrapper.tag [settable property]
    NEW:
        abjad.wrapper.Wrapper.tag()
        abjad.wrapper.Wrapper.tag_setter()

    OLD:
        abjad.wrapper.Wrapper.deactivate [settable property]
    NEW:
        abjad.wrapper.Wrapper.deactivate()
        abjad.wrapper.Wrapper.deactivate_setter()