### PR TITLE
Typeforce abjad.Skip constructor

### DIFF
--- a/source/abjad/illustrators.py
+++ b/source/abjad/illustrators.py
@@ -131,12 +131,12 @@ def _illustrate_pitch_set(set_):
         pitches = _pitch.pitches(upper)
         upper = _score.Chord.from_pitches_and_duration(pitches, _duration.Duration(1))
     else:
-        upper = _score.Skip((1, 1))
+        upper = _score.Skip("s1")
     if lower:
         pitches = _pitch.pitches(lower)
         lower = _score.Chord.from_pitches_and_duration(pitches, _duration.Duration(1))
     else:
-        lower = _score.Skip((1, 1))
+        lower = _score.Skip("s1")
     upper_voice = _score.Voice([upper], name="Treble_Voice")
     upper_staff = _score.Staff([upper_voice], name="Treble_Staff")
     lower_voice = _score.Voice([lower], name="Bass_Voice")

--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -155,16 +155,13 @@ def _make_tied_leaf(
                 multiplier=multiplier,
                 tag=tag,
             )
-        elif class_ is _score.Rest:
+        else:
+            assert class_ in (_score.Rest, _score.Skip), repr(class_)
             leaf = class_.from_duration(
                 written_duration,
                 multiplier=multiplier,
                 tag=tag,
             )
-        else:
-            assert class_ is _score.Skip, repr(class_)
-            arguments = (written_duration,)
-            leaf = class_(*arguments, multiplier=multiplier, tag=tag)
         leaves.append(leaf)
     if 1 < len(leaves):
         if not issubclass(class_, _score.Rest | _score.Skip):

--- a/source/abjad/parsers/parser.py
+++ b/source/abjad/parsers/parser.py
@@ -6261,7 +6261,7 @@ class LilyPondSyntacticalDefinition:
         if p[1] == "r":
             rest = _score.Rest.from_duration(p[2].duration, tag=self.tag)
         else:
-            rest = _score.Skip(p[2].duration, tag=self.tag)
+            rest = _score.Skip.from_duration(p[2].duration, tag=self.tag)
         if p[2].multiplier is not None:
             fraction = fractions.Fraction(p[2].multiplier)
             pair = (fraction.numerator, fraction.denominator)

--- a/tests/test_mutate_fuse.py
+++ b/tests/test_mutate_fuse.py
@@ -73,7 +73,7 @@ def test_mutate_fuse_05():
     Works with multiplied durations.
     """
 
-    staff = abjad.Staff([abjad.Skip((1, 1)), abjad.Skip((1, 1))])
+    staff = abjad.Staff([abjad.Skip("s1"), abjad.Skip("s1")])
     staff[0].set_multiplier((1, 16))
     staff[1].set_multiplier((5, 16))
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2212,7 +2212,8 @@ def test_LilyPondParser__leaves__Rest_01():
 
 
 def test_LilyPondParser__leaves__Skip_01():
-    target = abjad.Skip((3, 8))
+    duration = abjad.Duration(3, 8)
+    target = abjad.Skip.from_duration(duration)
     parser = abjad.parser.LilyPondParser()
     result = parser("{ %s }" % abjad.lilypond(target))
     assert (

--- a/tests/test_score_Skip.py
+++ b/tests/test_score_Skip.py
@@ -8,7 +8,7 @@ def test_Skip___copy___01():
     Copies skip.
     """
 
-    skip_1 = abjad.Skip((1, 4))
+    skip_1 = abjad.Skip("s4")
     skip_2 = copy.copy(skip_1)
 
     assert isinstance(skip_1, abjad.Skip)
@@ -36,7 +36,7 @@ def test_Skip___copy___03():
     Copies skip with LilyPond grob overrides and LilyPond context settings.
     """
 
-    skip_1 = abjad.Skip((1, 4))
+    skip_1 = abjad.Skip("s4")
     abjad.override(skip_1).Staff.NoteHead.color = "#red"
     abjad.override(skip_1).Accidental.color = "#red"
     abjad.setting(skip_1).tupletFullLength = True
@@ -53,9 +53,9 @@ def test_Skip___eq___01():
     Compares skips by equality.
     """
 
-    skip_1 = abjad.Skip((1, 4))
-    skip_2 = abjad.Skip((1, 4))
-    skip_3 = abjad.Skip((1, 8))
+    skip_1 = abjad.Skip("s4")
+    skip_2 = abjad.Skip("s4")
+    skip_3 = abjad.Skip("s8")
 
     assert not skip_1 == skip_2
     assert not skip_1 == skip_3
@@ -72,91 +72,14 @@ def test_Skip___init___01():
     assert isinstance(skip, abjad.Skip)
 
 
