### PR TITLE
Change abjad.Note.multiplier to abjad.Note.dmp

### DIFF
--- a/source/abjad/makers.py
+++ b/source/abjad/makers.py
@@ -148,7 +148,7 @@ def _make_tied_leaf(
             leaf = class_.from_duration_and_pitch(
                 duration,
                 pitches,
-                multiplier=multiplier,
+                dmp=multiplier,
                 tag=tag,
             )
         elif pitches is not None:
@@ -156,12 +156,12 @@ def _make_tied_leaf(
             leaf = class_.from_duration_and_pitches(
                 duration,
                 pitches,
-                multiplier=multiplier,
+                dmp=multiplier,
                 tag=tag,
             )
         else:
             assert class_ in (_score.Rest, _score.Skip), repr(class_)
-            leaf = class_.from_duration(duration, multiplier=multiplier, tag=tag)
+            leaf = class_.from_duration(duration, dmp=multiplier, tag=tag)
         leaves.append(leaf)
     if 1 < len(leaves):
         if not issubclass(class_, _score.Rest | _score.Skip):

--- a/source/abjad/mutate.py
+++ b/source/abjad/mutate.py
@@ -432,7 +432,7 @@ def _immediately_precedes(component_1, component_2, ignore_before_after_grace=No
 
 def _set_leaf_duration(leaf, new_duration, *, tag=None):
     assert isinstance(new_duration, _duration.Duration), repr(new_duration)
-    if leaf.multiplier() is not None:
+    if leaf.dmp() is not None:
         fraction = new_duration / leaf.written_duration()
         pair = (fraction.numerator, fraction.denominator)
         leaf.set_multiplier(pair)
@@ -1818,7 +1818,7 @@ def scale(argument, multiplier) -> None:
 
         Scales leaves carrying LilyPond multiplier:
 
-        >>> note = abjad.Note("c'8", multiplier=(1, 2))
+        >>> note = abjad.Note("c'8", dmp=(1, 2))
         >>> abjad.show(note) # doctest: +SKIP
 
         ..  docs::

--- a/source/abjad/score.py
+++ b/source/abjad/score.py
@@ -377,7 +377,7 @@ class Leaf(Component):
     __slots__ = (
         "_after_grace_container",
         "_before_grace_container",
-        "_multiplier",
+        "_dmp",
         "_written_duration",
     )
 
@@ -385,13 +385,13 @@ class Leaf(Component):
         self,
         written_duration: _duration.Duration,
         *,
-        multiplier=None,
+        dmp=None,
         tag: _tag.Tag | None = None,
     ) -> None:
         super().__init__(tag=tag)
         self._after_grace_container = None
         self._before_grace_container = None
-        self.set_multiplier(multiplier)
+        self.set_multiplier(dmp)
         if isinstance(written_duration, _duration.Duration):
             written_duration_ = written_duration
         elif isinstance(written_duration, tuple):
@@ -403,7 +403,7 @@ class Leaf(Component):
     def __copy__(self) -> typing.Self:
         leaf = super().__copy__()
         leaf.set_written_duration(self.written_duration())
-        leaf.set_multiplier(self.multiplier())
+        leaf.set_multiplier(self.dmp())
         before_grace_container = self._before_grace_container
         if before_grace_container is not None:
             grace_container = before_grace_container._copy_with_children()
@@ -563,7 +563,7 @@ class Leaf(Component):
 
     def _get_formatted_duration(self) -> str:
         strings = [self.written_duration().lilypond_duration_string()]
-        self_multiplier = self.multiplier()
+        self_multiplier = self.dmp()
         if self_multiplier is not None:
             string = f"{self_multiplier[0]}/{self_multiplier[1]}"
             strings.append(string)
@@ -572,7 +572,7 @@ class Leaf(Component):
 
     def _get_preprolated_duration(self) -> _duration.Duration:
         duration = self.written_duration()
-        self_multiplier = self.multiplier()
+        self_multiplier = self.dmp()
         if self_multiplier is not None:
             duration = fractions.Fraction(*self_multiplier) * duration
         return duration
@@ -617,20 +617,20 @@ class Leaf(Component):
         self_written_duration = multiplier * self.written_duration()
         self.set_written_duration(self_written_duration)
 
-    def multiplier(self) -> tuple[int, int] | None:
+    def dmp(self) -> tuple[int, int] | None:
         """
-        Gets leaf multiplier.
+        Gets duration-multiplier pair of leaf.
         """
-        return self._multiplier
+        return self._dmp
 
     def set_multiplier(self, pair: tuple[int, int] | None) -> None:
         """
-        Sets leaf multiplier.
+        Sets duration-multiplier pair on leaf.
         """
         if pair is not None:
             assert isinstance(pair, tuple), repr(pair)
             assert len(pair) == 2, repr(pair)
-        self._multiplier = pair
+        self._dmp = pair
 
     def set_written_duration(self, duration: _duration.Duration) -> None:
         """
@@ -2445,14 +2445,14 @@ class Chord(Leaf):
         self,
         string: str = "<c' e' g'>4",
         *,
+        dmp: tuple[int, int] | None = None,
         language: str = "english",
-        multiplier: tuple[int, int] | None = None,
         tag: _tag.Tag | None = None,
     ) -> None:
         assert isinstance(string, str), repr(string)
         assert isinstance(language, str), repr(language)
-        if multiplier is not None:
-            assert isinstance(multiplier, tuple), repr(multiplier)
+        if dmp is not None:
+            assert isinstance(dmp, tuple), repr(dmp)
         if tag is not None:
             assert isinstance(tag, _tag.Tag), repr(tag)
         if string == "<c' e' g'>4":
@@ -2465,12 +2465,12 @@ class Chord(Leaf):
             assert len(parsed) == 1 and isinstance(parsed[0], Chord)
             chord = parsed[0]
             duration = chord.written_duration()
-            if multiplier is None:
-                multiplier = chord.multiplier()
+            if dmp is None:
+                dmp = chord.dmp()
             if tag is None:
                 tag = chord.tag()
             note_heads = chord.note_heads()
-        super().__init__(duration, multiplier=multiplier, tag=tag)
+        super().__init__(duration, dmp=dmp, tag=tag)
         self.set_note_heads(note_heads)
 
     def __copy__(self) -> typing.Self:
@@ -2530,7 +2530,7 @@ class Chord(Leaf):
         duration: _duration.Duration,
         note_heads: typing.Sequence[NoteHead],
         *,
-        multiplier: tuple[int, int] | None = None,
+        dmp: tuple[int, int] | None = None,
         tag: _tag.Tag | None = None,
     ) -> Chord:
         """
@@ -2567,11 +2567,11 @@ class Chord(Leaf):
         """
         assert all(isinstance(_, NoteHead) for _ in note_heads), repr(note_heads)
         assert isinstance(duration, _duration.Duration), repr(duration)
-        if multiplier is not None:
-            assert isinstance(multiplier, tuple), repr(multiplier)
+        if dmp is not None:
+            assert isinstance(dmp, tuple), repr(dmp)
         if tag is not None:
             assert isinstance(tag, _tag.Tag), repr(tag)
-        chord = Chord("<c' e' g'>4", multiplier=multiplier, tag=tag)
+        chord = Chord("<c' e' g'>4", dmp=dmp, tag=tag)
         chord.set_note_heads([copy.copy(_) for _ in note_heads])
         chord.set_written_duration(duration)
         return chord
@@ -2581,7 +2581,7 @@ class Chord(Leaf):
         duration: _duration.Duration,
         pitches: typing.Sequence[_pitch.NamedPitch | str],
         *,
-        multiplier: tuple[int, int] | None = None,
+        dmp: tuple[int, int] | None = None,
         tag: _tag.Tag | None = None,
     ) -> Chord:
         """
@@ -2604,11 +2604,11 @@ class Chord(Leaf):
         prototype = (_pitch.NamedPitch, str)
         assert all(isinstance(_, prototype) for _ in pitches), repr(pitches)
         assert isinstance(duration, _duration.Duration), repr(duration)
-        if multiplier is not None:
-            assert isinstance(multiplier, tuple), repr(multiplier)
+        if dmp is not None:
+            assert isinstance(dmp, tuple), repr(dmp)
         if tag is not None:
             assert isinstance(tag, _tag.Tag), repr(tag)
-        chord = Chord("<c' e' g'>4", multiplier=multiplier, tag=tag)
+        chord = Chord("<c' e' g'>4", dmp=dmp, tag=tag)
         chord.set_written_pitches(pitches)
         chord.set_written_duration(duration)
         return chord
@@ -3127,14 +3127,14 @@ class MultimeasureRest(Leaf):
         self,
         string: str = "R1",
         *,
+        dmp: tuple[int, int] | None = None,
         language: str = "english",
-        multiplier: tuple[int, int] | None = None,
         tag: _tag.Tag | None = None,
     ) -> None:
         assert isinstance(string, str), repr(string)
         assert isinstance(language, str), repr(language)
-        if multiplier is not None:
-            assert isinstance(multiplier, tuple), repr(multiplier)
+        if dmp is not None:
+            assert isinstance(dmp, tuple), repr(dmp)
         if tag is not None:
             assert isinstance(tag, _tag.Tag), repr(tag)
         if string == "R1":
@@ -3146,7 +3146,7 @@ class MultimeasureRest(Leaf):
             assert len(parsed) == 1 and isinstance(parsed[0], MultimeasureRest)
             mmrest = parsed[0]
             written_duration = mmrest.written_duration()
-        super().__init__(written_duration, multiplier=multiplier, tag=tag)
+        super().__init__(written_duration, dmp=dmp, tag=tag)
 
     def _get_body(self) -> list[str]:
         result = "R" + str(self._get_formatted_duration())
@@ -3159,18 +3159,18 @@ class MultimeasureRest(Leaf):
     def from_duration(
         duration: _duration.Duration,
         *,
-        multiplier: tuple[int, int] | None = None,
+        dmp: tuple[int, int] | None = None,
         tag: _tag.Tag | None = None,
     ) -> MultimeasureRest:
         """
         Makes multimeasure rest from ``duration``.
         """
         assert isinstance(duration, _duration.Duration), repr(duration)
-        if multiplier is not None:
-            assert isinstance(multiplier, tuple), repr(multiplier)
+        if dmp is not None:
+            assert isinstance(dmp, tuple), repr(dmp)
         if tag is not None:
             assert isinstance(tag, _tag.Tag), repr(tag)
-        mmrest = MultimeasureRest("R1", multiplier=multiplier, tag=tag)
+        mmrest = MultimeasureRest("R1", dmp=dmp, tag=tag)
         mmrest.set_written_duration(duration)
         return mmrest
 
@@ -3920,14 +3920,14 @@ class Note(Leaf):
         self,
         string: str = "c'4",
         *,
+        dmp: tuple[int, int] | None = None,
         language: str = "english",
-        multiplier: tuple[int, int] | None = None,
         tag: _tag.Tag | None = None,
     ) -> None:
         assert isinstance(string, str), repr(string)
         assert isinstance(language, str), repr(language)
