### PR TITLE
Clean up transitional wrapper method names

### DIFF
--- a/source/abjad/_updatelib.py
+++ b/source/abjad/_updatelib.py
@@ -103,7 +103,7 @@ def _get_measure_start_offsets(component):
         wrappers.extend(wrappers_)
     pairs = []
     for wrapper in wrappers:
-        component = wrapper.component()
+        component = wrapper.get_component()
         start_offset = component._get_timespan().start_offset
         time_signature = wrapper.unbundle_indicator()
         pair = start_offset, time_signature
@@ -268,7 +268,7 @@ def _update_all_indicators(root):
     components = _iterate_entire_score(root)
     for component in components:
         for wrapper in component._get_wrappers():
-            if wrapper.context_name() is not None:
+            if wrapper.get_context_name() is not None:
                 wrapper._update_effective_context()
         component._indicators_are_current = True
 

--- a/source/abjad/bind.py
+++ b/source/abjad/bind.py
@@ -64,7 +64,7 @@ def _before_attach(
                 is True
             ):
                 continue
-            if hide != wrapper.hide():
+            if hide != wrapper.get_hide():
                 continue
             if getattr(indicator, "site", None) != getattr(
                 wrapper.unbundle_indicator(), "site", None
@@ -141,14 +141,14 @@ def _unsafe_attach(
         raise Exception(message)
     annotation = None
     if isinstance(indicator, _wrapper.Wrapper):
-        annotation = indicator.annotation()
-        context = context or indicator.context_name()
-        deactivate = deactivate or indicator.deactivate()
-        hide = hide or indicator.hide()
-        synthetic_offset = synthetic_offset or indicator.synthetic_offset()
-        tag = tag or indicator.tag()
+        annotation = indicator.get_annotation()
+        context = context or indicator.get_context_name()
+        deactivate = deactivate or indicator.get_deactivate()
+        hide = hide or indicator.get_hide()
+        synthetic_offset = synthetic_offset or indicator.get_synthetic_offset()
+        tag = tag or indicator.get_tag()
         indicator._detach()
-        indicator = indicator.indicator()
+        indicator = indicator.get_indicator()
     if hasattr(nonbundle_indicator, "context"):
         context = context or nonbundle_indicator.context
     if tag is None:
@@ -696,7 +696,7 @@ def detach(indicator, component: _score.Component, *, by_id: bool = False) -> tu
             }
 
         >>> wrapper = abjad.get.wrappers(staff[0])[0]
-        >>> wrappers = abjad.detach(wrapper, wrapper.component())
+        >>> wrappers = abjad.detach(wrapper, wrapper.get_component())
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -748,7 +748,7 @@ def detach(indicator, component: _score.Component, *, by_id: bool = False) -> tu
                     result.append(wrapper)
                 elif isinstance(wrapper.unbundle_indicator(), indicator):
                     wrapper._detach()
-                    result.append(wrapper.indicator())
+                    result.append(wrapper.get_indicator())
             return tuple(result)
     else:
         if "AfterGraceContainer" in indicator.__class__.__name__:
@@ -771,7 +771,7 @@ def detach(indicator, component: _score.Component, *, by_id: bool = False) -> tu
                         pass
                     else:
                         wrapper._detach()
-                        result.append(wrapper.indicator())
+                        result.append(wrapper.get_indicator())
             return tuple(result)
     items = []
     if after_grace_container is not None:

--- a/source/abjad/format.py
+++ b/source/abjad/format.py
@@ -60,25 +60,26 @@ def _get_indicator_contributions(component, contributions):
     context_wrappers = []
     noncontext_wrappers = []
     for wrapper in wrappers:
-        if wrapper.annotation():
+        if wrapper.get_annotation():
             continue
-        if not hasattr(wrapper.indicator(), "_get_contributions"):
+        if not hasattr(wrapper.get_indicator(), "_get_contributions"):
             continue
         if (
-            wrapper.context_name() is None
-            and getattr(wrapper.indicator(), "format_leaf_children", False) is not True
-            and wrapper.component() is not component
+            wrapper.get_context_name() is None
+            and getattr(wrapper.get_indicator(), "format_leaf_children", False)
+            is not True
+            and wrapper.get_component() is not component
         ):
             continue
         if isinstance(wrapper.unbundle_indicator(), _indicators.Markup):
-            if wrapper.direction() is _enums.UP:
+            if wrapper.get_direction() is _enums.UP:
                 up_markup_wrappers.append(wrapper)
-            elif wrapper.direction() is _enums.DOWN:
+            elif wrapper.get_direction() is _enums.DOWN:
                 down_markup_wrappers.append(wrapper)
-            elif wrapper.direction() in (_enums.CENTER, None):
+            elif wrapper.get_direction() in (_enums.CENTER, None):
                 neutral_markup_wrappers.append(wrapper)
-        elif wrapper.context_name() is not None:
-            if wrapper.component() is component:
+        elif wrapper.get_context_name() is not None:
+            if wrapper.get_component() is component:
                 context_wrappers.append(wrapper)
         else:
             noncontext_wrappers.append(wrapper)
@@ -92,14 +93,14 @@ def _get_indicator_contributions(component, contributions):
         noncontext_wrappers,
     ):
         for wrapper in wrappers:
-            item = wrapper.indicator()
+            item = wrapper.get_indicator()
             contributions_ = None
             try:
                 contributions_ = item._get_contributions(wrapper=wrapper)
             except TypeError:
                 contributions_ = item._get_contributions()
             contributions_.tag_contributions(
-                wrapper.tag(), deactivate=wrapper.deactivate()
+                wrapper.get_tag(), deactivate=wrapper.get_deactivate()
             )
             if getattr(item, "check_effective_context", False) is True:
                 if wrapper._get_effective_context() is None:

--- a/source/abjad/illustrators.py
+++ b/source/abjad/illustrators.py
@@ -546,10 +546,12 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
         for wrapper in markup_wrappers:
             markup = wrapper.unbundle_indicator()
             markup_copy = copy.copy(markup)
-            if wrapper.direction() in (_enums.UP, None):
-                _bind.attach(markup_copy, treble_leaf, direction=wrapper.direction())
+            if wrapper.get_direction() in (_enums.UP, None):
+                _bind.attach(
+                    markup_copy, treble_leaf, direction=wrapper.get_direction()
+                )
             else:
-                _bind.attach(markup_copy, bass_leaf, direction=wrapper.direction())
+                _bind.attach(markup_copy, bass_leaf, direction=wrapper.get_direction())
         treble_voice.append(treble_leaf)
         bass_voice.append(bass_leaf)
     if 0 < len(treble_voice):

--- a/source/abjad/indicators.py
+++ b/source/abjad/indicators.py
@@ -189,9 +189,9 @@ class Articulation:
             string = self.shortcut_to_word.get(self.name)
             if not string:
                 string = self.name
-            if wrapper.direction() is not None:
+            if wrapper.get_direction() is not None:
                 direction_ = _string.to_tridirectional_lilypond_symbol(
-                    wrapper.direction()
+                    wrapper.get_direction()
                 )
                 direction = direction_
             else:
@@ -778,7 +778,7 @@ class Clef:
     def _get_contributions(self, *, wrapper=None):
         assert wrapper is not None
         contributions = _contributions.ContributionsBySite()
-        if wrapper.hide() is False:
+        if wrapper.get_hide() is False:
             site = getattr(contributions, self.site)
             string = self._get_lilypond_format()
             site.commands.append(string)
@@ -1876,7 +1876,7 @@ class Dynamic:
         ]
         after = {"f": -0.2, "m": -0.1, "p": -0.25, "r": 0, "s": 0, "z": -0.2}[name[-1]]
         # direction = self.direction
-        direction = wrapper.direction() or _enums.DOWN
+        direction = wrapper.get_direction() or _enums.DOWN
         direction = _string.to_tridirectional_lilypond_symbol(direction)
         strings = []
         strings.append(f"{direction} #(make-dynamic-script")
