### PR TITLE
Rename logical tie get_ methods

### DIFF
--- a/source/abjad/get.py
+++ b/source/abjad/get.py
@@ -2673,12 +2673,12 @@ def is_sustained(argument) -> bool:
     leaves = _select.leaves(argument)
     for leaf in leaves:
         lt = logical_tie(leaf)
-        if lt.get_head() is leaf:
+        if lt.head() is leaf:
             lt_head_count += 1
     if lt_head_count == 0:
         return True
     lt = logical_tie(leaves[0])
-    if lt.get_head() is leaves[0] and lt_head_count == 1:
+    if lt.head() is leaves[0] and lt_head_count == 1:
         return True
     return False
 

--- a/source/abjad/label.py
+++ b/source/abjad/label.py
@@ -814,7 +814,7 @@ def with_durations(
             pair = _duration.with_denominator(duration, denominator)
         n, d = pair
         label = _indicators.Markup(rf"\markup \fraction {n} {d}")
-        _attach(label, logical_tie.get_head(), direction=direction)
+        _attach(label, logical_tie.head(), direction=direction)
 
 
 def with_indices(argument, direction=_enums.UP, prototype=None) -> None:
@@ -1519,7 +1519,7 @@ def with_pitches(argument, direction=_enums.UP, locale=None, prototype=None):
     prototype = prototype or _pitch.NamedPitch
     logical_ties = _iterate.logical_ties(argument)
     for logical_tie in logical_ties:
-        leaf = logical_tie.get_head()
+        leaf = logical_tie.head()
         label = None
         if prototype is _pitch.NamedPitch:
             if isinstance(leaf, _score.Note):
@@ -1863,13 +1863,13 @@ def with_start_offsets(
         assert isinstance(global_offset, _duration.Duration)
     for logical_tie in _iterate.logical_ties(argument):
         if clock_time:
-            timespan = logical_tie.get_head()._get_timespan(in_seconds=True)
+            timespan = logical_tie.head()._get_timespan(in_seconds=True)
             start_offset = timespan.start_offset
             if global_offset is not None:
                 start_offset += global_offset
             string = start_offset.to_clock_string()
         else:
-            timespan = logical_tie.get_head()._get_timespan()
+            timespan = logical_tie.head()._get_timespan()
             start_offset = timespan.start_offset
             if global_offset is not None:
                 start_offset += global_offset
@@ -1880,7 +1880,7 @@ def with_start_offsets(
             label = _indicators.Markup(rf"{markup_command} {{ {string} }}")
         else:
             label = _indicators.Markup(rf"\markup {{ {string} }}")
-        _attach(label, logical_tie.get_head(), direction=direction)
+        _attach(label, logical_tie.head(), direction=direction)
     total_duration = _duration.Duration(timespan.stop_offset)
     if global_offset is not None:
         total_duration += global_offset

--- a/source/abjad/select.py
+++ b/source/abjad/select.py
@@ -159,7 +159,7 @@ class LogicalTie(collections.abc.Sequence):
         """
         Is true when ``argument`` is in logical tie.
         """
-        return argument in self.get_items()
+        return argument in self.items()
 
     def __eq__(self, argument) -> bool:
         """
@@ -167,9 +167,9 @@ class LogicalTie(collections.abc.Sequence):
         equal those in logical tie.
         """
         if isinstance(argument, type(self)):
-            return self.get_items() == argument.get_items()
+            return self.items() == argument.items()
         elif isinstance(argument, collections.abc.Sequence):
-            return self.get_items() == tuple(argument)
+            return self.items() == tuple(argument)
         return False
 
     def __hash__(self) -> int:
@@ -182,13 +182,13 @@ class LogicalTie(collections.abc.Sequence):
         """
         Gets number of items in logical tie.
         """
-        return len(self.get_items())
+        return len(self.items())
 
     def __repr__(self) -> str:
         """
         Gets interpreter representation of logical tie.
         """
-        return f"{type(self).__name__}(items={list(self.get_items())!r})"
+        return f"{type(self).__name__}(items={list(self.items())!r})"
 
     def __getitem__(self, argument):
         """
@@ -196,7 +196,7 @@ class LogicalTie(collections.abc.Sequence):
 
         Returns component or list (not logical tie).
         """
-        result = self.get_items().__getitem__(argument)
+        result = self.items().__getitem__(argument)
         if isinstance(result, tuple):
             result = list(result)
         return result
@@ -205,43 +205,43 @@ class LogicalTie(collections.abc.Sequence):
         for leaf in list(self):
             leaf._scale(multiplier)
 
-    def get_head(self) -> _score.Leaf:
+    def head(self) -> _score.Leaf:
         """
         Reference to element ``0`` in logical tie.
         """
-        assert self.get_items()
-        return self.get_items()[0]
+        assert self.items()
+        return self.items()[0]
 
-    def get_items(self) -> tuple:
+    def items(self) -> tuple:
         """
         Gets items in logical tie.
         """
         return self._items
 
-    def get_is_pitched(self) -> bool:
+    def is_pitched(self) -> bool:
         """
         Is true when logical tie head is a note or chord.
         """
-        head = self.get_head()
+        head = self.head()
         # return hasattr(head, "written_pitch") or hasattr(head, "written_pitches")
         return hasattr(head, "get_written_pitch") or hasattr(
             head, "get_written_pitches"
         )
 
-    def get_is_trivial(self) -> bool:
+    def is_trivial(self) -> bool:
         """
         Is true when length of logical tie is less than or equal to ``1``.
         """
         return len(self) <= 1
 
-    def get_tail(self) -> _score.Leaf:
+    def tail(self) -> _score.Leaf:
         """
         Gets last leaf in logical tie.
         """
-        assert self.get_items()
-        return self.get_items()[-1]
+        assert self.items()
+        return self.items()[-1]
 
-    def get_written_duration(self) -> _duration.Duration:
+    def written_duration(self) -> _duration.Duration:
         """
         Sum of written duration of all components in logical tie.
         """
@@ -4231,8 +4231,8 @@ def logical_ties(
     for logical_tie in generator:
         if (
             grace is None
-            or (grace is True and _get.is_grace_music(logical_tie.get_head()))
-            or (grace is False and not _get.is_grace_music(logical_tie.get_head()))
+            or (grace is True and _get.is_grace_music(logical_tie.head()))
+            or (grace is False and not _get.is_grace_music(logical_tie.head()))
         ):
             result.append(logical_tie)
     return result

--- a/tests/test_LogicalTie.py
+++ b/tests/test_LogicalTie.py
@@ -5,11 +5,11 @@ def test_LogicalTie_written_duration_01():
     staff = abjad.Staff("c' ~ c'16")
 
     lt = abjad.get.logical_tie(staff[0])
-    assert lt.get_written_duration() == abjad.Duration(5, 16)
+    assert lt.written_duration() == abjad.Duration(5, 16)
 
 
 def test_LogicalTie_written_duration_02():
     staff = abjad.Staff("c'")
 
     lt = abjad.get.logical_tie(staff[0])
-    assert lt.get_written_duration() == abjad.Duration(1, 4)
+    assert lt.written_duration() == abjad.Duration(1, 4)


### PR DESCRIPTION
    3.27:
        abjad.select.LogicalTie.get_head()
        abjad.select.LogicalTie.get_items()
        abjad.select.LogicalTie.get_is_pitched()
        abjad.select.LogicalTie.get_is_trivial()
        abjad.select.LogicalTie.get_tail()
        abjad.select.LogicalTie.get_written_duration()
    3.28:
        abjad.select.LogicalTie.head()
        abjad.select.LogicalTie.items()
        abjad.select.LogicalTie.is_pitched()
        abjad.select.LogicalTie.is_trivial()
        abjad.select.LogicalTie.tail()
        abjad.select.LogicalTie.written_duration()