-        if multiplier is not None:
-            assert isinstance(multiplier, tuple), repr(multiplier)
+        if dmp is not None:
+            assert isinstance(dmp, tuple), repr(dmp)
         if tag is not None:
             assert isinstance(tag, _tag.Tag), repr(tag)
         is_cautionary = False
@@ -3943,15 +3943,15 @@ class Note(Leaf):
             assert len(parsed) == 1 and isinstance(parsed[0], Note)
             note = parsed[0]
             written_duration = note.written_duration()
-            if multiplier is None:
-                multiplier = note.multiplier()
+            if dmp is None:
+                dmp = note.dmp()
             note_head = note.note_head()
             assert isinstance(note_head, NoteHead)
             written_pitch = note_head.written_pitch()
             is_cautionary = note_head.is_cautionary()
             is_forced = note_head.is_forced()
             is_parenthesized = note_head.is_parenthesized()
-        super().__init__(written_duration, multiplier=multiplier, tag=tag)
+        super().__init__(written_duration, dmp=dmp, tag=tag)
         if isinstance(written_pitch, _pitch.NamedPitch):
             note_head = NoteHead(
                 written_pitch=written_pitch,
@@ -3988,7 +3988,7 @@ class Note(Leaf):
         duration: _duration.Duration,
         pitch: _pitch.NamedPitch | str,
         *,
-        multiplier: tuple[int, int] | None = None,
+        dmp: tuple[int, int] | None = None,
         tag: _tag.Tag | None = None,
     ) -> Note:
         """
@@ -4010,11 +4010,11 @@ class Note(Leaf):
         """
         assert isinstance(pitch, _pitch.NamedPitch | str), repr(pitch)
         assert isinstance(duration, _duration.Duration), repr(duration)