-def test_Skip___init___03():
-    """
-    Initializes skip from chord with parent.
-    """
-
-    tuplet = abjad.Tuplet("3:2", "<d' ef' e'>4 f' g'")
-    skip = abjad.Skip(tuplet[0])
-
-    assert isinstance(tuplet[0], abjad.Chord)
-    assert isinstance(skip, abjad.Skip)
-    assert abjad.get.parentage(tuplet[0]).parent() is tuplet
-    assert abjad.get.parentage(skip).parent() is None
-    assert tuplet[0].written_duration() == skip.written_duration()
-
-
-def test_Skip___init___05():
-    """
-    Initializes skip from orphan note.
-    """
-
-    note = abjad.Note("d'8")
-    skip = abjad.Skip(note)
-
-    assert isinstance(note, abjad.Note)
-    assert isinstance(skip, abjad.Skip)
-    assert dir(note) == dir(abjad.Note("c'4"))
-    assert dir(skip) == dir(abjad.Skip((1, 4)))
-    assert abjad.get.parentage(note).parent() is None
-    assert abjad.get.parentage(skip).parent() is None
-    assert note.written_duration() == skip.written_duration()
-
-
-def test_Skip___init___06():
-    """
-    Initializes skip from tupletized note.
-    """
-
-    tuplet = abjad.Tuplet("3:2", "c'8 c'8 c'8")
-    skip = abjad.Skip(tuplet[0])
-
-    assert isinstance(tuplet[0], abjad.Note)
-    assert isinstance(skip, abjad.Skip)
-    assert abjad.get.parentage(tuplet[0]).parent() is tuplet
-    assert abjad.get.parentage(skip).parent() is None
-    assert tuplet[0].written_duration() == skip.written_duration()
-
-
-def test_Skip___init___07():
-    """
-    Initializes skip from orphan rest.
-    """
-
-    rest = abjad.Rest("r8")
-    skip = abjad.Skip(rest)
-
-    assert isinstance(skip, abjad.Skip)
-    assert dir(rest) == dir(abjad.Rest("r4"))
-    assert dir(skip) == dir(abjad.Skip((1, 4)))
-    assert abjad.get.parentage(skip).parent() is None
-    assert skip.written_duration() == rest.written_duration()
-
-
-def test_Skip___init___08():
-    """
-    Initializes skip from tupletized rest.
-    """
-
-    tuplet = abjad.Tuplet("3:2", "r8 r8 r8")
-    skip = abjad.Skip(tuplet[0])
-
-    assert isinstance(tuplet[0], abjad.Rest)
-    assert isinstance(skip, abjad.Skip)
-    assert abjad.get.parentage(tuplet[0]).parent() is tuplet
-    assert abjad.get.parentage(skip).parent() is None
-    assert tuplet[0].written_duration() == skip.written_duration()
-
-
 def test_Skip___ne___01():
     """
     Compares skips by inequality.
     """
 
-    skip_1 = abjad.Skip((1, 4))
-    skip_2 = abjad.Skip((1, 4))
-    skip_3 = abjad.Skip((1, 8))
+    skip_1 = abjad.Skip("s4")
+    skip_2 = abjad.Skip("s4")
+    skip_3 = abjad.Skip("s8")
 
     assert skip_1 != skip_2
     assert skip_1 != skip_3

--- a/tests/test_score_Staff.py
+++ b/tests/test_score_Staff.py
@@ -37,7 +37,7 @@ def test_Staff___delitem___01():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -76,7 +76,7 @@ def test_Staff___delitem___02():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -115,7 +115,7 @@ def test_Staff___delitem___03():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -154,7 +154,7 @@ def test_Staff___getitem___01():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -179,7 +179,7 @@ def test_Staff___getitem___02():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -197,7 +197,7 @@ def test_Staff___getitem___03():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -218,7 +218,7 @@ def test_Staff___getitem___04():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -239,7 +239,7 @@ def test_Staff___getitem___05():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -262,7 +262,7 @@ def test_Staff___getitem___06():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -285,7 +285,7 @@ def test_Staff___getitem___07():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -308,7 +308,7 @@ def test_Staff___getitem___08():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -359,7 +359,7 @@ def test_Staff___setitem___01():
             abjad.Note("c'4"),
             abjad.Rest("r4"),
             abjad.Chord("<d' ef' f'>4"),
-            abjad.Skip((1, 4)),
+            abjad.Skip("s4"),
             abjad.Tuplet("5:4", "c'16 c'16 c'16 c'16"),
         ]
     )
@@ -403,7 +403,7 @@ def test_Staff___setitem___01():
     assert isinstance(staff[2], abjad.Chord)
     assert isinstance(staff[3], abjad.Tuplet)
     assert isinstance(staff[4], abjad.Note)
-    staff[-3] = abjad.Skip((1, 4))
+    staff[-3] = abjad.Skip("s4")
     assert len(staff) == 5
     assert abjad.wf.is_wellformed(staff)
     assert isinstance(staff[0], abjad.Rest)


### PR DESCRIPTION
Only a LilyPond string is allowed:

    >>> abjad.Skip("s4")

Use ...

    abjad.Skip.from_duration()

... to construct skips from an explicit duration.