### PR TITLE
Clean up transitional duration method names

### DIFF
--- a/source/abjad/_updatelib.py
+++ b/source/abjad/_updatelib.py
@@ -143,7 +143,7 @@ def _get_obgc_leaf_offsets(leaf):
     first_nongrace_leaf_start_offset = first_nongrace_leaf._start_offset
     assert first_nongrace_leaf_start_offset is not None
     first_nongrace_leaf_start_offset = _duration.Offset(
-        first_nongrace_leaf_start_offset.pair()
+        first_nongrace_leaf_start_offset.get_pair()
     )
     start_displacement = _duration.Duration(0)
     sibling = leaf._sibling(-1)
@@ -154,10 +154,10 @@ def _get_obgc_leaf_offsets(leaf):
     if start_displacement == 0:
         start_displacement = None
     start_offset = _duration.Offset(
-        first_nongrace_leaf_start_offset.pair(), displacement=start_displacement
+        first_nongrace_leaf_start_offset.get_pair(), displacement=start_displacement
     )
     stop_offset = _duration.Offset(
-        first_nongrace_leaf_start_offset.pair(), displacement=stop_displacement
+        first_nongrace_leaf_start_offset.get_pair(), displacement=stop_displacement
     )
     return start_offset, stop_offset
 
@@ -237,7 +237,7 @@ def _make_metronome_mark_map(root):
 # TODO: reimplement with some type of bisection
 def _to_measure_number(component, measure_start_offsets):
     component_start_offset = component._get_timespan().start_offset
