### PR TITLE
Typeforce chord constructor

### DIFF
--- a/docs/source/_mothballed/score-fragment-strings.rst
+++ b/docs/source/_mothballed/score-fragment-strings.rst
@@ -366,8 +366,10 @@ We define more functions:
     >>> def edit_cello(score, voice_to_descents):
     ...     voice = score["Cello_Voice"]
     ...     logical_tie = abjad.select.logical_tie(voice[-1], 0)
+    ...     pitches = abjad.pitch.pithces("e a".split())
+    ...     duration = leaf.written_duration()
     ...     for leaf in logical_tie:
-    ...         chord = abjad.Chord(["e,", "a,"], leaf.written_duration())
+    ...         chord = abjad.Chord.from_pitches_and_duration(pitches, duration)
     ...         abjad.mutate.replace(leaf, chord)
     ...     descents = voice_to_descents["Cello"]
     ...     descent = descents[-1]

--- a/source/abjad/duration.py
+++ b/source/abjad/duration.py
@@ -1270,28 +1270,28 @@ class Offset:
                     return True
         return False
 
-    def __ge__(self, argument) -> bool:
+    def __ge__(self, argument: object) -> bool:
         if not isinstance(argument, type(self)):
             raise TypeError
         if self.fraction == argument.fraction:
             return self._nonnone_displacement() >= argument._nonnone_displacement()
         return self.fraction >= argument.fraction
 
-    def __gt__(self, argument) -> bool:
+    def __gt__(self, argument: object) -> bool:
         if not isinstance(argument, type(self)):
             raise TypeError
         if self.fraction == argument.fraction:
             return self._nonnone_displacement() > argument._nonnone_displacement()
         return self.fraction > argument.fraction
 
-    def __le__(self, argument) -> bool:
+    def __le__(self, argument: object) -> bool:
         if not isinstance(argument, type(self)):
             raise TypeError
         if self.fraction == argument.fraction:
             return self._nonnone_displacement() <= argument._nonnone_displacement()
         return self.fraction <= argument.fraction
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         if not isinstance(argument, type(self)):
             raise TypeError
         if self.fraction == argument.fraction:

--- a/source/abjad/illustrators.py
+++ b/source/abjad/illustrators.py
@@ -53,7 +53,7 @@ def _illustrate_metric_modulation(metric_modulation):
 
 
 def _illustrate_pitch_class_set(set_):
-    chord = _score.Chord(set_, _duration.Duration(1))
+    chord = _score.Chord.from_pitches_and_duration(set_, _duration.Duration(1))
     voice = _score.Voice([chord], name="Voice")
     staff = _score.Staff([voice], name="Staff")
     score = _score.Score([staff], name="Score")
@@ -128,11 +128,13 @@ def _illustrate_pitch_set(set_):
         else:
             upper.append(pitch)
     if upper:
-        upper = _score.Chord(upper, _duration.Duration(1))
+        pitches = _pitch.pitches(upper)
+        upper = _score.Chord.from_pitches_and_duration(pitches, _duration.Duration(1))
     else:
         upper = _score.Skip((1, 1))
     if lower:
-        lower = _score.Chord(lower, _duration.Duration(1))
+        pitches = _pitch.pitches(lower)
+        lower = _score.Chord.from_pitches_and_duration(pitches, _duration.Duration(1))
     else:
         lower = _score.Skip((1, 1))
     upper_voice = _score.Voice([upper], name="Treble_Voice")
@@ -540,7 +542,10 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
                 )
                 treble_leaf.set_note_head(treble_note_heads[0])
             else:
-                treble_leaf = _score.Chord(treble_note_heads, written_duration)
+                treble_leaf = _score.Chord.from_note_heads_and_duration(
+                    treble_note_heads,
+                    written_duration,
+                )
             if not bass_note_heads:
                 bass_leaf = _score.Rest.from_duration(written_duration)
             elif len(bass_note_heads) == 1:
@@ -549,7 +554,10 @@ def make_piano_score(leaves=None, lowest_treble_pitch="B3"):
                 )
                 bass_leaf.set_note_head(bass_note_heads[0])
             else:
-                bass_leaf = _score.Chord(bass_note_heads, written_duration)
+                bass_leaf = _score.Chord.from_note_heads_and_duration(
+                    bass_note_heads,
+                    written_duration,
+                )
         else:
             treble_leaf = copy.copy(leaf)
             bass_leaf = copy.copy(leaf)

--- a/source/abjad/indicators.py
+++ b/source/abjad/indicators.py
@@ -3673,7 +3673,7 @@ class MetronomeMark:
         if self.decimal is not None:
             assert isinstance(self.decimal, bool | str), repr(self.decimal)
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Is true when ``argument`` is a metronome mark with quarters per minute greater
         than that of this metronome mark.

--- a/source/abjad/io.py
+++ b/source/abjad/io.py
@@ -39,7 +39,7 @@ class AbjadGrapher(uqbar.graphs.Grapher):
     """
 
     def __init__(self, graphable, format_="pdf", layout="dot"):
-        uqbar.graphs.Grapher.__init__(self, graphable, format_=format_, layout=layout)
+        super().__init__(graphable, format_=format_, layout=layout)
 
     def abjad_output_directory(self) -> pathlib.Path:
         """