-        if multiplier is not None:
-            assert isinstance(multiplier, tuple), repr(multiplier)
+        if dmp is not None:
+            assert isinstance(dmp, tuple), repr(dmp)
         if tag is not None:
             assert isinstance(tag, _tag.Tag), repr(tag)
-        note = Note("c'4", multiplier=multiplier, tag=tag)
+        note = Note("c'4", dmp=dmp, tag=tag)
         note.set_written_pitch(pitch)
         note.set_written_duration(duration)
         return note
@@ -4141,14 +4141,14 @@ class Rest(Leaf):
         self,
         string: str = "r4",
         *,
+        dmp: tuple[int, int] | None = None,
         language: str = "english",
-        multiplier: tuple[int, int] | None = None,
         tag: _tag.Tag | None = None,
     ) -> None:
         assert isinstance(string, str), repr(string)
         assert isinstance(language, str), repr(language)
-        if multiplier is not None:
-            assert isinstance(multiplier, tuple), repr(multiplier)
+        if dmp is not None:
+            assert isinstance(dmp, tuple), repr(dmp)
         if tag is not None:
             assert isinstance(tag, _tag.Tag), repr(tag)
         if string == "r4":
@@ -4160,7 +4160,7 @@ class Rest(Leaf):
             assert len(parsed) == 1 and isinstance(parsed[0], Rest)
             rest = parsed[0]
             written_duration = rest.written_duration()