-    displacement = component_start_offset.displacement()
+    displacement = component_start_offset.get_displacement()
     if displacement is not None:
         component_start_offset = _duration.Offset(
             component_start_offset, displacement=None

--- a/source/abjad/duration.py
+++ b/source/abjad/duration.py
@@ -452,7 +452,7 @@ class Duration(fractions.Fraction):
         result = 2 ** (int(math.ceil(math.log(n, 2))) + i)
         return result
 
-    def dot_count(self) -> int:
+    def get_dot_count(self) -> int:
         r"""
         Gets dot count.
 
@@ -466,7 +466,7 @@ class Duration(fractions.Fraction):
             ...     try:
             ...         duration = abjad.Duration(n, 16)
             ...         sixteenths = abjad.duration.with_denominator(duration, 16)
-            ...         dot_count = duration.dot_count()
+            ...         dot_count = duration.get_dot_count()
             ...         string = f"{sixteenths[0]}/{sixteenths[1]}\t{dot_count}"
             ...         print(string)
             ...     except abjad.AssignabilityError:
@@ -491,7 +491,7 @@ class Duration(fractions.Fraction):
             16/16   0
 
         """
-        if not self.is_assignable():
+        if not self.get_is_assignable():
             raise _exceptions.AssignabilityError
         binary_string = _math.integer_to_binary_string(self.numerator)
         digit_sum = sum([int(x) for x in list(binary_string)])
@@ -521,7 +521,7 @@ class Duration(fractions.Fraction):
         pairs = [with_denominator(_, lcd) for _ in durations_]
         return pairs
 
-    def equal_or_greater_assignable(self) -> "Duration":
+    def get_equal_or_greater_assignable(self) -> "Duration":
         r"""
         Gets assignable duration equal to or just greater than this duration.
 
@@ -529,7 +529,7 @@ class Duration(fractions.Fraction):
 
             >>> for numerator in range(1, 16 + 1):
             ...     duration = abjad.Duration(numerator, 16)
-            ...     result = duration.equal_or_greater_assignable()
+            ...     result = duration.get_equal_or_greater_assignable()
             ...     sixteenths = abjad.duration.with_denominator(duration, 16)
             ...     print(f"{sixteenths[0]}/{sixteenths[1]}\t{result!s}")
             ...
@@ -554,12 +554,12 @@ class Duration(fractions.Fraction):
         good_denominator = _math.greatest_power_of_two_less_equal(self.denominator)
         current_numerator = self.numerator
         candidate = type(self)(current_numerator, good_denominator)
-        while not candidate.is_assignable():
+        while not candidate.get_is_assignable():
             current_numerator += 1
             candidate = type(self)(current_numerator, good_denominator)
         return candidate
 
-    def equal_or_greater_power_of_two(self) -> "Duration":
+    def get_equal_or_greater_power_of_two(self) -> "Duration":
         r"""
         Gets duration equal or just greater power of two.
 
@@ -567,7 +567,7 @@ class Duration(fractions.Fraction):
 
             >>> for numerator in range(1, 16 + 1):
             ...     duration = abjad.Duration(numerator, 16)
-            ...     result = duration.equal_or_greater_power_of_two()
+            ...     result = duration.get_equal_or_greater_power_of_two()
             ...     sixteenths = abjad.duration.with_denominator(duration, 16)
             ...     print(f"{sixteenths[0]}/{sixteenths[1]}\t{result!s}")
             ...
@@ -592,7 +592,7 @@ class Duration(fractions.Fraction):
         denominator_exponent = -int(math.ceil(math.log(self, 2)))
         return type(self)(1, 2) ** denominator_exponent
 
-    def equal_or_lesser_assignable(self) -> "Duration":
+    def get_equal_or_lesser_assignable(self) -> "Duration":
         r"""
         Gets assignable duration equal or just less than this duration.
 
@@ -600,7 +600,7 @@ class Duration(fractions.Fraction):
 
             >>> for numerator in range(1, 16 + 1):
             ...     duration = abjad.Duration(numerator, 16)
-            ...     result = duration.equal_or_lesser_assignable()
+            ...     result = duration.get_equal_or_lesser_assignable()
             ...     sixteenths = abjad.duration.with_denominator(duration, 16)
             ...     print(f"{sixteenths[0]}/{sixteenths[1]}\t{result!s}")
             ...
@@ -625,12 +625,12 @@ class Duration(fractions.Fraction):
         good_denominator = self._least_power_of_two_greater_equal(self.denominator)
         current_numerator = self.numerator
         candidate = type(self)(current_numerator, good_denominator)
-        while not candidate.is_assignable():
+        while not candidate.get_is_assignable():
             current_numerator -= 1
             candidate = type(self)(current_numerator, good_denominator)
         return candidate
 
-    def equal_or_lesser_power_of_two(self) -> "Duration":
+    def get_equal_or_lesser_power_of_two(self) -> "Duration":
         r"""
         Gets duration of the form ``d**2`` equal to or just less than this
         duration.
@@ -639,7 +639,7 @@ class Duration(fractions.Fraction):
 
             >>> for numerator in range(1, 16 + 1):
             ...     duration = abjad.Duration(numerator, 16)
-            ...     result = duration.equal_or_lesser_power_of_two()
+            ...     result = duration.get_equal_or_lesser_power_of_two()
             ...     sixteenths = abjad.duration.with_denominator(duration, 16)
             ...     print(f"{sixteenths[0]}/{sixteenths[1]}\t{result!s}")
             ...
@@ -661,9 +661,9 @@ class Duration(fractions.Fraction):
             16/16   1
 
         """
-        return type(self)(1, 2) ** self.exponent()
+        return type(self)(1, 2) ** self.get_exponent()
 
-    def exponent(self) -> int:
+    def get_exponent(self) -> int:
         r"""
         Gets base-2 exponent.
 
@@ -671,9 +671,9 @@ class Duration(fractions.Fraction):
 
             >>> for numerator in range(1, 16 + 1):
             ...     duration = abjad.Duration(numerator, 16)
-            ...     exponent = duration.exponent()
+            ...     exponent = duration.get_exponent()
             ...     sixteenths = abjad.duration.with_denominator(duration, 16)
-            ...     print(f"{sixteenths[0]}/{sixteenths[1]}\t{duration.exponent()!s}")
+            ...     print(f"{sixteenths[0]}/{sixteenths[1]}\t{duration.get_exponent()!s}")
             ...
             1/16	4
             2/16	3
@@ -695,7 +695,7 @@ class Duration(fractions.Fraction):
         """
         return -int(math.floor(math.log(self, 2)))
 
-    def flag_count(self) -> int:
+    def get_flag_count(self) -> int:
         r"""
         Gets flag count.
 
@@ -707,7 +707,7 @@ class Duration(fractions.Fraction):
             >>> for n in range(1, 16 + 1):
             ...     duration = abjad.Duration(n, 64)
             ...     sixty_fourths = abjad.duration.with_denominator(duration, 64)
-            ...     print(f"{sixty_fourths[0]}/{sixty_fourths[1]}\t{duration.flag_count()}")
+            ...     print(f"{sixty_fourths[0]}/{sixty_fourths[1]}\t{duration.get_flag_count()}")
             ...
             1/64    4
             2/64    3
@@ -779,7 +779,7 @@ class Duration(fractions.Fraction):
         )
         return Duration(fraction)
 