--- a/source/abjad/label.py
+++ b/source/abjad/label.py
@@ -146,7 +146,7 @@ def color_note_heads(argument, color_map=pc_number_to_color) -> None:
 
     ..  container:: example
 
-        >>> chord = abjad.Chord([12, 14, 18, 21, 23], (1, 4))
+        >>> chord = abjad.Chord("<c'' d'' fs'' a'' b''>4")
         >>> pitches = [[-12, -10, 4], [-2, 8, 11, 17], [19, 27, 30, 33, 37]]
         >>> colors = ["#red", "#blue", "#green"]
         >>> color_map = abjad.ColorMap(colors=colors, pitch_iterables=pitches)

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -148,11 +148,18 @@ def _make_tied_leaf(
                 tag=tag,
             )
         elif pitches is not None:
-            arguments = (pitches, written_duration)
-            leaf = class_(*arguments, multiplier=multiplier, tag=tag)
+            assert class_ is _score.Chord
+            leaf = class_.from_pitches_and_duration(
+                pitches,
+                written_duration,
+                multiplier=multiplier,
+                tag=tag,
+            )
         elif class_ is _score.Rest:
             leaf = class_.from_duration(
-                written_duration, multiplier=multiplier, tag=tag
+                written_duration,
+                multiplier=multiplier,
+                tag=tag,
             )
         else:
             assert class_ is _score.Skip, repr(class_)

--- a/source/abjad/math.py
+++ b/source/abjad/math.py
@@ -1316,13 +1316,13 @@ class Infinity:
         """
         return self._value
 
-    def __ge__(self, argument) -> bool:
+    def __ge__(self, argument: object) -> bool:
         """
         Is true for all values of ``argument``.
         """
         return self._value >= argument
 
-    def __gt__(self, argument) -> bool:
+    def __gt__(self, argument: object) -> bool:
         """
         Is true for all noninfinite values of ``argument``.
         """
@@ -1334,13 +1334,13 @@ class Infinity:
         """
         return hash(self.__class__.__name__ + str(self))
 
-    def __le__(self, argument) -> bool:
+    def __le__(self, argument: object) -> bool:
         """
         Is true when ``argument`` is infinite.
         """
         return self._value <= argument
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Is true for no values of ``argument``.
         """

--- a/source/abjad/obgc.py
+++ b/source/abjad/obgc.py
@@ -261,7 +261,12 @@ class OnBeatGraceContainer(_score.Container):
         if not isinstance(first_obgc_leaf, _score.Note | _score.Chord):
             return
         if isinstance(first_obgc_leaf, _score.Note):
-            chord = _score.Chord(first_obgc_leaf, tag=tag)
+            chord = _score.Chord.from_note_heads_and_duration(
+                [first_obgc_leaf.note_head()],
+                first_obgc_leaf.written_duration(),
+                tag=tag,
+            )
+            _score.copy_overrides_settings_and_wrappers(first_obgc_leaf, chord)
             _mutate.replace(first_obgc_leaf, chord)
             first_obgc_leaf = chord
         generator = _iterate.pitches(first_nongrace_leaf)

--- a/source/abjad/parsers/reduced.py
+++ b/source/abjad/parsers/reduced.py
@@ -188,7 +188,7 @@ class ReducedLyParser(Parser):
     def __init__(self, debug=False):
         self._default_duration = _duration.Duration(1, 4)
         self._toplevel_component_count = None
-        Parser.__init__(self, debug=debug)
+        super().__init__(debug=debug)
 
     ### LEX SETUP ###
 
@@ -295,13 +295,13 @@ class ReducedLyParser(Parser):
         """
         chord_body : chord_pitches
         """
-        p[0] = _score.Chord(p[1], self._default_duration)
+        p[0] = _score.Chord.from_pitches_and_duration(p[1], self._default_duration)
 
     def p_chord_body__chord_pitches__positive_leaf_duration(self, p):
         """
         chord_body : chord_pitches positive_leaf_duration
         """
-        p[0] = _score.Chord(p[1], p[2])
+        p[0] = _score.Chord.from_pitches_and_duration(p[1], p[2])
 
     def p_chord_pitches__CARAT_L__pitches__CARAT_R(self, p):
         """

--- a/source/abjad/parsers/scheme.py
+++ b/source/abjad/parsers/scheme.py
@@ -47,7 +47,7 @@ class SchemeParser(Parser):
         self.expression_depth = None
         self.result = None
         self.string_accumulator = None
-        Parser.__init__(self, debug=debug)
+        super().__init__(debug=debug)
 
     ### PRIVATE METHODS ###
 