-        super().__init__(written_duration, multiplier=multiplier, tag=tag)
+        super().__init__(written_duration, dmp=dmp, tag=tag)
 
     def _get_body(self) -> list[str]:
         return [self._get_compact_representation()]
@@ -4172,7 +4172,7 @@ class Rest(Leaf):
     def from_duration(
         duration: _duration.Duration,
         *,
-        multiplier: tuple[int, int] | None = None,
+        dmp: tuple[int, int] | None = None,
         tag: _tag.Tag | None = None,
     ) -> Rest:
         """
@@ -4186,11 +4186,11 @@ class Rest(Leaf):
 
         """
         assert isinstance(duration, _duration.Duration), repr(duration)
-        if multiplier is not None:
-            assert isinstance(multiplier, tuple), repr(multiplier)
+        if dmp is not None:
+            assert isinstance(dmp, tuple), repr(dmp)
         if tag is not None:
             assert isinstance(tag, _tag.Tag), repr(tag)
-        rest = Rest("r4", multiplier=multiplier, tag=tag)
+        rest = Rest("r4", dmp=dmp, tag=tag)
         rest.set_written_duration(duration)
         return rest
 
@@ -4283,14 +4283,14 @@ class Skip(Leaf):
         self,
         string: str = "s4",
         *,