-    def is_assignable(self) -> bool:
+    def get_is_assignable(self) -> bool:
         r"""
         Is true when duration is assignable.
 
@@ -788,7 +788,7 @@ class Duration(fractions.Fraction):
             >>> for numerator in range(0, 16 + 1):
             ...     duration = abjad.Duration(numerator, 16)
             ...     sixteenths = abjad.duration.with_denominator(duration, 16)
-            ...     print(f"{sixteenths[0]}/{sixteenths[1]}\t{duration.is_assignable()}")
+            ...     print(f"{sixteenths[0]}/{sixteenths[1]}\t{duration.get_is_assignable()}")
             ...
             0/16    False
             1/16    True
@@ -862,7 +862,7 @@ class Duration(fractions.Fraction):
         except Exception:
             return False
 
-    def lilypond_duration_string(self) -> str:
+    def get_lilypond_duration_string(self) -> str:
         """
         Gets LilyPond duration string.
 
@@ -870,13 +870,13 @@ class Duration(fractions.Fraction):
 
             Raises assignability error when duration is not assignable.
 
-            >>> abjad.Duration(3, 16).lilypond_duration_string()
+            >>> abjad.Duration(3, 16).get_lilypond_duration_string()
             '8.'
 
         """
-        if not self.is_assignable():
+        if not self.get_is_assignable():
             raise _exceptions.AssignabilityError(self)
-        undotted_rational = self.equal_or_lesser_power_of_two()
+        undotted_rational = self.get_equal_or_lesser_power_of_two()
         if undotted_rational <= 1:
             undotted_duration_string = str(undotted_rational.denominator)
         elif undotted_rational == type(self)(2, 1):
@@ -887,30 +887,30 @@ class Duration(fractions.Fraction):
             undotted_duration_string = r"\maxima"
         else:
             raise ValueError(f"can not process undotted rational: {undotted_rational}")
-        dot_count = self.dot_count()
+        dot_count = self.get_dot_count()
         dot_string = "." * dot_count
         dotted_duration_string = undotted_duration_string + dot_string
         return dotted_duration_string
 
-    def pair(self) -> tuple[int, int]:
+    def get_pair(self) -> tuple[int, int]:
         """
         Gets numerator and denominator pair.
 
         ..  container:: example
 
-            >>> abjad.Duration(3, 16).pair()
+            >>> abjad.Duration(3, 16).get_pair()
             (3, 16)
 
         """
         return self.numerator, self.denominator
 
-    def reciprocal(self) -> "Duration":
+    def get_reciprocal(self) -> "Duration":
         """
         Gets reciprocal.
 
         ..  container:: example
 
-            >>> abjad.Duration(3, 7).reciprocal()
+            >>> abjad.Duration(3, 7).get_reciprocal()
             Duration(7, 3)
 
         """
@@ -1043,7 +1043,7 @@ class Offset(Duration):
         displacement = None
         for argument in arguments:
             try:
-                displacement = argument.displacement()
+                displacement = argument.get_displacement()
                 break
             except AttributeError:
                 pass
@@ -1052,7 +1052,7 @@ class Offset(Duration):
             displacement = Duration(displacement)
         displacement = displacement or None
         if len(arguments) == 1 and isinstance(arguments[0], Duration):
-            arguments = arguments[0].pair()
+            arguments = arguments[0].get_pair()
         self = Duration.__new__(class_, *arguments)
         self._displacement = displacement
         return self
@@ -1083,7 +1083,7 @@ class Offset(Duration):
             False
 
         """
-        return type(self)(self.pair(), displacement=self.displacement())
+        return type(self)(self.get_pair(), displacement=self.get_displacement())
 
     def __deepcopy__(self, *arguments) -> "Offset":
         """
@@ -1168,7 +1168,7 @@ class Offset(Duration):
             True
 
         """
-        if isinstance(argument, type(self)) and self.pair() == argument.pair():
+        if isinstance(argument, type(self)) and self.get_pair() == argument.get_pair():
             return self._get_displacement() == argument._get_displacement()
         return super().__eq__(argument)
 
@@ -1227,7 +1227,7 @@ class Offset(Duration):
             True
 
         """
-        if isinstance(argument, type(self)) and self.pair() == argument.pair():
+        if isinstance(argument, type(self)) and self.get_pair() == argument.get_pair():
             return self._get_displacement() >= argument._get_displacement()
         return super().__ge__(argument)
 
@@ -1286,7 +1286,7 @@ class Offset(Duration):
             False
 
         """
-        if isinstance(argument, type(self)) and self.pair() == argument.pair():
+        if isinstance(argument, type(self)) and self.get_pair() == argument.get_pair():
             return self._get_displacement() > argument._get_displacement()
         return Duration.__gt__(self, argument)
 