--- a/source/abjad/pcollections.py
+++ b/source/abjad/pcollections.py
@@ -916,7 +916,7 @@ class PitchRange:
         """
         return hash(repr(self))
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Is true when start pitch of this pitch-range is less than start pitch of
         ``argument`` pitch range.

--- a/source/abjad/pitch.py
+++ b/source/abjad/pitch.py
@@ -2,6 +2,8 @@
 Classes to model music pitch.
 """
 
+from __future__ import annotations
+
 import copy
 import dataclasses
 import fractions
@@ -779,11 +781,13 @@ class Accidental:
             raise TypeError(f"do not know how to apply accidental to {argument!r}.")
         return argument._apply_accidental(self)
 
-    def __lt__(self, argument):
+    def __lt__(self, argument: object) -> bool:
         """
         Returns true or false.
         """
-        return self.semitones < argument.semitones
+        if isinstance(argument, type(self)):
+            return self.semitones < argument.semitones
+        return False
 
     def __neg__(self):
         """
@@ -1222,7 +1226,7 @@ class IntervalClass:
         """
         return hash(self.__class__.__name__ + repr(self))
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Compares ``number``.
         """
@@ -1440,7 +1444,7 @@ class NamedIntervalClass(IntervalClass):
         """
         return super().__hash__()
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Is true when ``argument`` is a named interval class with a number greater than
         that of this named interval.
@@ -1886,7 +1890,7 @@ class NumberedIntervalClass(IntervalClass):
         """
         return super().__hash__()
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Compares ``number``.
 
@@ -2093,7 +2097,7 @@ class NumberedInversionEquivalentIntervalClass(NumberedIntervalClass):
         """
         return type(self)(abs(self.number()))
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Compares ``number``.
         """
@@ -2189,7 +2193,7 @@ class Interval:
         """
         return hash(self.__class__.__name__ + repr(self))
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Is true when interval is less than ``argument``
         """
@@ -2418,7 +2422,7 @@ class NamedInterval(Interval):
         new_pitch = dummy_pitch + self + argument
         return NamedInterval.from_pitch_carriers(dummy_pitch, new_pitch)
 
-    def __copy__(self, *arguments) -> "NamedInterval":
+    def __copy__(self) -> NamedInterval:
         """
         Copies named interval.
 
@@ -2481,7 +2485,7 @@ class NamedInterval(Interval):
         """
         return super().__hash__()
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Compares ``semitones``.
 
@@ -2953,7 +2957,7 @@ class NumberedInterval(Interval):
             return NotImplemented
         return type(self)(float(self) + float(argument))
 
-    def __copy__(self) -> "NumberedInterval":
+    def __copy__(self) -> NumberedInterval:
         """
         Copies numbered interval.
 
@@ -3016,7 +3020,7 @@ class NumberedInterval(Interval):
         """
         return super().__hash__()
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Is true when ``argument`` is a numbered interval with same direction number as
         this numbered interval and with number greater than that of this numbered
@@ -3322,7 +3326,7 @@ class PitchClass:
         """
         return hash(self.__class__.__name__ + repr(self))
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Is true when pitch-class is less than ``argument``.
         """
@@ -3554,7 +3558,7 @@ class NamedPitchClass(PitchClass):
         """
         return super().__hash__()
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Compares ``number``.
 
@@ -3847,7 +3851,7 @@ class NumberedPitchClass(PitchClass):
         interval = NumberedInterval(argument)
         return type(self)(self.number() + interval.number() % 12)
 
-    def __copy__(self, *arguments) -> "NumberedPitchClass":
+    def __copy__(self) -> NumberedPitchClass:
         """
         Copies numbered pitch-class.
 
@@ -3903,7 +3907,7 @@ class NumberedPitchClass(PitchClass):
         """
         return super().__hash__()
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Compares ``number``.
 
@@ -4246,7 +4250,7 @@ class Pitch:
         """
         return hash(self.__class__.__name__ + repr(self))
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Is true when pitch is less than ``argument``.
         """
@@ -4468,7 +4472,7 @@ class NamedPitch(Pitch):
         interval = NamedInterval(interval)
         return interval.transpose(self)
 
-    def __copy__(self, *arguments) -> "NamedPitch":
+    def __copy__(self) -> NamedPitch:
         """
         Copies named pitch.
 
@@ -4547,7 +4551,7 @@ class NamedPitch(Pitch):
     # https://github.com/python/mypy/issues/4610
     # remove __le__ (in favor of __lt__) when mypy supports functools.total_ordering
     # or, refactor this class as a dataclass and then remove __le__
-    def __le__(self, argument) -> bool:
+    def __le__(self, argument: object) -> bool:
         """
         Is true when named pitch is less than or equal to ``argument``.
 