+        dmp: tuple[int, int] | None = None,
         language: str = "english",
-        multiplier: tuple[int, int] | None = None,
         tag: _tag.Tag | None = None,
     ) -> None:
         assert isinstance(string, str), repr(string)
         assert isinstance(language, str), repr(language)
-        if multiplier is not None:
-            assert isinstance(multiplier, tuple), repr(multiplier)
+        if dmp is not None:
+            assert isinstance(dmp, tuple), repr(dmp)
         if tag is not None:
             assert isinstance(tag, _tag.Tag), repr(tag)
         if string == "s4":
@@ -4302,7 +4302,7 @@ class Skip(Leaf):
             skip = parsed[0]
             written_duration = skip.written_duration()
         assert isinstance(written_duration, _duration.Duration), repr(written_duration)
-        super().__init__(written_duration, multiplier=multiplier, tag=tag)
+        super().__init__(written_duration, dmp=dmp, tag=tag)
         self._measure_initial_grace_note = None
 
     def _get_body(self) -> list[str]:
@@ -4322,7 +4322,7 @@ class Skip(Leaf):
     def from_duration(
         duration: _duration.Duration,
         *,
-        multiplier: tuple[int, int] | None = None,
+        dmp: tuple[int, int] | None = None,
         tag: _tag.Tag | None = None,
     ) -> Skip:
         """
@@ -4336,11 +4336,11 @@ class Skip(Leaf):
 
         """
         assert isinstance(duration, _duration.Duration), repr(duration)
-        if multiplier is not None:
-            assert isinstance(multiplier, tuple), repr(multiplier)
+        if dmp is not None:
+            assert isinstance(dmp, tuple), repr(dmp)
         if tag is not None:
             assert isinstance(tag, _tag.Tag), repr(tag)
-        skip = Skip("s4", multiplier=multiplier, tag=tag)
+        skip = Skip("s4", dmp=dmp, tag=tag)
         skip.set_written_duration(duration)
         return skip
 
@@ -5109,7 +5109,7 @@ class Tuplet(Container):
             if isinstance(component, Tuplet):
                 continue
             elif hasattr(component, "written_duration"):
-                if component.multiplier() is not None:
+                if component.dmp() is not None:
                     return False
         return True
 
@@ -5196,7 +5196,6 @@ class Tuplet(Container):
                 continue
             assert isinstance(component, Leaf), repr(component)
             duration = self.multiplier() * component.written_duration()
-            # if not _duration.Duration(duration).is_assignable():
             if not duration.is_assignable():
                 return False
         return True
@@ -5497,16 +5496,13 @@ class Tuplet(Container):
         global_dot_count = dot_counts.pop()
         if global_dot_count == 0:
             return
-        # dot_duration = _duration.Duration.from_dot_count(global_dot_count)
         dot_duration = _duration.Duration.from_dot_count(global_dot_count)
-        # multiplier = _duration.Duration(self.multiplier() * dot_duration)
         multiplier = self.multiplier() * dot_duration
         ratio = _duration.Ratio(*multiplier.reciprocal().pair())
         self.set_ratio(ratio)
         reciprocal_dot_fraction = dot_duration.reciprocal().as_fraction()
         for component in self:
             duration = component.written_duration()
-            # duration *= reciprocal_dot_fraction
             duration = reciprocal_dot_fraction * duration
             component.set_written_duration(duration)
 
@@ -5703,7 +5699,6 @@ class Tuplet(Container):
                 component.set_ratio(ratio)
             elif isinstance(component, Leaf):
                 duration = component.written_duration()
-                # duration = _duration.Duration(self.multiplier() * duration)
                 duration = self.multiplier() * duration
                 component.set_written_duration(duration)
             else:

--- a/tests/test_mutate_split.py
+++ b/tests/test_mutate_split.py
@@ -236,7 +236,7 @@ def test_mutate__set_leaf_duration_06():
     duration does not.
     """
 
-    note = abjad.Note("c'8", multiplier=(1, 2))
+    note = abjad.Note("c'8", dmp=(1, 2))
 
     assert abjad.lilypond(note) == "c'8 * 1/2"
 
@@ -253,7 +253,7 @@ def test_mutate__set_leaf_duration_07():
     written duration does not.
     """
 
-    note = abjad.Note("c'8", multiplier=(1, 2))
+    note = abjad.Note("c'8", dmp=(1, 2))
 
     assert abjad.lilypond(note) == "c'8 * 1/2"
 
@@ -270,7 +270,7 @@ def test_mutate__set_leaf_duration_08():
     written duration does not.
     """
 
-    note = abjad.Note("c'8", multiplier=(1, 2))
+    note = abjad.Note("c'8", dmp=(1, 2))
 
     assert abjad.lilypond(note) == "c'8 * 1/2"
 
@@ -287,7 +287,7 @@ def test_mutate__set_leaf_duration_09():
     written duration does not.
     """
 
-    note = abjad.Note("c'8", multiplier=(1, 2))
+    note = abjad.Note("c'8", dmp=(1, 2))
 
     assert abjad.lilypond(note) == "c'8 * 1/2"
 
@@ -304,7 +304,7 @@ def test_mutate__set_leaf_duration_10():
     LilyPond multiplier changes but leaf written duration does not.
     """
 
-    note = abjad.Note("c'8", multiplier=(1, 2))
+    note = abjad.Note("c'8", dmp=(1, 2))
 
     assert abjad.lilypond(note) == "c'8 * 1/2"
 

--- a/tests/test_score_Note.py
+++ b/tests/test_score_Note.py
@@ -24,7 +24,7 @@ def test_Note___copy___02():
     Copies note with LilyPond multiplier.
     """
 
-    note_1 = abjad.Note("c''4", multiplier=(1, 2))
+    note_1 = abjad.Note("c''4", dmp=(1, 2))
     note_2 = copy.copy(note_1)
 
     assert isinstance(note_1, abjad.Note)

--- a/tests/test_score_Rest.py
+++ b/tests/test_score_Rest.py
@@ -42,7 +42,7 @@ def test_Rest___copy___02():
     Copies rest with LilyPond multiplier.
     """
 
-    rest_1 = abjad.Rest("r4", multiplier=(1, 2))
+    rest_1 = abjad.Rest("r4", dmp=(1, 2))
     rest_2 = copy.copy(rest_1)
 
     assert isinstance(rest_1, abjad.Rest)

--- a/tests/test_score_Skip.py
+++ b/tests/test_score_Skip.py
@@ -22,7 +22,7 @@ def test_Skip___copy___02():
     Copies skip with LilyPond multiplier.
     """
 
-    skip_1 = abjad.Skip("s4", multiplier=(1, 2))
+    skip_1 = abjad.Skip("s4", dmp=(1, 2))
     skip_2 = copy.copy(skip_1)
 
     assert isinstance(skip_1, abjad.Skip)


### PR DESCRIPTION
Change `abjad.Note.multiplier` to `abjad.Note.dmp`.

    3.29:
        abjad.Note(string: str, multiplier: pair[int, int] = None)
        abjad.Note.set_multiplier(pair: tuple[int, int])
    3.30:
        abjad.Note(string: str, dmp: pair[int, int] = None)
        abjad.Note.set_dmp(pair: tuple[int, int])

The acronym "dmp" stands for "duaration-multiplier pair."

The name reflects the fact that the ratio n/d does not reduce.

This means that ...

    c'4 * 1/2
    c'4 * 2/4
    c'4 * 4/8

... are all possible, as in any LilyPond input file.

By contrast, the Abjad codebase prefers to use the term "multiplier" to refer to a ``fractions.Fraction`` object, all of which are automatically reduced at initialization. It is not possible to express 2/4, 4/8 etc using built-in fractions.