@@ -1295,7 +1295,7 @@ class Offset(Duration):
         """
         Hashes offset.
         """
-        return hash((self.pair(), self._get_displacement()))
+        return hash((self.get_pair(), self._get_displacement()))
 
     def __le__(self, argument) -> bool:
         """
@@ -1352,7 +1352,7 @@ class Offset(Duration):
             True
 
         """
-        if isinstance(argument, type(self)) and self.pair() == argument.pair():
+        if isinstance(argument, type(self)) and self.get_pair() == argument.get_pair():
             return self._get_displacement() <= argument._get_displacement()
         return super().__le__(argument)
 
@@ -1428,7 +1428,7 @@ class Offset(Duration):
             False
 
         """
-        if isinstance(argument, type(self)) and self.pair() == argument.pair():
+        if isinstance(argument, type(self)) and self.get_pair() == argument.get_pair():
             return self._get_displacement() < argument._get_displacement()
         return super().__lt__(argument)
 
@@ -1445,10 +1445,10 @@ class Offset(Duration):
             Offset((1, 4), displacement=Duration(-1, 16))
 
         """
-        if self.displacement() is None:
-            return f"{type(self).__name__}({self.pair()})"
+        if self.get_displacement() is None:
+            return f"{type(self).__name__}({self.get_pair()})"
         else:
-            string = f"{self.pair()}, displacement={self.displacement()!r}"
+            string = f"{self.get_pair()}, displacement={self.get_displacement()!r}"
             return f"{type(self).__name__}({string})"
 
     def __sub__(self, argument):
@@ -1486,11 +1486,11 @@ class Offset(Duration):
             return self - argument
 
     def _get_displacement(self):
-        if self.displacement() is None:
+        if self.get_displacement() is None:
             return Duration(0)
-        return self.displacement()
+        return self.get_displacement()
 
-    def displacement(self):
+    def get_displacement(self):
         """
         Gets displacement.
 
@@ -1499,7 +1499,7 @@ class Offset(Duration):
             Gets displacement equal to none:
 
             >>> offset = abjad.Offset(1, 4)
-            >>> offset.displacement() is None
+            >>> offset.get_displacement() is None
             True
 
         ..  container:: example
@@ -1507,7 +1507,7 @@ class Offset(Duration):
             Gets displacement equal to a negative sixteenth:
 
             >>> offset = abjad.Offset(1, 4, displacement=(-1, 16))
-            >>> offset.displacement()
+            >>> offset.get_displacement()
             Duration(-1, 16)
 
         ..  container:: example
@@ -1515,7 +1515,7 @@ class Offset(Duration):
             Stores zero-valued displacement as none:
 
             >>> offset = abjad.Offset(1, 4, displacement=0)
-            >>> offset.displacement() is None
+            >>> offset.get_displacement() is None
             True
 
             >>> offset

--- a/source/abjad/illustrators.py
+++ b/source/abjad/illustrators.py
@@ -262,7 +262,7 @@ def components(
     score = _score.Score([staff], name="Score", simultaneous=False)
     if not time_signatures:
         duration = _get.duration(components)
-        time_signature = _indicators.TimeSignature(duration.pair())
+        time_signature = _indicators.TimeSignature(duration.get_pair())
         _bind.attach(time_signature, _select.leaf(components, 0))
     else:
         leaves = _select.leaves(components, grace=False)

--- a/source/abjad/indicators.py
+++ b/source/abjad/indicators.py
@@ -3690,7 +3690,7 @@ class MetronomeMark:
         return self_get_quarters_per_minute < argument_get_quarters_per_minute
 
     def _dotted(self):
-        return self.reference_duration.lilypond_duration_string()
+        return self.reference_duration.get_lilypond_duration_string()
 
     def _equation(self):
         if self.reference_duration is None:
@@ -3741,7 +3741,7 @@ class MetronomeMark:
         stem_height = 1
         string = r"\abjad-metronome-mark-markup"
         string += f" #{duration_log}"
-        string += f" #{self.reference_duration.dot_count()}"
+        string += f" #{self.reference_duration.get_dot_count()}"
         string += f" #{stem_height}"
         string += f' #"{self.units_per_minute}"'
         markup = Markup(rf"\markup {string}")
@@ -3750,7 +3750,7 @@ class MetronomeMark:
     def _get_markup_arguments(self):
         assert self.custom_markup is None
         duration_log = int(math.log(self.reference_duration.denominator, 2))
-        dot_count = self.reference_duration.dot_count()
+        dot_count = self.reference_duration.get_dot_count()
         stem_height = 1
         if not self.decimal:
             return {
@@ -3923,8 +3923,8 @@ class MetronomeMark:
 
         """
         reference_duration_ = _duration.Duration(reference_duration)