@@ -4589,7 +4593,7 @@ class NamedPitch(Pitch):
             return self.accidental() <= argument.accidental()
         return self_dpn <= argument_dpn
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         """
         Is true when named pitch is less than ``argument``.
 
@@ -5160,9 +5164,10 @@ class NumberedPitch(Pitch):
     # https://github.com/python/mypy/issues/4610
     # remove __le__ (in favor of __lt__) when mypy supports functools.total_ordering
     # or, refactor this class as a dataclass and then remove __le__
-    def __le__(self, argument) -> bool:
-        r"""Is true when ``argument`` can be coerced to a numbered pitch and when this
-        numbered pitch is less or equal to ``argument``.
+    def __le__(self, argument: object) -> bool:
+        r"""
+        Is true when ``argument`` can be coerced to a numbered pitch and when
+        this numbered pitch is less or equal to ``argument``.
 
         ..  container:: example
 
@@ -5198,9 +5203,10 @@ class NumberedPitch(Pitch):
             return False
         return self.number() <= argument.number()
 
-    def __lt__(self, argument) -> bool:
-        r"""Is true when ``argument`` can be coerced to a numbered pitch and when this
-        numbered pitch is less than ``argument``.
+    def __lt__(self, argument: object) -> bool:
+        r"""
+        Is true when ``argument`` can be coerced to a numbered pitch and when
+        this numbered pitch is less than ``argument``.
 
         ..  container:: example
 
@@ -5622,7 +5628,7 @@ class StaffPosition:
         assert isinstance(self.number, int), repr(self.number)
 
 
-def pitches(items: list[float]) -> list[NamedPitch]:
+def pitches(items: typing.Sequence[float | str]) -> list[NamedPitch]:
     """
     Changes ``items`` to pitches.
     """

--- a/source/abjad/timespan.py
+++ b/source/abjad/timespan.py
@@ -375,7 +375,7 @@ class Timespan:
                 return self.stop_offset == argument.stop_offset
         return False
 
-    def __ge__(self, argument) -> bool:
+    def __ge__(self, argument: object) -> bool:
         """
         Is true when ``argument`` start offset is greater or equal to timespan
         start offset.
@@ -393,20 +393,22 @@ class Timespan:
             False
 
         """
-        expr_start_offset = argument.start_offset
-        expr_stop_offset = argument.stop_offset
-        if expr_stop_offset is not None:
-            if self.start_offset >= expr_start_offset:
-                return True
-            elif (
-                self.start_offset == expr_start_offset
-                and self.stop_offset >= expr_stop_offset
-            ):
-                return True
-            return False
-        return self.start_offset >= expr_start_offset
+        if isinstance(argument, type(self)):
+            expr_start_offset = argument.start_offset
+            expr_stop_offset = argument.stop_offset
+            if expr_stop_offset is not None:
+                if self.start_offset >= expr_start_offset:
+                    return True
+                elif (
+                    self.start_offset == expr_start_offset
+                    and self.stop_offset >= expr_stop_offset
+                ):
+                    return True
+                return False
+            return self.start_offset >= expr_start_offset
+        return False
 
-    def __gt__(self, argument) -> bool:
+    def __gt__(self, argument: object) -> bool:
         """
         Is true when ``argument`` start offset is greater than timespan start
         offset.
@@ -424,20 +426,22 @@ class Timespan:
             False
 
         """
-        expr_start_offset = argument.start_offset
-        expr_stop_offset = argument.stop_offset
-        if expr_stop_offset is not None:
-            if self.start_offset > expr_start_offset:
-                return True
-            elif (
-                self.start_offset == expr_start_offset
-                and self.stop_offset > expr_stop_offset
-            ):
-                return True
-            return False
-        return self.start_offset > expr_start_offset
+        if isinstance(argument, type(self)):
+            expr_start_offset = argument.start_offset
+            expr_stop_offset = argument.stop_offset
+            if expr_stop_offset is not None:
+                if self.start_offset > expr_start_offset:
+                    return True
+                elif (
+                    self.start_offset == expr_start_offset
+                    and self.stop_offset > expr_stop_offset
+                ):
+                    return True
+                return False
+            return self.start_offset > expr_start_offset
+        return False
 
-    def __le__(self, argument) -> bool:
+    def __le__(self, argument: object) -> bool:
         """
         Is true when ``argument`` start offset is less than or equal to timespan start
         offset.
@@ -455,18 +459,20 @@ class Timespan:
             True
 
         """
-        expr_start_offset = argument.start_offset
-        expr_stop_offset = argument.stop_offset
-        if expr_stop_offset is not None:
-            if self.start_offset <= expr_start_offset:
-                return True
-            elif (
-                self.start_offset == expr_start_offset
-                and self.stop_offset <= expr_stop_offset
-            ):
-                return True
-            return False
-        return self.start_offset <= expr_start_offset
+        if isinstance(argument, type(self)):
+            expr_start_offset = argument.start_offset
+            expr_stop_offset = argument.stop_offset
+            if expr_stop_offset is not None:
+                if self.start_offset <= expr_start_offset:
+                    return True
+                elif (
+                    self.start_offset == expr_start_offset
+                    and self.stop_offset <= expr_stop_offset
+                ):
+                    return True
+                return False
+            return self.start_offset <= expr_start_offset
+        return False
 
     def __len__(self) -> int:
         """
@@ -481,7 +487,7 @@ class Timespan:
         """
         return 1
 
-    def __lt__(self, argument) -> bool:
+    def __lt__(self, argument: object) -> bool:
         r"""
         Is true when ``argument`` start offset is less than timespan start offset.
 