@@ -1896,7 +1896,7 @@ class Dynamic:
 
     @staticmethod
     def _format_textual(string, *, wrapper=None):
-        if wrapper.direction() is None:
+        if wrapper.get_direction() is None:
             direction = _enums.DOWN
         direction = _string.to_tridirectional_lilypond_symbol(direction)
         assert isinstance(string, str), repr(string)
@@ -1910,10 +1910,10 @@ class Dynamic:
         command = self._get_lilypond_format(wrapper=wrapper)
         if self.leak:
             contributions.after.leak.append(_EMPTY_CHORD)
-            if wrapper.hide() is False:
+            if wrapper.get_hide() is False:
                 contributions.after.leaks.append(command)
         else:
-            if wrapper.hide() is False:
+            if wrapper.get_hide() is False:
                 contributions.after.articulations.append(command)
         return contributions
 
@@ -1926,8 +1926,8 @@ class Dynamic:
             string = self._format_textual(self.name, wrapper=wrapper)
         else:
             string = rf"\{self.name}"
-            if wrapper.direction() is not None:
-                direction_ = wrapper.direction()
+            if wrapper.get_direction() is not None:
+                direction_ = wrapper.get_direction()
                 direction = _string.to_tridirectional_lilypond_symbol(direction_)
                 string = f"{direction} {string}"
         return string
@@ -2677,9 +2677,9 @@ class KeyCluster:
             assert self.hide_natural_markup is False
             string = r"\center-column \natural"
         string = rf"\markup {string}"
-        if wrapper.direction() is _enums.UP:
+        if wrapper.get_direction() is _enums.UP:
             string = rf"^ {string}"
-        elif wrapper.direction() is _enums.DOWN:
+        elif wrapper.get_direction() is _enums.DOWN:
             string = rf"_ {string}"
         site.markup.append(string)
         return contributions
@@ -3351,7 +3351,7 @@ class Markup:
     def _get_lilypond_format(self, *, wrapper=None):
         string = self.string
         if wrapper is not None:
-            direction = wrapper.direction() or "-"
+            direction = wrapper.get_direction() or "-"
             direction = _string.to_tridirectional_lilypond_symbol(direction)
             string = rf"{direction} {self.string}"
         return string
@@ -3714,7 +3714,7 @@ class MetronomeMark:
         assert wrapper is not None
         contributions = _contributions.ContributionsBySite()
         site = getattr(contributions, self.site)
-        if wrapper.hide() is False:
+        if wrapper.get_hide() is False:
             string = self._get_lilypond_format()
             site.commands.append(string)
         return contributions
@@ -4271,7 +4271,7 @@ class RepeatTie:
         [RepeatTie()]
 
         >>> wrapper = abjad.get.wrapper(voice[1], abjad.RepeatTie)
-        >>> wrapper.indicator()
+        >>> wrapper.get_indicator()
         Bundle(indicator=RepeatTie(), tweaks=(Tweak(string='- \\tweak color #blue', i=None, tag=None),), comment=None)
 
         >>> for leaf in voice:
@@ -4388,8 +4388,8 @@ class RepeatTie:
         contributions = _contributions.ContributionsBySite()
         site = getattr(contributions, self.site)
         strings = []
-        if wrapper.direction() is not None:
-            string = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
+        if wrapper.get_direction() is not None:
+            string = _string.to_tridirectional_lilypond_symbol(wrapper.get_direction())
             strings.append(string)
         strings.append(r"\repeatTie")
         site.spanner_starts.extend(strings)
@@ -4623,8 +4623,8 @@ class StartBeam:
     spanner_start: typing.ClassVar[bool] = True
 
     def _add_direction(self, string, wrapper):
-        if wrapper.direction() is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
+        if wrapper.get_direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.get_direction())
             string = f"{symbol} {string}"
         return string
 
@@ -5036,8 +5036,8 @@ class StartHairpin:
         assert self.shape in self.known_shapes, repr(self.shape)
 
     def _add_direction(self, string, *, wrapper=None):
