### PR TITLE
Typeforce abjad.Note constructor

### DIFF
--- a/source/abjad/illustrators.py
+++ b/source/abjad/illustrators.py
@@ -66,8 +66,9 @@ def _illustrate_pitch_range(range_):
     stop_pitch = _pitch.NamedPitch(range_.stop_pitch())
     start_pitch_clef = _indicators.Clef.from_pitches([start_pitch])
     stop_pitch_clef = _indicators.Clef.from_pitches([stop_pitch])
-    start_note = _score.Note(range_.start_pitch(), 1)
-    stop_note = _score.Note(range_.stop_pitch(), 1)
+    duration = _duration.Duration(1)
+    start_note = _score.Note.from_pitch_and_duration(range_.start_pitch(), duration)
+    stop_note = _score.Note.from_pitch_and_duration(range_.stop_pitch(), duration)
     if start_pitch_clef == stop_pitch_clef:
         if start_pitch_clef == _indicators.Clef("bass"):
             bass_voice = _score.Voice(name="Bass_Voice")
@@ -149,11 +150,14 @@ def _illustrate_pitch_set(set_):
 
 
 def _illustrate_pitch_class_segment(
-    segment, markup_direction=_enums.UP, figure_name=None
+    segment,
+    markup_direction=_enums.UP,
+    figure_name=None,
 ):
     notes = []
     for item in segment:
-        note = _score.Note(item, _duration.Duration(1, 8))
+        pitch = _pitch.NamedPitch(item)
+        note = _score.Note.from_pitch_and_duration(pitch, _duration.Duration(1, 8))
         notes.append(note)
     markup = None
     if isinstance(figure_name, str):
@@ -531,13 +535,19 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
             if not treble_note_heads:
                 treble_leaf = _score.Rest(written_duration)
             elif len(treble_note_heads) == 1:
-                treble_leaf = _score.Note(treble_note_heads[0], written_duration)
+                treble_leaf = _score.Note.from_pitch_and_duration(
+                    _pitch.NamedPitch("C4"), written_duration
+                )
+                treble_leaf.set_note_head(treble_note_heads[0])
             else:
                 treble_leaf = _score.Chord(treble_note_heads, written_duration)
             if not bass_note_heads:
                 bass_leaf = _score.Rest(written_duration)
             elif len(bass_note_heads) == 1:
-                bass_leaf = _score.Note(bass_note_heads[0], written_duration)
+                bass_leaf = _score.Note.from_pitch_and_duration(
+                    _pitch.NamedPitch("C4"), written_duration
+                )
+                bass_leaf.set_note_head(bass_note_heads[0])
             else:
                 bass_leaf = _score.Chord(bass_note_heads, written_duration)
         else:

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -140,11 +140,19 @@ def _make_tied_leaf(
     leaves = []
     for numerator in numerators:
         written_duration = _duration.Duration(numerator, duration_pair[1])
-        if pitches is not None:
+        if isinstance(pitches, _pitch.NamedPitch):
+            leaf = class_.from_pitch_and_duration(
+                pitches,
+                written_duration,
+                multiplier=multiplier,
+                tag=tag,
+            )
+        elif pitches is not None:
             arguments = (pitches, written_duration)
+            leaf = class_(*arguments, multiplier=multiplier, tag=tag)
         else:
             arguments = (written_duration,)
-        leaf = class_(*arguments, multiplier=multiplier, tag=tag)
+            leaf = class_(*arguments, multiplier=multiplier, tag=tag)
         leaves.append(leaf)
     if 1 < len(leaves):
         if not issubclass(class_, _score.Rest | _score.Skip):

--- a/source/abjad/mutate.py
+++ b/source/abjad/mutate.py
@@ -1388,8 +1388,11 @@ def logical_tie_to_tuplet(
     basic_written_duration = prolated_duration.equal_or_greater_power_of_two()
     written_durations = [_ * basic_written_duration for _ in proportions]
     notes: list[_score.Note | _score.Tuplet]
+    pitch = _pitch.NamedPitch("c'")
     try:
-        notes = [_score.Note(0, _) for _ in written_durations]
+        notes = [
+            _score.Note.from_pitch_and_duration(pitch, _) for _ in written_durations
+        ]
     except _exceptions.AssignabilityError:
         pitches = _makers.make_pitches([0])
         denominator = target_duration.denominator
@@ -2678,8 +2681,7 @@ def wrap(argument, container):
 
         Wraps leaves in container:
 
-        >>> notes = [abjad.Note(n, (1, 8)) for n in range(8)]
-        >>> staff = abjad.Staff(notes)
+        >>> staff = abjad.Staff("c'8 cs'8 d'8 ef'8 e'8 f'8 fs'8 g'8")
         >>> score = abjad.Score([staff], name="Score")
         >>> abjad.attach(abjad.TimeSignature((4, 8)), staff[0])
         >>> container = abjad.Container()
@@ -2709,8 +2711,7 @@ def wrap(argument, container):
 
         Wraps each leaf in tuplet:
 
-        >>> notes = [abjad.Note(n, (1, 1)) for n in range(4)]
-        >>> staff = abjad.Staff(notes)
+        >>> staff = abjad.Staff("c'1 cs'1 d'1 ef'1")
         >>> for note in staff:
         ...     tuplet = abjad.Tuplet("3:2")
         ...     abjad.mutate.wrap(note, tuplet)

--- a/source/abjad/parsers/parser.py
+++ b/source/abjad/parsers/parser.py
@@ -6269,7 +6269,7 @@ class LilyPondSyntacticalDefinition:
                 duration = p[5].duration
             else:
                 duration = _duration.Duration(*p[5].duration)
-            leaf = _score.Note(p[1], duration, tag=self.tag)
+            leaf = _score.Note.from_pitch_and_duration(p[1], duration, tag=self.tag)
             leaf.note_head().set_is_forced(bool(p[2]))
             leaf.note_head().set_is_cautionary(bool(p[3]))
         else:

--- a/source/abjad/parsers/reduced.py
+++ b/source/abjad/parsers/reduced.py
@@ -446,19 +446,19 @@ class ReducedLyParser(Parser):
         """
         note_body : pitch
         """
-        p[0] = _score.Note(p[1], self._default_duration)
+        p[0] = _score.Note.from_pitch_and_duration(p[1], self._default_duration)
 
     def p_note_body__pitch__positive_leaf_duration(self, p):
         """
         note_body : pitch positive_leaf_duration
         """
-        p[0] = _score.Note(p[1], p[2])
+        p[0] = _score.Note.from_pitch_and_duration(p[1], p[2])
 
     def p_note_body__positive_leaf_duration(self, p):
         """
         note_body : positive_leaf_duration
         """
-        p[0] = _score.Note(0, p[1])
+        p[0] = _score.Note.from_pitch_and_duration(_pitch.NamedPitch(0), p[1])
 
     def p_pitch__PITCHNAME(self, p):
         """

--- a/source/abjad/pcollections.py
+++ b/source/abjad/pcollections.py
@@ -3231,7 +3231,9 @@ def voice_horizontally(
 
         >>> pcs = [abjad.NamedPitchClass(_) for _ in "c b d e f g e b a c".split()]
         >>> pitches = abjad.pcollections.voice_horizontally(pcs)
-        >>> staff = abjad.Staff([abjad.Note(_, (1, 8)) for _ in pitches])
+        >>> duration = abjad.Duration(1, 8)
+        >>> notes = [abjad.Note.from_pitch_and_duration(_, duration) for _ in pitches]
+        >>> staff = abjad.Staff(notes)
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::
@@ -3285,7 +3287,9 @@ def voice_vertically(
 
         >>> pcs = [abjad.NamedPitchClass(_) for _ in "c ef g bf d f af".split()]
         >>> pitches = abjad.pcollections.voice_vertically(pcs)
-        >>> staff = abjad.Staff([abjad.Note(_, (1, 8)) for _ in pitches])
+        >>> duration = abjad.Duration(1, 8)
+        >>> notes = [abjad.Note.from_pitch_and_duration(_, duration) for _ in pitches]
+        >>> staff = abjad.Staff(notes)
         >>> abjad.show(staff) # doctest: +SKIP
 
         ..  docs::

--- a/source/abjad/pitch.py
+++ b/source/abjad/pitch.py
@@ -5620,3 +5620,11 @@ class StaffPosition:
 
     def __post_init__(self):
         assert isinstance(self.number, int), repr(self.number)
+
+
+def pitches(items: list[float]) -> list[NamedPitch]:
+    """
+    Changes ``items`` to pitches.
+    """
+    pitches = [NamedPitch(_) for _ in items]
+    return pitches

--- a/source/abjad/tweaks.py
+++ b/source/abjad/tweaks.py
@@ -355,9 +355,11 @@ def tweak(
         _score.Tuplet,
     )
     assert isinstance(indicator, prototype), repr(indicator)
-    try:
-        tweaks_ = list(indicator.tweaks)
-    except AttributeError:
+    if hasattr(indicator, "tweaks"):
+        indicator_tweaks = indicator.tweaks
+        assert all(isinstance(_, Tweak) for _ in indicator_tweaks)
+        tweaks_ = list(indicator_tweaks)
+    else:
         raise Exception(indicator)
     if tag is not None:
         assert isinstance(tag, _tag.Tag), repr(tag)

--- a/tests/test__iterlib.py
+++ b/tests/test__iterlib.py
@@ -1073,9 +1073,13 @@ def test__iterlib_are_logical_voice_27():
     Logical voice can not extend across differently named implicit voices.
     """
 
-    voice = abjad.Voice([abjad.Note(n, (1, 8)) for n in range(4)])
+    pitches = abjad.pitch.pitches([0, 1, 2, 3])
+    duration = abjad.Duration(1, 8)
+    notes = [abjad.Note.from_pitch_and_duration(_, duration) for _ in pitches]
+    voice = abjad.Voice(notes)
     container = abjad.Container([voice])
-    notes = [abjad.Note(n, (1, 8)) for n in range(4, 8)]
+    pitches = abjad.pitch.pitches([4, 5, 6, 7])
+    notes = [abjad.Note.from_pitch_and_duration(_, duration) for _ in pitches]
     container = abjad.Container([container] + notes)
 
     assert abjad.lilypond(container) == abjad.string.normalize(
@@ -1109,11 +1113,10 @@ def test__iterlib_are_logical_voice_28():
     Logical voice can not extend across differently named implicit voices.
     """
 
-    voice = abjad.Voice([abjad.Note(n, (1, 8)) for n in range(4)])
-    voice.set_name("foo")
+    voice = abjad.Voice("c'8 cs' d' ef'", name="foo")
     container = abjad.Container([voice])
-    notes = [abjad.Note(n, (1, 8)) for n in range(4, 8)]
-    container = abjad.Container([container] + notes)
+    container = abjad.Container([container])
+    container.extend("e'8 f'8 fs'8 g'8")
 
     r"""
     {
@@ -1143,12 +1146,10 @@ def test__iterlib_are_logical_voice_29():
     Logical voice can not extend across differently named implicit voices.
     """
 
-    voice_1 = abjad.Voice([abjad.Note(n, (1, 8)) for n in range(4)])
-    voice_1.set_name("foo")
-    voice_2 = abjad.Voice([voice_1])
-    voice_2.set_name("bar")
-    notes = [abjad.Note(n, (1, 8)) for n in range(4, 8)]
-    container = abjad.Container([voice_2] + notes)
+    voice_1 = abjad.Voice("c'8 cs'8 d'8 ef'8", name="foo")
+    voice_2 = abjad.Voice([voice_1], name="bar")
+    container = abjad.Container([voice_2])
+    container.extend("e'8 f'8 fs'8 g'8")
 
     assert abjad.lilypond(container) == abjad.string.normalize(
         r"""
@@ -1182,10 +1183,10 @@ def test__iterlib_are_logical_voice_30():
     Logical voice can not extend across differently named implicit voices.
     """
 
-    voice_1 = abjad.Voice([abjad.Note(n, (1, 8)) for n in range(4)])
+    voice_1 = abjad.Voice("c'8 cs'8 d'8 ef'8")
     voice_2 = abjad.Voice([voice_1])
-    notes = [abjad.Note(n, (1, 8)) for n in range(4, 8)]
-    container = abjad.Container([voice_2] + notes)
+    container = abjad.Container([voice_2])
+    container.extend("e'8 f'8 fs'8 g'8")
 
     assert abjad.lilypond(container) == abjad.string.normalize(
         r"""
@@ -1219,14 +1220,14 @@ def test__iterlib_are_logical_voice_31():
     Logical voice can not extend across differently named implicit voices.
     """
 
-    notes = [abjad.Note(n, (1, 8)) for n in range(4)]
+    container_1 = abjad.Container("c'8 cs'8 d'8 ef'8")
     voice_1 = abjad.Voice("c''8 c''8 c''8 c''8")
     voice_2 = abjad.Voice("c'8 c'8 c'8 c'8")
-    container = abjad.Container([voice_1, voice_2])
-    container.set_simultaneous(True)
-    container = abjad.Container(notes + [container])
+    container_2 = abjad.Container([voice_1, voice_2])
+    container_2.set_simultaneous(True)
+    container_1.append(container_2)
 
-    assert abjad.lilypond(container) == abjad.string.normalize(
+    assert abjad.lilypond(container_1) == abjad.string.normalize(
         r"""
         {
             c'8
@@ -1253,7 +1254,7 @@ def test__iterlib_are_logical_voice_31():
         """
     )
 
-    leaves = abjad.select.leaves(container)
+    leaves = abjad.select.leaves(container_1)
     assert not abjad._iterlib.are_logical_voice(leaves[:8])
     assert not abjad._iterlib.are_logical_voice(leaves[4:])
 

--- a/tests/test_get_leaf.py
+++ b/tests/test_get_leaf.py
@@ -2,9 +2,9 @@ import abjad
 
 
 def test_get_leaf_01():
-    staff = abjad.Staff(
-        [abjad.Voice("c'8 d'8 e'8 f'8"), abjad.Voice("g'8 a'8 b'8 c''8")]
-    )
+    staff = abjad.Staff()
+    staff.append(abjad.Voice("c'8 d'8 e'8 f'8"))
+    staff.append(abjad.Voice("g'8 a'8 b'8 c''8"))
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
         r"""
@@ -39,7 +39,7 @@ def test_get_leaf_02():
     Voice.
     """
 
-    voice = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4)])
+    voice = abjad.Voice("c'8 cs'8 d'8 ef'8")
 
     assert abjad.get.leaf(voice[0], 1) is voice[1]
     assert abjad.get.leaf(voice[1], 1) is voice[2]
@@ -69,7 +69,7 @@ def test_get_leaf_03():
     Staff.
     """
 
-    staff = abjad.Staff([abjad.Note(i, (1, 8)) for i in range(4)])
+    staff = abjad.Staff("c'8 cs'8 d'8 ef'8")
 
     assert abjad.get.leaf(staff[0], 1) is staff[1]
     assert abjad.get.leaf(staff[1], 1) is staff[2]
@@ -99,7 +99,7 @@ def test_get_leaf_04():
     Container.
     """
 
-    container = abjad.Container([abjad.Note(i, (1, 8)) for i in range(4)])
+    container = abjad.Container("c'8 cs'8 d'8 ef'8")
 
     assert abjad.lilypond(container) == abjad.string.normalize(
         r"""
@@ -155,8 +155,8 @@ def test_get_leaf_06():
     Contiguous containers inside a voice.
     """
 
-    container_1 = abjad.Container([abjad.Note(i, (1, 8)) for i in range(4)])
-    container_2 = abjad.Container([abjad.Note(i, (1, 8)) for i in range(4, 8)])
+    container_1 = abjad.Container("c'8 cs'8 d'8 ef'8")
+    container_2 = abjad.Container("e'8 f'8 fs'8 g'8")
     voice = abjad.Voice([container_1, container_2])
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
@@ -233,8 +233,8 @@ def test_get_leaf_08():
     Does not continue across contiguous anonymous voices inside a staff.
     """
 
-    voice_1 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4)])
-    voice_2 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4, 8)])
+    voice_1 = abjad.Voice("c'8 cs'8 d'8 ef'8")
+    voice_2 = abjad.Voice("e'8 f'8 fs'8 g'8")
     staff = abjad.Staff([voice_1, voice_2])
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
@@ -268,10 +268,8 @@ def test_get_leaf_09():
     Does cross contiguous equally named voices inside a staff.
     """
 
-    voice_1 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4)])
-    voice_1.set_name("My Voice")
-    voice_2 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4, 8)])
-    voice_2.set_name("My Voice")
+    voice_1 = abjad.Voice("c'8 cs'8 d'8 ef'8", name="My Voice")
+    voice_2 = abjad.Voice("e'8 f'8 fs'8 g'8", name="My Voice")
     staff = abjad.Staff([voice_1, voice_2])
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
@@ -312,10 +310,8 @@ def test_get_leaf_10():
     Does not connect through contiguous unequally named voices.
     """
 