@@ -498,18 +504,20 @@ class Timespan:
             False
 
         """
-        expr_start_offset = argument.start_offset
-        expr_stop_offset = argument.stop_offset
-        if expr_stop_offset is not None:
-            if self.start_offset < expr_start_offset:
-                return True
-            elif (
-                self.start_offset == expr_start_offset
-                and self.stop_offset < expr_stop_offset
-            ):
-                return True
-            return False
-        return self.start_offset < expr_start_offset
+        if isinstance(argument, type(self)):
+            expr_start_offset = argument.start_offset
+            expr_stop_offset = argument.stop_offset
+            if expr_stop_offset is not None:
+                if self.start_offset < expr_start_offset:
+                    return True
+                elif (
+                    self.start_offset == expr_start_offset
+                    and self.stop_offset < expr_stop_offset
+                ):
+                    return True
+                return False
+            return self.start_offset < expr_start_offset
+        return False
 
     def __or__(self, argument) -> TimespanList:
         """

--- a/source/abjad/wrapper.py
+++ b/source/abjad/wrapper.py
@@ -2,6 +2,8 @@
 Wrapper.
 """
 
+from __future__ import annotations
+
 import copy
 import importlib
 import typing
@@ -93,7 +95,7 @@ class Wrapper:
                 check_duplicate_indicator=check_duplicate_indicator,
             )
 
-    def __copy__(self, *arguments) -> "Wrapper":
+    def __copy__(self) -> Wrapper:
         """
         Copies all properties except component; calling code must supply
         component after copy.

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -285,7 +285,7 @@ def test_get_indicators_03():
 
 
 def test_get_markup_01():
-    chord = abjad.Chord([-11, 2, 5], (1, 4))
+    chord = abjad.Chord("<c' d' e'>4")
     up_markup = abjad.Markup(r"\markup UP")
     abjad.attach(up_markup, chord, direction=abjad.UP)
     down_markup = abjad.Markup(r"\markup DOWN")
@@ -295,7 +295,7 @@ def test_get_markup_01():
 
 
 def test_get_markup_02():
-    chord = abjad.Chord([-11, 2, 5], (1, 4))
+    chord = abjad.Chord("<c' d' e'>4")
     up_markup = abjad.Markup(r"\markup UP")
     abjad.attach(up_markup, chord, direction=abjad.UP)
     down_markup = abjad.Markup(r"\markup DOWN")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -563,9 +563,18 @@ def test_LilyPondParser__functions__relative_08():
     target = abjad.Container(
         [
             abjad.Note.from_pitch_and_duration(abjad.NamedPitch("c'"), duration),
-            abjad.Chord(["c'", "e'", "g'"], duration),
-            abjad.Chord(["c''", "e''", "g'''"], duration),
-            abjad.Chord(["e", "c'", "g''"], duration),
+            abjad.Chord.from_pitches_and_duration(
+                abjad.pitch.pitches(["c'", "e'", "g'"]),
+                duration,
+            ),
+            abjad.Chord.from_pitches_and_duration(
+                abjad.pitch.pitches(["c''", "e''", "g'''"]),
+                duration,
+            ),
+            abjad.Chord.from_pitches_and_duration(
+                abjad.pitch.pitches(["e", "c'", "g''"]),
+                duration,
+            ),
         ]
     )
 
@@ -2163,7 +2172,10 @@ def test_LilyPondParser__indicators__Trill_06():
 
 
 def test_LilyPondParser__leaves__Chord_01():