-        if wrapper.direction() is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
+        if wrapper.get_direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.get_direction())
             string = f"{symbol} {string}"
         return string
 
@@ -5144,8 +5144,8 @@ class StartPhrasingSlur:
     spanner_start: typing.ClassVar[bool] = True
 
     def _add_direction(self, string, *, wrapper=None):
-        if wrapper.direction() is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
+        if wrapper.get_direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.get_direction())
             string = f"{symbol} {string}"
         return string
 
@@ -5378,8 +5378,8 @@ class StartSlur:
     spanner_start: typing.ClassVar[bool] = True
 
     def _add_direction(self, string, *, wrapper=None):
-        if wrapper.direction() is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
+        if wrapper.get_direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.get_direction())
             string = f"{symbol} {string}"
         return string
 
@@ -5798,8 +5798,8 @@ class StartTextSpan:
         return contributions
 
     def _add_direction(self, string, *, wrapper=None):
-        if wrapper.direction() is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
+        if wrapper.get_direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.get_direction())
             string = f"{symbol} {string}"
         return string
 
@@ -5983,7 +5983,7 @@ class StartTrillSpan:
             if self.pitch:
                 pitch = self.pitch
             else:
-                pitch = wrapper.component().written_pitch + self.interval
+                pitch = wrapper.get_component().written_pitch + self.interval
             string = string + f" {pitch.name}"
             if self.force_trill_pitch_head_accidental is True:
                 # LilyPond's TrillPitchHead does not obey LilyPond's \accidentalStyle;
@@ -7131,8 +7131,8 @@ class Tie:
     site: typing.ClassVar[str] = "after"
 
     def _add_direction(self, string, *, wrapper=None):
-        if wrapper.direction() is not None:
-            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.direction())
+        if wrapper.get_direction() is not None:
+            symbol = _string.to_tridirectional_lilypond_symbol(wrapper.get_direction())
             string = f"{symbol} {string}"
         return string
 
@@ -7316,7 +7316,7 @@ class TimeSignature:
         assert wrapper is not None
         contributions = _contributions.ContributionsBySite()
         site = getattr(contributions, self.site)
-        if not self.is_dyadic() and wrapper.hide() is False:
+        if not self.is_dyadic() and wrapper.get_hide() is False:
             string = '#(ly:expect-warning "strange time signature found")'
             site.commands.append(string)
         strings = self._get_lilypond_format(wrapper)
@@ -7325,7 +7325,7 @@ class TimeSignature:
 
     def _get_lilypond_format(self, wrapper):
         result = []
-        if wrapper.hide() is True:
+        if wrapper.get_hide() is True:
             return result
         if self.partial is None:
             result.append(rf"\time {self.numerator}/{self.denominator}")

--- a/source/abjad/iterpitches.py
+++ b/source/abjad/iterpitches.py
@@ -247,11 +247,11 @@ def transpose_from_sounding_pitch(argument) -> None:
             new_start_trill_span = dataclasses.replace(
                 start_trill_span, pitch=new_pitch
             )
-            wrapper_tag = wrapper.tag()
+            wrapper_tag = wrapper.get_tag()
             _bind.detach(wrapper, leaf)
             if wrapper.is_bundled():
                 new_bundle = dataclasses.replace(
-                    wrapper.indicator(),
+                    wrapper.get_indicator(),
                     indicator=new_start_trill_span,
                 )
                 _bind.attach(new_bundle, leaf, tag=wrapper_tag)
@@ -322,7 +322,7 @@ def transpose_from_written_pitch(argument) -> None:
             _bind.detach(wrapper, leaf)
             if wrapper.is_bundled():
                 new_bundle = dataclasses.replace(
-                    wrapper.indicator(),
+                    wrapper.get_indicator(),
                     indicator=new_start_trill_span,
                 )
                 _bind.attach(new_bundle, leaf)

--- a/source/abjad/metricmodulation.py
+++ b/source/abjad/metricmodulation.py
@@ -451,7 +451,7 @@ class MetricModulation:
     def _get_contributions(self, *, wrapper=None):
         assert wrapper is not None, repr(wrapper)
         contributions = _contributions.ContributionsBySite()