-    voice_1 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4)])
-    voice_1.set_name("Your Voice")
-    voice_2 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4, 8)])
-    voice_2.set_name("My Voice")
+    voice_1 = abjad.Voice("c'8 cs'8 d'8 ef'8", name="Your Voice")
+    voice_2 = abjad.Voice("e'8 f'8 fs'8 g'8", name="My Voice")
     staff = abjad.Staff([voice_1, voice_2])
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
@@ -359,16 +355,10 @@ def test_get_leaf_11():
     Does connect through like-named staves containing like-named voices.
     """
 
-    voice_1 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4)])
-    voice_1.set_name("low")
-    voice_2 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4, 8)])
-    voice_2.set_name("low")
-
-    staff_1 = abjad.Staff([voice_1])
-    staff_1.set_name("mystaff")
-    staff_2 = abjad.Staff([voice_2])
-    staff_2.set_name("mystaff")
-
+    voice_1 = abjad.Voice("c'8 cs'8 d'8 ef'8", name="low")
+    voice_2 = abjad.Voice("e'8 f'8 fs'8 g'8", name="low")
+    staff_1 = abjad.Staff([voice_1], name="mystaff")
+    staff_2 = abjad.Staff([voice_2], name="mystaff")
     container = abjad.Container([staff_1, staff_2])
 
     assert abjad.lilypond(container) == abjad.string.normalize(
@@ -407,21 +397,20 @@ def test_get_leaf_12():
     Does connect through like-named staves containing like-named voices.
     """
 
-    lower_voice_1 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4)])
-    lower_voice_1.set_name("low")
-    lower_voice_2 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4, 8)])
-    lower_voice_2.set_name("low")
-    higher_voice_1 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(12, 16)])
-    higher_voice_1.set_name("high")
-    higher_voice_2 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(16, 20)])
-    higher_voice_2.set_name("high")
-
-    staff_1 = abjad.Staff([higher_voice_1, lower_voice_1])
-    staff_1.set_name("mystaff")
-    staff_1.set_simultaneous(True)
-    staff_2 = abjad.Staff([lower_voice_2, higher_voice_2])
-    staff_2.set_name("mystaff")
-    staff_2.set_simultaneous(True)
+    lower_voice_1 = abjad.Voice("c'8 cs'8 d'8 ef'8", name="low")
+    lower_voice_2 = abjad.Voice("e'8 f'8 fs'8 g'8", name="low")
+    higher_voice_1 = abjad.Voice("c''8 cs''8 d''8 ef''8", name="high")
+    higher_voice_2 = abjad.Voice("e''8 f''8 fs''8 g''8", name="high")
+    staff_1 = abjad.Staff(
+        [higher_voice_1, lower_voice_1],
+        name="mystaff",
+        simultaneous=True,
+    )
+    staff_2 = abjad.Staff(
+        [lower_voice_2, higher_voice_2],
+        name="mystaff",
+        simultaneous=True,
+    )
 
     container = abjad.Container([staff_1, staff_2])
 
@@ -478,9 +467,9 @@ def test_get_leaf_13():
     Does connect through symmetrical nested containers in a voice.
     """
 
-    container_1 = abjad.Container([abjad.Note(i, (1, 8)) for i in range(4)])
+    container_1 = abjad.Container("c'8 cs'8 d'8 ef'8")
     container_1 = abjad.Container([container_1])
-    container_2 = abjad.Container([abjad.Note(i, (1, 8)) for i in range(4, 8)])
+    container_2 = abjad.Container("e'8 f'8 fs'8 g'8")
     container_2 = abjad.Container([container_2])
     voice = abjad.Voice([container_1, container_2])
 
@@ -525,8 +514,8 @@ def test_get_leaf_14():
     voice parentage.
     """
 
-    container_1 = abjad.Container([abjad.Note(i, (1, 8)) for i in range(4)])
-    container_2 = abjad.Container([abjad.Note(i, (1, 8)) for i in range(4, 8)])
+    container_1 = abjad.Container("c'8 cs'8 d'8 ef'8")
+    container_2 = abjad.Container("e'8 f'8 fs'8 g'8")
     container_2 = abjad.Container([container_2])
     container_2 = abjad.Container([container_2])
     voice = abjad.Voice([container_1, container_2])
@@ -572,10 +561,10 @@ def test_get_leaf_15():
     voice parentage.
     """
 
-    container_1 = abjad.Container([abjad.Note(i, (1, 8)) for i in range(4)])
+    container_1 = abjad.Container("c'8 cs'8 d'8 ef'8")
     container_1 = abjad.Container([container_1])
     container_1 = abjad.Container([container_1])
-    container_2 = abjad.Container([abjad.Note(i, (1, 8)) for i in range(4, 8)])
+    container_2 = abjad.Container("e'8 f'8 fs'8 g'8")
     voice = abjad.Voice([container_1, container_2])
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
@@ -618,9 +607,9 @@ def test_get_leaf_16():
     Does connect in sequence of alternating containers and notes.
     """
 
-    container_1 = abjad.Container([abjad.Note(i, (1, 8)) for i in range(2)])
-    container_2 = abjad.Container([abjad.Note(i, (1, 8)) for i in range(3, 5)])
-    voice = abjad.Voice([container_1, abjad.Note(2, (1, 8)), container_2])
+    container_1 = abjad.Container("c'8 cs'8")
+    container_2 = abjad.Container("ef'8 e'8")
+    voice = abjad.Voice([container_1, abjad.Note("d'8"), container_2])
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
@@ -651,11 +640,9 @@ def test_get_leaf_17():
     Does connect in sequence of alternating tuplets and notes.
     """
 
-    notes = [abjad.Note(i, abjad.Duration(1, 8)) for i in range(3)]
-    tuplet_1 = abjad.Tuplet("3:2", notes)
-    notes = [abjad.Note(i, abjad.Duration(1, 8)) for i in range(4, 7)]
-    tuplet_2 = abjad.Tuplet("3:2", notes)
-    voice = abjad.Voice([tuplet_1, abjad.Note(3, (1, 8)), tuplet_2])
+    tuplet_1 = abjad.Tuplet("3:2", "c'8 cs'8 d'8")
+    tuplet_2 = abjad.Tuplet("3:2", "e'8 f'8 fs'8")
+    voice = abjad.Voice([tuplet_1, abjad.Note("ef'8"), tuplet_2])
 
     assert abjad.lilypond(voice) == abjad.string.normalize(
         r"""
@@ -721,9 +708,9 @@ def test_get_leaf_19():
     Returns none in asymmetric logical voice parentage structures.
     """
 
-    voice_1 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(3)])
-    note = abjad.Note(3, (1, 8))
-    voice_2 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4, 8)])
+    voice_1 = abjad.Voice("c'8 cs'8 d'8")
+    note = abjad.Note("ef'8")
+    voice_2 = abjad.Voice("e'8 f'8 fs'8 g'8")
     staff = abjad.Staff([voice_1, note, voice_2])
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
@@ -760,12 +747,9 @@ def test_get_leaf_20():
     Noncontiguous or broken logical voices do not connect.
     """
 