-        log = reference_duration_.exponent()
-        dots = reference_duration_.dot_count()
+        log = reference_duration_.get_exponent()
+        dots = reference_duration_.get_dot_count()
         stem = 1
         if isinstance(
             units_per_minute, fractions.Fraction
@@ -7330,7 +7330,7 @@ class TimeSignature:
         if self.partial is None:
             result.append(rf"\time {self.numerator}/{self.denominator}")
         else:
-            duration_string = self.partial.lilypond_duration_string()
+            duration_string = self.partial.get_lilypond_duration_string()
             partial_directive = rf"\partial {duration_string}"
             result.append(partial_directive)
             string = rf"\time {self.numerator}/{self.denominator}"

--- a/source/abjad/label.py
+++ b/source/abjad/label.py
@@ -809,7 +809,7 @@ def with_durations(
     """
     for logical_tie in _iterate.logical_ties(argument):
         duration = _getlib._get_duration(logical_tie, in_seconds=in_seconds)
-        pair = duration.pair()
+        pair = duration.get_pair()
         if denominator is not None:
             pair = _duration.with_denominator(duration, denominator)
         n, d = pair

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -62,7 +62,7 @@ def _make_leaf_on_pitch(
             )
         elif use_multimeasure_rests is True:
             multimeasure_rest = _score.MultimeasureRest((1), tag=tag)
-            multimeasure_rest.multiplier = duration.pair()
+            multimeasure_rest.multiplier = duration.get_pair()
             leaves = [multimeasure_rest]
         else:
             leaves = _make_tied_leaf(
@@ -109,9 +109,9 @@ def _make_tied_leaf(
     assert isinstance(duration, _duration.Duration), repr(duration)
     if multiplier is not None:
         assert isinstance(multiplier, tuple), repr(multiplier)
-    duration_pair = duration.pair()
+    duration_pair = duration.get_pair()
     if forbidden_duration is not None:
-        assert forbidden_duration.is_assignable()
+        assert forbidden_duration.get_is_assignable()
         assert forbidden_duration.numerator == 1
     if forbidden_duration is not None and forbidden_duration <= duration:
         denominators = [2 * forbidden_duration.denominator, duration.denominator]
@@ -819,7 +819,7 @@ def make_notes(
             denominator = duration_list[0].denominator
             numerator = _math.greatest_power_of_two_less_equal(denominator)
             duration = _duration.Duration(numerator, denominator)
-            duration_list = [duration.reciprocal() * _ for _ in duration_list]
+            duration_list = [duration.get_reciprocal() * _ for _ in duration_list]
             notes = _make_unprolated_notes(
                 pitches_,
                 duration_list,
@@ -1195,7 +1195,7 @@ def make_tuplet(
         leaves = make_leaves([pitch_list], [duration], tag=tag)
         tuplet = _score.Tuplet("1:1", leaves, tag=tag)
     else:
-        numerator, denominator = duration.pair()
+        numerator, denominator = duration.get_pair()
         exponent = int(math.log(_math.weight(proportion), 2) - math.log(numerator, 2))
         denominator = int(denominator * 2**exponent)
         components: list[_score.Leaf | _score.Tuplet] = []

--- a/source/abjad/meter.py
+++ b/source/abjad/meter.py
@@ -868,8 +868,8 @@ class Meter:
         for offset_tuple in inventory:
             assert isinstance(offset_tuple, tuple)
             assert all(isinstance(_, _duration.Offset) for _ in offset_tuple)
-        old_flag_count = _duration.Duration(1, self.denominator()).flag_count()
-        new_flag_count = _duration.Duration(1, denominator).flag_count()
+        old_flag_count = _duration.Duration(1, self.denominator()).get_flag_count()
+        new_flag_count = _duration.Duration(1, denominator).get_flag_count()
         extra_depth = new_flag_count - old_flag_count
         assert isinstance(extra_depth, int), repr(extra_depth)
         for _ in range(extra_depth):
@@ -2140,7 +2140,7 @@ class Meter:
                     denominator = 4 * duration.denominator
                     pair = _duration.with_denominator(duration, denominator)
                 else:
-                    pair = duration.pair()
+                    pair = duration.get_pair()
                 rtc_ = make_best_guess_rtc(pair)
                 sub_metrical_hierarchy = Meter(rtc_)
                 sub_boundary_depth: int | None = 1
@@ -2191,11 +2191,11 @@ def _is_acceptable_logical_tie(
     assert isinstance(logical_tie_duration, _duration.Duration)
     assert isinstance(logical_tie_starts_in_offsets, bool)
     assert isinstance(logical_tie_stops_in_offsets, bool)
-    if not logical_tie_duration.is_assignable():
+    if not logical_tie_duration.get_is_assignable():
         return False
     if (
         maximum_dot_count is not None
-        and maximum_dot_count < logical_tie_duration.dot_count()
+        and maximum_dot_count < logical_tie_duration.get_dot_count()
     ):
         return False
     if not logical_tie_starts_in_offsets and not logical_tie_stops_in_offsets:

--- a/source/abjad/metricmodulation.py
+++ b/source/abjad/metricmodulation.py
@@ -480,19 +480,19 @@ class MetricModulation:
         left_rhythm = self._initialize_rhythm(self.left_rhythm)
         right_rhythm = self._initialize_rhythm(self.right_rhythm)
         if self._note_to_note():
-            left_exponent = left_rhythm[0].written_duration.exponent()
-            left_dots = left_rhythm[0].written_duration.dot_count()
-            right_exponent = right_rhythm[0].written_duration.exponent()
-            right_dots = right_rhythm[0].written_duration.dot_count()
+            left_exponent = left_rhythm[0].written_duration.get_exponent()
+            left_dots = left_rhythm[0].written_duration.get_dot_count()
+            right_exponent = right_rhythm[0].written_duration.get_exponent()
+            right_dots = right_rhythm[0].written_duration.get_dot_count()
             return (left_exponent, left_dots, right_exponent, right_dots)
         elif self._lhs_tuplet():
-            tuplet_exponent = left_rhythm[0][0].written_duration.exponent()
-            tuplet_dots = left_rhythm[0][0].written_duration.dot_count()
+            tuplet_exponent = left_rhythm[0][0].written_duration.get_exponent()
+            tuplet_dots = left_rhythm[0][0].written_duration.get_dot_count()
             # tuplet_n, tuplet_d = left_rhythm[0].multiplier
             tuplet_n = left_rhythm[0].ratio.denominator
             tuplet_d = left_rhythm[0].ratio.numerator
-            note_exponent = right_rhythm[0].written_duration.exponent()
-            note_dots = right_rhythm[0].written_duration.dot_count()
+            note_exponent = right_rhythm[0].written_duration.get_exponent()
+            note_dots = right_rhythm[0].written_duration.get_dot_count()
             return (
                 tuplet_exponent,
                 tuplet_dots,
@@ -502,10 +502,10 @@ class MetricModulation:
                 note_dots,
             )
         elif self._rhs_tuplet():
-            note_exponent = left_rhythm[0].written_duration.exponent()
-            note_dots = left_rhythm[0].written_duration.dot_count()
-            tuplet_exponent = right_rhythm[0][0].written_duration.exponent()
-            tuplet_dots = right_rhythm[0][0].written_duration.dot_count()
+            note_exponent = left_rhythm[0].written_duration.get_exponent()
+            note_dots = left_rhythm[0].written_duration.get_dot_count()
+            tuplet_exponent = right_rhythm[0][0].written_duration.get_exponent()
+            tuplet_dots = right_rhythm[0][0].written_duration.get_dot_count()
             # tuplet_n, tuplet_d = right_rhythm[0].multiplier
             tuplet_n = right_rhythm[0].ratio.denominator
             tuplet_d = right_rhythm[0].ratio.numerator

--- a/source/abjad/mutate.py
+++ b/source/abjad/mutate.py
@@ -1380,7 +1380,7 @@ def logical_tie_to_tuplet(
     target_duration = sum(_._get_preprolated_duration() for _ in argument)
     assert isinstance(target_duration, _duration.Duration)
     prolated_duration = target_duration / sum(proportions)
-    basic_written_duration = prolated_duration.equal_or_greater_power_of_two()
+    basic_written_duration = prolated_duration.get_equal_or_greater_power_of_two()
     written_durations = [_ * basic_written_duration for _ in proportions]
     notes: list[_score.Note | _score.Tuplet]
     try:

--- a/source/abjad/parsers/parser.py
+++ b/source/abjad/parsers/parser.py
@@ -6375,7 +6375,7 @@ class LilyPondSyntacticalDefinition:
         duration = p[1].duration
         multiplier = p[1].multiplier
         if dots:
-            duration = duration.lilypond_duration_string()
+            duration = duration.get_lilypond_duration_string()
             duration += "." * dots
             duration = _duration.Duration.from_lilypond_duration_string(duration)
         p[0] = LilyPondDuration(duration, multiplier)

--- a/source/abjad/rhythmtrees.py
+++ b/source/abjad/rhythmtrees.py
@@ -72,10 +72,10 @@ class RhythmTreeNode:
             assert isinstance(fraction, fractions.Fraction), repr(fraction)
             duration = _duration.Duration(fraction)
             assert isinstance(duration, _duration.Duration), repr(duration)
-            result.append(duration.pair())
+            result.append(duration.get_pair())
             node = node.parent
         duration = _duration.Duration(node.pair())
-        result.append(duration.pair())
+        result.append(duration.get_pair())
         return tuple(reversed(result))
 
     def _update_offsets_of_entire_tree(self):
@@ -580,7 +580,7 @@ class RhythmTreeContainer(RhythmTreeNode, uqbar.containers.UniqueTreeList):
         assert isinstance(rtc, RhythmTreeContainer), repr(rtc)
         new_duration = _duration.Duration(self.duration())
         new_duration += _duration.Duration(rtc.duration())
-        container = RhythmTreeContainer(new_duration.pair())
+        container = RhythmTreeContainer(new_duration.get_pair())
         container.extend(self[:])
         container.extend(rtc[:])
         return container
@@ -632,7 +632,7 @@ class RhythmTreeContainer(RhythmTreeNode, uqbar.containers.UniqueTreeList):
             assert isinstance(basic_prolated_fraction, fractions.Fraction)
             basic_written_duration = _duration.Duration(basic_prolated_fraction)
             basic_written_duration = (
-                basic_written_duration.equal_or_greater_power_of_two()
+                basic_written_duration.get_equal_or_greater_power_of_two()
             )
             assert isinstance(basic_written_duration, _duration.Duration)
             tuplet = _score.Tuplet("1:1", [])
@@ -920,7 +920,7 @@ class RhythmTreeParser(Parser):
             pair = p[2]
         else:
             assert isinstance(p[2], _duration.Duration)
-            pair = p[2].pair()
+            pair = p[2].get_pair()
         p[0] = RhythmTreeContainer(pair, children=p[3])
 
     def p_error(self, p):
@@ -937,7 +937,7 @@ class RhythmTreeParser(Parser):
             pair = (abs(p[1]), 1)
         else:
             assert isinstance(p[1], _duration.Duration), repr(p[1])
-            pair = abs(p[1]).pair()
+            pair = abs(p[1]).get_pair()
         p[0] = RhythmTreeLeaf(pair, is_unpitched=not 0 < p[1])
 
     def p_node__container(self, p):

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -625,7 +625,7 @@ class Leaf(Component):
                 return False
 
     def _get_formatted_duration(self):
-        strings = [self.written_duration.lilypond_duration_string()]
+        strings = [self.written_duration.get_lilypond_duration_string()]
         if self.multiplier is not None:
             string = f"{self.multiplier[0]}/{self.multiplier[1]}"
             strings.append(string)
@@ -703,7 +703,7 @@ class Leaf(Component):
     @written_duration.setter
     def written_duration(self, argument):
         duration = _duration.Duration(argument)
-        if not duration.is_assignable():
+        if not duration.get_is_assignable():
             message = f"not assignable duration: {duration!r}."
             raise _exceptions.AssignabilityError(message)
         self._written_duration = duration
@@ -5379,7 +5379,7 @@ class Tuplet(Container):
                 continue
             assert isinstance(component, Leaf), repr(component)
             duration = self.multiplier() * component.written_duration
-            if not duration.is_assignable():
+            if not duration.get_is_assignable():
                 return False
         return True
 
@@ -5671,7 +5671,7 @@ class Tuplet(Container):
         for component in self:
             if isinstance(component, Tuplet):
                 return
-            dot_count = component.written_duration.dot_count()
+            dot_count = component.written_duration.get_dot_count()
             dot_counts.add(dot_count)
         if 1 < len(dot_counts):
             return
@@ -5683,7 +5683,7 @@ class Tuplet(Container):
         multiplier = dot_multiplier * self.multiplier()
         self.ratio = _duration.Ratio(multiplier.denominator, multiplier.numerator)
         dot_multiplier_duration = _duration.Duration(dot_multiplier)
-        dot_multiplier_reciprocal_duration = dot_multiplier_duration.reciprocal()
+        dot_multiplier_reciprocal_duration = dot_multiplier_duration.get_reciprocal()
         for component in self:
             component.written_duration *= dot_multiplier_reciprocal_duration
 

--- a/source/abjad/select.py
+++ b/source/abjad/select.py
@@ -1838,9 +1838,9 @@ def group_by_contiguity(argument) -> list[list]:
         that_timespan = _getlib._get_timespan(item)
         # remove displacement
         this_stop_offset = this_timespan.stop_offset
-        this_stop_offset = _duration.Offset(this_stop_offset.pair())
+        this_stop_offset = _duration.Offset(this_stop_offset.get_pair())
         that_start_offset = that_timespan.start_offset
-        that_start_offset = _duration.Offset(that_start_offset.pair())
+        that_start_offset = _duration.Offset(that_start_offset.get_pair())
         # if this_timespan.stop_offset == that_timespan.start_offset:
         if this_stop_offset == that_start_offset:
             components.append(item)

--- a/source/abjad/spanners.py
+++ b/source/abjad/spanners.py
@@ -145,7 +145,7 @@ def beam(
 
     def _is_beamable(argument, beam_rests=False):
         if isinstance(argument, _score.Chord | _score.Note):
-            if 0 < argument.written_duration.flag_count():
+            if 0 < argument.written_duration.get_flag_count():
                 return True
         if beam_rests and isinstance(argument, silent_prototype):
             return True
@@ -216,11 +216,11 @@ def beam(
         previous_leaf = original_leaves[this_index - 1]
         previous = 0
         if _is_beamable(previous_leaf, beam_rests=beam_rests):
-            previous = previous_leaf.written_duration.flag_count()
+            previous = previous_leaf.written_duration.get_flag_count()
         next_leaf = original_leaves[this_index + 1]
         next_ = 0
         if _is_beamable(next_leaf, beam_rests=beam_rests):
-            next_ = next_leaf.written_duration.flag_count()
+            next_ = next_leaf.written_duration.get_flag_count()
         return previous, next_
 
     span_beam_count = span_beam_count or 1
@@ -238,7 +238,7 @@ def beam(
         if i == total_parts - 1:
             is_last_part = True
         first_leaf = part[0]
-        flag_count = first_leaf.written_duration.flag_count()
+        flag_count = first_leaf.written_duration.get_flag_count()
         if len(part) == 1:
             if not _is_beamable(first_leaf, beam_rests=False):
                 continue
@@ -256,7 +256,7 @@ def beam(
             _bind.attach(beam_count, first_leaf, tag=tag)
         last_leaf = part[-1]
         if _is_beamable(last_leaf, beam_rests=False):
-            flag_count = last_leaf.written_duration.flag_count()
+            flag_count = last_leaf.written_duration.get_flag_count()
             if is_last_part:
                 left = flag_count
                 right = 0
@@ -287,7 +287,7 @@ def beam(
                 continue
             if isinstance(middle_leaf, silent_prototype):
                 continue
-            flag_count = middle_leaf.written_duration.flag_count()
+            flag_count = middle_leaf.written_duration.get_flag_count()
             previous, next_ = _leaf_neighbors(middle_leaf, original_leaves)
             if previous == next_ == 0:
                 left = right = flag_count


### PR DESCRIPTION
Use these name changes in in the Abjad 3.27 release notes:

    OLD: abjad.Duration.dot_count
        abjad.Duration.equal_or_greater_assignable
        abjad.Duration.equal_or_greater_power_of_two
        abjad.Duration.equal_or_lesser_assignable
        abjad.Duration.equal_or_lesser_power_of_two
        abjad.Duration.exponent
        abjad.Duration.flag_count
        abjad.Duration.is_assignable
        abjad.Duration.lilypond_duration_string
        abjad.Duration.pair
        abjad.Duration.reciprocal
    NEW: abjad.Duration.get_dot_count()
        abjad.Duration.get_equal_or_greater_assignable()
        abjad.Duration.get_equal_or_greater_power_of_two()
        abjad.Duration.get_equal_or_lesser_assignable()
        abjad.Duration.get_equal_or_lesser_power_of_two()
        abjad.Duration.get_exponent()
        abjad.Duration.get_flag_count()
        abjad.Duration.get_is_assignable()
        abjad.Duration.get_lilypond_duration_string()
        abjad.Duration.get_pair()
        abjad.Duration.get_reciprocal()

    OLD: abjad.Offset.displacement
    NEW: abjad.Offset.get_displacement()