-        if wrapper.hide() is False:
+        if wrapper.get_hide() is False:
             markup = self._get_markup()
             contributions = markup._get_contributions(wrapper=wrapper)
         return contributions

--- a/source/abjad/mutate.py
+++ b/source/abjad/mutate.py
@@ -1636,10 +1636,10 @@ def replace(argument, recipients, *, wrappers: bool = False) -> None:
         donor._wrappers.remove(wrapper)
         wrapper._component = recipient
         recipient._wrappers.append(wrapper)
-        context_name = wrapper.context_name()
+        context_name = wrapper.get_context_name()
         if context_name is not None:
             context = wrapper._find_correct_effective_context(
-                wrapper.component(),
+                wrapper.get_component(),
                 context_name,
             )
             assert context is not None

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -122,7 +122,7 @@ class Component:
                 _overrides.setting(self)
             )
         for wrapper in self._wrappers:
-            if not wrapper.annotation():
+            if not wrapper.get_annotation():
                 continue
             wrapper_ = copy.copy(wrapper)
             wrapper_._component = component
@@ -226,12 +226,14 @@ class Component:
     def _get_markup(self, direction=None):
         wrappers = self._get_wrappers(_indicators.Markup)
         if direction is _enums.UP:
-            return tuple(_.indicator() for _ in wrappers if _.direction() is _enums.UP)
+            return tuple(
+                _.get_indicator() for _ in wrappers if _.get_direction() is _enums.UP
+            )
         elif direction is _enums.DOWN:
             return tuple(
-                _.indicator() for _ in wrappers if _.direction() is _enums.DOWN
+                _.get_indicator() for _ in wrappers if _.get_direction() is _enums.DOWN
             )
-        indicators = [_.indicator() for _ in wrappers]
+        indicators = [_.get_indicator() for _ in wrappers]
         return indicators
 
     def _get_parentage(self):
@@ -288,7 +290,7 @@ class Component:
         prototype_classes = tuple(prototype_classes)
         wrappers = []
         for wrapper in self._wrappers:
-            if wrapper.annotation():
+            if wrapper.get_annotation():
                 continue
             if isinstance(wrapper, prototype_classes):
                 wrappers.append(wrapper)
@@ -296,7 +298,7 @@ class Component:
                 wrappers.append(wrapper)
             elif isinstance(wrapper.unbundle_indicator(), prototype_classes):
                 wrappers.append(wrapper)
-            elif any(wrapper.indicator() == _ for _ in prototype_objects):
+            elif any(wrapper.get_indicator() == _ for _ in prototype_objects):
                 wrappers.append(wrapper)
             elif any(wrapper.unbundle_indicator() == _ for _ in prototype_objects):
                 wrappers.append(wrapper)
@@ -321,7 +323,7 @@ class Component:
             if not hasattr(component, "_lilypond_type"):
                 continue
             for wrapper in component._dependent_wrappers[:]:
-                if wrapper.component() is self:
+                if wrapper.get_component() is self:
                     component._dependent_wrappers.remove(wrapper)
         if self._parent is not None:
             self._parent._components.remove(self)

--- a/source/abjad/wf.py
+++ b/source/abjad/wf.py
@@ -313,7 +313,7 @@ def check_orphaned_dependent_wrappers(argument) -> tuple[list, int]:
         >>> voice = abjad.Voice("c'8 [ d' e' f'")
         >>> assert len(voice._dependent_wrappers) == 1
         >>> wrapper = voice._dependent_wrappers[0]
-        >>> wrapper.component()
+        >>> wrapper.get_component()
         Note("c'8")
 
         >>> abjad.wf.check_orphaned_dependent_wrappers(voice)
@@ -328,7 +328,7 @@ def check_orphaned_dependent_wrappers(argument) -> tuple[list, int]:
 
         >>> voice._dependent_wrappers.append(wrapper)
         >>> assert len(voice._dependent_wrappers) == 1