-    voice_1 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(3)])
-    voice_1.set_name("My Voice")
-    voice_2 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4, 8)])
-    voice_2.set_name("Your Voice")
-    voice_3 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(4, 8)])
-    voice_3.set_name("My Voice")
+    voice_1 = abjad.Voice("c'8 cs'8 d'8", name="My Voice")
+    voice_2 = abjad.Voice("e'8 f'8 fs'8 g'8", name="Your Voice")
+    voice_3 = abjad.Voice("e'8 f'8 fs'8 g'8", name="My Voice")
     staff = abjad.Staff([voice_1, voice_2, voice_3])
 
     assert abjad.lilypond(staff) == abjad.string.normalize(
@@ -813,8 +797,8 @@ def test_get_leaf_21():
     Does not connect through nested anonymous voices.
     """
 
-    inner_voice = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(3)])
-    outer_voice = abjad.Voice([inner_voice, abjad.Note(3, (1, 8))])
+    inner_voice = abjad.Voice("c'8 cs'8 d'8")
+    outer_voice = abjad.Voice([inner_voice, abjad.Note("ef'8")])
 
     assert abjad.lilypond(outer_voice) == abjad.string.normalize(
         r"""
@@ -845,8 +829,8 @@ def test_get_leaf_22():
     Does not connect through nested anonymous voices.
     """
 
-    inner_voice = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(1, 4)])
-    outer_voice = abjad.Voice([abjad.Note(0, (1, 8)), inner_voice])
+    inner_voice = abjad.Voice("cs'8 d'8 ef'8")
+    outer_voice = abjad.Voice([abjad.Note("c'8"), inner_voice])
 
     assert abjad.lilypond(outer_voice) == abjad.string.normalize(
         r"""
@@ -877,10 +861,8 @@ def test_get_leaf_23():
     Does connect through nested equally named voices.
     """
 
-    inner_voice = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(3)])
-    inner_voice.set_name("My Voice")
-    outer_voice = abjad.Voice([inner_voice, abjad.Note(3, (1, 8))])
-    outer_voice.set_name("My Voice")
+    inner_voice = abjad.Voice("c'8 cs'8 d'8", name="My Voice")
+    outer_voice = abjad.Voice([inner_voice, abjad.Note("ef'8")], name="My Voice")
 
     assert abjad.lilypond(outer_voice) == abjad.string.normalize(
         r"""
@@ -911,10 +893,8 @@ def test_get_leaf_24():
     Does connect through nested equally named voices.
     """
 
-    inner_voice = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(1, 4)])
-    inner_voice.set_name("My Voice")
-    outer_voice = abjad.Voice([abjad.Note(0, (1, 8)), inner_voice])
-    outer_voice.set_name("My Voice")
+    inner_voice = abjad.Voice("cs'8 d'8 ef'8", name="My Voice")
+    outer_voice = abjad.Voice([abjad.Note("c'8"), inner_voice], name="My Voice")
 
     assert abjad.lilypond(outer_voice) == abjad.string.normalize(
         r"""
@@ -945,10 +925,8 @@ def test_get_leaf_25():
     Returns none on nested differently named voices.
     """
 
-    inner_voice = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(3)])
-    inner_voice.set_name("Your Voice")
-    outer_voice = abjad.Voice([inner_voice, abjad.Note(3, (1, 8))])
-    outer_voice.set_name("My Voice")
+    inner_voice = abjad.Voice("c'8 cs'8 d'8", name="Your Voice")
+    outer_voice = abjad.Voice([inner_voice, abjad.Note("ef'8")], name="My Voice")
 
     assert abjad.lilypond(outer_voice) == abjad.string.normalize(
         r"""
@@ -979,10 +957,8 @@ def test_get_leaf_26():
     Returns none on nested differently named voices.
     """
 
-    voice_2 = abjad.Voice([abjad.Note(i, (1, 8)) for i in range(1, 4)])
-    voice_2.set_name("Voice 2")
-    voice_1 = abjad.Voice([abjad.Note(0, (1, 8)), voice_2])
-    voice_1.set_name("Voice 1")
+    voice_2 = abjad.Voice("cs'8 d'8 ef'8", name="Voice 2")
+    voice_1 = abjad.Voice([abjad.Note("c'8"), voice_2], name="Voice 1")
 
     assert abjad.lilypond(voice_1) == abjad.string.normalize(
         r"""

--- a/tests/test_get_timespan.py
+++ b/tests/test_get_timespan.py
@@ -59,7 +59,7 @@ def test_get_timespan_07():
 
 def test_get_timespan_08():
     tuplet_1 = abjad.Tuplet("3:2", "c'8 c'8 c'8")
-    voice = abjad.Voice([abjad.Note(0, (1, 8)), tuplet_1, abjad.Note(0, (1, 8))])
+    voice = abjad.Voice([abjad.Note("c'8"), tuplet_1, abjad.Note("c'8")])
     offset = abjad.duration.offset(0)
     pairs = [(1, 8), (1, 12), (1, 12), (1, 12), (1, 8)]
     durations = abjad.duration.durations(pairs)
@@ -108,7 +108,7 @@ def test_get_timespan_11():
     """
 
     voice = abjad.Voice("c'8 d'8 e'8 f'8")
-    staff = abjad.Staff([abjad.Note(0, (1, 8)), voice, abjad.Note(0, (1, 8))])
+    staff = abjad.Staff([abjad.Note("c'8"), voice, abjad.Note("c'8")])
     leaves = abjad.select.leaves(staff)
     for i, leaf in enumerate(leaves):
         start_offset = abjad.get.timespan(leaf).start_offset
@@ -252,7 +252,7 @@ def test_get_timespan_20():
     """
 
     tuplet_1 = abjad.Tuplet("3:2", "c'8 c'8 c'8")
-    voice = abjad.Voice([abjad.Note(0, (1, 8)), tuplet_1, abjad.Note(0, (1, 8))])
+    voice = abjad.Voice([abjad.Note("c'8"), tuplet_1, abjad.Note("c'8")])
     assert abjad.get.timespan(voice[0]).start_offset == abjad.duration.offset(0, 8)
     assert abjad.get.timespan(voice[1]).start_offset == abjad.duration.offset(1, 8)
     assert abjad.get.timespan(voice[2]).start_offset == abjad.duration.offset(3, 8)
@@ -276,11 +276,9 @@ def test_get_timespan_22():
     Offsets work on nested contexts.
     """
 
-    inner_voice = abjad.Voice("c'8 d'8 e'8 f'8")
-    outer_voice = abjad.Voice([abjad.Note(0, (1, 8)), inner_voice])
-    inner_voice.set_name("voice")
-    outer_voice.set_name("voice")
-    abjad.Staff([abjad.Note(1, (1, 8)), outer_voice])
+    inner_voice = abjad.Voice("c'8 d'8 e'8 f'8", name="voice")
+    outer_voice = abjad.Voice([abjad.Note("c'8"), inner_voice], name="voice")
+    abjad.Staff([abjad.Note("cs'8"), outer_voice])
     assert abjad.get.timespan(inner_voice).start_offset == abjad.duration.offset(2, 8)
     assert abjad.get.timespan(outer_voice).start_offset == abjad.duration.offset(1, 8)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,8 +19,12 @@ def test_io_count_function_calls_01():
     reason="Benchmarking is only for CPython.",
 )
 def test_io_count_function_calls_02():
+    pitch = abjad.NamedPitch(-12)
+    duration = abjad.Duration(1, 4)
     result = abjad.io.count_function_calls(
-        "abjad.Note(-12, (1, 4))", global_context=globals()
+        "abjad.Note.from_pitch_and_duration(pitch, duration)",
+        global_context=globals(),
+        local_context=locals(),
     )
     assert result < 400
 

--- a/tests/test_mutate_fuse.py
+++ b/tests/test_mutate_fuse.py
@@ -51,7 +51,7 @@ def test_mutate_fuse_04():
     Makes tied notes.
     """
 
-    voice = abjad.Voice([abjad.Note(0, (2, 16)), abjad.Note(9, (3, 16))])
+    voice = abjad.Voice("c'8 a'8.")
     abjad.mutate.fuse(voice[:])
 
     assert abjad.lilypond(voice) == abjad.string.normalize(

--- a/tests/test_mutate_split.py
+++ b/tests/test_mutate_split.py
@@ -236,7 +236,7 @@ def test_mutate__set_leaf_duration_06():
     duration does not.
     """
 
-    note = abjad.Note(0, (1, 8), multiplier=(1, 2))
+    note = abjad.Note("c'8", multiplier=(1, 2))
 
     assert abjad.lilypond(note) == "c'8 * 1/2"
 
@@ -253,7 +253,7 @@ def test_mutate__set_leaf_duration_07():
     written duration does not.
     """
 
-    note = abjad.Note(0, (1, 8), multiplier=(1, 2))
+    note = abjad.Note("c'8", multiplier=(1, 2))
 
     assert abjad.lilypond(note) == "c'8 * 1/2"
 
@@ -270,7 +270,7 @@ def test_mutate__set_leaf_duration_08():
     written duration does not.
     """
 
-    note = abjad.Note(0, (1, 8), multiplier=(1, 2))
+    note = abjad.Note("c'8", multiplier=(1, 2))
 
     assert abjad.lilypond(note) == "c'8 * 1/2"
 
@@ -287,7 +287,7 @@ def test_mutate__set_leaf_duration_09():
     written duration does not.
     """
 
-    note = abjad.Note(0, (1, 8), multiplier=(1, 2))
+    note = abjad.Note("c'8", multiplier=(1, 2))
 
     assert abjad.lilypond(note) == "c'8 * 1/2"
 
@@ -304,7 +304,7 @@ def test_mutate__set_leaf_duration_10():
     LilyPond multiplier changes but leaf written duration does not.
     """
 
-    note = abjad.Note(0, (1, 8), multiplier=(1, 2))
+    note = abjad.Note("c'8", multiplier=(1, 2))
 
     assert abjad.lilypond(note) == "c'8 * 1/2"
 
@@ -647,7 +647,7 @@ def test_mutate__split_leaf_by_durations_07():
     """
 
     note = abjad.Note("c'4")
-    after_grace = abjad.AfterGraceContainer([abjad.Note(0, (1, 32))])
+    after_grace = abjad.AfterGraceContainer([abjad.Note("c'32")])
     abjad.attach(after_grace, note)
 
     new_leaves = abjad.mutate._split_leaf_by_durations(note, [abjad.Duration(1, 8)])
@@ -679,7 +679,7 @@ def test_mutate__split_leaf_by_durations_08():
     """
 
     note = abjad.Note("c'4")
-    grace = abjad.AfterGraceContainer([abjad.Note(0, (1, 32))])
+    grace = abjad.AfterGraceContainer([abjad.Note("c'32")])
     abjad.attach(grace, note)
 
     new_leaves = abjad.mutate._split_leaf_by_durations(note, [abjad.Duration(5, 32)])
@@ -711,7 +711,7 @@ def test_mutate__split_leaf_by_durations_09():
     """
 
     note = abjad.Note("c'4")
-    grace = abjad.BeforeGraceContainer([abjad.Note(0, (1, 32))])
+    grace = abjad.BeforeGraceContainer([abjad.Note("c'32")])
     abjad.attach(grace, note)
 
     new_leaves = abjad.mutate._split_leaf_by_durations(note, [abjad.Duration(1, 16)])

--- a/tests/test_parentage.py
+++ b/tests/test_parentage.py
@@ -362,8 +362,8 @@ def test_Parentage_logical_voice_08():
     Orphan leaves carry equivalent containment signatures.
     """
 
-    note_1 = abjad.Note(0, (1, 8))
-    note_2 = abjad.Note(0, (1, 8))
+    note_1 = abjad.Note("c'8")
+    note_2 = abjad.Note("c'8")
 
     signature_1 = abjad.get.parentage(note_1).logical_voice()
     signature_2 = abjad.get.parentage(note_2).logical_voice()
@@ -375,14 +375,8 @@ def test_Parentage_logical_voice_09():
     Notes appear in the same logical voice.
     """
 
-    staff_1 = abjad.Staff([abjad.Voice([abjad.Note(0, (1, 8))])])
-    staff_1.set_name("staff")
-    staff_1[0].set_name("voice")
-
-    staff_2 = abjad.Staff([abjad.Voice([abjad.Note(0, (1, 8))])])
-    staff_2.set_name("staff")
-    staff_2[0].set_name("voice")
-
+    staff_1 = abjad.Staff([abjad.Voice("c'8", name="voice")], name="staff")
+    staff_2 = abjad.Staff([abjad.Voice("c'8", name="voice")], name="staff")
     staff_1_leaf_signature = abjad.get.parentage(staff_1[0][0]).logical_voice()
     staff_2_leaf_signature = abjad.get.parentage(staff_2[0][0]).logical_voice()
     assert staff_1_leaf_signature == staff_2_leaf_signature

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,7 +4,9 @@ import abjad
 
 
 def test_LilyPondParser__comments_01():
-    target = abjad.Container([abjad.Note(0, (1, 4))])
+    pitch, duration = abjad.NamedPitch("c'"), abjad.Duration(1, 4)
+    note = abjad.Note.from_pitch_and_duration(pitch, duration)
+    target = abjad.Container([note])
 
     string = r"""
     { c'4 }
@@ -457,18 +459,27 @@ def test_LilyPondParser__functions__relative_05():
 
 
 def test_LilyPondParser__functions__relative_06():
+    duration = abjad.Duration(1, 4)
     target = abjad.Container(
         [
-            abjad.Note("c'", (1, 4)),
-            abjad.Note("d'", (1, 4)),
-            abjad.Note("e'", (1, 4)),
-            abjad.Note("f'", (1, 4)),
+            abjad.Note.from_pitch_and_duration(abjad.NamedPitch("c'"), duration),
+            abjad.Note.from_pitch_and_duration(abjad.NamedPitch("d'"), duration),
+            abjad.Note.from_pitch_and_duration(abjad.NamedPitch("e'"), duration),
+            abjad.Note.from_pitch_and_duration(abjad.NamedPitch("f'"), duration),
             abjad.Container(
                 [
-                    abjad.Note("c''", (1, 4)),
-                    abjad.Note("d''", (1, 4)),
-                    abjad.Note("e''", (1, 4)),
-                    abjad.Note("f''", (1, 4)),
+                    abjad.Note.from_pitch_and_duration(
+                        abjad.NamedPitch("c''"), duration
+                    ),
+                    abjad.Note.from_pitch_and_duration(
+                        abjad.NamedPitch("d''"), duration
+                    ),
+                    abjad.Note.from_pitch_and_duration(
+                        abjad.NamedPitch("e''"), duration
+                    ),
+                    abjad.Note.from_pitch_and_duration(
+                        abjad.NamedPitch("f''"), duration
+                    ),
                 ]
             ),
         ]
@@ -498,16 +509,26 @@ def test_LilyPondParser__functions__relative_06():
 
 
 def test_LilyPondParser__functions__relative_07():
+    duration = abjad.Duration(1, 4)
     target = abjad.Container(
         [
-            abjad.Note("d'", (1, 4)),
-            abjad.Note("e'", (1, 4)),
+            abjad.Note.from_pitch_and_duration(abjad.NamedPitch("d'"), duration),
+            abjad.Note.from_pitch_and_duration(abjad.NamedPitch("e'"), duration),
             abjad.Container(
                 [
-                    abjad.Note("e", (1, 4)),
-                    abjad.Note("fs", (1, 4)),
+                    abjad.Note.from_pitch_and_duration(abjad.NamedPitch("e"), duration),
+                    abjad.Note.from_pitch_and_duration(
+                        abjad.NamedPitch("fs"), duration
+                    ),
                     abjad.Container(
-                        [abjad.Note("e'", (1, 4)), abjad.Note("fs'", (1, 4))]
+                        [
+                            abjad.Note.from_pitch_and_duration(
+                                abjad.NamedPitch("e'"), duration
+                            ),
+                            abjad.Note.from_pitch_and_duration(
+                                abjad.NamedPitch("fs'"), duration
+                            ),
+                        ]
                     ),
                 ]
             ),
@@ -538,12 +559,13 @@ def test_LilyPondParser__functions__relative_07():
 
 
 def test_LilyPondParser__functions__relative_08():
+    duration = abjad.Duration(1, 4)
     target = abjad.Container(
         [
-            abjad.Note("c'", (1, 4)),
-            abjad.Chord(["c'", "e'", "g'"], (1, 4)),
-            abjad.Chord(["c''", "e''", "g'''"], (1, 4)),
-            abjad.Chord(["e", "c'", "g''"], (1, 4)),
+            abjad.Note.from_pitch_and_duration(abjad.NamedPitch("c'"), duration),
+            abjad.Chord(["c'", "e'", "g'"], duration),
+            abjad.Chord(["c''", "e''", "g'''"], duration),
+            abjad.Chord(["e", "c'", "g''"], duration),
         ]
     )
 
@@ -796,7 +818,7 @@ def test_LilyPondParser__indicators__Articulation_01():
 
 
 def test_LilyPondParser__indicators__Articulation_02():
-    target = abjad.Staff([abjad.Note("c'", (1, 4))])
+    target = abjad.Staff("c'4")
     articulation = abjad.Articulation("marcato")
     abjad.attach(articulation, target[0], direction=abjad.UP)
     articulation = abjad.Articulation("stopped")
@@ -1013,7 +1035,7 @@ def test_LilyPondParser__indicators__Beam_05():
 
 
 def test_LilyPondParser__indicators__Clef_01():
-    target = abjad.Staff([abjad.Note(0, 1)])
+    target = abjad.Staff("c'1")
     clef = abjad.Clef("bass")
     abjad.attach(clef, target[0])
 
@@ -1079,7 +1101,7 @@ def test_LilyPondParser__indicators__Dynamic_01():
 
 
 def test_LilyPondParser__indicators__Glissando_01():
-    target = abjad.Container([abjad.Note(0, 1), abjad.Note(0, 1)])
+    target = abjad.Container("c'1 c'1")
     abjad.glissando(target[:])
     parser = abjad.parser.LilyPondParser()
     result = parser(abjad.lilypond(target))
@@ -1322,7 +1344,7 @@ def test_LilyPondParser__indicators__HorizontalBracket_05():
 
 
 def test_LilyPondParser__indicators__KeySignature_01():
-    target = abjad.Staff([abjad.Note("fs'", 1)])
+    target = abjad.Staff("fs'1")
     key_signature = abjad.KeySignature(abjad.NamedPitchClass("g"), abjad.Mode("major"))
     abjad.attach(key_signature, target[0])
 
@@ -1344,7 +1366,7 @@ def test_LilyPondParser__indicators__KeySignature_01():
 
 
 def test_LilyPondParser__indicators__Markup_01():
-    target = abjad.Staff([abjad.Note(0, 1)])
+    target = abjad.Staff("c'1")
     markup = abjad.Markup(r"\markup { hello! }")
     abjad.attach(markup, target[0], direction=abjad.UP)
 
@@ -1367,7 +1389,7 @@ def test_LilyPondParser__indicators__Markup_01():
 
 
 def test_LilyPondParser__indicators__Markup_02():
-    target = abjad.Staff([abjad.Note(0, (1, 4))])
+    target = abjad.Staff("c'4")
     markup = abjad.Markup(r'\markup { X Y Z "a b c" }')
     abjad.attach(markup, target[0], direction=abjad.DOWN)
 
@@ -1385,10 +1407,10 @@ def test_LilyPondParser__indicators__Markup_02():
 def test_LilyPondParser__indicators__Markup_03():
     """
     Articulations following markup block are (re)lexed correctly after
-    returning to the "notes" lexical state after popping the "markup lexical state.
+    returning to the "notes" lexical state after popping the "markup lexical
+    state.
     """
-
-    target = abjad.Staff([abjad.Note(0, (1, 4)), abjad.Note(2, (1, 4))])
+    target = abjad.Staff("c'4 d'4")
     markup = abjad.Markup(r"\markup { hello }")
     abjad.attach(markup, target[0], direction=abjad.UP)
     articulation = abjad.Articulation(".")
@@ -1431,7 +1453,8 @@ def test_LilyPondParser__indicators__Markup_04():
 
 
 def test_LilyPondParser__indicators__MetronomeMark_01():
-    target = abjad.Score([abjad.Staff([abjad.Note(0, 1)])])
+    staff = abjad.Staff("c'1")
+    target = abjad.Score([staff])
     mark = abjad.MetronomeMark(textual_indication='"As fast as possible"')
     abjad.attach(mark, target[0][0], context="Staff")
 
@@ -1458,7 +1481,8 @@ def test_LilyPondParser__indicators__MetronomeMark_01():
 
 
 def test_LilyPondParser__indicators__MetronomeMark_02():
-    target = abjad.Score([abjad.Staff([abjad.Note(0, 1)])])
+    staff = abjad.Staff("c'1")
+    target = abjad.Score([staff])
     leaves = abjad.select.leaves(target)
     mark = abjad.MetronomeMark(abjad.Duration(1, 4), 60)
     abjad.attach(mark, leaves[0], context="Staff")
@@ -1486,7 +1510,8 @@ def test_LilyPondParser__indicators__MetronomeMark_02():
 
 
 def test_LilyPondParser__indicators__MetronomeMark_03():
-    target = abjad.Score([abjad.Staff([abjad.Note(0, 1)])])
+    staff = abjad.Staff("c'1")
+    target = abjad.Score([staff])
     leaves = abjad.select.leaves(target)
     mark = abjad.MetronomeMark(abjad.Duration(1, 4), (59, 63))
     abjad.attach(mark, leaves[0], context="Staff")
@@ -1514,7 +1539,8 @@ def test_LilyPondParser__indicators__MetronomeMark_03():
 
 
 def test_LilyPondParser__indicators__MetronomeMark_04():
-    target = abjad.Score([abjad.Staff([abjad.Note(0, 1)])])
+    staff = abjad.Staff("c'1")
+    target = abjad.Score([staff])
     mark = abjad.MetronomeMark(
         reference_duration=abjad.Duration(1, 4),
         units_per_minute=60,
@@ -1546,7 +1572,8 @@ def test_LilyPondParser__indicators__MetronomeMark_04():
 
 
 def test_LilyPondParser__indicators__MetronomeMark_05():
-    target = abjad.Score([abjad.Staff([abjad.Note(0, 1)])])
+    staff = abjad.Staff("c'1")
+    target = abjad.Score([staff])
     mark = abjad.MetronomeMark(
         reference_duration=abjad.Duration(1, 16),
         units_per_minute=(34, 55),
@@ -1681,7 +1708,7 @@ def test_LilyPondParser__indicators__PhrasingSlur_06():
 
 
 def test_LilyPondParser__indicators__RepeatTie_01():
-    target = abjad.Container([abjad.Note(0, 1), abjad.Note(0, 1)])
+    target = abjad.Container("c'1 c'1")
     repeat_tie = abjad.RepeatTie()
     abjad.attach(repeat_tie, target[-1])
     parser = abjad.parser.LilyPondParser()
@@ -1826,7 +1853,7 @@ def test_LilyPondParser__indicators__Slur_07():
 
 
 def test_LilyPondParser__indicators__StemTremolo_01():
-    target = abjad.Staff([abjad.Note(0, 1)])
+    target = abjad.Staff("c'1")
     stem_tremolo = abjad.StemTremolo(4)
     abjad.attach(stem_tremolo, target[0])
     assert abjad.lilypond(target) == abjad.string.normalize(
@@ -1955,7 +1982,7 @@ def test_LilyPondParser__indicators__Text_06():
 
 
 def test_LilyPondParser__indicators__Tie_01():
-    target = abjad.Container([abjad.Note(0, 1), abjad.Note(0, 1)])
+    target = abjad.Container("c'1 c'1")
     abjad.tie(target[:])
     parser = abjad.parser.LilyPondParser()
     result = parser(abjad.lilypond(target))
@@ -1979,7 +2006,7 @@ def test_LilyPondParser__indicators__Tie_04():
     With direction.
     """
 
-    target = abjad.Container([abjad.Note(0, 1), abjad.Note(0, 1)])
+    target = abjad.Container("c'1 c'1")
     abjad.tie(target[:], direction=abjad.UP)
     parser = abjad.parser.LilyPondParser()
     result = parser(abjad.lilypond(target))
@@ -1991,7 +2018,7 @@ def test_LilyPondParser__indicators__Tie_05():
     With direction.
     """
 
-    target = abjad.Container([abjad.Note(0, 1), abjad.Note(0, 1)])
+    target = abjad.Container("c'1 c'1")
     abjad.tie(target[:], direction=abjad.DOWN)
     parser = abjad.parser.LilyPondParser()
     result = parser(abjad.lilypond(target))
@@ -1999,7 +2026,8 @@ def test_LilyPondParser__indicators__Tie_05():
 
 
 def test_LilyPondParser__indicators__TimeSignature_01():
-    target = abjad.Score([abjad.Staff([abjad.Note(0, 1)])])
+    staff = abjad.Staff("c'1")
+    target = abjad.Score([staff])
     time_signature = abjad.TimeSignature((8, 8))
     abjad.attach(time_signature, target[0][0])
     assert abjad.lilypond(target) == abjad.string.normalize(
@@ -2153,7 +2181,8 @@ def test_LilyPondParser__leaves__MultiMeasureRest_01():
 
 
 def test_LilyPondParser__leaves__Note_01():
-    target = abjad.Note(0, 1)
+    pitch, duration = abjad.NamedPitch("c'"), abjad.Duration(1, 4)
+    target = abjad.Note.from_pitch_and_duration(pitch, duration)
     parser = abjad.parser.LilyPondParser()
     result = parser("{ %s }" % abjad.lilypond(target))
     assert (
@@ -2268,9 +2297,13 @@ def test_LilyPondParser__misc__chord_repetition_03():
     target = abjad.Container(
         [
             abjad.Chord([0, 4, 7], (1, 8)),
-            abjad.Note(12, (1, 8)),
+            abjad.Note.from_pitch_and_duration(
+                abjad.NamedPitch(12), abjad.Duration(1, 8)
+            ),
             abjad.Chord([0, 4, 7], (1, 8)),
-            abjad.Note(12, (1, 8)),
+            abjad.Note.from_pitch_and_duration(
+                abjad.NamedPitch(12), abjad.Duration(1, 8)
+            ),
             abjad.Rest((1, 4)),
             abjad.Chord([0, 4, 7], (1, 4)),
         ]
@@ -2344,20 +2377,39 @@ def test_LilyPondParser__misc__variables_01():
                         [
                             abjad.Container(
                                 [
-                                    abjad.Container([abjad.Note(0, (1, 8))]),
-                                    abjad.Note(2, (1, 8)),
-                                    abjad.Note(4, (1, 4)),
+                                    abjad.Container(
+                                        [
+                                            abjad.Note.from_pitch_and_duration(
+                                                abjad.NamedPitch(0),
+                                                abjad.Duration(1, 8),
+                                            )
+                                        ]
+                                    ),
+                                    abjad.Note.from_pitch_and_duration(
+                                        abjad.NamedPitch(2), abjad.Duration(1, 8)
+                                    ),
+                                    abjad.Note.from_pitch_and_duration(
+                                        abjad.NamedPitch(4), abjad.Duration(1, 4)
+                                    ),
                                 ]
                             ),
-                            abjad.Note(5, (1, 4)),
-                            abjad.Note(7, (1, 2)),
+                            abjad.Note.from_pitch_and_duration(
+                                abjad.NamedPitch(5), abjad.Duration(1, 4)
+                            ),
+                            abjad.Note.from_pitch_and_duration(
+                                abjad.NamedPitch(7), abjad.Duration(1, 2)
+                            ),
                         ]
                     ),
-                    abjad.Note(9, (1, 2)),
-                    abjad.Note(11, 1),
+                    abjad.Note.from_pitch_and_duration(
+                        abjad.NamedPitch(9), abjad.Duration(1, 2)
+                    ),
+                    abjad.Note.from_pitch_and_duration(
+                        abjad.NamedPitch(11), abjad.Duration(1)
+                    ),
                 ]
             ),
-            abjad.Note(12, 1),
+            abjad.Note.from_pitch_and_duration(abjad.NamedPitch(12), abjad.Duration(1)),
         ]
     )
 

--- a/tests/test_score_Container.py
+++ b/tests/test_score_Container.py
@@ -1494,7 +1494,7 @@ def test_Container_append_02():
     tuplet = abjad.Tuplet("3:2", "c'8 d'8 e'8")
     abjad.Voice([tuplet])
     abjad.beam(tuplet[:])
-    tuplet.append(abjad.Note(5, (1, 16)), preserve_duration=True)
+    tuplet.append(abjad.Note("f'16"), preserve_duration=True)
 
     assert abjad.lilypond(tuplet) == abjad.string.normalize(
         r"""
@@ -1987,7 +1987,7 @@ def test_Container_insert_01():
 def test_Container_insert_02():
     voice = abjad.Voice("c'8 d'8 e'8 f'8")
     abjad.beam(voice[:])
-    voice.insert(1, abjad.Note(1, (1, 8)))
+    voice.insert(1, abjad.Note("cs'8"))
 
     assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(
@@ -2007,7 +2007,7 @@ def test_Container_insert_02():
 
 
 def test_Container_insert_03():
-    voice = abjad.Voice([abjad.Note(n, (1, 8)) for n in range(4)])
+    voice = abjad.Voice("c'8 cs'8 d'8 ef'8")
     abjad.beam(voice[:])
     voice.insert(4, abjad.Rest((1, 4)))
 
@@ -2033,7 +2033,7 @@ def test_Container_insert_04():
     Insert works with really big positive values.
     """
 
-    voice = abjad.Voice([abjad.Note(n, (1, 8)) for n in range(4)])
+    voice = abjad.Voice("c'8 cs'8 d'8 ef'8")
     abjad.beam(voice[:])
     voice.insert(1000, abjad.Rest((1, 4)))
 
@@ -2061,7 +2061,7 @@ def test_Container_insert_05():
 
     voice = abjad.Voice("c'8 d'8 e'8 f'8")
     abjad.beam(voice[:])
-    voice.insert(-1, abjad.Note(4.5, (1, 8)))
+    voice.insert(-1, abjad.Note("eqs'8"))
 
     assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(

--- a/tests/test_score_Leaf.py
+++ b/tests/test_score_Leaf.py
@@ -8,7 +8,7 @@ def test_Leaf_duration_assign_01():
     Written duration can be assigned a duration.
     """
 
-    note = abjad.Note(1, (1, 4))
+    note = abjad.Note("cs'4")
     note.set_written_duration(abjad.Duration(1, 8))
     assert note.written_duration() == abjad.Duration(1, 8)
 
@@ -27,7 +27,7 @@ def test_Leaf_duration_compare_02():
     Written durations can be evaluated for equality with integers.
     """
 
-    note = abjad.Note(0, 1)
+    note = abjad.Note("c'1")
     assert note.written_duration() == 1
 
 
@@ -47,7 +47,7 @@ def test_Leaf_written_duration_01():
     Leaf durations can go up to 'maxima...': duration < (16, 1).
     """
 
-    note = abjad.Note(1, 2)
+    note = abjad.Note(r"cs'\breve")
 
     assert abjad.lilypond(note) == "cs'\\breve"
     note.set_written_duration(abjad.Duration(3))
@@ -68,4 +68,5 @@ def test_Leaf_written_duration_01():
     assert abjad.lilypond(note) == "cs'\\maxima..."
 
     with pytest.raises(abjad.AssignabilityError):
-        abjad.Note(1, 16)
+        pitch = abjad.NamedPitch("cs")
+        abjad.Note.from_pitch_and_duration(pitch, abjad.Duration(16))

--- a/tests/test_score_Note.py
+++ b/tests/test_score_Note.py
@@ -10,7 +10,7 @@ def test_Note___copy___01():
     Copies note.
     """
 
-    note_1 = abjad.Note(12, (1, 4))
+    note_1 = abjad.Note("c''4")
     note_2 = copy.copy(note_1)
 
     assert isinstance(note_1, abjad.Note)
@@ -38,7 +38,7 @@ def test_Note___copy___03():
     Copies note with LilyPond grob overrides and LilyPond context settings.
     """
 
-    note_1 = abjad.Note(12, (1, 4))
+    note_1 = abjad.Note("c''4")
     abjad.override(note_1).Staff.NoteHead.color = "#red"
     abjad.override(note_1).Accidental.color = "#red"
     abjad.setting(note_1).tupletFullLength = True
@@ -194,7 +194,7 @@ def test_Note___init___02():
     Initializes note with pitch in octave zero.
     """
 
-    note = abjad.Note(-37, (1, 4))
+    note = abjad.Note("b,,,4")
 
     assert abjad.lilypond(note) == "b,,,4"
 
@@ -205,17 +205,8 @@ def test_Note___init___03():
     """
 
     with pytest.raises(abjad.AssignabilityError):
-        abjad.Note(0, (5, 8))
-
-
-def test_Note___init___04():
-    """
-    Initializes note with LilyPond-style pitch string.
-    """
-
-    note = abjad.Note("c,,", (1, 4))
-
-    assert abjad.lilypond(note) == "c,,4"
+        pitch = abjad.NamedPitch(0)
+        abjad.Note.from_pitch_and_duration(pitch, abjad.Duration(5, 8))
 
 
 def test_Note___init___05():
@@ -230,20 +221,6 @@ def test_Note___init___05():
 
 def test_Note__init__06():
     """
-    REGRESSION. Initializes note from other note with multiplier.
-    """
-
-    note = abjad.Note("cs''4", multiplier=(1, 1))
-
-    assert abjad.lilypond(note) == "cs''4 * 1/1"
-
-    new_note = abjad.Note(note)
-
-    assert abjad.lilypond(new_note) == "cs''4 * 1/1"
-
-
-def test_Note__init__07():
-    """
     Initializes note with French note names.
     """
 
@@ -252,64 +229,7 @@ def test_Note__init__07():
     assert abjad.lilypond(note) == "cs''8."
 
 
-def test_Note___init___08():
-    """
-    Initializes note from chord.
-    """
-
-    chord = abjad.Chord([2, 3, 4], (1, 4))
-    note = abjad.Note(chord)
-
-    assert abjad.lilypond(note) == abjad.string.normalize(
-        r"""
-        d'4
-        """
-    )
-
-    assert abjad.wf.is_wellformed(note)
-
-
-def test_Note___init___09():
-    """
-    Initializes note from tupletized chord.
-    """
-
-    chord = abjad.Chord([2, 3, 4], (1, 4))
-    chords = abjad.mutate.copy(chord, 3)
-    tuplet = abjad.Tuplet("3:2", chords)
-    note = abjad.Note(tuplet[0])
-
-    assert abjad.lilypond(note) == abjad.string.normalize(
-        r"""
-        d'4
-        """
-    )
-
-    assert abjad.wf.is_wellformed(note)
-
-
-def test_Note___init___10():
-    """
-    Initializes note from beamed chord.
-    """
-
-    chord = abjad.Chord([2, 3, 4], (1, 8))
-    chords = abjad.mutate.copy(chord, 3)
-    voice = abjad.Voice(chords)
-    abjad.beam(voice[:])
-    note = abjad.Note(voice[0])
-
-    assert abjad.lilypond(note) == abjad.string.normalize(
-        r"""
-        d'8
-        [
-        """
-    ), print(abjad.lilypond(note))
-
-    assert abjad.wf.is_wellformed(note)
-
-
-def test_Note___init___17():
+def test_Note___init___07():
     """
     Initializes note with cautionary accidental.
     """
@@ -319,7 +239,7 @@ def test_Note___init___17():
     assert abjad.lilypond(note) == "c'?4"
 
 
-def test_Note___init___18():
+def test_Note___init___08():
     """
     Initializes note with forced accidental.
     """
@@ -329,7 +249,7 @@ def test_Note___init___18():
     assert abjad.lilypond(note) == "c'!4"
 
 
-def test_Note___init___19():
+def test_Note___init___09():
     """
     Initializes note with both forced and cautionary accidental.
     """
@@ -339,18 +259,7 @@ def test_Note___init___19():
     assert abjad.lilypond(note) == "c'!?4"
 
 
-def test_Note___init___20():
-    """
-    Initializes note from chord with forced and cautionary accidental.
-    """
-
-    chord = abjad.Chord("<c'!? e' g'>4")
-    note = abjad.Note(chord)
-
-    assert abjad.lilypond(note) == "c'!?4"
-
-
-def test_Note___init___21():
+def test_Note___init___10():
     """
     Initializes note with drum pitch.
     """

--- a/tests/test_score_NoteHead.py
+++ b/tests/test_score_NoteHead.py
@@ -92,7 +92,7 @@ def test_NoteHead___init___02():
 
 def test_NoteHead_is_forced_01():
     note_head = abjad.NoteHead(abjad.NamedPitch("c'"))
-    assert note_head.is_forced() is None
+    assert note_head.is_forced() is False
     note_head.set_is_forced(True)
     assert note_head.is_forced() is True
     note_head.set_is_forced(False)
@@ -101,7 +101,7 @@ def test_NoteHead_is_forced_01():
 
 def test_NoteHead_is_parenthesized_01():
     note_head = abjad.NoteHead(abjad.NamedPitch("c'"))
-    assert note_head.is_parenthesized() is None
+    assert note_head.is_parenthesized() is False
     note_head.set_is_parenthesized(True)
     assert note_head.is_parenthesized() is True
     note_head.set_is_parenthesized(False)
@@ -150,7 +150,7 @@ def test_NoteHead_written_pitch_01():
     Sets note-head pitch with pitch.
     """
 
-    note = abjad.Note(13, (1, 4))
+    note = abjad.Note("cs''4")
     note.note_head().set_written_pitch(abjad.NamedPitch(14))
 
     "NoteHead(d'')"
@@ -165,8 +165,8 @@ def test_NoteHead_written_pitch_02():
     Makes sure this does not cause reference problems.
     """
 
-    n1 = abjad.Note(12, (1, 4))
-    n2 = abjad.Note(14, (1, 4))
+    n1 = abjad.Note("c''4")
+    n2 = abjad.Note("d''4")
     n1.set_written_pitch(n2.written_pitch())
 
     assert n1.written_pitch() == abjad.NamedPitch(14)

--- a/tests/test_score_Skip.py
+++ b/tests/test_score_Skip.py
@@ -106,7 +106,7 @@ def test_Skip___init___05():
     Initializes skip from orphan note.
     """
 
-    note = abjad.Note(2, (1, 8))
+    note = abjad.Note("d'8")
     skip = abjad.Skip(note)
 
     assert isinstance(note, abjad.Note)

--- a/tests/test_score_Staff.py
+++ b/tests/test_score_Staff.py
@@ -395,7 +395,7 @@ def test_Staff___setitem___01():
     assert isinstance(staff[2], abjad.Chord)
     assert isinstance(staff[3], abjad.Tuplet)
     assert isinstance(staff[4], abjad.Tuplet)
-    staff[-1] = abjad.Note(13, (1, 4))
+    staff[-1] = abjad.Note("cs''4")
     assert len(staff) == 5
     assert abjad.wf.is_wellformed(staff)
     assert isinstance(staff[0], abjad.Rest)
@@ -450,7 +450,7 @@ def test_Staff___setitem___05():
     staff = abjad.Staff("c'4 c'4 c'4 c'4")
 
     with pytest.raises(AssertionError):
-        staff[0] = [abjad.Note(2, (1, 4)), abjad.Note(2, (1, 4))]
+        staff[0] = [abjad.Note("d'4"), abjad.Note("d'4")]
 
 
 def test_Staff___setitem___06():


### PR DESCRIPTION
Only abjad.Note("c'8") with a single string argument is allowed.

Use abjad.Note.from_pitch_and_duration(pitch, duration) where needed otherwise.

Can no longer initialize from existing note, rest or chord.