### PR TITLE
Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ classifiers = [
 ]
 dependencies = [
     "ply>=3.11",
-    "roman>=5.0",
-    "uqbar>=0.7.4"
+    "roman>=5.1",
+    "uqbar>=0.9.6"
 ]
 
 [[project.authors]]
@@ -38,14 +38,14 @@ dev = [
     "flake8==7.3.0",
     "isort==6.0.1",
     "mypy==1.18.2",
-    "pytest==8.3.5",
-    "pytest-cov==6.1.1",
+    "pytest==8.4.2",
+    "pytest-cov==7.0.0",
     "pytest-helpers-namespace==2021.12.29",
-    "setuptools==80.0.0",
+    "setuptools==80.9.0",
     "sphinx==8.1.3",
     "sphinx-rtd-theme==3.0.2",
     "sphinx-toggleprompt==0.6.0",
-    "twine==6.1.0"
+    "twine==6.2.0"
 ]
 
 [project.urls]

--- a/tests/test_ext_sphinx.py
+++ b/tests/test_ext_sphinx.py
@@ -15,8 +15,6 @@ def rm_dirs(app):
 
 def _assert_no_unexpected_warnings(warning_output: str):
     for line in warning_output.splitlines():
-        if "directive 'shell' is already registered" in line:
-            continue
         assert False, f"Unexpected warning: {line}"
 
 


### PR DESCRIPTION
    isort 6.0.1 -> 6.1.0
    pytest 8.3.5 -> 8.4.2
    pytest-cov 6.1.1 -> 7.0.0
    roman 5.0 -> 5.1
    setuptools 80.0.0 -> 80.9.0
    twine 6.1.0 -> 6.2.0
    uqbar 0.7.4 -> 0.9.6

Remove ShellDirective from abjad.ext.sphinx

Use the Uqbar shell directive instead