-        >>> assert wrapper.component() not in voice
+        >>> assert wrapper.get_component() not in voice
 
         >>> abjad.wf.check_orphaned_dependent_wrappers(voice)
         ([Wrapper(annotation=None, context_name='Voice', deactivate=False, direction=None, hide=False, indicator=StartBeam(), synthetic_offset=None, tag=Tag(string=''))], 1)
@@ -339,7 +339,7 @@ def check_orphaned_dependent_wrappers(argument) -> tuple[list, int]:
         assert isinstance(context, _score.Context)
         for wrapper in context._dependent_wrappers:
             total += 1
-            parentage = _get.parentage(wrapper.component())
+            parentage = _get.parentage(wrapper.get_component())
             if context not in parentage:
                 violators.append(wrapper)
     return violators, total
@@ -492,10 +492,10 @@ def check_overlapping_beams(argument) -> tuple[list, int]:
     violators, total = [], 0
     context_name_to_wrappers = _aggregate_context_wrappers(argument)
     for _, wrappers in context_name_to_wrappers.items():
-        wrappers.sort(key=lambda _: _get.timespan(_.component()).start_offset)
+        wrappers.sort(key=lambda _: _get.timespan(_.get_component()).start_offset)
         open_beam_count = 0
         for wrapper in wrappers:
-            if _get.is_grace_music(wrapper.component()) is True:
+            if _get.is_grace_music(wrapper.get_component()) is True:
                 continue
             total += 1
             if isinstance(wrapper.unbundle_indicator(), _indicators.StartBeam):
@@ -503,7 +503,7 @@ def check_overlapping_beams(argument) -> tuple[list, int]:
             elif isinstance(wrapper.unbundle_indicator(), _indicators.StopBeam):
                 open_beam_count -= 1
             if open_beam_count < 0 or 1 < open_beam_count:
-                violators.append(wrapper.component())
+                violators.append(wrapper.get_component())
     return violators, total
 
 
@@ -635,7 +635,7 @@ def check_overlapping_text_spanners(argument) -> tuple[list, int]:
         wrappers.sort(key=key)
         open_spanners: dict = {}
         for wrapper in wrappers:
-            if wrapper.deactivate() is True:
+            if wrapper.get_deactivate() is True:
                 continue
             if isinstance(wrapper.unbundle_indicator(), _indicators.StartTextSpan):
                 total += 1
@@ -645,8 +645,8 @@ def check_overlapping_text_spanners(argument) -> tuple[list, int]:
                 if command not in open_spanners:
                     open_spanners[command] = []
                 if open_spanners[command]:
-                    violators.append(wrapper.component())
-                open_spanners[command].append(wrapper.component())
+                    violators.append(wrapper.get_component())
+                open_spanners[command].append(wrapper.get_component())
             elif isinstance(wrapper.unbundle_indicator(), _indicators.StopTextSpan):
                 command = wrapper.unbundle_indicator().command
                 command = command.replace("stop", "")
@@ -721,13 +721,13 @@ def check_unmatched_stop_text_spans(argument) -> tuple[list, int]:
                 command = command.replace("Start", "")
                 if command not in open_spanners:
                     open_spanners[command] = []
-                open_spanners[command].append(wrapper.component())
+                open_spanners[command].append(wrapper.get_component())
             elif isinstance(wrapper.unbundle_indicator(), _indicators.StopTextSpan):
                 command = wrapper.unbundle_indicator().command
                 command = command.replace("stop", "")
                 command = command.replace("Stop", "")
                 if command not in open_spanners or not open_spanners[command]:
-                    violators.append(wrapper.component())
+                    violators.append(wrapper.get_component())
                 else:
                     open_spanners[command].pop()
     return violators, total
@@ -847,14 +847,14 @@ def check_unterminated_hairpins(argument) -> tuple[list, int]:
                 wrapper.unbundle_indicator(), _indicators.StopHairpin
             ):
                 last_dynamic = wrapper.unbundle_indicator()
