### PR TITLE
Typeforce rest constructor

### DIFF
--- a/docs/source/_mothballed/score-fragment-strings.rst
+++ b/docs/source/_mothballed/score-fragment-strings.rst
@@ -120,13 +120,13 @@ strings start with some rests, and use a long-short pattern for their rhythms:
     ...         short_duration = long_duration / 2
     ...         rest_duration = abjad.Fraction(3, 2) * long_duration
     ...         div = rest_duration // abjad.Duration(3, 2)
-    ...         mod = rest_duration % abjad.Duration(3, 2)
+    ...         mod = abjad.Duration(rest_duration % abjad.Duration(3, 2))
     ...         initial_rest = []
     ...         for i in range(div):
-    ...             rest = abjad.MultimeasureRest((3, 2))
+    ...             rest = abjad.MultimeasureRest("R1.")
     ...             initial_rest.append(rest)
     ...         if mod:
-    ...             rest = abjad.Rest(mod)
+    ...             rest = abjad.Rest.from_duration(mod)
     ...             initial_rest.append(rest)
     ...         chord_descents = [tuple(initial_rest)]
     ...         pitch_pair_descents = voice_to_pitch_pair_descents[voice_name]
@@ -141,7 +141,7 @@ strings start with some rests, and use a long-short pattern for their rhythms:
     ...                     chord_descent.append(chord)
     ...                 else:
     ...                     assert isinstance(pitch, abjad.NamedPitch)
-    ...                     note = abjad.Note(pitch, duration)
+    ...                     note = abjad.Note.from_pitch_and_duration(pitch, duration)
     ...                     chord_descent.append(note)
     ...                 counter = (counter + 1) % 2
     ...             chord_descents.append(tuple(chord_descent))
@@ -209,7 +209,8 @@ too:
     >>> notes = abjad.sequence.flatten(descents)
     >>> staff = abjad.Staff(notes)
     >>> score = abjad.Score([staff], name="Score")
-    >>> lists = abjad.mutate.split(staff[:], [(3, 2)], cyclic=True)
+    >>> duration = abjad.Duration(3, 2)
+    >>> lists = abjad.mutate.split(staff[:], [duration], cyclic=True)
     >>> time_signature = abjad.TimeSignature((6, 4))
     >>> leaf = abjad.select.leaf(staff, 0)
     >>> abjad.attach(time_signature, leaf)
@@ -286,8 +287,9 @@ We define more functions:
     ...     edit_cello(score, extra_components)
     ...     edit_bass(score, extra_components)
     ...     strings_staff_group = score["Strings_Staff_Group"]
+    ...     duration = abjad.Duration(6, 4)
     ...     for voice in abjad.select.components(strings_staff_group, abjad.Voice):
-    ...         lists = abjad.mutate.split(voice[:], [(6, 4)], cyclic=True)
+    ...         lists = abjad.mutate.split(voice[:], [duration], cyclic=True)
     ...         for components in lists:
     ...             container = abjad.Container()
     ...             abjad.mutate.wrap(components, container)

--- a/docs/source/_mothballed/working-with-tuplets.rst
+++ b/docs/source/_mothballed/working-with-tuplets.rst
@@ -159,7 +159,7 @@ Use ``extend()`` to extend a tuplet with multiple components at once:
 ::
 
     >>> notes = [abjad.Note("fs'32"), abjad.Note("e'32")]
-    >>> notes.extend([abjad.Note("d'32"), abjad.Rest((1, 32))])
+    >>> notes.extend([abjad.Note("d'32"), abjad.Rest("r32"))])
     >>> tuplet.extend(notes)
     >>> abjad.show(tuplet)
 

--- a/source/abjad/illustrators.py
+++ b/source/abjad/illustrators.py
@@ -519,11 +519,11 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
         written_duration = leaf.written_duration()
         if isinstance(leaf, _score.Note):
             if leaf.written_pitch() < lowest_treble_pitch:
-                treble_leaf = _score.Rest(written_duration)
+                treble_leaf = _score.Rest.from_duration(written_duration)
                 bass_leaf = copy.copy(leaf)
             else:
                 treble_leaf = copy.copy(leaf)
-                bass_leaf = _score.Rest(written_duration)
+                bass_leaf = _score.Rest.from_duration(written_duration)
         elif isinstance(leaf, _score.Chord):
             treble_note_heads, bass_note_heads = [], []
             for note_head in leaf.note_heads():