-    target = abjad.Chord([0, 1, 4], (1, 4))
+    target = abjad.Chord.from_pitches_and_duration(
+        abjad.pitch.pitches([0, 1, 4]),
+        abjad.Duration(1, 4),
+    )
     parser = abjad.parser.LilyPondParser()
     result = parser("{ %s }" % abjad.lilypond(target))
     assert (
@@ -2226,10 +2238,22 @@ def test_LilyPondParser__lilypondfile__ScoreBlock_01():
 def test_LilyPondParser__misc__chord_repetition_01():
     target = abjad.Container(
         [
-            abjad.Chord([0, 4, 7], (1, 4)),
-            abjad.Chord([0, 4, 7], (1, 4)),
-            abjad.Chord([0, 4, 7], (1, 4)),
-            abjad.Chord([0, 4, 7], (1, 4)),
+            abjad.Chord.from_pitches_and_duration(
+                abjad.pitch.pitches([0, 4, 7]),
+                abjad.Duration(1, 4),
+            ),
+            abjad.Chord.from_pitches_and_duration(
+                abjad.pitch.pitches([0, 4, 7]),
+                abjad.Duration(1, 4),
+            ),
+            abjad.Chord.from_pitches_and_duration(
+                abjad.pitch.pitches([0, 4, 7]),
+                abjad.Duration(1, 4),
+            ),
+            abjad.Chord.from_pitches_and_duration(
+                abjad.pitch.pitches([0, 4, 7]),
+                abjad.Duration(1, 4),
+            ),
         ]
     )
 
@@ -2251,14 +2275,15 @@ def test_LilyPondParser__misc__chord_repetition_01():
 
 
 def test_LilyPondParser__misc__chord_repetition_02():
+    pitches = abjad.pitch.pitches([0, 4, 7])
     target = abjad.Voice(
         [
-            abjad.Chord([0, 4, 7], (1, 8)),
-            abjad.Chord([0, 4, 7], (1, 8)),
-            abjad.Chord([0, 4, 7], (1, 4)),
-            abjad.Chord([0, 4, 7], (3, 16)),
-            abjad.Chord([0, 4, 7], (1, 16)),
-            abjad.Chord([0, 4, 7], (1, 4)),
+            abjad.Chord.from_pitches_and_duration(pitches, abjad.Duration(1, 8)),
+            abjad.Chord.from_pitches_and_duration(pitches, abjad.Duration(1, 8)),
+            abjad.Chord.from_pitches_and_duration(pitches, abjad.Duration(1, 4)),
+            abjad.Chord.from_pitches_and_duration(pitches, abjad.Duration(3, 16)),
+            abjad.Chord.from_pitches_and_duration(pitches, abjad.Duration(1, 16)),
+            abjad.Chord.from_pitches_and_duration(pitches, abjad.Duration(1, 4)),
         ]
     )
     dynamic = abjad.Dynamic("p")
@@ -2294,18 +2319,30 @@ def test_LilyPondParser__misc__chord_repetition_02():
 
 
 def test_LilyPondParser__misc__chord_repetition_03():
+    pitches = abjad.pitch.pitches([0, 4, 7])
     target = abjad.Container(
         [
-            abjad.Chord([0, 4, 7], (1, 8)),
-            abjad.Note.from_pitch_and_duration(
-                abjad.NamedPitch(12), abjad.Duration(1, 8)
+            abjad.Chord.from_pitches_and_duration(
+                pitches,
+                abjad.Duration(1, 8),
             ),
-            abjad.Chord([0, 4, 7], (1, 8)),
             abjad.Note.from_pitch_and_duration(
-                abjad.NamedPitch(12), abjad.Duration(1, 8)
+                abjad.NamedPitch(12),
+                abjad.Duration(1, 8),
+            ),
+            abjad.Chord.from_pitches_and_duration(
+                pitches,
+                abjad.Duration(1, 8),
+            ),
+            abjad.Note.from_pitch_and_duration(
+                abjad.NamedPitch(12),
+                abjad.Duration(1, 8),
             ),
             abjad.Rest("r4"),
-            abjad.Chord([0, 4, 7], (1, 4)),
+            abjad.Chord.from_pitches_and_duration(
+                pitches,
+                abjad.Duration(1, 4),
+            ),
         ]
     )
 

--- a/tests/test_score_Chord.py
+++ b/tests/test_score_Chord.py
@@ -162,9 +162,9 @@ def test_Chord___eq____01():
     Is true only when chords have the same object ID.
     """
 
-    chord_1 = abjad.Chord([0, 4, 7], (1, 4))
-    chord_2 = abjad.Chord([0, 4, 7], (1, 4))
-    chord_3 = abjad.Chord([0, 4, 6], (1, 4))
+    chord_1 = abjad.Chord("<c' e' g'>4")
+    chord_2 = abjad.Chord("<c' e' g'>4")
+    chord_3 = abjad.Chord("<c' e' fs'>4")
 
     assert chord_1 == chord_1
     assert not chord_1 == chord_2
@@ -182,58 +182,8 @@ def test_Chord___init___01():
     Initializes empty chord.
     """
 
-    chord = abjad.Chord([], (1, 4))
+    chord = abjad.Chord("<>4")
     assert abjad.lilypond(chord) == "<>4"
-
-
-def test_Chord___init___02():
-    """
-    Initializes chord with pitch numbers.
-    """
-
-    chord = abjad.Chord([2, 4, 5], (1, 4))
-    assert abjad.lilypond(chord) == "<d' e' f'>4"
-
-
-def test_Chord___init___03():
-    """
-    Initializes chord with pitch tokens.
-    """
-
-    chord = abjad.Chord([("ds", 4), ("ef", 4)], (1, 4))
-    assert abjad.lilypond(chord) == "<ds' ef'>4"
-
-
-def test_Chord___init___04():
-    """
-    Initializes chord with pitches.
-    """
-
-    pitches = []
-    pitches.append(abjad.NamedPitch("D#4"))
-    pitches.append(abjad.NamedPitch("Eb4"))
-    chord = abjad.Chord(pitches, (1, 4))
-    assert abjad.lilypond(chord) == "<ds' ef'>4"
-
-
-def test_Chord___init___05():
-    """
-    Initializes chord with pitches and pitch numbers together.
-    """
-
-    pitches = [2, ("ef", 4), abjad.NamedPitch(4)]
-    chord = abjad.Chord(pitches, (1, 4))
-    assert abjad.lilypond(chord) == "<d' ef' e'>4"
-
-
-def test_Chord___init___06():
-    """
-    Initializes chord with list of pitch names.
-    """
-
-    pitches = ["d'", "ef'", "e'"]
-    chord = abjad.Chord(pitches, (1, 4))
-    assert abjad.lilypond(chord) == "<d' ef' e'>4"
 
 
 def test_Chord___init___07():
@@ -245,138 +195,6 @@ def test_Chord___init___07():
     assert abjad.lilypond(chord) == "<d' ef' e'>4"
 
 
-def test_Chord___init___08():
-    """
-    Initializes chord from skip.
-    """
-
-    skip = abjad.Skip("s8")
-    chord = abjad.Chord(skip)
-
-    assert abjad.lilypond(skip) == "s8"
-    assert abjad.lilypond(chord) == "<>8"
-
-    assert abjad.wf.is_wellformed(skip)
-    assert abjad.wf.is_wellformed(chord)
-
-
-def test_Chord___init___09():
-    """
-    Initializes chord from tupletized skip.
-    """
-
-    tuplet = abjad.Tuplet("3:2", "s8 s8 s8")
-    chord = abjad.Chord(tuplet[0])
-
-    assert abjad.lilypond(chord) == "<>8"
-    assert abjad.get.parentage(chord).parent() is None
-    assert abjad.wf.is_wellformed(chord)
-
-
-def test_Chord___init___10():
-    """
-    Initializes chord from containerized skip.
-    """
-
-    tuplet = abjad.Voice("s8 s8 s8")
-    chord = abjad.Chord(tuplet[0])
-
-    assert abjad.lilypond(chord) == "<>8"
-    assert abjad.get.parentage(chord).parent() is None
-    assert abjad.wf.is_wellformed(chord)
-
-
-def test_Chord___init___11():
-    """
-    Initializes chord from beamed skip.
-    """
-
-    staff = abjad.Staff("c'8 [ s8 c'8 ]")
-    chord = abjad.Chord(staff[1])
-
-    assert abjad.lilypond(chord) == "<>8"
-    assert abjad.get.parentage(chord).parent() is None
-    assert abjad.wf.is_wellformed(chord)
-
-
-def test_Chord___init___12():
-    """
-    Initializes chord from rest.
-    """
-
-    rest = abjad.Rest("r8")
-    chord = abjad.Chord(rest)
-
-    assert abjad.lilypond(rest) == "r8"
-    assert abjad.lilypond(chord) == "<>8"
-    assert abjad.wf.is_wellformed(rest)
-    assert abjad.wf.is_wellformed(chord)
-
-
-def test_Chord___init___13():
-    """
-    Initializes chord from tupletized rest.
-    """
-
-    tuplet = abjad.Tuplet("3:2", "r8 r8 r8")
-    chord = abjad.Chord(tuplet[1])
-
-    assert abjad.lilypond(chord) == "<>8"
-    assert abjad.wf.is_wellformed(chord)
-    assert abjad.get.parentage(chord).parent() is None
-
-
-def test_Chord___init___14():
-    """
-    Initializes chord from note.
-    """
-
-    note = abjad.Note("d'8")
-    chord = abjad.Chord(note)
-
-    assert abjad.lilypond(note) == "d'8"
-    assert abjad.lilypond(chord) == "<d'>8"
-    assert abjad.wf.is_wellformed(note)
-    assert abjad.wf.is_wellformed(chord)
-
-
-def test_Chord___init___15():
-    """
-    Initializes chord from tupletized note.
-    """
-
-    tuplet = abjad.Tuplet("3:2", "c'8 c'8 c'8")
-    chord = abjad.Chord(tuplet[1])
-
-    assert abjad.lilypond(chord) == "<c'>8"
-    assert abjad.wf.is_wellformed(chord)
-    assert abjad.get.parentage(chord).parent() is None
-
-
-def test_Chord___init___16():
-    """
-    Initializes chord from spanned note.
-    """
-
-    staff = abjad.Staff("c'8 ( d'8 e'8 f'8 )")
-    chord = abjad.Chord(staff[1])
-
-    assert abjad.lilypond(chord) == "<d'>8"
-    assert abjad.wf.is_wellformed(chord)
-    assert abjad.get.parentage(chord).parent() is None
-
-
-def test_Chord___init___17():
-    """
-    Initializes empty chord from LilyPond input string.
-    """
-
-    chord = abjad.Chord("<>8.")
-
-    assert abjad.lilypond(chord) == "<>8."
-    assert not len(chord.note_heads())
-
-
 def test_Chord___init___18():
     """
     Initializes chord from LilyPond input string with forced and cautionary
@@ -386,35 +204,6 @@ def test_Chord___init___18():
     chord = abjad.Chord("<c!? e? g! b>4")
 
     assert abjad.lilypond(chord) == "<c!? e? g! b>4"
-
-
-def test_Chord___init___19():
-    """
-    Initializes chord from note with forced and cautionary accidentals.
-    """
-
-    note = abjad.Note("c'!?4")
-    chord = abjad.Chord(note)
-
-    assert abjad.lilypond(chord) == "<c'!?>4"
-
-
-def test_Chord___init___20():
-    """
-    Initializes chord from other chord.
-    """
-
-    chord_1 = abjad.Chord("<c' e' g' bf'>4")
-    chord_2 = abjad.Chord(chord_1, abjad.Duration(1, 8))
-
-    assert abjad.lilypond(chord_2) == "<c' e' g' bf'>8"
-
-    # REGRESSION
-
-    chord_1 = abjad.Chord("<e' cs'' f''>4", multiplier=(1, 2))
-    chord_2 = abjad.Chord(chord_1)
-
-    assert abjad.lilypond(chord_2) == "<e' cs'' f''>4 * 1/2"
 
 
 def test_Chord___init___21():
@@ -459,7 +248,7 @@ def test_Chord_set_written_pitches_01():
     Sets written pitches.
     """
 
-    chord = abjad.Chord([], (1, 4))
+    chord = abjad.Chord("<>4")
     pitches = [abjad.NamedPitch(_) for _ in [4, 3, 2]]
     chord.set_written_pitches(pitches)
     assert abjad.lilypond(chord) == "<d' ef' e'>4"

--- a/tests/test_score_Skip.py
+++ b/tests/test_score_Skip.py
@@ -72,20 +72,6 @@ def test_Skip___init___01():
     assert isinstance(skip, abjad.Skip)
 
 
-def test_Skip___init___02():
-    """
-    Initializes skip from orphan chord.
-    """
-
-    chord = abjad.Chord([2, 3, 4], (1, 4))
-    skip = abjad.Skip(chord)
-
-    assert isinstance(skip, abjad.Skip)
-    assert dir(skip) == dir(abjad.Skip((1, 4)))
-    assert abjad.get.parentage(skip).parent() is None
-    assert skip.written_duration() == chord.written_duration()
-
-
 def test_Skip___init___03():
     """
     Initializes skip from chord with parent.

--- a/tests/test_score_Staff.py
+++ b/tests/test_score_Staff.py
@@ -36,7 +36,7 @@ def test_Staff___delitem___01():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -75,7 +75,7 @@ def test_Staff___delitem___02():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -114,7 +114,7 @@ def test_Staff___delitem___03():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -153,7 +153,7 @@ def test_Staff___getitem___01():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -178,7 +178,7 @@ def test_Staff___getitem___02():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -196,7 +196,7 @@ def test_Staff___getitem___03():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -217,7 +217,7 @@ def test_Staff___getitem___04():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -238,7 +238,7 @@ def test_Staff___getitem___05():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -261,7 +261,7 @@ def test_Staff___getitem___06():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -284,7 +284,7 @@ def test_Staff___getitem___07():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -307,7 +307,7 @@ def test_Staff___getitem___08():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -358,7 +358,7 @@ def test_Staff___setitem___01():
         [
             abjad.Note("c'4"),
             abjad.Rest("r4"),
-            abjad.Chord([2, 3, 4], (1, 4)),
+            abjad.Chord("<d' ef' f'>4"),
             abjad.Skip((1, 4)),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
@@ -371,7 +371,7 @@ def test_Staff___setitem___01():
     assert isinstance(staff[2], abjad.Chord)
     assert isinstance(staff[3], abjad.Skip)
     assert isinstance(staff[4], abjad.Tuplet)
-    staff[1] = abjad.Chord([12, 13, 15], (1, 4))
+    staff[1] = abjad.Chord("<c'' cs'' ef''>4")
     assert len(staff) == 5
     assert abjad.wf.is_wellformed(staff)
     assert isinstance(staff[0], abjad.Note)
@@ -485,7 +485,7 @@ def test_Staff___setitem___08():
     """
 
     staff = abjad.Staff("c'8 c'8 c'8 c'8 c'8 c'8 c'8 c'8")
-    chord = abjad.Chord([2, 3, 4], (1, 4))
+    chord = abjad.Chord("<d' ef' f'>4")
     chords = abjad.mutate.copy(chord, 4)
     staff[0:4] = chords
     assert len(staff) == 8
@@ -532,7 +532,7 @@ def test_Staff_append_02():
     """
 
     staff = abjad.Staff("c'4 c'4 c'4 c'4")
-    staff.append(abjad.Chord([2, 3, 4], (1, 4)))
+    staff.append("<d' ef' f'>4")
     assert abjad.wf.is_wellformed(staff)
     assert len(staff) == 5
     assert staff._get_contents_duration() == abjad.Duration(5, 4)


### PR DESCRIPTION
Initialization from existing notes, rests, chords no longer allowed

Only a single LilyPond input string is allowed:

    >>> abjad.Chord("<c' d' bf'>4")

Use ....

    abjad.Chord.from_pitches_and_duration()
    abjad.Chord.from_note_heads_and_duration()

... to construct chords from explicit pitch and duration.

Use ...

    abjad.score.copy_overrides_settings_and_wrappers(donor, recipient)

... to copy override, settings and wrappers from any note, rest, chord to any other note, rest, chord.