-                last_tag = wrapper.tag()
+                last_tag = wrapper.get_tag()
                 if isinstance(wrapper.unbundle_indicator(), _indicators.StartHairpin):
                     total += 1
         if (
             isinstance(last_dynamic, _indicators.StartHairpin)
             and _tag.Tag("RIGHT_BROKEN").string not in last_tag.string
         ):
-            violators.append(wrapper.component())
+            violators.append(wrapper.get_component())
     return violators, total
 
 
@@ -916,7 +916,7 @@ def check_unterminated_text_spanners(argument) -> tuple[list, int]:
         wrappers.sort(key=lambda _: _.leaked_start_offset())
         open_spanners: dict = {}
         for wrapper in wrappers:
-            if wrapper.deactivate() is True:
+            if wrapper.get_deactivate() is True:
                 continue
             if isinstance(wrapper.unbundle_indicator(), _indicators.StartTextSpan):
                 total += 1
@@ -925,7 +925,7 @@ def check_unterminated_text_spanners(argument) -> tuple[list, int]:
                 command = command.replace("Start", "")
                 if command not in open_spanners:
                     open_spanners[command] = []
-                open_spanners[command].append(wrapper.component())
+                open_spanners[command].append(wrapper.get_component())
             elif isinstance(wrapper.unbundle_indicator(), _indicators.StopTextSpan):
                 command = wrapper.unbundle_indicator().command
                 command = command.replace("stop", "")

--- a/tests/test_wrapper_Wrapper.py
+++ b/tests/test_wrapper_Wrapper.py
@@ -27,12 +27,12 @@ def test_wrapper_Wrapper___copy___02():
     abjad.attach(clef, staff_1[0], tag=tag)
     wrapper = abjad.get.wrapper(staff_1[0], abjad.Clef)
 
-    assert wrapper.tag() == tag
+    assert wrapper.get_tag() == tag
 
     staff_2 = abjad.mutate.copy(staff_1)
     wrapper = abjad.get.wrapper(staff_2[0], abjad.Clef)
 
-    assert wrapper.tag() == tag
+    assert wrapper.get_tag() == tag
 
 
 def test_wrapper_Wrapper___copy___03():
@@ -45,9 +45,9 @@ def test_wrapper_Wrapper___copy___03():
     abjad.attach(clef, staff_1[0], deactivate=True, tag=abjad.Tag("RED"))
     wrapper_1 = abjad.get.wrapper(staff_1[0], abjad.Clef)
 
-    assert wrapper_1.deactivate() is True
+    assert wrapper_1.get_deactivate() is True
 
     staff_2 = abjad.mutate.copy(staff_1)
     wrapper_2 = abjad.get.wrapper(staff_2[0], abjad.Clef)
 
-    assert wrapper_2.deactivate() is True
+    assert wrapper_2.get_deactivate() is True


### PR DESCRIPTION
Abjad 3.27 will be a bridge release.

Use these name changes in the public announcement of Abjad 3.27:

    OLD:
        abjad.wrapper.Wrapper.annotation
        abjad.wrapper.Wrapper.component
        abjad.wrapper.Wrapper.context_name
        abjad.wrapper.Wrapper.direction
        abjad.wrapper.Wrapper.hide
        abjad.wrapper.Wrapper.indicator
        abjad.wrapper.Wrapper.synthetic_offset
    NEW:
        abjad.wrapper.Wrapper.get_annotation()
        abjad.wrapper.Wrapper.get_component()
        abjad.wrapper.Wrapper.get_context_name()
        abjad.wrapper.Wrapper.get_deactivate()
        abjad.wrapper.Wrapper.get_direction()
        abjad.wrapper.Wrapper.get_hide()
        abjad.wrapper.Wrapper.get_indicator()
        abjad.wrapper.Wrapper.get_synthetic_offset()

    OLD:
        abjad.wrapper.Wrapper.tag
    NEW:
        abjad.wrapper.Wrapper.get_tag()
        abjad.wrapper.Wrapper.set_tag()

    OLD:
        abjad.wrapper.Wrapper.deactivate
    NEW:
        abjad.wrapper.Wrapper.get_deactivate()
        abjad.wrapper.Wrapper.set_deactivate()