@@ -533,7 +533,7 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
                 else:
                     treble_note_heads.append(new_note_head)
             if not treble_note_heads:
-                treble_leaf = _score.Rest(written_duration)
+                treble_leaf = _score.Rest.from_duration(written_duration)
             elif len(treble_note_heads) == 1:
                 treble_leaf = _score.Note.from_pitch_and_duration(
                     _pitch.NamedPitch("C4"), written_duration
@@ -542,7 +542,7 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
             else:
                 treble_leaf = _score.Chord(treble_note_heads, written_duration)
             if not bass_note_heads:
-                bass_leaf = _score.Rest(written_duration)
+                bass_leaf = _score.Rest.from_duration(written_duration)
             elif len(bass_note_heads) == 1:
                 bass_leaf = _score.Note.from_pitch_and_duration(
                     _pitch.NamedPitch("C4"), written_duration

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -62,7 +62,7 @@ def _make_leaf_on_pitch(
                 tag=tag,
             )
         elif use_multimeasure_rests is True:
-            multimeasure_rest = _score.MultimeasureRest((1), tag=tag)
+            multimeasure_rest = _score.MultimeasureRest("R1", tag=tag)
             multimeasure_rest.set_multiplier(duration.pair())
             leaves = [multimeasure_rest]
         else:
@@ -150,7 +150,12 @@ def _make_tied_leaf(
         elif pitches is not None:
             arguments = (pitches, written_duration)
             leaf = class_(*arguments, multiplier=multiplier, tag=tag)
+        elif class_ is _score.Rest:
+            leaf = class_.from_duration(
+                written_duration, multiplier=multiplier, tag=tag
+            )
         else:
+            assert class_ is _score.Skip, repr(class_)
             arguments = (written_duration,)
             leaf = class_(*arguments, multiplier=multiplier, tag=tag)
         leaves.append(leaf)

--- a/source/abjad/parsers/parser.py
+++ b/source/abjad/parsers/parser.py
@@ -4622,7 +4622,8 @@ class LilyPondSyntacticalDefinition:
         self, p
     ):
         "event_chord : MULTI_MEASURE_REST optional_notemode_duration post_events"
-        rest = _score.MultimeasureRest(p[2].duration, tag=self.tag)
+        # rest = _score.MultimeasureRest(p[2].duration, tag=self.tag)
+        rest = _score.MultimeasureRest.from_duration(p[2].duration, tag=self.tag)
         if p[2].multiplier is not None:
             fraction = fractions.Fraction(p[2].multiplier)
             pair = (fraction.numerator, fraction.denominator)
@@ -6251,7 +6252,7 @@ class LilyPondSyntacticalDefinition:
     def p_simple_element__RESTNAME__optional_notemode_duration(self, p):
         "simple_element : RESTNAME optional_notemode_duration"
         if p[1] == "r":
-            rest = _score.Rest(p[2].duration, tag=self.tag)
+            rest = _score.Rest.from_duration(p[2].duration, tag=self.tag)
         else:
             rest = _score.Skip(p[2].duration, tag=self.tag)
         if p[2].multiplier is not None:

--- a/source/abjad/parsers/reduced.py
+++ b/source/abjad/parsers/reduced.py
@@ -541,19 +541,19 @@ class ReducedLyParser(Parser):
         """
         rest_body : RESTNAME
         """
-        p[0] = _score.Rest(self._default_duration)
+        p[0] = _score.Rest.from_duration(self._default_duration)
 
     def p_rest_body__RESTNAME__positive_leaf_duration(self, p):
         """
         rest_body : RESTNAME positive_leaf_duration
         """
-        p[0] = _score.Rest(p[2])
+        p[0] = _score.Rest.from_duration(p[2])
 
     def p_rest_body__negative_leaf_duration(self, p):
         """
         rest_body : negative_leaf_duration
         """
-        p[0] = _score.Rest(p[1])
+        p[0] = _score.Rest.from_duration(p[1])
 
     def p_slur__PAREN_L(self, p):
         """

--- a/tests/test_get_timespan.py
+++ b/tests/test_get_timespan.py
@@ -17,21 +17,21 @@ def test_get_timespan_02():
 
 def test_get_timespan_03():
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    staff[-1] = abjad.Rest((1, 8))
+    staff[-1] = abjad.Rest("r8")
     for i, x in enumerate(staff):
         assert abjad.get.timespan(x).start_offset == abjad.duration.offset(i, 8)
 
 
 def test_get_timespan_04():
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    staff[10:10] = [abjad.Rest((1, 8))]
+    staff[10:10] = [abjad.Rest("r8")]
     for i, x in enumerate(staff):
         assert abjad.get.timespan(x).start_offset == abjad.duration.offset(i, 8)
 
 
 def test_get_timespan_05():
     staff = abjad.Staff("c'8 d'8 e'8 f'8")
-    staff[10:12] = [abjad.Rest((1, 8))]
+    staff[10:12] = [abjad.Rest("r8")]
     for i, x in enumerate(staff):
         assert abjad.get.timespan(x).start_offset == abjad.duration.offset(i, 8)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2172,7 +2172,7 @@ def test_LilyPondParser__leaves__Chord_01():
 
 
 def test_LilyPondParser__leaves__MultiMeasureRest_01():
-    target = abjad.MultimeasureRest((1, 4))
+    target = abjad.MultimeasureRest("R1")
     parser = abjad.parser.LilyPondParser()
     result = parser("{ %s }" % abjad.lilypond(target))
     assert (
@@ -2191,7 +2191,7 @@ def test_LilyPondParser__leaves__Note_01():
 
 
 def test_LilyPondParser__leaves__Rest_01():
-    target = abjad.Rest((1, 8))
+    target = abjad.Rest("r8")
     parser = abjad.parser.LilyPondParser()
     result = parser("{ %s }" % abjad.lilypond(target))
     assert (
@@ -2304,7 +2304,7 @@ def test_LilyPondParser__misc__chord_repetition_03():
             abjad.Note.from_pitch_and_duration(
                 abjad.NamedPitch(12), abjad.Duration(1, 8)
             ),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([0, 4, 7], (1, 4)),
         ]
     )

--- a/tests/test_score_Container.py
+++ b/tests/test_score_Container.py
@@ -1965,7 +1965,7 @@ def test_Container_insert_01():
 
     voice = abjad.Voice("c'8 d'8 e'8 f'8")
     abjad.beam(voice[:])
-    voice.insert(0, abjad.Rest((1, 8)))
+    voice.insert(0, abjad.Rest("r8"))
 
     assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(
@@ -2009,7 +2009,7 @@ def test_Container_insert_02():
 def test_Container_insert_03():
     voice = abjad.Voice("c'8 cs'8 d'8 ef'8")
     abjad.beam(voice[:])
-    voice.insert(4, abjad.Rest((1, 4)))
+    voice.insert(4, abjad.Rest("r4"))
 
     assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(
@@ -2035,7 +2035,7 @@ def test_Container_insert_04():
 
     voice = abjad.Voice("c'8 cs'8 d'8 ef'8")
     abjad.beam(voice[:])
-    voice.insert(1000, abjad.Rest((1, 4)))
+    voice.insert(1000, abjad.Rest("r4"))
 
     assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(
@@ -2087,7 +2087,7 @@ def test_Container_insert_06():
 
     voice = abjad.Voice("c'8 d'8 e'8 f'8")
     abjad.beam(voice[:])
-    voice.insert(-1000, abjad.Rest((1, 8)))
+    voice.insert(-1000, abjad.Rest("r8"))
 
     assert abjad.wf.is_wellformed(voice)
     assert abjad.lilypond(voice) == abjad.string.normalize(

--- a/tests/test_score_MultimeasureRest.py
+++ b/tests/test_score_MultimeasureRest.py
@@ -4,7 +4,7 @@ import abjad
 
 
 def test_MultimeasureRest___copy___01():
-    multi_measure_rest_1 = abjad.MultimeasureRest((1, 4))
+    multi_measure_rest_1 = abjad.MultimeasureRest("R1")
     multi_measure_rest_2 = copy.copy(multi_measure_rest_1)
 
     assert isinstance(multi_measure_rest_1, abjad.MultimeasureRest)
@@ -15,17 +15,12 @@ def test_MultimeasureRest___copy___01():
 
 def test_MultimeasureRest___init___01():
     """
-    Initializes multimeasure rest from empty input.
+    Initializes multimeasure rest from LilyPond input.
     """
 
-    multimeasure_rest = abjad.MultimeasureRest()
+    multimeasure_rest = abjad.MultimeasureRest("R2")
 
-    assert abjad.lilypond(multimeasure_rest) == abjad.string.normalize(
-        r"""
-        R4
-        """
-    )
-
+    assert abjad.lilypond(multimeasure_rest) == abjad.string.normalize("R2")
     assert abjad.wf.is_wellformed(multimeasure_rest)
 
 
@@ -49,7 +44,6 @@ def test_MultimeasureRest___init___02():
         >>
         """
     )
-
     assert abjad.wf.is_wellformed(score)
 
 

--- a/tests/test_score_Note.py
+++ b/tests/test_score_Note.py
@@ -181,16 +181,6 @@ def test_Note___copy___07():
 
 def test_Note___init___01():
     """
-    Initializes note from empty input.
-    """
-
-    note = abjad.Note()
-
-    assert abjad.lilypond(note) == "c'4"
-
-
-def test_Note___init___02():
-    """
     Initializes note with pitch in octave zero.
     """
 
@@ -199,7 +189,7 @@ def test_Note___init___02():
     assert abjad.lilypond(note) == "b,,,4"
 
 
-def test_Note___init___03():
+def test_Note___init___02():
     """
     Initializes note with non-assignable duration.
     """
@@ -209,7 +199,7 @@ def test_Note___init___03():
         abjad.Note.from_pitch_and_duration(pitch, abjad.Duration(5, 8))
 
 
-def test_Note___init___05():
+def test_Note___init___03():
     """
     Initializes note with complete LilyPond-style note string.
     """
@@ -219,7 +209,7 @@ def test_Note___init___05():
     assert abjad.lilypond(note) == "cs8."
 
 
-def test_Note__init__06():
+def test_Note__init__04():
     """
     Initializes note with French note names.
     """
@@ -229,7 +219,7 @@ def test_Note__init__06():
     assert abjad.lilypond(note) == "cs''8."
 
 
-def test_Note___init___07():
+def test_Note___init___05():
     """
     Initializes note with cautionary accidental.
     """
@@ -239,7 +229,7 @@ def test_Note___init___07():
     assert abjad.lilypond(note) == "c'?4"
 
 
-def test_Note___init___08():
+def test_Note___init___06():
     """
     Initializes note with forced accidental.
     """
@@ -249,7 +239,7 @@ def test_Note___init___08():
     assert abjad.lilypond(note) == "c'!4"
 
 
-def test_Note___init___09():
+def test_Note___init___07():
     """
     Initializes note with both forced and cautionary accidental.
     """
@@ -259,7 +249,7 @@ def test_Note___init___09():
     assert abjad.lilypond(note) == "c'!?4"
 
 
-def test_Note___init___10():
+def test_Note___init___08():
     """
     Initializes note with drum pitch.
     """

--- a/tests/test_score_Rest.py
+++ b/tests/test_score_Rest.py
@@ -4,9 +4,9 @@ import abjad
 
 
 def test_Rest___cmp___01():
-    rest_1 = abjad.Rest((1, 4))
-    rest_2 = abjad.Rest((1, 4))
-    rest_3 = abjad.Rest((1, 8))
+    rest_1 = abjad.Rest("r4")
+    rest_2 = abjad.Rest("r4")
+    rest_3 = abjad.Rest("r8")
 
     assert not rest_1 == rest_2
     assert not rest_1 == rest_3
@@ -14,9 +14,9 @@ def test_Rest___cmp___01():
 
 
 def test_Rest___cmp___02():
-    rest_1 = abjad.Rest((1, 4))
-    rest_2 = abjad.Rest((1, 4))
-    rest_3 = abjad.Rest((1, 8))
+    rest_1 = abjad.Rest("r4")
+    rest_2 = abjad.Rest("r4")
+    rest_3 = abjad.Rest("r8")
 
     assert rest_1 != rest_2
     assert rest_1 != rest_3
@@ -28,7 +28,7 @@ def test_Rest___copy___01():
     Copies rest.
     """
 
-    rest_1 = abjad.Rest((1, 4))
+    rest_1 = abjad.Rest("r4")
     rest_2 = copy.copy(rest_1)
 
     assert isinstance(rest_1, abjad.Rest)
@@ -56,7 +56,7 @@ def test_Rest___copy___03():
     Copies rest with LilyPond grob overrides and LilyPond context settings.
     """
 
-    rest_1 = abjad.Rest((1, 4))
+    rest_1 = abjad.Rest("r4")
     abjad.override(rest_1).Staff.NoteHead.color = "#red"
     abjad.override(rest_1).Accidental.color = "#red"
     abjad.setting(rest_1).tupletFullLength = True
@@ -76,218 +76,3 @@ def test_Rest___init___01():
     rest = abjad.Rest("r8.")
 
     assert rest.written_duration() == abjad.Duration(3, 16)
-
-
-def test_Rest___init___02():
-    """
-    Initializes rest from other rest.
-    """
-
-    rest_1 = abjad.Rest("r4", multiplier=(1, 2))
-    abjad.override(rest_1).Staff.NoteHead.color = "#red"
-    rest_2 = abjad.Rest(rest_1)
-
-    assert isinstance(rest_1, abjad.Rest)
-    assert isinstance(rest_2, abjad.Rest)
-    assert abjad.lilypond(rest_1) == abjad.lilypond(rest_2)
-    assert rest_1 is not rest_2
-
-
-def test_Rest___init___03():
-    """
-    Initializes rest from chord.
-    """
-
-    chord = abjad.Chord([2, 3, 4], (1, 4))
-    rest = abjad.Rest(chord)
-
-    assert isinstance(rest, abjad.Rest)
-    assert dir(chord) == dir(abjad.Chord([2, 3, 4], (1, 4)))
-    assert dir(rest) == dir(abjad.Rest((1, 4)))
-    assert rest.written_duration() == chord.written_duration()
-
-
-def test_Rest___init___04():
-    """
-    Initializes rest from tupletized chord.
-    """
-
-    chord = abjad.Chord([2, 3, 4], abjad.Duration(1, 4))
-    chords = abjad.mutate.copy(chord, 3)
-    tuplet = abjad.Tuplet("3:2", chords)
-    rest = abjad.Rest(tuplet[0])
-
-    assert abjad.lilypond(rest) == abjad.string.normalize(
-        r"""
-        r4
-        """
-    )
-
-    assert abjad.wf.is_wellformed(rest)
-
-
-def test_Rest___init___05():
-    """
-    Initializes rest from beamed chord.
-    """
-
-    chord = abjad.Chord([2, 3, 4], abjad.Duration(1, 8))
-    chords = abjad.mutate.copy(chord, 3)
-    voice = abjad.Voice(chords)
-    abjad.beam(voice[:])
-    rest = abjad.Rest(voice[0])
-
-    assert abjad.lilypond(rest) == abjad.string.normalize(
-        r"""
-        r8
-        [
-        """
-    )
-
-    assert abjad.wf.is_wellformed(rest)
-
-
-def test_Rest___init___06():
-    """
-    Initializes rest from skip.
-    """
-
-    skip = abjad.Skip("s4")
-    rest = abjad.Rest(skip)
-
-    assert abjad.lilypond(rest) == abjad.string.normalize(
-        r"""
-        r4
-        """
-    )
-
-    assert abjad.wf.is_wellformed(rest)
-
-
-def test_Rest___init___07():
-    """
-    Initializes rest from tupletted skip.
-    """
-
-    tuplet = abjad.Tuplet("3:2", "s4 s4 s4")
-    rest = abjad.Rest(tuplet[0])
-
-    assert abjad.lilypond(rest) == abjad.string.normalize(
-        r"""
-        r4
-        """
-    )
-
-    assert abjad.wf.is_wellformed(rest)
-
-
-def test_Rest___init___08():
-    """
-    Initializes rest from beamed skip.
-    """
-
-    staff = abjad.Staff("c'8 [ s4 c'd ]")
-    rest = abjad.Rest(staff[1])
-
-    assert abjad.lilypond(rest) == abjad.string.normalize(
-        r"""
-        r4
-        """
-    )
-
-    assert abjad.wf.is_wellformed(rest)
-
-
-def test_Rest___init___09():
-    """
-    Initializes rest from note.
-    """
-
-    note = abjad.Note("c'4")
-    rest = abjad.Rest(note)
-
-    assert abjad.lilypond(rest) == abjad.string.normalize(
-        r"""
-        r4
-        """
-    )
-
-    assert abjad.wf.is_wellformed(rest)
-
-
-def test_Rest___init___10():
-    """
-    Initializes rest from tupletized note.
-    """
-
-    tuplet = abjad.Tuplet("3:2", "c'4 d'4 e'4")
-    rest = abjad.Rest(tuplet[0])
-
-    assert abjad.lilypond(rest) == abjad.string.normalize(
-        r"""
-        r4
-        """
-    )
-
-    assert abjad.wf.is_wellformed(rest)
-
-
-def test_Rest___init___11():
-    """
-    Initializes rest from beamed note.
-    """
-
-    staff = abjad.Staff("c'8 [ d'8 e'8 ]")
-    rest = abjad.Rest(staff[0])
-
-    assert abjad.lilypond(rest) == abjad.string.normalize(
-        r"""
-        r8
-        [
-        """
-    )
-
-    assert abjad.wf.is_wellformed(rest)
-
-
-def test_Rest___init___12():
-    """
-    Initializes multiple rests from spanned notes.
-    """
-
-    voice = abjad.Voice("c'8 ( d'8 e'8 f'8 )")
-    for note in voice:
-        rest = abjad.Rest(note)
-        abjad.mutate.replace(note, rest)
-
-    assert abjad.lilypond(voice) == abjad.string.normalize(
-        r"""
-        \new Voice
-        {
-            r8
-            (
-            r8
-            r8
-            r8
-            )
-        }
-        """
-    )
-
-    assert abjad.wf.is_wellformed(voice)
-
-
-def test_Rest___init___13():
-    """
-    Initializes rest from empty input.
-    """
-
-    rest = abjad.Rest()
-
-    assert abjad.lilypond(rest) == abjad.string.normalize(
-        r"""
-        r4
-        """
-    )
-
-    assert abjad.wf.is_wellformed(rest)

--- a/tests/test_score_Skip.py
+++ b/tests/test_score_Skip.py
@@ -138,11 +138,11 @@ def test_Skip___init___07():
     Initializes skip from orphan rest.
     """
 
-    rest = abjad.Rest((1, 8))
+    rest = abjad.Rest("r8")
     skip = abjad.Skip(rest)
 
     assert isinstance(skip, abjad.Skip)
-    assert dir(rest) == dir(abjad.Rest((1, 4)))
+    assert dir(rest) == dir(abjad.Rest("r4"))
     assert dir(skip) == dir(abjad.Skip((1, 4)))
     assert abjad.get.parentage(skip).parent() is None
     assert skip.written_duration() == rest.written_duration()

--- a/tests/test_score_Staff.py
+++ b/tests/test_score_Staff.py
@@ -35,7 +35,7 @@ def test_Staff___delitem___01():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -74,7 +74,7 @@ def test_Staff___delitem___02():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -113,7 +113,7 @@ def test_Staff___delitem___03():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -152,7 +152,7 @@ def test_Staff___getitem___01():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -177,7 +177,7 @@ def test_Staff___getitem___02():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -195,7 +195,7 @@ def test_Staff___getitem___03():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -216,7 +216,7 @@ def test_Staff___getitem___04():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -237,7 +237,7 @@ def test_Staff___getitem___05():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -260,7 +260,7 @@ def test_Staff___getitem___06():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -283,7 +283,7 @@ def test_Staff___getitem___07():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -306,7 +306,7 @@ def test_Staff___getitem___08():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -357,7 +357,7 @@ def test_Staff___setitem___01():
     staff = abjad.Staff(
         [
             abjad.Note("c'4"),
-            abjad.Rest((1, 4)),
+            abjad.Rest("r4"),
             abjad.Chord([2, 3, 4], (1, 4)),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
@@ -379,7 +379,7 @@ def test_Staff___setitem___01():
     assert isinstance(staff[2], abjad.Chord)
     assert isinstance(staff[3], abjad.Skip)
     assert isinstance(staff[4], abjad.Tuplet)
-    staff[0] = abjad.Rest((1, 4))
+    staff[0] = abjad.Rest("r4")
     assert len(staff) == 5
     assert abjad.wf.is_wellformed(staff)
     assert isinstance(staff[0], abjad.Rest)


### PR DESCRIPTION
Typeforce rest constructor

    3.28: abjad.Rest(*arguments)
    3.29: abjad.Rest(string: str)

Only a single string of the form abjad.Rest("r4") is now allowed.

Use abjad.Rest.from_duration(duration) where otherwise required.